### PR TITLE
CUDA GPU health check

### DIFF
--- a/dashboard/components/__tests__/SessionView.canary-language.test.tsx
+++ b/dashboard/components/__tests__/SessionView.canary-language.test.tsx
@@ -227,6 +227,7 @@ const baseProps = {
     ready: true,
     error: null,
     gpuError: null,
+    gpuErrorRecoveryHint: null,
     refresh: vi.fn(),
   },
   clientRunning: true,

--- a/dashboard/components/__tests__/SessionView.test.tsx
+++ b/dashboard/components/__tests__/SessionView.test.tsx
@@ -222,6 +222,7 @@ const baseProps = {
     ready: true,
     error: null,
     gpuError: null,
+    gpuErrorRecoveryHint: null,
     refresh: vi.fn(),
   },
   clientRunning: true,

--- a/dashboard/components/views/GpuHealthCard.tsx
+++ b/dashboard/components/views/GpuHealthCard.tsx
@@ -1,4 +1,6 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { Button } from '../ui/Button';
+import { writeToClipboard } from '../../src/hooks/useClipboard';
 
 export interface GpuPreflightCheckProp {
   name: string;
@@ -42,36 +44,50 @@ const STATE_LABEL: Record<CardState, string> = {
   red: 'GPU unavailable — fell back to CPU',
 };
 
-const STATE_COLOR: Record<CardState, string> = {
-  green: '#1f8a3a',
-  yellow: '#b88a00',
-  red: '#b53030',
+const STATE_BORDER: Record<CardState, string> = {
+  green: 'border-green-600',
+  yellow: 'border-amber-600',
+  red: 'border-red-700',
+};
+
+const STATE_TEXT: Record<CardState, string> = {
+  green: 'text-green-600',
+  yellow: 'text-amber-600',
+  red: 'text-red-700',
 };
 
 function CopyableCommand({ cmd }: { cmd: string }): React.ReactElement {
   const [copied, setCopied] = useState(false);
+  const timerRef = useRef<number | undefined>(undefined);
+
   const handleCopy = (): void => {
-    void navigator.clipboard.writeText(cmd).then(() => {
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1500);
-    });
+    writeToClipboard(cmd)
+      .then(() => {
+        setCopied(true);
+        if (timerRef.current) window.clearTimeout(timerRef.current);
+        timerRef.current = window.setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => {
+        /* silent — matches LogsView pattern */
+      });
   };
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) window.clearTimeout(timerRef.current);
+    };
+  }, []);
+
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 4 }}>
-      <code
-        style={{
-          padding: '4px 8px',
-          background: '#222',
-          color: '#eee',
-          borderRadius: 4,
-          fontSize: 12,
-          flex: 1,
-          overflowX: 'auto',
-        }}
-      >
+    <div className="mt-1 flex items-center gap-2">
+      <code className="flex-1 overflow-x-auto rounded bg-neutral-900 px-2 py-1 text-xs text-neutral-100">
         {cmd}
       </code>
-      <button type="button" onClick={handleCopy} style={{ fontSize: 12 }}>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="rounded bg-neutral-700 px-2 py-1 text-xs text-neutral-100 hover:bg-neutral-600"
+      >
         {copied ? 'Copied' : 'Copy'}
       </button>
     </div>
@@ -92,43 +108,30 @@ export function GpuHealthCard({
   return (
     <section
       aria-labelledby="gpu-health-title"
-      style={{
-        border: `1px solid ${STATE_COLOR[state]}`,
-        borderRadius: 6,
-        padding: 12,
-        marginTop: 12,
-      }}
+      className={`mt-3 rounded-md border p-3 ${STATE_BORDER[state]}`}
     >
-      <h3 id="gpu-health-title" style={{ marginTop: 0, color: STATE_COLOR[state] }}>
+      <h3 id="gpu-health-title" className={`mt-0 ${STATE_TEXT[state]}`}>
         GPU Health (NVIDIA)
       </h3>
-      <p style={{ fontSize: 12, marginTop: 0, color: '#888' }}>
+      <p className="mt-0 text-xs text-neutral-400">
         This card appears only on systems with an NVIDIA GPU. AMD / Intel / Apple Silicon setups do
         not need it.
       </p>
 
-      <p style={{ fontWeight: 600 }}>{STATE_LABEL[state]}</p>
+      <p className="font-semibold">{STATE_LABEL[state]}</p>
 
       {state === 'red' && backendError?.recovery_hint ? (
-        <p
-          style={{
-            background: '#3a1313',
-            padding: 8,
-            borderRadius: 4,
-            color: '#fbb',
-            fontSize: 13,
-          }}
-        >
+        <p className="rounded bg-red-900/50 p-2 text-sm text-red-200">
           {backendError.recovery_hint}
         </p>
       ) : null}
 
       {failedChecks.length > 0 ? (
-        <div style={{ marginTop: 12 }}>
-          <p style={{ marginBottom: 4, fontWeight: 500 }}>Failing checks:</p>
+        <div className="mt-3">
+          <p className="mb-1 font-medium">Failing checks:</p>
           {failedChecks.map((check) => (
-            <div key={check.name} style={{ marginBottom: 10 }}>
-              <div style={{ fontSize: 13 }}>
+            <div key={check.name} className="mb-2.5">
+              <div className="text-sm">
                 ✗ {check.name}
                 {check.docsUrl ? (
                   <>
@@ -145,10 +148,10 @@ export function GpuHealthCard({
         </div>
       ) : null}
 
-      <div style={{ marginTop: 12 }}>
-        <button type="button" onClick={onRunDiagnostic}>
+      <div className="mt-3">
+        <Button variant="secondary" size="sm" onClick={onRunDiagnostic}>
           Run Full Diagnostic
-        </button>
+        </Button>
       </div>
     </section>
   );

--- a/dashboard/components/views/GpuHealthCard.tsx
+++ b/dashboard/components/views/GpuHealthCard.tsx
@@ -1,0 +1,155 @@
+import React, { useState } from 'react';
+
+export interface GpuPreflightCheckProp {
+  name: string;
+  pass: boolean;
+  fixCommand?: string;
+  docsUrl?: string;
+}
+
+export interface GpuPreflightProp {
+  status: 'healthy' | 'warning' | 'unknown';
+  checks: GpuPreflightCheckProp[];
+}
+
+export interface GpuBackendErrorProp {
+  status: 'unrecoverable';
+  error: string;
+  recovery_hint?: string;
+}
+
+export interface GpuHealthCardProps {
+  gpuDetected: boolean;
+  preflight: GpuPreflightProp | null;
+  backendError: GpuBackendErrorProp | null;
+  onRunDiagnostic: () => void;
+}
+
+type CardState = 'green' | 'yellow' | 'red';
+
+function deriveState(
+  preflight: GpuPreflightProp | null,
+  backendError: GpuBackendErrorProp | null,
+): CardState {
+  if (backendError && backendError.status === 'unrecoverable') return 'red';
+  if (preflight && preflight.status === 'warning') return 'yellow';
+  return 'green';
+}
+
+const STATE_LABEL: Record<CardState, string> = {
+  green: 'GPU healthy — CUDA operational',
+  yellow: 'GPU may be misconfigured — server will fall back to CPU',
+  red: 'GPU unavailable — fell back to CPU',
+};
+
+const STATE_COLOR: Record<CardState, string> = {
+  green: '#1f8a3a',
+  yellow: '#b88a00',
+  red: '#b53030',
+};
+
+function CopyableCommand({ cmd }: { cmd: string }): React.ReactElement {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = (): void => {
+    void navigator.clipboard.writeText(cmd).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    });
+  };
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 4 }}>
+      <code
+        style={{
+          padding: '4px 8px',
+          background: '#222',
+          color: '#eee',
+          borderRadius: 4,
+          fontSize: 12,
+          flex: 1,
+          overflowX: 'auto',
+        }}
+      >
+        {cmd}
+      </code>
+      <button type="button" onClick={handleCopy} style={{ fontSize: 12 }}>
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+    </div>
+  );
+}
+
+export function GpuHealthCard({
+  gpuDetected,
+  preflight,
+  backendError,
+  onRunDiagnostic,
+}: GpuHealthCardProps): React.ReactElement | null {
+  if (!gpuDetected) return null;
+
+  const state = deriveState(preflight, backendError);
+  const failedChecks = preflight ? preflight.checks.filter((c) => !c.pass) : [];
+
+  return (
+    <section
+      aria-labelledby="gpu-health-title"
+      style={{
+        border: `1px solid ${STATE_COLOR[state]}`,
+        borderRadius: 6,
+        padding: 12,
+        marginTop: 12,
+      }}
+    >
+      <h3 id="gpu-health-title" style={{ marginTop: 0, color: STATE_COLOR[state] }}>
+        GPU Health (NVIDIA)
+      </h3>
+      <p style={{ fontSize: 12, marginTop: 0, color: '#888' }}>
+        This card appears only on systems with an NVIDIA GPU. AMD / Intel / Apple Silicon setups do
+        not need it.
+      </p>
+
+      <p style={{ fontWeight: 600 }}>{STATE_LABEL[state]}</p>
+
+      {state === 'red' && backendError?.recovery_hint ? (
+        <p
+          style={{
+            background: '#3a1313',
+            padding: 8,
+            borderRadius: 4,
+            color: '#fbb',
+            fontSize: 13,
+          }}
+        >
+          {backendError.recovery_hint}
+        </p>
+      ) : null}
+
+      {failedChecks.length > 0 ? (
+        <div style={{ marginTop: 12 }}>
+          <p style={{ marginBottom: 4, fontWeight: 500 }}>Failing checks:</p>
+          {failedChecks.map((check) => (
+            <div key={check.name} style={{ marginBottom: 10 }}>
+              <div style={{ fontSize: 13 }}>
+                ✗ {check.name}
+                {check.docsUrl ? (
+                  <>
+                    {' — '}
+                    <a href={check.docsUrl} target="_blank" rel="noopener noreferrer">
+                      docs
+                    </a>
+                  </>
+                ) : null}
+              </div>
+              {check.fixCommand ? <CopyableCommand cmd={check.fixCommand} /> : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      <div style={{ marginTop: 12 }}>
+        <button type="button" onClick={onRunDiagnostic}>
+          Run Full Diagnostic
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/dashboard/components/views/ServerView.tsx
+++ b/dashboard/components/views/ServerView.tsx
@@ -34,9 +34,11 @@ import { NvidiaIcon } from '../ui/icons/NvidiaIcon';
 import { AmdIcon } from '../ui/icons/AmdIcon';
 import { IntelIcon } from '../ui/icons/IntelIcon';
 import { AppleIcon } from '../ui/icons/AppleIcon';
+import { GpuHealthCard } from './GpuHealthCard';
 
 import { useActivityStore } from '../../src/stores/activityStore';
 import { useAdminStatus } from '../../src/hooks/useAdminStatus';
+import { useServerStatus } from '../../src/hooks/useServerStatus';
 import { useDockerContext } from '../../src/hooks/DockerContext';
 import { apiClient } from '../../src/api/client';
 import { writeToClipboard } from '../../src/hooks/useClipboard';
@@ -1154,6 +1156,93 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
     vulkan: boolean;
   } | null>(cachedGpuInfo ?? null);
 
+  // ─── GPU Health Card state (NVIDIA Linux only) ─────────────────────────────
+  // Phase 2 of the CUDA error 999 recovery plan. Three pieces of state feed the
+  // GpuHealthCard rendered below the setup checklist:
+  //   - gpuPreflight: result of dockerManager.validateGpuPreflight() — cheap
+  //     host checks (CDI spec, /dev/char symlinks, nvidia_uvm). Drives the
+  //     yellow "may be misconfigured" state when a check fails.
+  //   - gpuBackendError: structured object built from useServerStatus()'s
+  //     gpuError + gpuErrorRecoveryHint when /api/status reports a GPU failure.
+  //     Drives the red "fell back to CPU" state with the recovery hint visible.
+  //   - hostPlatform: read once from electronAPI.app.getPlatform() so the card
+  //     can gate on Linux without depending on navigator.platform (which may
+  //     report 'Linux x86_64' or be absent in jsdom test mounts).
+  const [gpuPreflight, setGpuPreflight] = useState<{
+    status: 'healthy' | 'warning' | 'unknown';
+    checks: Array<{
+      name: string;
+      pass: boolean;
+      fixCommand?: string;
+      docsUrl?: string;
+    }>;
+  } | null>(null);
+  const [gpuBackendError, setGpuBackendError] = useState<{
+    status: 'unrecoverable';
+    error: string;
+    recovery_hint?: string;
+  } | null>(null);
+  const [hostPlatform, setHostPlatform] = useState<string>('unknown');
+
+  // Subscribe to backend GPU error via the existing useServerStatus poll
+  // (polls /api/status every 10s through React Query). When the backend
+  // reports gpuError, build the structured object the GpuHealthCard expects.
+  // The recovery_hint is only present when cuda_health_check matched the
+  // error-999 fingerprint; we pass it through verbatim.
+  const { gpuError, gpuErrorRecoveryHint } = useServerStatus();
+  useEffect(() => {
+    if (gpuError) {
+      setGpuBackendError({
+        status: 'unrecoverable',
+        error: gpuError,
+        recovery_hint: gpuErrorRecoveryHint ?? undefined,
+      });
+    } else {
+      setGpuBackendError(null);
+    }
+  }, [gpuError, gpuErrorRecoveryHint]);
+
+  // Read host platform once via electronAPI bridge. Synchronous in production
+  // (preload returns process.platform directly); defaults to 'unknown' for
+  // jsdom/test mounts that don't expose getPlatform.
+  useEffect(() => {
+    const api = (window as any).electronAPI;
+    const getPlatformFn = api?.app?.getPlatform;
+    if (typeof getPlatformFn !== 'function') return;
+    try {
+      const p = getPlatformFn();
+      if (typeof p === 'string' && p) setHostPlatform(p);
+    } catch {
+      // Best-effort: leave hostPlatform as 'unknown'; card will not render.
+    }
+  }, []);
+
+  // Run-diagnostic handler for the "Run Full Diagnostic" button on the card.
+  // Invokes the docker:runGpuDiagnostic IPC (added in Task 10) which spawns
+  // scripts/diagnose-gpu.sh and returns the log path. Surfaces the result via
+  // window.alert as the simplest first-cut UI; can be promoted to a modal
+  // later if UX feedback warrants it.
+  const handleRunGpuDiagnostic = useCallback((): void => {
+    const api = (window as any).electronAPI;
+    if (!api?.docker?.runGpuDiagnostic) return;
+    api.docker
+      .runGpuDiagnostic()
+      .then((res: { status: string; logPath?: string; manualCommand?: string }) => {
+        if (res.status === 'started' && res.logPath) {
+          window.alert(
+            `GPU diagnostic started.\n\nLog file: ${res.logPath}\n\nTail it with:\n  tail -f "${res.logPath}"`,
+          );
+        } else if (res.status === 'script-missing' && res.manualCommand) {
+          window.alert(`Diagnostic script not bundled. Run it manually:\n\n  ${res.manualCommand}`);
+        } else if (res.status === 'unsupported') {
+          window.alert('GPU diagnostic is for Linux NVIDIA hosts only.');
+        }
+      })
+      .catch(() => {
+        window.alert('Failed to start GPU diagnostic — see console.');
+      });
+  }, []);
+
   // Load dismissed state and GPU info on mount (GPU check cached per session)
   useEffect(() => {
     const api = (window as any).electronAPI;
@@ -1209,6 +1298,17 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
               api.config?.set('server.gpuAutoDetectDone', true);
             })
             .catch(() => {});
+          // Phase 2 GPU health: when an NVIDIA GPU was detected, run the cheap
+          // host-side preflight (CDI spec, /dev/char symlinks, nvidia_uvm,
+          // mtime drift). The result drives the GpuHealthCard yellow state.
+          // Silently no-op on non-Linux or when the IPC isn't exposed
+          // (older preload builds, jsdom test mounts).
+          if (info.gpu && api?.docker?.validateGpuPreflight) {
+            api.docker
+              .validateGpuPreflight()
+              .then((p: typeof gpuPreflight) => setGpuPreflight(p))
+              .catch(() => setGpuPreflight(null));
+          }
         })
         .catch(() => {
           cachedGpuInfo = null;
@@ -1482,6 +1582,23 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                 </div>
               )}
             </div>
+          )}
+
+          {/*
+            GPU Health card (NVIDIA Linux only). Sits adjacent to the setup
+            checklist so all hardware/runtime status is colocated at the top
+            of the wizard. Self-gates: returns null when gpuDetected is false,
+            so the outer Linux + NVIDIA conditional is the authoritative gate.
+            See: dashboard/components/views/GpuHealthCard.tsx
+            Plan:  docs/superpowers/plans/2026-04-29-cuda-error-999-recovery.md
+          */}
+          {hostPlatform === 'linux' && (gpuInfo?.gpu ?? false) && (
+            <GpuHealthCard
+              gpuDetected={true}
+              preflight={gpuPreflight}
+              backendError={gpuBackendError}
+              onRunDiagnostic={handleRunGpuDiagnostic}
+            />
           )}
 
           {/* 1. Docker Image or Inference Server (metal) Card */}

--- a/dashboard/components/views/ServerView.tsx
+++ b/dashboard/components/views/ServerView.tsx
@@ -1298,17 +1298,6 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
               api.config?.set('server.gpuAutoDetectDone', true);
             })
             .catch(() => {});
-          // Phase 2 GPU health: when an NVIDIA GPU was detected, run the cheap
-          // host-side preflight (CDI spec, /dev/char symlinks, nvidia_uvm,
-          // mtime drift). The result drives the GpuHealthCard yellow state.
-          // Silently no-op on non-Linux or when the IPC isn't exposed
-          // (older preload builds, jsdom test mounts).
-          if (info.gpu && api?.docker?.validateGpuPreflight) {
-            api.docker
-              .validateGpuPreflight()
-              .then((p: typeof gpuPreflight) => setGpuPreflight(p))
-              .catch(() => setGpuPreflight(null));
-          }
         })
         .catch(() => {
           cachedGpuInfo = null;
@@ -1316,6 +1305,19 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
         });
     }
   }, []);
+
+  // Re-fetch GPU preflight whenever an NVIDIA GPU is detected — including
+  // re-mounts of ServerView where cachedGpuInfo was already populated by
+  // an earlier mount (in which case the GPU-detection effect skips).
+  useEffect(() => {
+    if (!gpuInfo?.gpu) return;
+    const api = (window as any).electronAPI;
+    if (!api?.docker?.validateGpuPreflight) return;
+    api.docker
+      .validateGpuPreflight()
+      .then((p: typeof gpuPreflight) => setGpuPreflight(p))
+      .catch(() => setGpuPreflight(null));
+  }, [gpuInfo?.gpu]);
 
   // Setup checks — gated by the currently selected runtime profile
   const rtName = docker.runtimeKind ?? 'Docker';

--- a/dashboard/components/views/__tests__/GpuHealthCard.test.tsx
+++ b/dashboard/components/views/__tests__/GpuHealthCard.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { GpuHealthCard } from '../GpuHealthCard';
+
+const healthyPreflight = {
+  status: 'healthy' as const,
+  checks: [
+    { name: 'CDI spec exists', pass: true },
+    { name: 'CDI spec newer than driver', pass: true },
+    { name: '/dev/char NVIDIA symlinks', pass: true },
+    { name: 'nvidia_uvm module loaded', pass: true },
+  ],
+};
+
+const warningPreflight = {
+  status: 'warning' as const,
+  checks: [
+    { name: 'CDI spec exists', pass: true },
+    { name: 'CDI spec newer than driver', pass: true },
+    {
+      name: '/dev/char NVIDIA symlinks',
+      pass: false,
+      fixCommand: 'sudo nvidia-ctk system create-dev-char-symlinks --create-all',
+      docsUrl: 'https://github.com/NVIDIA/nvidia-container-toolkit/issues/48',
+    },
+    { name: 'nvidia_uvm module loaded', pass: true },
+  ],
+};
+
+describe('GpuHealthCard', () => {
+  it('renders nothing when no NVIDIA GPU is detected', () => {
+    const { container } = render(
+      <GpuHealthCard
+        gpuDetected={false}
+        preflight={null}
+        backendError={null}
+        onRunDiagnostic={vi.fn()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the NVIDIA-only label so non-NVIDIA users are not confused', () => {
+    render(
+      <GpuHealthCard
+        gpuDetected={true}
+        preflight={healthyPreflight}
+        backendError={null}
+        onRunDiagnostic={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/GPU Health \(NVIDIA\)/i)).toBeInTheDocument();
+  });
+
+  it('green state: healthy preflight + no backend error', () => {
+    render(
+      <GpuHealthCard
+        gpuDetected={true}
+        preflight={healthyPreflight}
+        backendError={null}
+        onRunDiagnostic={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/CUDA operational/i)).toBeInTheDocument();
+  });
+
+  it('yellow state: preflight has a failed check, no backend error', () => {
+    render(
+      <GpuHealthCard
+        gpuDetected={true}
+        preflight={warningPreflight}
+        backendError={null}
+        onRunDiagnostic={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/may be misconfigured/i)).toBeInTheDocument();
+    expect(
+      screen.getByText('sudo nvidia-ctk system create-dev-char-symlinks --create-all'),
+    ).toBeInTheDocument();
+  });
+
+  it('red state: backend reported unrecoverable; recovery_hint shown verbatim', () => {
+    const backendError = {
+      status: 'unrecoverable' as const,
+      error: 'CUDA unknown error',
+      recovery_hint: 'GPU init failed with error 999 (CUDA unknown). Run scripts/diagnose-gpu.sh.',
+    };
+    render(
+      <GpuHealthCard
+        gpuDetected={true}
+        preflight={warningPreflight}
+        backendError={backendError}
+        onRunDiagnostic={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/GPU unavailable/i)).toBeInTheDocument();
+    expect(screen.getByText(/Run scripts\/diagnose-gpu\.sh/)).toBeInTheDocument();
+  });
+
+  it('clicking Run Full Diagnostic invokes the prop', async () => {
+    const onRun = vi.fn();
+    render(
+      <GpuHealthCard
+        gpuDetected={true}
+        preflight={healthyPreflight}
+        backendError={null}
+        onRunDiagnostic={onRun}
+      />,
+    );
+    const button = screen.getByRole('button', { name: /Run Full Diagnostic/i });
+    button.click();
+    expect(onRun).toHaveBeenCalledTimes(1);
+  });
+});

--- a/dashboard/electron/__tests__/dockerManagerGpuPreflight.test.ts
+++ b/dashboard/electron/__tests__/dockerManagerGpuPreflight.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment node
+
+/**
+ * GPU preflight — validates the cheap subset of scripts/diagnose-gpu.sh that
+ * runs at dashboard startup. Mirrors the dockerManagerVulkanPreflight test
+ * pattern: the function under test is pure (all OS access is injected) and
+ * returns a structured result the UI renders.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: (name: string) => `/tmp/mock-${name}`,
+    setPath: vi.fn(),
+  },
+}));
+
+vi.mock('electron-store', () => ({
+  default: class MockStore {
+    get() {
+      return undefined;
+    }
+    set() {}
+  },
+}));
+
+import { validateGpuPreflight } from '../dockerManager.js';
+
+interface Env {
+  cdiExists: boolean;
+  cdiMtime: number;
+  driverMtime: number;
+  charSymlinks: string[];
+  lsmodOutput: string;
+}
+
+function makeDeps(env: Env) {
+  return {
+    fsExists: (p: string) => {
+      if (p === '/etc/cdi/nvidia.yaml') return env.cdiExists;
+      if (p === '/dev/char') return true;
+      return false;
+    },
+    readDir: (p: string) => {
+      if (p === '/dev/char') return env.charSymlinks;
+      return [];
+    },
+    statMtime: (p: string) => {
+      if (p === '/etc/cdi/nvidia.yaml') return env.cdiExists ? env.cdiMtime : null;
+      if (p.includes('/lib/modules')) return env.driverMtime;
+      return null;
+    },
+    runLsmod: () => env.lsmodOutput,
+  };
+}
+
+const healthyEnv: Env = {
+  cdiExists: true,
+  cdiMtime: 2_000_000_000,
+  driverMtime: 1_000_000_000,
+  charSymlinks: ['195:0', '195:255', '512:0'],
+  lsmodOutput: 'nvidia\nnvidia_modeset\nnvidia_uvm\nnvidia_drm\n',
+};
+
+describe('validateGpuPreflight', () => {
+  it('non-Linux platform: returns status=unknown, no checks run', () => {
+    const deps = makeDeps(healthyEnv);
+    const result = validateGpuPreflight('darwin', deps);
+    expect(result.status).toBe('unknown');
+    expect(result.checks).toEqual([]);
+  });
+
+  it('Windows: returns status=unknown, no checks run', () => {
+    const deps = makeDeps(healthyEnv);
+    const result = validateGpuPreflight('win32', deps);
+    expect(result.status).toBe('unknown');
+    expect(result.checks).toEqual([]);
+  });
+
+  it('Linux + healthy environment: status=healthy, all checks pass', () => {
+    const result = validateGpuPreflight('linux', makeDeps(healthyEnv));
+    expect(result.status).toBe('healthy');
+    expect(result.checks.every((c) => c.pass)).toBe(true);
+    expect(result.checks.map((c) => c.name)).toEqual([
+      'CDI spec exists',
+      'CDI spec newer than driver',
+      '/dev/char NVIDIA symlinks',
+      'nvidia_uvm module loaded',
+    ]);
+  });
+
+  it('Linux + missing /dev/char symlinks: status=warning, fixCommand provided', () => {
+    const result = validateGpuPreflight(
+      'linux',
+      makeDeps({ ...healthyEnv, charSymlinks: ['512:0', '999:1'] }),
+    );
+    expect(result.status).toBe('warning');
+    const failed = result.checks.find((c) => c.name === '/dev/char NVIDIA symlinks');
+    expect(failed?.pass).toBe(false);
+    expect(failed?.fixCommand).toMatch(/nvidia-ctk system create-dev-char-symlinks/);
+  });
+
+  it('Linux + stale CDI spec: status=warning with regenerate command', () => {
+    const result = validateGpuPreflight(
+      'linux',
+      makeDeps({ ...healthyEnv, cdiMtime: 500_000_000, driverMtime: 1_000_000_000 }),
+    );
+    expect(result.status).toBe('warning');
+    const failed = result.checks.find((c) => c.name === 'CDI spec newer than driver');
+    expect(failed?.pass).toBe(false);
+    expect(failed?.fixCommand).toMatch(/nvidia-ctk cdi generate/);
+  });
+
+  it('Linux + missing CDI spec: status=warning, generate command shown', () => {
+    const result = validateGpuPreflight('linux', makeDeps({ ...healthyEnv, cdiExists: false }));
+    expect(result.status).toBe('warning');
+    const failed = result.checks.find((c) => c.name === 'CDI spec exists');
+    expect(failed?.pass).toBe(false);
+    expect(failed?.fixCommand).toMatch(/nvidia-ctk cdi generate/);
+    // The "newer than driver" check is skipped (passes vacuously) when the spec is missing.
+    const driverCheck = result.checks.find((c) => c.name === 'CDI spec newer than driver');
+    expect(driverCheck?.pass).toBe(true);
+  });
+
+  it('Linux + nvidia_uvm not loaded: status=warning, modprobe command shown', () => {
+    const result = validateGpuPreflight(
+      'linux',
+      makeDeps({ ...healthyEnv, lsmodOutput: 'nvidia\nnvidia_modeset\nnvidia_drm\n' }),
+    );
+    expect(result.status).toBe('warning');
+    const failed = result.checks.find((c) => c.name === 'nvidia_uvm module loaded');
+    expect(failed?.pass).toBe(false);
+    expect(failed?.fixCommand).toMatch(/modprobe nvidia_uvm/);
+  });
+
+  it('Linux + missing driver mtime info: skips comparison, no warning', () => {
+    const deps = {
+      ...makeDeps(healthyEnv),
+      statMtime: (p: string) => {
+        if (p === '/etc/cdi/nvidia.yaml') return 2_000_000_000;
+        return null; // driver path not located
+      },
+    };
+    const result = validateGpuPreflight('linux', deps);
+    const driverCheck = result.checks.find((c) => c.name === 'CDI spec newer than driver');
+    expect(driverCheck?.pass).toBe(true); // conservative: skip rather than false-warn
+  });
+});

--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -15,7 +15,7 @@
  *                 podman-compose.gpu.yml         (CDI device passthrough, Podman)
  */
 
-import { execFile, execFileSync, spawn, ChildProcess } from 'child_process';
+import { execFile, execFileSync, execSync, spawn, ChildProcess } from 'child_process';
 import { promisify } from 'util';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -256,6 +256,106 @@ export function validateGpuPreflight(
   const status: GpuPreflightResult['status'] = checks.every((c) => c.pass) ? 'healthy' : 'warning';
 
   return { status, checks };
+}
+
+/**
+ * Real-OS wrapper around validateGpuPreflight() — used by the
+ * docker:validateGpuPreflight IPC handler. Kept separate from the pure
+ * function so tests can inject without touching fs/exec.
+ */
+export function runGpuPreflight(): GpuPreflightResult {
+  // Lazy-import fs so the unit tests can mock electron without dragging in
+  // real fs operations during validateGpuPreflight() unit tests.
+  // (validateGpuPreflight() itself is pure; this wrapper is the impure shell.)
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const fs = require('fs') as typeof import('fs');
+
+  const deps: GpuPreflightDeps = {
+    fsExists: (p) => {
+      try {
+        return fs.existsSync(p);
+      } catch {
+        return false;
+      }
+    },
+    readDir: (p) => {
+      try {
+        return fs.readdirSync(p);
+      } catch {
+        return [];
+      }
+    },
+    statMtime: (p) => {
+      try {
+        // For driver-module roots, walk one level deep and find the newest
+        // nvidia*.ko* file mtime. (The bash diagnose script does the same.)
+        // For everything else, just stat the path itself.
+        if (p === '/lib/modules' || p === '/usr/lib/modules') {
+          return newestNvidiaKoMtime(p, fs);
+        }
+        return Math.floor(fs.statSync(p).mtimeMs / 1000);
+      } catch {
+        return null;
+      }
+    },
+    runLsmod: () => {
+      try {
+        // lsmod is column-formatted: "Module  Size  Used by". The pure
+        // function expects one module name per line. Extract column 1
+        // and skip the header row.
+        const raw = execSync('lsmod', { timeout: 2000, encoding: 'utf8' });
+        const lines = raw.split('\n');
+        return lines
+          .slice(1) // drop header
+          .map((line) => line.split(/\s+/)[0] ?? '')
+          .filter((name) => name.length > 0)
+          .join('\n');
+      } catch {
+        return '';
+      }
+    },
+  };
+
+  return validateGpuPreflight(process.platform, deps);
+}
+
+/**
+ * Recursively walk a kernel-module root looking for nvidia*.ko[.zst] files
+ * and return the newest mtime (epoch seconds), or null if none found.
+ * Bounded depth to avoid runaway walks.
+ */
+function newestNvidiaKoMtime(root: string, fs: typeof import('fs')): number | null {
+  let newest: number | null = null;
+  const stack: Array<{ path: string; depth: number }> = [{ path: root, depth: 0 }];
+  const MAX_DEPTH = 6;
+  while (stack.length > 0) {
+    const entry = stack.pop();
+    if (!entry || entry.depth > MAX_DEPTH) continue;
+    let children: string[];
+    try {
+      children = fs.readdirSync(entry.path);
+    } catch {
+      continue;
+    }
+    for (const name of children) {
+      const childPath = `${entry.path}/${name}`;
+      let stat;
+      try {
+        stat = fs.statSync(childPath);
+      } catch {
+        continue;
+      }
+      if (stat.isDirectory()) {
+        stack.push({ path: childPath, depth: entry.depth + 1 });
+      } else if (/^nvidia.*\.ko(\..*)?$/.test(name)) {
+        const epoch = Math.floor(stat.mtimeMs / 1000);
+        if (newest === null || epoch > newest) {
+          newest = epoch;
+        }
+      }
+    }
+  }
+  return newest;
 }
 
 /**
@@ -3113,6 +3213,7 @@ export const dockerManager = {
   retryDetection,
   getRuntimeKind,
   checkGpu,
+  runGpuPreflight,
   listImages,
   pullImage,
   cancelPull,

--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -352,14 +352,23 @@ export function runGpuDiagnostic(): RunGpuDiagnosticResult {
     };
   }
 
+  // Per-user diagnostics directory inside the Electron userData root, NOT in
+  // multi-user /tmp. Restrictive 0o700 dir + O_EXCL+0o600 file (the 'wx' flag)
+  // mean only this user can read or pre-create the log — closes the symlink-
+  // attack surface flagged by CodeQL js/insecure-temporary-file. Random suffix
+  // on the filename makes same-second back-to-back clicks not collide on the
+  // O_EXCL check.
+  const dir = path.join(app.getPath('userData'), 'gpu-diagnostics');
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   const ts = new Date().toISOString().replace(/[-:.]/g, '').slice(0, 15);
-  const logPath = path.join(os.tmpdir(), `gpu-diagnostic-${ts}.log`);
-  const out = fs.openSync(logPath, 'w');
+  const suffix = crypto.randomBytes(3).toString('hex');
+  const logPath = path.join(dir, `gpu-diagnostic-${ts}-${suffix}.log`);
+  const out = fs.openSync(logPath, 'wx', 0o600);
 
   const child = spawn('bash', [scriptPath], {
     stdio: ['ignore', out, out],
     detached: true,
-    cwd: os.tmpdir(),
+    cwd: dir,
   });
   child.unref();
 

--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -319,6 +319,58 @@ export function runGpuPreflight(): GpuPreflightResult {
   return validateGpuPreflight(process.platform, deps);
 }
 
+export interface RunGpuDiagnosticResult {
+  status: 'started' | 'unsupported' | 'script-missing';
+  /** Absolute path to the log file the script writes (when status=started). */
+  logPath?: string;
+  /** Resolved script path (always present for status=started or script-missing). */
+  scriptPath?: string;
+  /** The exact command string the user could run themselves. */
+  manualCommand?: string;
+}
+
+function resolveDiagnosticScriptPath(): string {
+  // Packaged: <app>/resources/scripts/diagnose-gpu.sh
+  // Dev: <repo>/scripts/diagnose-gpu.sh (relative to dist-electron/dockerManager.js)
+  if (app.isPackaged) {
+    return path.join(process.resourcesPath, 'scripts', 'diagnose-gpu.sh');
+  }
+  // __dirname at runtime is dist-electron/; the repo's scripts/ is two levels up.
+  return path.resolve(__dirname, '..', '..', 'scripts', 'diagnose-gpu.sh');
+}
+
+export function runGpuDiagnostic(): RunGpuDiagnosticResult {
+  if (process.platform !== 'linux') {
+    return { status: 'unsupported' };
+  }
+  const scriptPath = resolveDiagnosticScriptPath();
+  if (!fs.existsSync(scriptPath)) {
+    return {
+      status: 'script-missing',
+      scriptPath,
+      manualCommand: `bash ${scriptPath}`,
+    };
+  }
+
+  const ts = new Date().toISOString().replace(/[-:.]/g, '').slice(0, 15);
+  const logPath = path.join(os.tmpdir(), `gpu-diagnostic-${ts}.log`);
+  const out = fs.openSync(logPath, 'w');
+
+  const child = spawn('bash', [scriptPath], {
+    stdio: ['ignore', out, out],
+    detached: true,
+    cwd: os.tmpdir(),
+  });
+  child.unref();
+
+  return {
+    status: 'started',
+    logPath,
+    scriptPath,
+    manualCommand: `bash ${scriptPath}`,
+  };
+}
+
 /**
  * Recursively walk a kernel-module root looking for nvidia*.ko[.zst] files
  * and return the newest mtime (epoch seconds), or null if none found.
@@ -3214,6 +3266,7 @@ export const dockerManager = {
   getRuntimeKind,
   checkGpu,
   runGpuPreflight,
+  runGpuDiagnostic,
   listImages,
   pullImage,
   cancelPull,

--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -149,6 +149,115 @@ export function checkVulkanSupport(
   return null;
 }
 
+// ─── GPU Preflight (NVIDIA, Linux) ─────────────────────────────────────────
+// Runs the cheap subset of scripts/diagnose-gpu.sh at dashboard startup so
+// the GpuHealthCard can warn about misconfigurations before the container
+// is started. Pure function — all OS access is injected for testability.
+
+export interface GpuPreflightCheck {
+  name: string;
+  pass: boolean;
+  /** Documented NVIDIA fix command. Present only when pass=false. */
+  fixCommand?: string;
+  /** External URL with more context. Present only when pass=false. */
+  docsUrl?: string;
+}
+
+export interface GpuPreflightResult {
+  status: 'healthy' | 'warning' | 'unknown';
+  checks: GpuPreflightCheck[];
+}
+
+export interface GpuPreflightDeps {
+  fsExists: (path: string) => boolean;
+  readDir: (path: string) => string[];
+  /** Returns mtime (epoch seconds) or null when the path cannot be stat'd. */
+  statMtime: (path: string) => number | null;
+  /** Returns lsmod stdout (one module name per line). Empty string on failure. */
+  runLsmod: () => string;
+}
+
+const NVIDIA_DRIVER_MTIME_PATHS: readonly string[] = ['/lib/modules', '/usr/lib/modules'];
+const CDI_SPEC_PATH = '/etc/cdi/nvidia.yaml';
+
+function newestDriverMtime(statMtime: GpuPreflightDeps['statMtime']): number | null {
+  // Conservative heuristic: try a handful of distro-typical roots. The actual
+  // recursive walk lives in the IPC handler — we just take what it produces.
+  let newest: number | null = null;
+  for (const root of NVIDIA_DRIVER_MTIME_PATHS) {
+    const mt = statMtime(root);
+    if (mt !== null && (newest === null || mt > newest)) {
+      newest = mt;
+    }
+  }
+  return newest;
+}
+
+export function validateGpuPreflight(
+  platform: NodeJS.Platform,
+  deps: GpuPreflightDeps,
+): GpuPreflightResult {
+  if (platform !== 'linux') {
+    return { status: 'unknown', checks: [] };
+  }
+
+  const checks: GpuPreflightCheck[] = [];
+
+  // Check 1: CDI spec exists
+  const cdiExists = deps.fsExists(CDI_SPEC_PATH);
+  checks.push({
+    name: 'CDI spec exists',
+    pass: cdiExists,
+    fixCommand: cdiExists ? undefined : `sudo nvidia-ctk cdi generate --output=${CDI_SPEC_PATH}`,
+    docsUrl: cdiExists
+      ? undefined
+      : 'https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html',
+  });
+
+  // Check 2: CDI spec newer than driver (only meaningful when both mtimes available)
+  const cdiMtime = cdiExists ? deps.statMtime(CDI_SPEC_PATH) : null;
+  const driverMtime = newestDriverMtime(deps.statMtime);
+  let cdiFresh = true;
+  if (cdiMtime !== null && driverMtime !== null && cdiMtime < driverMtime) {
+    cdiFresh = false;
+  }
+  checks.push({
+    name: 'CDI spec newer than driver',
+    pass: cdiFresh,
+    fixCommand: cdiFresh ? undefined : `sudo nvidia-ctk cdi generate --output=${CDI_SPEC_PATH}`,
+  });
+
+  // Check 3: /dev/char symlinks for major 195 (NVIDIA)
+  const charEntries = deps.fsExists('/dev/char') ? deps.readDir('/dev/char') : [];
+  const hasNvidiaSymlinks = charEntries.some((e) => e.startsWith('195:'));
+  checks.push({
+    name: '/dev/char NVIDIA symlinks',
+    pass: hasNvidiaSymlinks,
+    fixCommand: hasNvidiaSymlinks
+      ? undefined
+      : 'sudo nvidia-ctk system create-dev-char-symlinks --create-all',
+    docsUrl: hasNvidiaSymlinks
+      ? undefined
+      : 'https://github.com/NVIDIA/nvidia-container-toolkit/issues/48',
+  });
+
+  // Check 4: nvidia_uvm kernel module loaded
+  const lsmodLines = deps
+    .runLsmod()
+    .split('\n')
+    .map((l) => l.trim());
+  const uvmLoaded = lsmodLines.includes('nvidia_uvm');
+  checks.push({
+    name: 'nvidia_uvm module loaded',
+    pass: uvmLoaded,
+    fixCommand: uvmLoaded ? undefined : 'sudo modprobe nvidia_uvm',
+  });
+
+  const status: GpuPreflightResult['status'] = checks.every((c) => c.pass) ? 'healthy' : 'warning';
+
+  return { status, checks };
+}
+
 /**
  * Resolve compose directory.
  *

--- a/dashboard/electron/main.ts
+++ b/dashboard/electron/main.ts
@@ -1164,6 +1164,10 @@ ipcMain.handle('docker:checkGpu', async () => {
   return dockerManager.checkGpu();
 });
 
+ipcMain.handle('docker:validateGpuPreflight', async () => {
+  return dockerManager.runGpuPreflight();
+});
+
 ipcMain.handle('docker:listImages', async () => {
   return dockerManager.listImages();
 });

--- a/dashboard/electron/main.ts
+++ b/dashboard/electron/main.ts
@@ -1168,6 +1168,10 @@ ipcMain.handle('docker:validateGpuPreflight', async () => {
   return dockerManager.runGpuPreflight();
 });
 
+ipcMain.handle('docker:runGpuDiagnostic', async () => {
+  return dockerManager.runGpuDiagnostic();
+});
+
 ipcMain.handle('docker:listImages', async () => {
   return dockerManager.listImages();
 });

--- a/dashboard/electron/preload.ts
+++ b/dashboard/electron/preload.ts
@@ -141,6 +141,15 @@ export interface ElectronAPI {
     getDetectionGuidance: () => Promise<string | null>;
     getComposeAvailable: () => Promise<boolean>;
     checkGpu: () => Promise<{ gpu: boolean; toolkit: boolean; vulkan: boolean }>;
+    validateGpuPreflight: () => Promise<{
+      status: 'healthy' | 'warning' | 'unknown';
+      checks: Array<{
+        name: string;
+        pass: boolean;
+        fixCommand?: string;
+        docsUrl?: string;
+      }>;
+    }>;
     listImages: () => Promise<
       Array<{ tag: string; fullName: string; size: string; created: string; id: string }>
     >;
@@ -473,6 +482,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('docker:getDetectionGuidance') as Promise<string | null>,
     getComposeAvailable: () => ipcRenderer.invoke('docker:getComposeAvailable') as Promise<boolean>,
     checkGpu: () => ipcRenderer.invoke('docker:checkGpu'),
+    validateGpuPreflight: () => ipcRenderer.invoke('docker:validateGpuPreflight'),
     listImages: () => ipcRenderer.invoke('docker:listImages'),
     listRemoteTags: () =>
       ipcRenderer.invoke('docker:listRemoteTags') as Promise<

--- a/dashboard/electron/preload.ts
+++ b/dashboard/electron/preload.ts
@@ -150,6 +150,12 @@ export interface ElectronAPI {
         docsUrl?: string;
       }>;
     }>;
+    runGpuDiagnostic: () => Promise<{
+      status: 'started' | 'unsupported' | 'script-missing';
+      logPath?: string;
+      scriptPath?: string;
+      manualCommand?: string;
+    }>;
     listImages: () => Promise<
       Array<{ tag: string; fullName: string; size: string; created: string; id: string }>
     >;
@@ -483,6 +489,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getComposeAvailable: () => ipcRenderer.invoke('docker:getComposeAvailable') as Promise<boolean>,
     checkGpu: () => ipcRenderer.invoke('docker:checkGpu'),
     validateGpuPreflight: () => ipcRenderer.invoke('docker:validateGpuPreflight'),
+    runGpuDiagnostic: () => ipcRenderer.invoke('docker:runGpuDiagnostic'),
     listImages: () => ipcRenderer.invoke('docker:listImages'),
     listRemoteTags: () =>
       ipcRenderer.invoke('docker:listRemoteTags') as Promise<

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -134,6 +134,14 @@
       {
         "from": "../server/config.yaml",
         "to": "config.yaml"
+      },
+      {
+        "from": "../scripts/diagnose-gpu.sh",
+        "to": "scripts/diagnose-gpu.sh"
+      },
+      {
+        "from": "../scripts/README-gpu-diagnostic.md",
+        "to": "scripts/README-gpu-diagnostic.md"
       }
     ],
     "afterPack": "./scripts/afterPack.cjs",

--- a/dashboard/src/api/types.ts
+++ b/dashboard/src/api/types.ts
@@ -28,6 +28,13 @@ export interface ServerStatus {
   gpu_memory?: string;
   gpu_error?: string;
   gpu_error_action?: string;
+  /**
+   * Diagnostic hint surfaced when the backend's CUDA health check
+   * returns the error-999 "unrecoverable" fingerprint. Present only on
+   * the error-999 path; absent for other GPU failure modes.
+   * Consumed by the GpuHealthCard on the Server tab.
+   */
+  gpu_error_recovery_hint?: string;
   diarization_available?: boolean;
   active_connections?: number;
   tls_enabled?: boolean;

--- a/dashboard/src/hooks/useServerStatus.test.ts
+++ b/dashboard/src/hooks/useServerStatus.test.ts
@@ -66,6 +66,47 @@ describe('deriveStatus', () => {
     expect(info.serverLabel).toContain('GPU unavailable');
   });
 
+  it('surfaces gpu_error_recovery_hint when backend included it (error-999 path)', () => {
+    const HINT =
+      'GPU init failed with error 999 (CUDA unknown). Run scripts/diagnose-gpu.sh on the host for details.';
+    const info = deriveStatus(
+      makeResult({
+        reachable: true,
+        ready: false,
+        status: {
+          gpu_error: 'CUDA unknown error (999)',
+          gpu_error_action: 'Restart your computer to reset the GPU driver.',
+          gpu_error_recovery_hint: HINT,
+        },
+      }),
+    );
+
+    expect(info.gpuError).toBe('CUDA unknown error (999)');
+    expect(info.gpuErrorRecoveryHint).toBe(HINT);
+  });
+
+  it('returns null gpuErrorRecoveryHint when backend omitted it (non-999 path)', () => {
+    const info = deriveStatus(
+      makeResult({
+        reachable: true,
+        ready: false,
+        status: {
+          gpu_error: 'Some other CUDA error',
+        },
+      }),
+    );
+
+    expect(info.gpuError).toBe('Some other CUDA error');
+    expect(info.gpuErrorRecoveryHint).toBeNull();
+  });
+
+  it('returns null gpuErrorRecoveryHint when there is no gpu_error', () => {
+    const info = deriveStatus(makeResult({ reachable: true, ready: true, status: {} }));
+
+    expect(info.gpuError).toBeNull();
+    expect(info.gpuErrorRecoveryHint).toBeNull();
+  });
+
   it('returns error state when gpu_error present even if ready is true', () => {
     // In practice this shouldn't happen (GPU failed → model can't load),
     // but gpu_error must always take priority over the ready flag.

--- a/dashboard/src/hooks/useServerStatus.ts
+++ b/dashboard/src/hooks/useServerStatus.ts
@@ -20,6 +20,12 @@ export interface ServerConnectionInfo {
   error: string | null;
   /** GPU error string when CUDA is in a failed state, null otherwise */
   gpuError: string | null;
+  /**
+   * Diagnostic recovery hint surfaced for the error-999 unrecoverable
+   * fingerprint. Present only when both `gpuError` is set and the backend
+   * matched the error-999 heuristic; null otherwise. Used by GpuHealthCard.
+   */
+  gpuErrorRecoveryHint: string | null;
   /** Force an immediate re-check */
   refresh: () => void;
 }
@@ -37,6 +43,7 @@ export function deriveStatus(
       ready: false,
       error: null,
       gpuError: null,
+      gpuErrorRecoveryHint: null,
     };
   }
 
@@ -50,6 +57,7 @@ export function deriveStatus(
       ready: false,
       error: result.error,
       gpuError: null,
+      gpuErrorRecoveryHint: null,
     };
   }
 
@@ -66,6 +74,7 @@ export function deriveStatus(
       ready: false,
       error: result.error,
       gpuError: result.status.gpu_error,
+      gpuErrorRecoveryHint: result.status.gpu_error_recovery_hint ?? null,
     };
   }
 
@@ -79,6 +88,7 @@ export function deriveStatus(
       ready: true,
       error: result.error,
       gpuError: null,
+      gpuErrorRecoveryHint: null,
     };
   }
 
@@ -91,6 +101,7 @@ export function deriveStatus(
     ready: false,
     error: result.error,
     gpuError: null,
+    gpuErrorRecoveryHint: null,
   };
 }
 

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.0.26",
-  "contract_sha256": "3870bd8dccf70d87b75096c34b831ae7eb869c6a52ac7fd3a0bdf4d4674310a1",
-  "updated_at": "2026-04-26T18:55:58.208Z"
+  "spec_version": "1.0.27",
+  "contract_sha256": "8bfdf74f93c2567132cc36f732673f455a7cebd9eeb9a8c233fdb01ec3a3311a",
+  "updated_at": "2026-04-29T06:02:02.319Z"
 }

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.0.27",
-  "contract_sha256": "8bfdf74f93c2567132cc36f732673f455a7cebd9eeb9a8c233fdb01ec3a3311a",
-  "updated_at": "2026-04-29T06:02:02.319Z"
+  "spec_version": "1.0.28",
+  "contract_sha256": "9cd4bbc93b9bceeffb091331057efaef35d782785a357aac2b09cc1c059f4b42",
+  "updated_at": "2026-04-29T06:09:54.801Z"
 }

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.0.28",
-  "contract_sha256": "9cd4bbc93b9bceeffb091331057efaef35d782785a357aac2b09cc1c059f4b42",
-  "updated_at": "2026-04-29T06:09:54.801Z"
+  "spec_version": "1.0.29",
+  "contract_sha256": "0f88da1a16b7a55c884374a46feda090c2f7f4565bdf379aa7e022ad83a593f6",
+  "updated_at": "2026-04-29T06:22:11.800Z"
 }

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.0.29",
-  "contract_sha256": "0f88da1a16b7a55c884374a46feda090c2f7f4565bdf379aa7e022ad83a593f6",
-  "updated_at": "2026-04-29T06:22:11.800Z"
+  "spec_version": "1.0.30",
+  "contract_sha256": "00e9504d29fb7efdccb77d2d2cc555fd8a1502306e0c016303ce7d9225bd1e1a",
+  "updated_at": "2026-04-29T11:51:18.589Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.0.29
+  spec_version: 1.0.30
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -56,7 +56,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-04-29T06:21:17.814Z
+    generated_at: 2026-04-29T11:50:14.967Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -220,8 +220,10 @@ foundation:
       classes:
         - shadow
         - shadow-[0_0_10px_#22d3ee]
+        - shadow-[0_0_15px_rgba(251,146,60,0.5)]
         - shadow-[0_0_15px_rgba(34,211,238,0.2)]
         - shadow-[0_0_15px_rgba(34,211,238,0.2)]!
+        - shadow-[0_0_15px_rgba(34,211,238,0.5)]
         - shadow-[0_0_18px_rgba(239,68,68,0.35)]
         - shadow-[0_0_20px_rgba(255,255,255,0.3)]
         - shadow-[0_0_5px_rgba(217,70,239,0.5)]
@@ -300,14 +302,17 @@ foundation:
         - h-[85%]
         - h-[85vh]
         - max-h-[80vh]
+        - max-w-[55%]
         - min-h-[38px]
         - min-h-[calc(100vh-30rem)]
         - min-w-[3ch]
         - min-w-[5rem]
         - p-[3px]
         - shadow-[0_0_10px_#22d3ee]
+        - shadow-[0_0_15px_rgba(251,146,60,0.5)]
         - shadow-[0_0_15px_rgba(34,211,238,0.2)]
         - shadow-[0_0_15px_rgba(34,211,238,0.2)]!
+        - shadow-[0_0_15px_rgba(34,211,238,0.5)]
         - shadow-[0_0_18px_rgba(239,68,68,0.35)]
         - shadow-[0_0_20px_rgba(255,255,255,0.3)]
         - shadow-[0_0_5px_rgba(217,70,239,0.5)]
@@ -447,6 +452,7 @@ utility_allowlist:
     - bg-black/70
     - bg-black/75
     - bg-blue-400
+    - bg-blue-500
     - bg-blue-500/10
     - bg-cyan-400/10
     - bg-cyan-400/20
@@ -465,7 +471,9 @@ utility_allowlist:
     - bg-linear-to-t
     - bg-neutral-700
     - bg-neutral-900
+    - bg-orange-500
     - bg-orange-500/10
+    - bg-purple-500
     - bg-purple-500/10
     - bg-red-400/10
     - bg-red-500
@@ -495,6 +503,7 @@ utility_allowlist:
     - border
     - border-2
     - border-4
+    - border-accent-amber/30
     - border-accent-cyan/10
     - border-accent-cyan/20
     - border-accent-cyan/30
@@ -503,6 +512,8 @@ utility_allowlist:
     - border-accent-magenta/20
     - border-accent-magenta/5
     - border-accent-orange/20
+    - border-accent-orange/25
+    - border-accent-rose/20
     - border-amber-400/20
     - border-amber-400/30
     - border-amber-400/40
@@ -738,6 +749,7 @@ utility_allowlist:
     - md:grid-cols-4
     - md:items-center
     - md:items-end
+    - md:justify-between
     - min-h-0
     - min-h-32
     - min-h-full
@@ -751,6 +763,7 @@ utility_allowlist:
     - ml-0.5
     - ml-1
     - ml-2
+    - ml-3
     - ml-auto
     - ml-model
     - mr-1
@@ -824,6 +837,7 @@ utility_allowlist:
     - pr-20
     - pr-3
     - pr-4
+    - pr-5
     - pr-6
     - pr-8
     - pt-0
@@ -912,6 +926,7 @@ utility_allowlist:
     - space-y-1
     - space-y-1.5
     - space-y-2
+    - space-y-2.5
     - space-y-3
     - space-y-4
     - space-y-6
@@ -924,6 +939,7 @@ utility_allowlist:
     - text-accent-cyan/80
     - text-accent-magenta
     - text-accent-orange
+    - text-accent-rose
     - text-accent-violet
     - text-amber-100
     - text-amber-200
@@ -955,6 +971,7 @@ utility_allowlist:
     - text-purple-400
     - text-red-100
     - text-red-200
+    - text-red-200/90
     - text-red-300
     - text-red-400
     - text-red-400/80
@@ -968,6 +985,7 @@ utility_allowlist:
     - text-slate-700
     - text-slate-900
     - text-sm
+    - text-violet-400
     - text-white
     - text-white/60
     - text-white/90
@@ -1057,6 +1075,7 @@ utility_allowlist:
     - h-[85%]
     - h-[85vh]
     - max-h-[80vh]
+    - max-w-[55%]
     - md:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]
     - min-h-[38px]
     - min-h-[calc(100vh-30rem)]
@@ -1064,8 +1083,10 @@ utility_allowlist:
     - min-w-[5rem]
     - p-[3px]
     - shadow-[0_0_10px_#22d3ee]
+    - shadow-[0_0_15px_rgba(251,146,60,0.5)]
     - shadow-[0_0_15px_rgba(34,211,238,0.2)]
     - shadow-[0_0_15px_rgba(34,211,238,0.2)]!
+    - shadow-[0_0_15px_rgba(34,211,238,0.5)]
     - shadow-[0_0_18px_rgba(239,68,68,0.35)]
     - shadow-[0_0_20px_rgba(255,255,255,0.3)]
     - shadow-[0_0_5px_rgba(217,70,239,0.5)]

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.0.27
+  spec_version: 1.0.28
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -56,7 +56,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-04-29T06:01:02.317Z
+    generated_at: 2026-04-29T06:09:26.668Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -100,13 +100,10 @@ foundation:
         - "#1886"
         - "#1e293b"
         - "#1e3a5f"
-        - "#1f8a3a"
-        - "#222"
         - "#22c55e"
         - "#22d3ee"
         - "#2563eb"
         - "#334155"
-        - "#3a1313"
         - "#3b82f6"
         - "#475569"
         - "#4ade80"
@@ -118,15 +115,11 @@ foundation:
         - "#7f1d1d"
         - "#818cf8"
         - "#86efac"
-        - "#888"
         - "#94a3b8"
         - "#a855f7"
-        - "#b53030"
-        - "#b88a00"
         - "#cbd5e1"
         - "#d946ef"
         - "#e2e8f0"
-        - "#eee"
         - "#ef4444"
         - "#f0abfc"
         - "#f43f5e"
@@ -134,7 +127,6 @@ foundation:
         - "#f97316"
         - "#fb7185"
         - "#fb923c"
-        - "#fbb"
         - "#fbbf24"
         - "#fca5a5"
         - "#fed7aa"
@@ -477,6 +469,8 @@ utility_allowlist:
     - bg-linear-to-br
     - bg-linear-to-r
     - bg-linear-to-t
+    - bg-neutral-700
+    - bg-neutral-900
     - bg-orange-500
     - bg-orange-500/10
     - bg-purple-500
@@ -486,6 +480,7 @@ utility_allowlist:
     - bg-red-500/10
     - bg-red-500/25
     - bg-red-500/5
+    - bg-red-900/50
     - bg-slate-400/10
     - bg-slate-500
     - bg-slate-500/10
@@ -524,6 +519,7 @@ utility_allowlist:
     - border-amber-400/40
     - border-amber-500/20
     - border-amber-500/30
+    - border-amber-600
     - border-b
     - border-b-2
     - border-blue-500/20
@@ -533,6 +529,7 @@ utility_allowlist:
     - border-glass-100
     - border-glass-border
     - border-green-500/30
+    - border-green-600
     - border-l
     - border-l-2
     - border-l-accent-magenta
@@ -549,6 +546,7 @@ utility_allowlist:
     - border-red-400/40
     - border-red-500/20
     - border-red-500/25
+    - border-red-700
     - border-slate-400/30
     - border-slate-900
     - border-t
@@ -662,6 +660,7 @@ utility_allowlist:
     - hover:bg-cyan-400/30
     - hover:bg-glass-100
     - hover:bg-glass-300
+    - hover:bg-neutral-600
     - hover:bg-red-500/10
     - hover:bg-red-500/20
     - hover:bg-red-500/35
@@ -740,6 +739,7 @@ utility_allowlist:
     - mb-1
     - mb-1.5
     - mb-2
+    - mb-2.5
     - mb-3
     - mb-4
     - mb-6
@@ -770,6 +770,7 @@ utility_allowlist:
     - mr-1.5
     - mr-2
     - mr-4
+    - mt-0
     - mt-0.5
     - mt-1
     - mt-1.5
@@ -948,6 +949,7 @@ utility_allowlist:
     - text-amber-400
     - text-amber-400/60
     - text-amber-400/80
+    - text-amber-600
     - text-base
     - text-black
     - text-blue-400
@@ -958,17 +960,22 @@ utility_allowlist:
     - text-emerald-400
     - text-green-400
     - text-green-400/70
+    - text-green-600
     - text-indigo-400
     - text-left
     - text-lg
+    - text-neutral-100
+    - text-neutral-400
     - text-orange-400
     - text-orange-500
     - text-purple-400
     - text-red-100
+    - text-red-200
     - text-red-200/90
     - text-red-300
     - text-red-400
     - text-red-400/80
+    - text-red-700
     - text-right
     - text-slate-200
     - text-slate-300
@@ -1096,33 +1103,20 @@ utility_allowlist:
     - w-[var(--button-width)]
 inline_style_allowlist:
   allowed_properties:
-    - alignItems
     - animation
     - animationDelay
-    - background
     - backgroundAttachment
     - backgroundColor
     - backgroundImage
     - backgroundSize
-    - border
-    - borderRadius
-    - color
     - containIntrinsicSize
     - contentVisibility
     - display
-    - flex
-    - fontSize
-    - fontWeight
-    - gap
     - gridTemplateRows
     - height
     - left
-    - marginBottom
-    - marginTop
     - maskImage
     - opacity
-    - overflowX
-    - padding
     - top
     - transform
     - undefined
@@ -1130,11 +1124,6 @@ inline_style_allowlist:
     - width
   allowed_literals:
     - "#0f172a"
-    - "#222"
-    - "#3a1313"
-    - "#888"
-    - "#eee"
-    - "#fbb"
     - ${100 / visibleSlots}%
     - ${item.progress}%
     - ${percent}%
@@ -1144,44 +1133,27 @@ inline_style_allowlist:
     - 0.4s
     - 0%
     - "1"
-    - "10"
     - "100"
     - 100%
-    - "12"
     - 120px
-    - "13"
     - 16%
     - 1px
-    - 1px solid ${STATE_COLOR[state]}
     - 1rem
     - 20px
     - 20px 20px
-    - "222"
     - "225"
     - "253"
-    - "3"
     - 30%
     - "339"
     - 39%
-    - "4"
     - 49%
-    - 4px
-    - 4px 8px
     - 50%
-    - "500"
-    - "6"
-    - "600"
     - 7%
-    - "8"
-    - "888"
-    - 8px
     - "90"
     - auto
     - auto 120px
     - auto repeat(${gridRows}, 1fr)
-    - center
     - fixed
-    - flex
     - "linear-gradient(#fff 1px, transparent 1px), linear-gradient(90deg, #fff 1px, transparent 1px)"
     - linear-gradient(to bottom, black 50%, transparent 100%)
     - linear-gradient(to top, black 50%, transparent 100%)

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.0.28
+  spec_version: 1.0.29
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -56,7 +56,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-04-29T06:09:26.668Z
+    generated_at: 2026-04-29T06:21:17.814Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -220,10 +220,8 @@ foundation:
       classes:
         - shadow
         - shadow-[0_0_10px_#22d3ee]
-        - shadow-[0_0_15px_rgba(251,146,60,0.5)]
         - shadow-[0_0_15px_rgba(34,211,238,0.2)]
         - shadow-[0_0_15px_rgba(34,211,238,0.2)]!
-        - shadow-[0_0_15px_rgba(34,211,238,0.5)]
         - shadow-[0_0_18px_rgba(239,68,68,0.35)]
         - shadow-[0_0_20px_rgba(255,255,255,0.3)]
         - shadow-[0_0_5px_rgba(217,70,239,0.5)]
@@ -302,17 +300,14 @@ foundation:
         - h-[85%]
         - h-[85vh]
         - max-h-[80vh]
-        - max-w-[55%]
         - min-h-[38px]
         - min-h-[calc(100vh-30rem)]
         - min-w-[3ch]
         - min-w-[5rem]
         - p-[3px]
         - shadow-[0_0_10px_#22d3ee]
-        - shadow-[0_0_15px_rgba(251,146,60,0.5)]
         - shadow-[0_0_15px_rgba(34,211,238,0.2)]
         - shadow-[0_0_15px_rgba(34,211,238,0.2)]!
-        - shadow-[0_0_15px_rgba(34,211,238,0.5)]
         - shadow-[0_0_18px_rgba(239,68,68,0.35)]
         - shadow-[0_0_20px_rgba(255,255,255,0.3)]
         - shadow-[0_0_5px_rgba(217,70,239,0.5)]
@@ -452,7 +447,6 @@ utility_allowlist:
     - bg-black/70
     - bg-black/75
     - bg-blue-400
-    - bg-blue-500
     - bg-blue-500/10
     - bg-cyan-400/10
     - bg-cyan-400/20
@@ -471,9 +465,7 @@ utility_allowlist:
     - bg-linear-to-t
     - bg-neutral-700
     - bg-neutral-900
-    - bg-orange-500
     - bg-orange-500/10
-    - bg-purple-500
     - bg-purple-500/10
     - bg-red-400/10
     - bg-red-500
@@ -503,7 +495,6 @@ utility_allowlist:
     - border
     - border-2
     - border-4
-    - border-accent-amber/30
     - border-accent-cyan/10
     - border-accent-cyan/20
     - border-accent-cyan/30
@@ -512,8 +503,6 @@ utility_allowlist:
     - border-accent-magenta/20
     - border-accent-magenta/5
     - border-accent-orange/20
-    - border-accent-orange/25
-    - border-accent-rose/20
     - border-amber-400/20
     - border-amber-400/30
     - border-amber-400/40
@@ -749,7 +738,6 @@ utility_allowlist:
     - md:grid-cols-4
     - md:items-center
     - md:items-end
-    - md:justify-between
     - min-h-0
     - min-h-32
     - min-h-full
@@ -763,7 +751,6 @@ utility_allowlist:
     - ml-0.5
     - ml-1
     - ml-2
-    - ml-3
     - ml-auto
     - ml-model
     - mr-1
@@ -837,7 +824,6 @@ utility_allowlist:
     - pr-20
     - pr-3
     - pr-4
-    - pr-5
     - pr-6
     - pr-8
     - pt-0
@@ -926,7 +912,6 @@ utility_allowlist:
     - space-y-1
     - space-y-1.5
     - space-y-2
-    - space-y-2.5
     - space-y-3
     - space-y-4
     - space-y-6
@@ -939,7 +924,6 @@ utility_allowlist:
     - text-accent-cyan/80
     - text-accent-magenta
     - text-accent-orange
-    - text-accent-rose
     - text-accent-violet
     - text-amber-100
     - text-amber-200
@@ -971,7 +955,6 @@ utility_allowlist:
     - text-purple-400
     - text-red-100
     - text-red-200
-    - text-red-200/90
     - text-red-300
     - text-red-400
     - text-red-400/80
@@ -985,7 +968,6 @@ utility_allowlist:
     - text-slate-700
     - text-slate-900
     - text-sm
-    - text-violet-400
     - text-white
     - text-white/60
     - text-white/90
@@ -1075,7 +1057,6 @@ utility_allowlist:
     - h-[85%]
     - h-[85vh]
     - max-h-[80vh]
-    - max-w-[55%]
     - md:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]
     - min-h-[38px]
     - min-h-[calc(100vh-30rem)]
@@ -1083,10 +1064,8 @@ utility_allowlist:
     - min-w-[5rem]
     - p-[3px]
     - shadow-[0_0_10px_#22d3ee]
-    - shadow-[0_0_15px_rgba(251,146,60,0.5)]
     - shadow-[0_0_15px_rgba(34,211,238,0.2)]
     - shadow-[0_0_15px_rgba(34,211,238,0.2)]!
-    - shadow-[0_0_15px_rgba(34,211,238,0.5)]
     - shadow-[0_0_18px_rgba(239,68,68,0.35)]
     - shadow-[0_0_20px_rgba(255,255,255,0.3)]
     - shadow-[0_0_5px_rgba(217,70,239,0.5)]

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.0.26
+  spec_version: 1.0.27
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -8,6 +8,7 @@ meta:
     source_files:
       - App.tsx
       - components/__tests__/AudioVisualizer.test.tsx
+      - components/__tests__/LogsView.test.tsx
       - components/__tests__/NotebookView.test.tsx
       - components/__tests__/ServerView.test.tsx
       - components/__tests__/SessionView.canary-language.test.tsx
@@ -34,11 +35,13 @@ meta:
       - components/ui/StatusLight.tsx
       - components/ui/UpdateBanner.tsx
       - components/ui/UpdateModal.tsx
+      - components/views/__tests__/GpuHealthCard.test.tsx
       - components/views/AboutModal.tsx
       - components/views/AddNoteModal.tsx
       - components/views/AudioNoteModal.tsx
       - components/views/BugReportModal.tsx
       - components/views/FullscreenVisualizer.tsx
+      - components/views/GpuHealthCard.tsx
       - components/views/LogsView.tsx
       - components/views/ModelManagerTab.tsx
       - components/views/ModelManagerView.tsx
@@ -53,7 +56,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-04-26T18:55:24.053Z
+    generated_at: 2026-04-29T06:01:02.317Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -97,10 +100,13 @@ foundation:
         - "#1886"
         - "#1e293b"
         - "#1e3a5f"
+        - "#1f8a3a"
+        - "#222"
         - "#22c55e"
         - "#22d3ee"
         - "#2563eb"
         - "#334155"
+        - "#3a1313"
         - "#3b82f6"
         - "#475569"
         - "#4ade80"
@@ -112,11 +118,15 @@ foundation:
         - "#7f1d1d"
         - "#818cf8"
         - "#86efac"
+        - "#888"
         - "#94a3b8"
         - "#a855f7"
+        - "#b53030"
+        - "#b88a00"
         - "#cbd5e1"
         - "#d946ef"
         - "#e2e8f0"
+        - "#eee"
         - "#ef4444"
         - "#f0abfc"
         - "#f43f5e"
@@ -124,6 +134,7 @@ foundation:
         - "#f97316"
         - "#fb7185"
         - "#fb923c"
+        - "#fbb"
         - "#fbbf24"
         - "#fca5a5"
         - "#fed7aa"
@@ -1085,20 +1096,33 @@ utility_allowlist:
     - w-[var(--button-width)]
 inline_style_allowlist:
   allowed_properties:
+    - alignItems
     - animation
     - animationDelay
+    - background
     - backgroundAttachment
     - backgroundColor
     - backgroundImage
     - backgroundSize
+    - border
+    - borderRadius
+    - color
     - containIntrinsicSize
     - contentVisibility
     - display
+    - flex
+    - fontSize
+    - fontWeight
+    - gap
     - gridTemplateRows
     - height
     - left
+    - marginBottom
+    - marginTop
     - maskImage
     - opacity
+    - overflowX
+    - padding
     - top
     - transform
     - undefined
@@ -1106,6 +1130,11 @@ inline_style_allowlist:
     - width
   allowed_literals:
     - "#0f172a"
+    - "#222"
+    - "#3a1313"
+    - "#888"
+    - "#eee"
+    - "#fbb"
     - ${100 / visibleSlots}%
     - ${item.progress}%
     - ${percent}%
@@ -1115,27 +1144,44 @@ inline_style_allowlist:
     - 0.4s
     - 0%
     - "1"
+    - "10"
     - "100"
     - 100%
+    - "12"
     - 120px
+    - "13"
     - 16%
     - 1px
+    - 1px solid ${STATE_COLOR[state]}
     - 1rem
     - 20px
     - 20px 20px
+    - "222"
     - "225"
     - "253"
+    - "3"
     - 30%
     - "339"
     - 39%
+    - "4"
     - 49%
+    - 4px
+    - 4px 8px
     - 50%
+    - "500"
+    - "6"
+    - "600"
     - 7%
+    - "8"
+    - "888"
+    - 8px
     - "90"
     - auto
     - auto 120px
     - auto repeat(${gridRows}, 1fr)
+    - center
     - fixed
+    - flex
     - "linear-gradient(#fff 1px, transparent 1px), linear-gradient(90deg, #fff 1px, transparent 1px)"
     - linear-gradient(to bottom, black 50%, transparent 100%)
     - linear-gradient(to top, black 50%, transparent 100%)
@@ -1536,6 +1582,23 @@ component_contracts:
     state_rules:
       - id: open-accent
         rule: Open state title accent remains magenta and chevron rotates with white highlighted background.
+  CopyableCommand:
+    file: components/views/GpuHealthCard.tsx
+    required_tokens:
+      - colors
+      - motion
+      - radii
+      - shadows
+    allowed_variants: {}
+    structural_invariants:
+      - id: structure-stable
+        rule: Preserve current structural layout and region hierarchy for this component.
+    behavior_rules:
+      - id: motion-locked
+        rule: Use only approved motion tokens and classes from foundation token registry.
+    state_rules:
+      - id: closed-set-styles
+        rule: Do not introduce unregistered utility, arbitrary, or inline style values.
   CustomModelRow:
     file: components/views/ModelManagerTab.tsx
     required_tokens:
@@ -1657,6 +1720,23 @@ component_contracts:
     state_rules:
       - id: header-optional
         rule: Title/action header is optional but when present must retain h-14 bordered header pattern.
+  GpuHealthCard:
+    file: components/views/GpuHealthCard.tsx
+    required_tokens:
+      - colors
+      - motion
+      - radii
+      - shadows
+    allowed_variants: {}
+    structural_invariants:
+      - id: structure-stable
+        rule: Preserve current structural layout and region hierarchy for this component.
+    behavior_rules:
+      - id: motion-locked
+        rule: Use only approved motion tokens and classes from foundation token registry.
+    state_rules:
+      - id: closed-set-styles
+        rule: Do not introduce unregistered utility, arbitrary, or inline style values.
   HistoryPicker:
     file: components/views/NotebookView.tsx
     required_tokens:

--- a/docs/superpowers/plans/2026-04-29-cuda-error-999-recovery.md
+++ b/docs/superpowers/plans/2026-04-29-cuda-error-999-recovery.md
@@ -1,0 +1,1850 @@
+# CUDA Error 999 Diagnosis & GPU Health Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Diagnose the recurring "CUDA unknown error / error 999" Docker GPU init failure with a host-side script, and add an in-app NVIDIA-only "GPU Health" card on the Server tab so future occurrences self-explain instead of producing the misleading "Please restart your computer" message.
+
+**Architecture:** Two phases. Phase 1 ships a self-contained, observation-only bash diagnostic (`scripts/diagnose-gpu.sh`) plus README — no project code touched, no `sudo`. Phase 2 adds (a) a `recovery_hint` field to `cuda_health_check()` so the backend tells the dashboard *what* probably broke, (b) a pure `validateGpuPreflight()` function in `dockerManager.ts` that runs cheap host checks, exposed over IPC, and (c) an NVIDIA-only `GpuHealthCard` rendered on `ServerView.tsx` with a "Run Full Diagnostic" button that invokes the Phase 1 script. No `pkexec`, no auto-fix, no per-distro recipes.
+
+**Tech Stack:** Bash 5+, Python 3.13 / pytest, TypeScript / Vitest, React 18 / @testing-library/react, Electron IPC. Tests follow existing patterns in `server/backend/tests/` and `dashboard/electron/__tests__/`.
+
+**Spec:** [`docs/superpowers/specs/2026-04-29-cuda-error-999-recovery-design.md`](../specs/2026-04-29-cuda-error-999-recovery-design.md)
+
+---
+
+## File Structure
+
+| Path | Status | Responsibility |
+|---|---|---|
+| `scripts/diagnose-gpu.sh` | new | Bash diagnostic, 11 checks, observation-only, writes timestamped log. |
+| `scripts/README-gpu-diagnostic.md` | new | Companion docs: what each check measures, fix command per failure mode. |
+| `server/backend/core/audio_utils.py` | modify | Add `recovery_hint` field to `cuda_health_check()` result for error-999 unrecoverable case. |
+| `server/backend/tests/test_audio_utils.py` | modify | Add `TestRecoveryHint` covering hint presence/absence per error class. |
+| `server/backend/api/main.py` | modify | Surface `recovery_hint` in lifespan log + `app.state.gpu_error`. |
+| `dashboard/electron/dockerManager.ts` | modify | Add pure `validateGpuPreflight(platform, fsExists, readDir, statMtime, lsmodOutput)` function + `GpuPreflightResult` type. |
+| `dashboard/electron/__tests__/dockerManagerGpuPreflight.test.ts` | new | Unit tests for `validateGpuPreflight` mirroring `dockerManagerVulkanPreflight.test.ts` pattern. |
+| `dashboard/electron/main.ts` | modify | Add `docker:validateGpuPreflight` and `docker:runGpuDiagnostic` IPC handlers. |
+| `dashboard/electron/preload.ts` | modify | Expose `docker.validateGpuPreflight()` and `docker.runGpuDiagnostic()` plus their TS types. |
+| `dashboard/package.json` | modify | Add `scripts/diagnose-gpu.sh` to `extraResources`. |
+| `dashboard/components/views/GpuHealthCard.tsx` | new | React component — three states (green / yellow / red), copyable fix commands, "Run Full Diagnostic" button. |
+| `dashboard/components/views/__tests__/GpuHealthCard.test.tsx` | new | Render tests for each card state. |
+| `dashboard/components/views/ServerView.tsx` | modify | Mount `<GpuHealthCard />` gated on `gpuInfo.gpu === true && process.platform === 'linux'`. |
+
+---
+
+# Phase 1 — Host Diagnostic
+
+## Task 1: Create `scripts/diagnose-gpu.sh`
+
+**Files:**
+- Create: `scripts/diagnose-gpu.sh`
+
+- [ ] **Step 1: Create the script**
+
+```bash
+mkdir -p scripts
+```
+
+Then create `scripts/diagnose-gpu.sh` with the following content:
+
+```bash
+#!/usr/bin/env bash
+# diagnose-gpu.sh — observation-only host diagnostic for the recurring
+# "CUDA unknown error / error 999" Docker GPU initialization failure.
+#
+# Usage:
+#   bash scripts/diagnose-gpu.sh
+#   bash scripts/diagnose-gpu.sh > my-log.txt 2>&1
+#
+# Writes both to stdout and to ./gpu-diagnostic-<UTC-timestamp>.log so the
+# output can be pasted back without loss.
+#
+# Performs 11 read-only checks (no sudo, no mutations, no package operations)
+# and prints PASS / WARN / FAIL for each. See scripts/README-gpu-diagnostic.md
+# for the fix corresponding to each FAIL.
+
+set -u
+
+# ── Setup ─────────────────────────────────────────────────────────────────
+TIMESTAMP="$(date -u '+%Y%m%dT%H%M%SZ')"
+LOGFILE="gpu-diagnostic-${TIMESTAMP}.log"
+PASS_COUNT=0
+WARN_COUNT=0
+FAIL_COUNT=0
+
+# Tee everything to the log file from this point on.
+exec > >(tee -a "$LOGFILE") 2>&1
+
+print_header() {
+  echo
+  echo "============================================================"
+  echo "$1"
+  echo "============================================================"
+}
+
+print_check() {
+  # $1 = check number, $2 = title, $3 = status (PASS|WARN|FAIL|INFO), $4 = detail
+  local num="$1" title="$2" status="$3" detail="$4"
+  printf '[%s] #%-2s %-50s %s\n' "$status" "$num" "$title" "$detail"
+  case "$status" in
+    PASS) PASS_COUNT=$((PASS_COUNT + 1));;
+    WARN) WARN_COUNT=$((WARN_COUNT + 1));;
+    FAIL) FAIL_COUNT=$((FAIL_COUNT + 1));;
+  esac
+}
+
+# ── Linux gate ────────────────────────────────────────────────────────────
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "diagnose-gpu.sh is for Linux NVIDIA installs only."
+  echo "Detected: $(uname -s). Exiting cleanly."
+  exit 0
+fi
+
+print_header "TranscriptionSuite GPU Diagnostic — ${TIMESTAMP}"
+echo "Log file: $LOGFILE"
+
+# ── #1 baseline ───────────────────────────────────────────────────────────
+print_header "#1 Host baseline"
+echo "Kernel: $(uname -r)"
+if [ -r /etc/os-release ]; then
+  # shellcheck disable=SC1091
+  . /etc/os-release
+  echo "Distro: ${PRETTY_NAME:-unknown}"
+fi
+DRIVER_VERSION=""
+if command -v nvidia-smi >/dev/null 2>&1; then
+  DRIVER_VERSION="$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -n1 || true)"
+  echo "NVIDIA driver: ${DRIVER_VERSION:-unknown}"
+  print_check 1 "nvidia-smi present" PASS "driver=${DRIVER_VERSION:-unknown}"
+else
+  print_check 1 "nvidia-smi present" FAIL "nvidia-smi not in PATH — install NVIDIA driver first"
+fi
+
+# ── #2 nvidia-container-toolkit ──────────────────────────────────────────
+print_header "#2 NVIDIA Container Toolkit"
+if command -v nvidia-ctk >/dev/null 2>&1; then
+  CTK_VERSION="$(nvidia-ctk --version 2>/dev/null | head -n1 || true)"
+  print_check 2 "nvidia-ctk installed" PASS "${CTK_VERSION:-unknown version}"
+else
+  print_check 2 "nvidia-ctk installed" FAIL "nvidia-container-toolkit not installed"
+fi
+if command -v nvidia-container-cli >/dev/null 2>&1; then
+  CLI_VERSION="$(nvidia-container-cli --version 2>/dev/null | head -n1 || true)"
+  echo "nvidia-container-cli: ${CLI_VERSION:-unknown}"
+fi
+
+# ── #3 CDI spec exists ───────────────────────────────────────────────────
+print_header "#3 CDI spec presence"
+CDI_PATH="/etc/cdi/nvidia.yaml"
+if [ -f "$CDI_PATH" ]; then
+  CDI_SIZE="$(stat -c '%s' "$CDI_PATH" 2>/dev/null || echo '?')"
+  CDI_MTIME="$(stat -c '%y' "$CDI_PATH" 2>/dev/null || echo '?')"
+  print_check 3 "CDI spec at $CDI_PATH" PASS "size=${CDI_SIZE}B mtime=${CDI_MTIME}"
+  if command -v nvidia-ctk >/dev/null 2>&1; then
+    echo "--- nvidia-ctk cdi list ---"
+    nvidia-ctk cdi list 2>&1 || true
+    echo "---------------------------"
+  fi
+else
+  print_check 3 "CDI spec at $CDI_PATH" WARN "missing — only matters if dashboard selected CDI mode (regenerate with: sudo nvidia-ctk cdi generate --output=$CDI_PATH)"
+fi
+
+# ── #4 CDI spec drift after driver update ────────────────────────────────
+print_header "#4 CDI spec freshness vs. driver"
+if [ -f "$CDI_PATH" ]; then
+  CDI_EPOCH="$(stat -c '%Y' "$CDI_PATH" 2>/dev/null || echo 0)"
+  # Heuristic: locate any nvidia.ko* under /lib/modules or /usr/lib/modules; take newest mtime.
+  DRIVER_NEWEST_EPOCH=0
+  while IFS= read -r f; do
+    mt="$(stat -c '%Y' "$f" 2>/dev/null || echo 0)"
+    if [ "$mt" -gt "$DRIVER_NEWEST_EPOCH" ]; then
+      DRIVER_NEWEST_EPOCH="$mt"
+    fi
+  done < <(find /lib/modules /usr/lib/modules -maxdepth 6 -name 'nvidia*.ko*' 2>/dev/null)
+  if [ "$DRIVER_NEWEST_EPOCH" -eq 0 ]; then
+    print_check 4 "CDI spec vs driver mtime" INFO "driver module path not located on this distro — skipped"
+  elif [ "$CDI_EPOCH" -lt "$DRIVER_NEWEST_EPOCH" ]; then
+    print_check 4 "CDI spec vs driver mtime" WARN "CDI spec is older than driver modules — regenerate with: sudo nvidia-ctk cdi generate --output=$CDI_PATH"
+  else
+    print_check 4 "CDI spec vs driver mtime" PASS "spec newer or equal to driver modules"
+  fi
+else
+  print_check 4 "CDI spec vs driver mtime" INFO "skipped — no CDI spec to compare"
+fi
+
+# ── #5 /dev/char NVIDIA symlinks ─────────────────────────────────────────
+print_header "#5 /dev/char NVIDIA symlinks"
+if [ -d /dev/char ]; then
+  CHAR_NV_COUNT="$(ls -1 /dev/char 2>/dev/null | grep -c '^195:' || true)"
+  if [ "$CHAR_NV_COUNT" -gt 0 ]; then
+    print_check 5 "/dev/char NVIDIA symlinks" PASS "found $CHAR_NV_COUNT entries with major 195"
+  else
+    print_check 5 "/dev/char NVIDIA symlinks" FAIL "missing — fix: sudo nvidia-ctk system create-dev-char-symlinks --create-all (also add udev rule per nvidia-container-toolkit issue #48)"
+  fi
+else
+  print_check 5 "/dev/char NVIDIA symlinks" WARN "/dev/char does not exist on this host"
+fi
+
+# ── #6 NVIDIA kernel modules ─────────────────────────────────────────────
+print_header "#6 NVIDIA kernel modules"
+LSMOD_OUTPUT="$(lsmod 2>/dev/null | awk '{print $1}' || true)"
+for mod in nvidia nvidia_modeset nvidia_uvm nvidia_drm; do
+  if echo "$LSMOD_OUTPUT" | grep -qx "$mod"; then
+    print_check 6 "module $mod loaded" PASS ""
+  else
+    if [ "$mod" = "nvidia_uvm" ]; then
+      print_check 6 "module $mod loaded" FAIL "fix: sudo modprobe $mod (or sudo rmmod $mod && sudo modprobe $mod after suspend/resume)"
+    else
+      print_check 6 "module $mod loaded" WARN "fix: sudo modprobe $mod"
+    fi
+  fi
+done
+
+# ── #7 Docker daemon config ──────────────────────────────────────────────
+print_header "#7 Docker daemon config"
+DAEMON_JSON="/etc/docker/daemon.json"
+if [ -r "$DAEMON_JSON" ]; then
+  echo "--- $DAEMON_JSON ---"
+  cat "$DAEMON_JSON"
+  echo "--------------------"
+  if grep -q 'native.cgroupdriver=systemd' "$DAEMON_JSON" 2>/dev/null; then
+    print_check 7 "Docker cgroup driver" WARN "uses systemd cgroups — NVIDIA recommends cgroupfs for GPU workloads (set exec-opts native.cgroupdriver=cgroupfs and restart docker)"
+  else
+    print_check 7 "Docker cgroup driver" PASS "no systemd cgroupdriver override detected in daemon.json"
+  fi
+else
+  print_check 7 "Docker daemon.json" INFO "no daemon.json present (Docker uses defaults)"
+fi
+NCT_CONFIG="/etc/nvidia-container-runtime/config.toml"
+if [ -r "$NCT_CONFIG" ]; then
+  echo "--- $NCT_CONFIG ---"
+  grep -E 'no-cgroups|^\[' "$NCT_CONFIG" || true
+  echo "-------------------"
+fi
+
+# ── #8 Docker runtime info ───────────────────────────────────────────────
+print_header "#8 Docker runtime info"
+if command -v docker >/dev/null 2>&1; then
+  DOCKER_INFO="$(docker info --format '{{json .}}' 2>/dev/null || echo '{}')"
+  echo "Runtimes: $(echo "$DOCKER_INFO" | grep -oP '"Runtimes":\{[^}]*\}' || echo 'unparseable')"
+  echo "DefaultRuntime: $(echo "$DOCKER_INFO" | grep -oP '"DefaultRuntime":"[^"]*"' || echo 'unknown')"
+  echo "CgroupDriver: $(echo "$DOCKER_INFO" | grep -oP '"CgroupDriver":"[^"]*"' || echo 'unknown')"
+  print_check 8 "docker info readable" PASS ""
+else
+  print_check 8 "docker present" FAIL "docker CLI not in PATH"
+fi
+
+# ── #9 Smoke test: --gpus all in a small NVIDIA base image ──────────────
+print_header "#9 Container smoke test"
+SMOKE_IMAGE="nvidia/cuda:12.6.0-base-ubuntu24.04"
+if ! command -v docker >/dev/null 2>&1; then
+  print_check 9 "container --gpus all smoke test" INFO "skipped — docker not present"
+elif ! docker image inspect "$SMOKE_IMAGE" >/dev/null 2>&1; then
+  echo "Image $SMOKE_IMAGE not present locally; this check would pull ~150MB."
+  echo "Skipping the pull. To run manually: docker pull $SMOKE_IMAGE"
+  print_check 9 "container --gpus all smoke test" INFO "skipped — image not pulled (would pull ~150MB)"
+else
+  echo "Running: docker run --rm --gpus all $SMOKE_IMAGE nvidia-smi"
+  if SMOKE_OUT="$(docker run --rm --gpus all "$SMOKE_IMAGE" nvidia-smi 2>&1)"; then
+    echo "$SMOKE_OUT" | head -n 20
+    print_check 9 "container --gpus all smoke test" PASS "GPU visible inside a fresh NVIDIA base container"
+  else
+    echo "$SMOKE_OUT"
+    print_check 9 "container --gpus all smoke test" FAIL "GPU NOT visible inside container — host-side breakage confirmed; see checks #5/#6/#3 for the most likely fix"
+  fi
+fi
+
+# ── #10 NVIDIA proc files inside a container (only if smoke passed) ─────
+print_header "#10 NVIDIA proc files inside container"
+if docker image inspect "$SMOKE_IMAGE" >/dev/null 2>&1; then
+  if PROC_OUT="$(docker run --rm --gpus all "$SMOKE_IMAGE" bash -c 'ls /dev/nvidia* 2>&1; echo ---; cat /proc/driver/nvidia/version 2>&1' 2>&1)"; then
+    echo "$PROC_OUT"
+    print_check 10 "container can read /dev/nvidia* and /proc/driver/nvidia" PASS ""
+  else
+    echo "$PROC_OUT"
+    print_check 10 "container can read /dev/nvidia* and /proc/driver/nvidia" FAIL "container has --gpus all but cannot read NVIDIA proc files"
+  fi
+else
+  print_check 10 "container can read NVIDIA proc files" INFO "skipped — image not pulled"
+fi
+
+# ── #11 Summary ─────────────────────────────────────────────────────────
+print_header "#11 Summary"
+echo "PASS: $PASS_COUNT   WARN: $WARN_COUNT   FAIL: $FAIL_COUNT"
+echo
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "RESULT: One or more FAIL checks. See scripts/README-gpu-diagnostic.md"
+  echo "        for the recommended fix per failure mode."
+elif [ "$WARN_COUNT" -gt 0 ]; then
+  echo "RESULT: Some WARN checks — host is likely operational but not optimally"
+  echo "        configured. Review WARN entries above."
+else
+  echo "RESULT: All checks PASS — host GPU/Docker setup looks healthy."
+fi
+echo
+echo "Full log: $LOGFILE"
+exit 0
+```
+
+- [ ] **Step 2: Make the script executable**
+
+```bash
+chmod +x scripts/diagnose-gpu.sh
+```
+
+- [ ] **Step 3: Run it on this machine to confirm it works**
+
+```bash
+bash scripts/diagnose-gpu.sh > /tmp/gpu-diag-test.log 2>&1
+echo "Exit code: $?"
+ls -la gpu-diagnostic-*.log | head -1
+grep -E '^\[(PASS|WARN|FAIL|INFO)\]' /tmp/gpu-diag-test.log | head -20
+```
+
+Expected: exit code 0; a `gpu-diagnostic-<timestamp>.log` file is created in the current directory; at least the "#1 nvidia-smi present" line appears with one of PASS/FAIL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/diagnose-gpu.sh
+git commit -m "feat(scripts): add observation-only GPU diagnostic for CUDA error 999
+
+* feat(scripts): scripts/diagnose-gpu.sh — 11 read-only host checks (driver, nvidia-container-toolkit, CDI spec age, /dev/char symlinks, NVIDIA kernel modules, Docker daemon config, container smoke test) with PASS/WARN/FAIL summary; tees output to gpu-diagnostic-<UTC>.log; exits cleanly on non-Linux"
+```
+
+---
+
+## Task 2: Create companion README
+
+**Files:**
+- Create: `scripts/README-gpu-diagnostic.md`
+
+- [ ] **Step 1: Write the README**
+
+Create `scripts/README-gpu-diagnostic.md`:
+
+```markdown
+# `diagnose-gpu.sh` — GPU host diagnostic
+
+Runs 11 read-only checks against a Linux NVIDIA host to identify why a Docker
+container can fail to initialise CUDA (PyTorch error 999, "CUDA unknown error")
+even when `nvidia-smi` succeeds on the host.
+
+The script is **observation-only**: no `sudo`, no package operations, no
+mutations to your system. Output is tee'd to both stdout and a timestamped
+`gpu-diagnostic-<UTC>.log` file in the current directory so it can be pasted
+back without loss.
+
+## When to run it
+
+- The TranscriptionSuite server logs `CUDA health check failed — GPU
+  transcription disabled for this session`.
+- The dashboard's GPU Health card shows yellow or red.
+- A fresh container start hangs at GPU init or falls back to CPU
+  unexpectedly.
+- After any `pacman -Syu` / `apt upgrade` / `dnf upgrade` that bumped
+  `nvidia-utils`, `nvidia-dkms`, `nvidia-container-toolkit`, or the kernel.
+
+## Usage
+
+```
+bash scripts/diagnose-gpu.sh
+```
+
+The script exits 0 on every platform — on macOS / Windows it prints a friendly
+"Linux only" message and returns. On Linux it always completes the 11 checks
+even if some fail.
+
+## What each check measures and how to fix it
+
+| # | Check | What it measures | If it fails |
+|---|---|---|---|
+| 1 | `nvidia-smi present` | NVIDIA userspace driver tool is installed | Install the NVIDIA driver from your distro (e.g. `sudo pacman -S nvidia` on Arch). |
+| 2 | `nvidia-ctk installed` | NVIDIA Container Toolkit is installed | `sudo pacman -S nvidia-container-toolkit` (or distro equivalent). Required for both CDI and legacy modes. |
+| 3 | `CDI spec at /etc/cdi/nvidia.yaml` | The CDI spec file exists | Only matters if the dashboard auto-detected CDI mode. Generate with `sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml`. |
+| 4 | `CDI spec vs driver mtime` | The CDI spec is newer than the installed driver | The spec is a static snapshot. Regenerate after any driver update: `sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml`. |
+| 5 | `/dev/char NVIDIA symlinks` | Symlinks under `/dev/char/195:*` exist for the NVIDIA char devices | This is the most common Phase-1 root cause. Run `sudo nvidia-ctk system create-dev-char-symlinks --create-all`. To make it persistent across reboots, install the udev rule from [NVIDIA/nvidia-container-toolkit issue #48](https://github.com/NVIDIA/nvidia-container-toolkit/issues/48). |
+| 6 | NVIDIA kernel modules loaded | `nvidia`, `nvidia_modeset`, `nvidia_uvm`, `nvidia_drm` are loaded | `sudo modprobe nvidia_uvm` (replace with the missing module). After suspend/resume you may need `sudo rmmod nvidia_uvm && sudo modprobe nvidia_uvm`. If `modprobe` fails, your DKMS module did not rebuild for the running kernel — reboot, or rebuild via `sudo dkms autoinstall`. |
+| 7 | Docker daemon config | `/etc/docker/daemon.json` does not force the systemd cgroup driver | Add `"exec-opts": ["native.cgroupdriver=cgroupfs"]` to `/etc/docker/daemon.json`, then `sudo systemctl restart docker`. NVIDIA documents this for GPU workloads. |
+| 8 | `docker info` | Docker is reachable and reports its runtimes / cgroup driver | Confirm Docker is running: `sudo systemctl status docker`. |
+| 9 | Container smoke test | `docker run --rm --gpus all <NVIDIA base image> nvidia-smi` succeeds | If checks 5/6/3 are clean and this still fails, capture the exact docker error — it usually names the missing piece (`failed to inject CDI devices`, `unknown runtime: nvidia`, etc.). |
+| 10 | NVIDIA proc files inside container | `/dev/nvidia*` and `/proc/driver/nvidia/version` are readable inside the container | Same fixes as check 9. |
+| 11 | Summary | PASS / WARN / FAIL totals | — |
+
+## References
+
+- [NVIDIA Container Toolkit Troubleshooting](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/troubleshooting.html)
+- [NVIDIA/nvidia-container-toolkit Issue #48](https://github.com/NVIDIA/nvidia-container-toolkit/issues/48)
+- [Arch Linux forum — Docker with GPU NVML Unknown Error](https://bbs.archlinux.org/viewtopic.php?id=266915)
+- [PyTorch issue #115340](https://github.com/pytorch/pytorch/issues/115340)
+- Internal spec: `docs/superpowers/specs/2026-04-29-cuda-error-999-recovery-design.md`
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/README-gpu-diagnostic.md
+git commit -m "docs(scripts): add README for diagnose-gpu.sh
+
+* docs(scripts): scripts/README-gpu-diagnostic.md — explain when to run the diagnostic, what each of the 11 checks measures, and the canonical NVIDIA-doc fix command for each failure mode"
+```
+
+---
+
+# Phase 2 — Backend `recovery_hint`
+
+## Task 3: TDD — write failing tests for `recovery_hint`
+
+**Files:**
+- Modify: `server/backend/tests/test_audio_utils.py`
+
+- [ ] **Step 1: Add the test class to the bottom of `TestCudaHealthCheck` block**
+
+Open `server/backend/tests/test_audio_utils.py` and add the following to the existing `TestCudaHealthCheck` class (after `test_retry_also_fails_returns_no_cuda` at ~line 221):
+
+```python
+    def test_error_999_unrecoverable_includes_recovery_hint(self):
+        """When error 999 fails all retries, result includes a recovery_hint."""
+        mock_torch = MagicMock()
+        mock_torch.cuda.init.side_effect = RuntimeError("CUDA unknown error")
+
+        with (
+            patch.object(au, "torch", mock_torch),
+            patch.object(au, "HAS_TORCH", True),
+            patch.object(au, "_capture_nvidia_smi", return_value="ok"),
+            patch.object(au, "time"),
+        ):
+            result = au.cuda_health_check()
+
+        assert result["status"] == "unrecoverable"
+        hint = result.get("recovery_hint")
+        assert hint is not None
+        assert "error 999" in hint.lower() or "cuda unknown" in hint.lower()
+        assert "diagnose-gpu.sh" in hint
+
+    def test_error_999_recovered_omits_recovery_hint(self):
+        """If error 999 recovers on retry, no recovery_hint is added."""
+        mock_props = MagicMock()
+        mock_props.name = "NVIDIA RTX 3060"
+        mock_props.total_mem = 12 * 1024**3
+
+        mock_torch = MagicMock()
+        mock_torch.cuda.init.side_effect = [RuntimeError("CUDA unknown error"), None]
+        mock_torch.cuda.get_device_properties.return_value = mock_props
+
+        with (
+            patch.object(au, "torch", mock_torch),
+            patch.object(au, "HAS_TORCH", True),
+            patch.object(au, "time"),
+        ):
+            result = au.cuda_health_check()
+
+        assert result["status"] == "healthy"
+        assert "recovery_hint" not in result
+
+    def test_non_999_unrecoverable_omits_recovery_hint(self):
+        """A non-999 error path that still yields a non-healthy status must not
+        carry the error-999-specific recovery_hint."""
+        mock_torch = MagicMock()
+        mock_torch.cuda.init.side_effect = RuntimeError("no CUDA-capable device")
+
+        with patch.object(au, "torch", mock_torch), patch.object(au, "HAS_TORCH", True):
+            result = au.cuda_health_check()
+
+        assert result["status"] == "no_cuda"
+        assert "recovery_hint" not in result
+```
+
+- [ ] **Step 2: Run the new tests and confirm they fail**
+
+```bash
+cd server/backend
+../../build/.venv/bin/pytest tests/test_audio_utils.py::TestCudaHealthCheck::test_error_999_unrecoverable_includes_recovery_hint tests/test_audio_utils.py::TestCudaHealthCheck::test_error_999_recovered_omits_recovery_hint tests/test_audio_utils.py::TestCudaHealthCheck::test_non_999_unrecoverable_omits_recovery_hint -v
+```
+
+Expected: 1 FAILED (the unrecoverable case — no `recovery_hint` key yet) and 2 PASSED (the cases where the key should be absent are already absent).
+
+---
+
+## Task 4: Implement `recovery_hint` in `cuda_health_check`
+
+**Files:**
+- Modify: `server/backend/core/audio_utils.py:251-265`
+
+- [ ] **Step 1: Update the unrecoverable branch to attach the hint**
+
+Open `server/backend/core/audio_utils.py`. Locate the unrecoverable branch inside `cuda_health_check` (around line 251):
+
+```python
+            # All retries exhausted — mark as unrecoverable.
+            _cuda_probe_failed = True
+            smi_output = _capture_nvidia_smi()
+            logger.error(
+                "CUDA health check: unrecoverable GPU state after %d retries",
+                len(_error_999_delays),
+                exc_info=last_exc,
+                extra={"nvidia_smi": smi_output},
+            )
+            return {
+                "status": "unrecoverable",
+                "error": str(last_exc),
+                "nvidia_smi": smi_output,
+                "attempts": len(_error_999_delays) + 1,
+            }
+```
+
+Replace it with:
+
+```python
+            # All retries exhausted — mark as unrecoverable.
+            _cuda_probe_failed = True
+            smi_output = _capture_nvidia_smi()
+            recovery_hint = (
+                "GPU init failed with error 999 (CUDA unknown). This is "
+                "almost always host-side: missing /dev/char symlinks, stale "
+                "CDI spec, nvidia_uvm not loaded, or systemd cgroup driver "
+                "interference. Run scripts/diagnose-gpu.sh on the host for "
+                "details and the recommended fix."
+            )
+            logger.error(
+                "CUDA health check: unrecoverable GPU state after %d retries",
+                len(_error_999_delays),
+                exc_info=last_exc,
+                extra={"nvidia_smi": smi_output, "recovery_hint": recovery_hint},
+            )
+            return {
+                "status": "unrecoverable",
+                "error": str(last_exc),
+                "nvidia_smi": smi_output,
+                "attempts": len(_error_999_delays) + 1,
+                "recovery_hint": recovery_hint,
+            }
+```
+
+- [ ] **Step 2: Run the three new tests — they should now pass**
+
+```bash
+cd server/backend
+../../build/.venv/bin/pytest tests/test_audio_utils.py::TestCudaHealthCheck -v
+```
+
+Expected: all `TestCudaHealthCheck` tests pass (including the three new `recovery_hint` tests).
+
+- [ ] **Step 3: Run the full audio_utils test file to confirm no regressions**
+
+```bash
+cd server/backend
+../../build/.venv/bin/pytest tests/test_audio_utils.py -v --tb=short
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/backend/core/audio_utils.py server/backend/tests/test_audio_utils.py
+git commit -m "feat(server, audio_utils): add recovery_hint field for error-999 unrecoverable GPU state
+
+* feat(server, audio_utils): cuda_health_check() now returns recovery_hint field on the unrecoverable branch, pointing the user at scripts/diagnose-gpu.sh and naming the four likely host-side causes (/dev/char symlinks, stale CDI spec, nvidia_uvm not loaded, systemd cgroup driver). The hint is omitted on healthy/recovered/no_cuda paths so consumers can branch on its presence.
+
+* test(server, audio_utils): three new TestCudaHealthCheck cases — hint present on error-999 unrecoverable, hint absent on error-999 recovered, hint absent on non-999 errors"
+```
+
+---
+
+## Task 5: Surface `recovery_hint` in lifespan log
+
+**Files:**
+- Modify: `server/backend/api/main.py:511-519`
+
+- [ ] **Step 1: Update the lifespan error log to include the hint**
+
+Open `server/backend/api/main.py`. Locate the unrecoverable branch (around line 511):
+
+```python
+    if gpu_unrecoverable:
+        logger.error(
+            "CUDA health check failed — GPU transcription disabled for this session",
+            extra={
+                "error": gpu_health["error"],
+                "nvidia_smi": gpu_health.get("nvidia_smi", "N/A"),
+            },
+        )
+        app.state.gpu_error = gpu_health
+```
+
+Replace with:
+
+```python
+    if gpu_unrecoverable:
+        logger.error(
+            "CUDA health check failed — GPU transcription disabled for this session",
+            extra={
+                "error": gpu_health["error"],
+                "nvidia_smi": gpu_health.get("nvidia_smi", "N/A"),
+                "recovery_hint": gpu_health.get("recovery_hint"),
+            },
+        )
+        app.state.gpu_error = gpu_health
+```
+
+(`app.state.gpu_error = gpu_health` already carries the new `recovery_hint` field through to any HTTP route that reads `app.state.gpu_error`, because the dict reference is shared.)
+
+- [ ] **Step 2: Verify the import and usage compile cleanly**
+
+```bash
+cd server/backend
+../../build/.venv/bin/python -c "import ast; ast.parse(open('api/main.py').read()); print('OK')"
+```
+
+Expected: `OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/backend/api/main.py
+git commit -m "feat(server, lifespan): include recovery_hint in unrecoverable-GPU error log
+
+* feat(server, lifespan): the structured logger now emits the recovery_hint alongside the existing error/nvidia_smi fields when cuda_health_check returns unrecoverable, so log readers see the diagnostic-script pointer immediately"
+```
+
+---
+
+# Phase 2 — Dashboard preflight
+
+## Task 6: TDD — write failing tests for `validateGpuPreflight`
+
+**Files:**
+- Create: `dashboard/electron/__tests__/dockerManagerGpuPreflight.test.ts`
+
+- [ ] **Step 1: Create the test file**
+
+Create `dashboard/electron/__tests__/dockerManagerGpuPreflight.test.ts`:
+
+```typescript
+// @vitest-environment node
+
+/**
+ * GPU preflight — validates the cheap subset of scripts/diagnose-gpu.sh that
+ * runs at dashboard startup. Mirrors the dockerManagerVulkanPreflight test
+ * pattern: the function under test is pure (all OS access is injected) and
+ * returns a structured result the UI renders.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: (name: string) => `/tmp/mock-${name}`,
+    setPath: vi.fn(),
+  },
+}));
+
+vi.mock('electron-store', () => ({
+  default: class MockStore {
+    get() {
+      return undefined;
+    }
+    set() {}
+  },
+}));
+
+import { validateGpuPreflight } from '../dockerManager.js';
+
+interface Env {
+  cdiExists: boolean;
+  cdiMtime: number;
+  driverMtime: number;
+  charSymlinks: string[];
+  lsmodOutput: string;
+}
+
+function makeDeps(env: Env) {
+  return {
+    fsExists: (p: string) => {
+      if (p === '/etc/cdi/nvidia.yaml') return env.cdiExists;
+      if (p === '/dev/char') return true;
+      return false;
+    },
+    readDir: (p: string) => {
+      if (p === '/dev/char') return env.charSymlinks;
+      return [];
+    },
+    statMtime: (p: string) => {
+      if (p === '/etc/cdi/nvidia.yaml') return env.cdiExists ? env.cdiMtime : null;
+      if (p.includes('/lib/modules')) return env.driverMtime;
+      return null;
+    },
+    runLsmod: () => env.lsmodOutput,
+  };
+}
+
+const healthyEnv: Env = {
+  cdiExists: true,
+  cdiMtime: 2_000_000_000,
+  driverMtime: 1_000_000_000,
+  charSymlinks: ['195:0', '195:255', '512:0'],
+  lsmodOutput: 'nvidia\nnvidia_modeset\nnvidia_uvm\nnvidia_drm\n',
+};
+
+describe('validateGpuPreflight', () => {
+  it('non-Linux platform: returns status=unknown, no checks run', () => {
+    const deps = makeDeps(healthyEnv);
+    const result = validateGpuPreflight('darwin', deps);
+    expect(result.status).toBe('unknown');
+    expect(result.checks).toEqual([]);
+  });
+
+  it('Windows: returns status=unknown, no checks run', () => {
+    const deps = makeDeps(healthyEnv);
+    const result = validateGpuPreflight('win32', deps);
+    expect(result.status).toBe('unknown');
+    expect(result.checks).toEqual([]);
+  });
+
+  it('Linux + healthy environment: status=healthy, all checks pass', () => {
+    const result = validateGpuPreflight('linux', makeDeps(healthyEnv));
+    expect(result.status).toBe('healthy');
+    expect(result.checks.every((c) => c.pass)).toBe(true);
+    expect(result.checks.map((c) => c.name)).toEqual([
+      'CDI spec exists',
+      'CDI spec newer than driver',
+      '/dev/char NVIDIA symlinks',
+      'nvidia_uvm module loaded',
+    ]);
+  });
+
+  it('Linux + missing /dev/char symlinks: status=warning, fixCommand provided', () => {
+    const result = validateGpuPreflight(
+      'linux',
+      makeDeps({ ...healthyEnv, charSymlinks: ['512:0', '999:1'] }),
+    );
+    expect(result.status).toBe('warning');
+    const failed = result.checks.find((c) => c.name === '/dev/char NVIDIA symlinks');
+    expect(failed?.pass).toBe(false);
+    expect(failed?.fixCommand).toMatch(/nvidia-ctk system create-dev-char-symlinks/);
+  });
+
+  it('Linux + stale CDI spec: status=warning with regenerate command', () => {
+    const result = validateGpuPreflight(
+      'linux',
+      makeDeps({ ...healthyEnv, cdiMtime: 500_000_000, driverMtime: 1_000_000_000 }),
+    );
+    expect(result.status).toBe('warning');
+    const failed = result.checks.find((c) => c.name === 'CDI spec newer than driver');
+    expect(failed?.pass).toBe(false);
+    expect(failed?.fixCommand).toMatch(/nvidia-ctk cdi generate/);
+  });
+
+  it('Linux + missing CDI spec: status=warning, generate command shown', () => {
+    const result = validateGpuPreflight(
+      'linux',
+      makeDeps({ ...healthyEnv, cdiExists: false }),
+    );
+    expect(result.status).toBe('warning');
+    const failed = result.checks.find((c) => c.name === 'CDI spec exists');
+    expect(failed?.pass).toBe(false);
+    expect(failed?.fixCommand).toMatch(/nvidia-ctk cdi generate/);
+    // The "newer than driver" check is skipped (passes vacuously) when the spec is missing.
+    const driverCheck = result.checks.find((c) => c.name === 'CDI spec newer than driver');
+    expect(driverCheck?.pass).toBe(true);
+  });
+
+  it('Linux + nvidia_uvm not loaded: status=warning, modprobe command shown', () => {
+    const result = validateGpuPreflight(
+      'linux',
+      makeDeps({ ...healthyEnv, lsmodOutput: 'nvidia\nnvidia_modeset\nnvidia_drm\n' }),
+    );
+    expect(result.status).toBe('warning');
+    const failed = result.checks.find((c) => c.name === 'nvidia_uvm module loaded');
+    expect(failed?.pass).toBe(false);
+    expect(failed?.fixCommand).toMatch(/modprobe nvidia_uvm/);
+  });
+
+  it('Linux + missing driver mtime info: skips comparison, no warning', () => {
+    const deps = {
+      ...makeDeps(healthyEnv),
+      statMtime: (p: string) => {
+        if (p === '/etc/cdi/nvidia.yaml') return 2_000_000_000;
+        return null; // driver path not located
+      },
+    };
+    const result = validateGpuPreflight('linux', deps);
+    const driverCheck = result.checks.find((c) => c.name === 'CDI spec newer than driver');
+    expect(driverCheck?.pass).toBe(true); // conservative: skip rather than false-warn
+  });
+});
+```
+
+- [ ] **Step 2: Run the new test file — it should fail with import error**
+
+```bash
+cd dashboard
+npx vitest run electron/__tests__/dockerManagerGpuPreflight.test.ts
+```
+
+Expected: FAIL with `validateGpuPreflight is not exported from '../dockerManager.js'` (or similar).
+
+---
+
+## Task 7: Implement `validateGpuPreflight`
+
+**Files:**
+- Modify: `dashboard/electron/dockerManager.ts` — add type and function near the existing `checkVulkanSupport` definition (line 130) for code locality.
+
+- [ ] **Step 1: Add the type and pure function to `dockerManager.ts`**
+
+Open `dashboard/electron/dockerManager.ts`. Add the following block immediately after the existing `checkVulkanSupport` function (around line 220 — find the closing `}` of `checkVulkanSupport` and insert after it):
+
+```typescript
+// ─── GPU Preflight (NVIDIA, Linux) ─────────────────────────────────────────
+// Runs the cheap subset of scripts/diagnose-gpu.sh at dashboard startup so
+// the GpuHealthCard can warn about misconfigurations before the container
+// is started. Pure function — all OS access is injected for testability.
+
+export interface GpuPreflightCheck {
+  name: string;
+  pass: boolean;
+  /** Documented NVIDIA fix command. Present only when pass=false. */
+  fixCommand?: string;
+  /** External URL with more context. Present only when pass=false. */
+  docsUrl?: string;
+}
+
+export interface GpuPreflightResult {
+  status: 'healthy' | 'warning' | 'unknown';
+  checks: GpuPreflightCheck[];
+}
+
+export interface GpuPreflightDeps {
+  fsExists: (path: string) => boolean;
+  readDir: (path: string) => string[];
+  /** Returns mtime (epoch seconds) or null when the path cannot be stat'd. */
+  statMtime: (path: string) => number | null;
+  /** Returns lsmod stdout (one module name per line). Empty string on failure. */
+  runLsmod: () => string;
+}
+
+const NVIDIA_DRIVER_MTIME_PATHS: readonly string[] = [
+  '/lib/modules',
+  '/usr/lib/modules',
+];
+const CDI_SPEC_PATH = '/etc/cdi/nvidia.yaml';
+
+function newestDriverMtime(statMtime: GpuPreflightDeps['statMtime']): number | null {
+  // Conservative heuristic: try a handful of distro-typical roots. The actual
+  // recursive walk lives in the IPC handler — we just take what it produces.
+  let newest: number | null = null;
+  for (const root of NVIDIA_DRIVER_MTIME_PATHS) {
+    const mt = statMtime(root);
+    if (mt !== null && (newest === null || mt > newest)) {
+      newest = mt;
+    }
+  }
+  return newest;
+}
+
+export function validateGpuPreflight(
+  platform: NodeJS.Platform,
+  deps: GpuPreflightDeps,
+): GpuPreflightResult {
+  if (platform !== 'linux') {
+    return { status: 'unknown', checks: [] };
+  }
+
+  const checks: GpuPreflightCheck[] = [];
+
+  // Check 1: CDI spec exists
+  const cdiExists = deps.fsExists(CDI_SPEC_PATH);
+  checks.push({
+    name: 'CDI spec exists',
+    pass: cdiExists,
+    fixCommand: cdiExists
+      ? undefined
+      : `sudo nvidia-ctk cdi generate --output=${CDI_SPEC_PATH}`,
+    docsUrl: cdiExists
+      ? undefined
+      : 'https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html',
+  });
+
+  // Check 2: CDI spec newer than driver (only meaningful when both mtimes available)
+  const cdiMtime = cdiExists ? deps.statMtime(CDI_SPEC_PATH) : null;
+  const driverMtime = newestDriverMtime(deps.statMtime);
+  let cdiFresh = true;
+  if (cdiMtime !== null && driverMtime !== null && cdiMtime < driverMtime) {
+    cdiFresh = false;
+  }
+  checks.push({
+    name: 'CDI spec newer than driver',
+    pass: cdiFresh,
+    fixCommand: cdiFresh
+      ? undefined
+      : `sudo nvidia-ctk cdi generate --output=${CDI_SPEC_PATH}`,
+  });
+
+  // Check 3: /dev/char symlinks for major 195 (NVIDIA)
+  const charEntries = deps.fsExists('/dev/char') ? deps.readDir('/dev/char') : [];
+  const hasNvidiaSymlinks = charEntries.some((e) => e.startsWith('195:'));
+  checks.push({
+    name: '/dev/char NVIDIA symlinks',
+    pass: hasNvidiaSymlinks,
+    fixCommand: hasNvidiaSymlinks
+      ? undefined
+      : 'sudo nvidia-ctk system create-dev-char-symlinks --create-all',
+    docsUrl: hasNvidiaSymlinks
+      ? undefined
+      : 'https://github.com/NVIDIA/nvidia-container-toolkit/issues/48',
+  });
+
+  // Check 4: nvidia_uvm kernel module loaded
+  const lsmodLines = deps.runLsmod().split('\n').map((l) => l.trim());
+  const uvmLoaded = lsmodLines.includes('nvidia_uvm');
+  checks.push({
+    name: 'nvidia_uvm module loaded',
+    pass: uvmLoaded,
+    fixCommand: uvmLoaded ? undefined : 'sudo modprobe nvidia_uvm',
+  });
+
+  const status: GpuPreflightResult['status'] = checks.every((c) => c.pass)
+    ? 'healthy'
+    : 'warning';
+
+  return { status, checks };
+}
+```
+
+- [ ] **Step 2: Run the test file — it should now pass**
+
+```bash
+cd dashboard
+npx vitest run electron/__tests__/dockerManagerGpuPreflight.test.ts
+```
+
+Expected: all 8 tests pass.
+
+- [ ] **Step 3: Run the full electron test suite to confirm no regressions**
+
+```bash
+cd dashboard
+npx vitest run electron/
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dashboard/electron/dockerManager.ts dashboard/electron/__tests__/dockerManagerGpuPreflight.test.ts
+git commit -m "feat(dashboard, electron): add validateGpuPreflight pure function for NVIDIA host checks
+
+* feat(dashboard, electron): dockerManager.ts now exports GpuPreflightCheck/Result/Deps types and a pure validateGpuPreflight(platform, deps) function that runs the cheap subset of scripts/diagnose-gpu.sh — CDI spec presence, CDI spec freshness vs driver, /dev/char NVIDIA symlinks, nvidia_uvm module load. Each failing check carries the documented NVIDIA fix command and docs URL. Returns status=unknown on non-Linux without touching the filesystem.
+
+* test(dashboard, electron): dockerManagerGpuPreflight.test.ts mirrors the existing checkVulkanSupport test layout — non-Linux gating, healthy environment, each individual check failure mode, and the conservative skip when driver mtime cannot be located"
+```
+
+---
+
+## Task 8: Wire `validateGpuPreflight` to IPC
+
+**Files:**
+- Modify: `dashboard/electron/dockerManager.ts` — add a non-pure wrapper that fills in real `fs`/shell deps.
+- Modify: `dashboard/electron/main.ts` — add `docker:validateGpuPreflight` IPC handler.
+- Modify: `dashboard/electron/preload.ts` — expose `docker.validateGpuPreflight()` plus its type.
+
+- [ ] **Step 1: Add a real-deps wrapper to `dockerManager.ts`**
+
+First ensure `execSync` is importable. At the top of `dockerManager.ts`, near other Node/Electron imports, add (if not already present):
+
+```typescript
+import { execSync } from 'child_process';
+```
+
+(Search the file first: `grep -n "from 'child_process'" dashboard/electron/dockerManager.ts` — extend the existing import list if `child_process` is already imported.)
+
+Then add this immediately after `validateGpuPreflight` in `dockerManager.ts`:
+
+```typescript
+/**
+ * Real-OS wrapper around validateGpuPreflight() — used by the
+ * docker:validateGpuPreflight IPC handler. Kept separate from the pure
+ * function so tests can inject without touching fs/exec.
+ */
+export function runGpuPreflight(): GpuPreflightResult {
+  // Lazy-import fs so the unit tests can mock electron without dragging in
+  // real fs operations during validateGpuPreflight() unit tests.
+  // (validateGpuPreflight() itself is pure; this wrapper is the impure shell.)
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const fs = require('fs') as typeof import('fs');
+
+  const deps: GpuPreflightDeps = {
+    fsExists: (p) => {
+      try {
+        return fs.existsSync(p);
+      } catch {
+        return false;
+      }
+    },
+    readDir: (p) => {
+      try {
+        return fs.readdirSync(p);
+      } catch {
+        return [];
+      }
+    },
+    statMtime: (p) => {
+      try {
+        // For directory roots we want the latest modification time of any
+        // file underneath — but a deep walk is too expensive at preflight.
+        // Stat the root itself; that's enough to compare with the CDI spec
+        // mtime (driver updates touch the modules root directory).
+        return Math.floor(fs.statSync(p).mtimeMs / 1000);
+      } catch {
+        return null;
+      }
+    },
+    runLsmod: () => {
+      try {
+        return execSync('lsmod', { timeout: 2000, encoding: 'utf8' });
+      } catch {
+        return '';
+      }
+    },
+  };
+
+  return validateGpuPreflight(process.platform, deps);
+}
+```
+
+- [ ] **Step 2: Add the IPC handler in `main.ts`**
+
+Open `dashboard/electron/main.ts`. After the existing `ipcMain.handle('docker:checkGpu', ...)` block (around line 1163), add:
+
+```typescript
+ipcMain.handle('docker:validateGpuPreflight', async () => {
+  return dockerManager.runGpuPreflight();
+});
+```
+
+- [ ] **Step 3: Expose the API in `preload.ts`**
+
+Open `dashboard/electron/preload.ts`. In the `docker:` interface block (around line 137), add the type after `checkGpu`:
+
+```typescript
+    checkGpu: () => Promise<{ gpu: boolean; toolkit: boolean; vulkan: boolean }>;
+    validateGpuPreflight: () => Promise<{
+      status: 'healthy' | 'warning' | 'unknown';
+      checks: Array<{
+        name: string;
+        pass: boolean;
+        fixCommand?: string;
+        docsUrl?: string;
+      }>;
+    }>;
+```
+
+Then in the implementation block (around line 475 where `checkGpu` is wired), add:
+
+```typescript
+    checkGpu: () => ipcRenderer.invoke('docker:checkGpu'),
+    validateGpuPreflight: () => ipcRenderer.invoke('docker:validateGpuPreflight'),
+```
+
+- [ ] **Step 4: Verify the dashboard still type-checks**
+
+```bash
+cd dashboard
+npx tsc --noEmit -p electron/tsconfig.json
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Run the full electron test suite**
+
+```bash
+cd dashboard
+npx vitest run electron/
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/electron/dockerManager.ts dashboard/electron/main.ts dashboard/electron/preload.ts
+git commit -m "feat(dashboard, electron): expose validateGpuPreflight over docker IPC
+
+* feat(dashboard, electron): dockerManager.ts now exports a runGpuPreflight() wrapper that fills the pure validateGpuPreflight() with real fs.existsSync/readdirSync/statSync and execSync('lsmod') — kept separate so unit tests can keep injecting mock dependencies
+
+* feat(dashboard, electron): main.ts adds the docker:validateGpuPreflight IPC handler; preload.ts exposes window.electronAPI.docker.validateGpuPreflight() with the matching type"
+```
+
+---
+
+# Phase 2 — Run Full Diagnostic IPC
+
+## Task 9: Bundle the diagnostic script with the packaged app
+
+**Files:**
+- Modify: `dashboard/package.json:89-130` — add `scripts/diagnose-gpu.sh` to `extraResources`.
+
+- [ ] **Step 1: Append the script to the existing extraResources array**
+
+Open `dashboard/package.json`. Locate the `extraResources` array (line ~89). Inside the array, **after the last existing object and before the closing `]`**, add:
+
+```json
+      ,
+      {
+        "from": "../scripts/diagnose-gpu.sh",
+        "to": "scripts/diagnose-gpu.sh"
+      },
+      {
+        "from": "../scripts/README-gpu-diagnostic.md",
+        "to": "scripts/README-gpu-diagnostic.md"
+      }
+```
+
+(If the existing last entry already has a trailing comma after it, do not add another one — adapt to whatever JSON style the file already uses.)
+
+- [ ] **Step 2: Verify package.json is still valid JSON**
+
+```bash
+cd dashboard
+node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('OK')"
+```
+
+Expected: `OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/package.json
+git commit -m "chore(dashboard, build): bundle scripts/diagnose-gpu.sh and README into packaged app
+
+* chore(dashboard, build): package.json extraResources now copies scripts/diagnose-gpu.sh and scripts/README-gpu-diagnostic.md into the packaged Electron app under resources/scripts/, so the GpuHealthCard 'Run Full Diagnostic' button can locate the script in both dev (../scripts/) and production (process.resourcesPath/scripts/) builds"
+```
+
+---
+
+## Task 10: Add `docker:runGpuDiagnostic` IPC handler
+
+**Files:**
+- Modify: `dashboard/electron/dockerManager.ts` — add `runGpuDiagnostic()` that spawns the script.
+- Modify: `dashboard/electron/main.ts` — add the IPC handler.
+- Modify: `dashboard/electron/preload.ts` — expose the renderer-side API.
+
+- [ ] **Step 1: Add `runGpuDiagnostic` to `dockerManager.ts`**
+
+Ensure these imports exist at the top of `dockerManager.ts` (extend the existing import lines for `child_process` and `electron`; add fresh imports for `path` and `os` if missing):
+
+```typescript
+import { execSync, spawn } from 'child_process';
+import { app as electronApp } from 'electron';
+import * as path from 'path';
+import * as os from 'os';
+```
+
+(Search the file: `grep -n "^import" dashboard/electron/dockerManager.ts | head -20`. Merge with existing imports — do not create duplicates.)
+
+Then add this after `runGpuPreflight` in `dockerManager.ts`:
+
+```typescript
+export interface RunGpuDiagnosticResult {
+  status: 'started' | 'unsupported' | 'script-missing';
+  /** Absolute path to the log file the script writes (when status=started). */
+  logPath?: string;
+  /** Resolved script path (always present for status=started or script-missing). */
+  scriptPath?: string;
+  /** The exact command string the user could run themselves. */
+  manualCommand?: string;
+}
+
+function resolveDiagnosticScriptPath(): string {
+  // Packaged: <app>/resources/scripts/diagnose-gpu.sh
+  // Dev: <repo>/scripts/diagnose-gpu.sh (relative to dist-electron/dockerManager.js)
+  if (electronApp.isPackaged) {
+    return path.join(process.resourcesPath, 'scripts', 'diagnose-gpu.sh');
+  }
+  // __dirname at runtime is dist-electron/; the repo's scripts/ is two levels up.
+  return path.resolve(__dirname, '..', '..', 'scripts', 'diagnose-gpu.sh');
+}
+
+export function runGpuDiagnostic(): RunGpuDiagnosticResult {
+  if (process.platform !== 'linux') {
+    return { status: 'unsupported' };
+  }
+  const scriptPath = resolveDiagnosticScriptPath();
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const fs = require('fs') as typeof import('fs');
+  if (!fs.existsSync(scriptPath)) {
+    return {
+      status: 'script-missing',
+      scriptPath,
+      manualCommand: `bash ${scriptPath}`,
+    };
+  }
+
+  const ts = new Date().toISOString().replace(/[-:.]/g, '').slice(0, 15);
+  const logPath = path.join(os.tmpdir(), `gpu-diagnostic-${ts}.log`);
+  const out = fs.openSync(logPath, 'w');
+
+  const child = spawn('bash', [scriptPath], {
+    stdio: ['ignore', out, out],
+    detached: true,
+    cwd: os.tmpdir(),
+  });
+  child.unref();
+
+  return {
+    status: 'started',
+    logPath,
+    scriptPath,
+    manualCommand: `bash ${scriptPath}`,
+  };
+}
+```
+
+- [ ] **Step 2: Add the IPC handler in `main.ts`**
+
+In `dashboard/electron/main.ts`, after the `docker:validateGpuPreflight` handler from Task 8, add:
+
+```typescript
+ipcMain.handle('docker:runGpuDiagnostic', async () => {
+  return dockerManager.runGpuDiagnostic();
+});
+```
+
+- [ ] **Step 3: Expose the API in `preload.ts`**
+
+In `dashboard/electron/preload.ts`, add the type after `validateGpuPreflight` in the `docker:` interface:
+
+```typescript
+    runGpuDiagnostic: () => Promise<{
+      status: 'started' | 'unsupported' | 'script-missing';
+      logPath?: string;
+      scriptPath?: string;
+      manualCommand?: string;
+    }>;
+```
+
+And in the implementation block:
+
+```typescript
+    runGpuDiagnostic: () => ipcRenderer.invoke('docker:runGpuDiagnostic'),
+```
+
+- [ ] **Step 4: Verify type-checks**
+
+```bash
+cd dashboard
+npx tsc --noEmit -p electron/tsconfig.json
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Smoke test from the dev build**
+
+```bash
+cd dashboard
+npm run dev:electron &
+DEV_PID=$!
+sleep 5
+# Inspect the rendered UI by hand once integration is done in Task 12, or
+# call the IPC handler from Electron devtools console:
+#   await window.electronAPI.docker.runGpuDiagnostic();
+# expected return: { status: 'started', logPath: '/tmp/gpu-diagnostic-…log', ... }
+kill $DEV_PID 2>/dev/null || true
+```
+
+Expected: the IPC call returns `status: 'started'` and the `logPath` file exists in `/tmp`. (You can defer this manual smoke until after Task 12 wires up the button.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/electron/dockerManager.ts dashboard/electron/main.ts dashboard/electron/preload.ts
+git commit -m "feat(dashboard, electron): add runGpuDiagnostic IPC handler that spawns scripts/diagnose-gpu.sh
+
+* feat(dashboard, electron): dockerManager.ts adds runGpuDiagnostic() that resolves the script path (packaged app: process.resourcesPath/scripts/; dev: ../../scripts/), spawns it detached with stdout/stderr redirected to /tmp/gpu-diagnostic-<ts>.log, and returns the log path so the UI can surface it
+
+* feat(dashboard, electron): docker:runGpuDiagnostic IPC handler + window.electronAPI.docker.runGpuDiagnostic() preload binding. Returns 'unsupported' on non-Linux and 'script-missing' when the bundled script cannot be located, both with the manual command string for copy-paste"
+```
+
+---
+
+# Phase 2 — `GpuHealthCard` component
+
+## Task 11: TDD — write failing tests for `GpuHealthCard`
+
+**Files:**
+- Create: `dashboard/components/views/__tests__/GpuHealthCard.test.tsx`
+
+- [ ] **Step 1: Create the test file**
+
+```typescript
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { GpuHealthCard } from '../GpuHealthCard';
+
+const healthyPreflight = {
+  status: 'healthy' as const,
+  checks: [
+    { name: 'CDI spec exists', pass: true },
+    { name: 'CDI spec newer than driver', pass: true },
+    { name: '/dev/char NVIDIA symlinks', pass: true },
+    { name: 'nvidia_uvm module loaded', pass: true },
+  ],
+};
+
+const warningPreflight = {
+  status: 'warning' as const,
+  checks: [
+    { name: 'CDI spec exists', pass: true },
+    { name: 'CDI spec newer than driver', pass: true },
+    {
+      name: '/dev/char NVIDIA symlinks',
+      pass: false,
+      fixCommand: 'sudo nvidia-ctk system create-dev-char-symlinks --create-all',
+      docsUrl: 'https://github.com/NVIDIA/nvidia-container-toolkit/issues/48',
+    },
+    { name: 'nvidia_uvm module loaded', pass: true },
+  ],
+};
+
+describe('GpuHealthCard', () => {
+  it('renders nothing when no NVIDIA GPU is detected', () => {
+    const { container } = render(
+      <GpuHealthCard
+        gpuDetected={false}
+        preflight={null}
+        backendError={null}
+        onRunDiagnostic={vi.fn()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the NVIDIA-only label so non-NVIDIA users are not confused', () => {
+    render(
+      <GpuHealthCard
+        gpuDetected={true}
+        preflight={healthyPreflight}
+        backendError={null}
+        onRunDiagnostic={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/GPU Health \(NVIDIA\)/i)).toBeInTheDocument();
+  });
+
+  it('green state: healthy preflight + no backend error', () => {
+    render(
+      <GpuHealthCard
+        gpuDetected={true}
+        preflight={healthyPreflight}
+        backendError={null}
+        onRunDiagnostic={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/CUDA operational/i)).toBeInTheDocument();
+  });
+
+  it('yellow state: preflight has a failed check, no backend error', () => {
+    render(
+      <GpuHealthCard
+        gpuDetected={true}
+        preflight={warningPreflight}
+        backendError={null}
+        onRunDiagnostic={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/may be misconfigured/i)).toBeInTheDocument();
+    expect(
+      screen.getByText('sudo nvidia-ctk system create-dev-char-symlinks --create-all'),
+    ).toBeInTheDocument();
+  });
+
+  it('red state: backend reported unrecoverable; recovery_hint shown verbatim', () => {
+    const backendError = {
+      status: 'unrecoverable' as const,
+      error: 'CUDA unknown error',
+      recovery_hint:
+        'GPU init failed with error 999 (CUDA unknown). Run scripts/diagnose-gpu.sh.',
+    };
+    render(
+      <GpuHealthCard
+        gpuDetected={true}
+        preflight={warningPreflight}
+        backendError={backendError}
+        onRunDiagnostic={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/GPU unavailable/i)).toBeInTheDocument();
+    expect(screen.getByText(/Run scripts\/diagnose-gpu\.sh/)).toBeInTheDocument();
+  });
+
+  it('clicking Run Full Diagnostic invokes the prop', async () => {
+    const onRun = vi.fn();
+    render(
+      <GpuHealthCard
+        gpuDetected={true}
+        preflight={healthyPreflight}
+        backendError={null}
+        onRunDiagnostic={onRun}
+      />,
+    );
+    const button = screen.getByRole('button', { name: /Run Full Diagnostic/i });
+    button.click();
+    expect(onRun).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test file — it should fail with import error**
+
+```bash
+cd dashboard
+npx vitest run components/views/__tests__/GpuHealthCard.test.tsx
+```
+
+Expected: FAIL with `Cannot find module '../GpuHealthCard'`.
+
+---
+
+## Task 12: Implement `GpuHealthCard.tsx`
+
+**Files:**
+- Create: `dashboard/components/views/GpuHealthCard.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `dashboard/components/views/GpuHealthCard.tsx`:
+
+```tsx
+import React, { useState } from 'react';
+
+export interface GpuPreflightCheckProp {
+  name: string;
+  pass: boolean;
+  fixCommand?: string;
+  docsUrl?: string;
+}
+
+export interface GpuPreflightProp {
+  status: 'healthy' | 'warning' | 'unknown';
+  checks: GpuPreflightCheckProp[];
+}
+
+export interface GpuBackendErrorProp {
+  status: 'unrecoverable';
+  error: string;
+  recovery_hint?: string;
+}
+
+export interface GpuHealthCardProps {
+  gpuDetected: boolean;
+  preflight: GpuPreflightProp | null;
+  backendError: GpuBackendErrorProp | null;
+  onRunDiagnostic: () => void;
+}
+
+type CardState = 'green' | 'yellow' | 'red';
+
+function deriveState(
+  preflight: GpuPreflightProp | null,
+  backendError: GpuBackendErrorProp | null,
+): CardState {
+  if (backendError && backendError.status === 'unrecoverable') return 'red';
+  if (preflight && preflight.status === 'warning') return 'yellow';
+  return 'green';
+}
+
+const STATE_LABEL: Record<CardState, string> = {
+  green: 'GPU healthy — CUDA operational',
+  yellow: 'GPU may be misconfigured — server will fall back to CPU',
+  red: 'GPU unavailable — fell back to CPU',
+};
+
+const STATE_COLOR: Record<CardState, string> = {
+  green: '#1f8a3a',
+  yellow: '#b88a00',
+  red: '#b53030',
+};
+
+function CopyableCommand({ cmd }: { cmd: string }): React.ReactElement {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = (): void => {
+    void navigator.clipboard.writeText(cmd).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    });
+  };
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 4 }}>
+      <code
+        style={{
+          padding: '4px 8px',
+          background: '#222',
+          color: '#eee',
+          borderRadius: 4,
+          fontSize: 12,
+          flex: 1,
+          overflowX: 'auto',
+        }}
+      >
+        {cmd}
+      </code>
+      <button type="button" onClick={handleCopy} style={{ fontSize: 12 }}>
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+    </div>
+  );
+}
+
+export function GpuHealthCard({
+  gpuDetected,
+  preflight,
+  backendError,
+  onRunDiagnostic,
+}: GpuHealthCardProps): React.ReactElement | null {
+  if (!gpuDetected) return null;
+
+  const state = deriveState(preflight, backendError);
+  const failedChecks = preflight ? preflight.checks.filter((c) => !c.pass) : [];
+
+  return (
+    <section
+      aria-labelledby="gpu-health-title"
+      style={{
+        border: `1px solid ${STATE_COLOR[state]}`,
+        borderRadius: 6,
+        padding: 12,
+        marginTop: 12,
+      }}
+    >
+      <h3 id="gpu-health-title" style={{ marginTop: 0, color: STATE_COLOR[state] }}>
+        GPU Health (NVIDIA)
+      </h3>
+      <p style={{ fontSize: 12, marginTop: 0, color: '#888' }}>
+        This card appears only on systems with an NVIDIA GPU. AMD / Intel /
+        Apple Silicon setups do not need it.
+      </p>
+
+      <p style={{ fontWeight: 600 }}>{STATE_LABEL[state]}</p>
+
+      {state === 'red' && backendError?.recovery_hint ? (
+        <p
+          style={{
+            background: '#3a1313',
+            padding: 8,
+            borderRadius: 4,
+            color: '#fbb',
+            fontSize: 13,
+          }}
+        >
+          {backendError.recovery_hint}
+        </p>
+      ) : null}
+
+      {failedChecks.length > 0 ? (
+        <div style={{ marginTop: 12 }}>
+          <p style={{ marginBottom: 4, fontWeight: 500 }}>Failing checks:</p>
+          {failedChecks.map((check) => (
+            <div key={check.name} style={{ marginBottom: 10 }}>
+              <div style={{ fontSize: 13 }}>
+                ✗ {check.name}
+                {check.docsUrl ? (
+                  <>
+                    {' — '}
+                    <a href={check.docsUrl} target="_blank" rel="noopener noreferrer">
+                      docs
+                    </a>
+                  </>
+                ) : null}
+              </div>
+              {check.fixCommand ? <CopyableCommand cmd={check.fixCommand} /> : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      <div style={{ marginTop: 12 }}>
+        <button type="button" onClick={onRunDiagnostic}>
+          Run Full Diagnostic
+        </button>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Run the test file — it should now pass**
+
+```bash
+cd dashboard
+npx vitest run components/views/__tests__/GpuHealthCard.test.tsx
+```
+
+Expected: all 6 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/components/views/GpuHealthCard.tsx dashboard/components/views/__tests__/GpuHealthCard.test.tsx
+git commit -m "feat(dashboard, ui): add GpuHealthCard component (NVIDIA-only, 3 states)
+
+* feat(dashboard, ui): GpuHealthCard.tsx renders only when gpuDetected=true; three states (green/yellow/red) derived from preflight + backend error; failing checks render with copyable fix commands and docs links; recovery_hint from the backend rendered verbatim in the red state; 'Run Full Diagnostic' button wired to a prop callback
+
+* test(dashboard, ui): GpuHealthCard.test.tsx — null render when no GPU, NVIDIA-only label, all three states, copyable command rendering, button click invokes the callback"
+```
+
+---
+
+## Task 13: Integrate `GpuHealthCard` into `ServerView.tsx`
+
+**Files:**
+- Modify: `dashboard/components/views/ServerView.tsx` — add state for preflight + backend error, render the card.
+
+- [ ] **Step 1: Import the component and add state**
+
+Open `dashboard/components/views/ServerView.tsx`. Near the existing imports (top of file), add:
+
+```typescript
+import { GpuHealthCard } from './GpuHealthCard';
+```
+
+In the same component-state block where `gpuInfo` is declared (around line 1151), add two new state hooks:
+
+```typescript
+  const [gpuPreflight, setGpuPreflight] = useState<{
+    status: 'healthy' | 'warning' | 'unknown';
+    checks: Array<{
+      name: string;
+      pass: boolean;
+      fixCommand?: string;
+      docsUrl?: string;
+    }>;
+  } | null>(null);
+  const [gpuBackendError, setGpuBackendError] = useState<{
+    status: 'unrecoverable';
+    error: string;
+    recovery_hint?: string;
+  } | null>(null);
+```
+
+- [ ] **Step 2: Fetch the preflight on mount, after `checkGpu` resolves**
+
+Find the `useEffect` block where `api.docker.checkGpu()` is called (around line 1171). At the very end of the `.then((info) => { ... })` callback (just before `.catch`), add:
+
+```typescript
+          // Phase 2: run the cheap NVIDIA host preflight whenever an NVIDIA GPU was detected.
+          if (info.gpu && api?.docker?.validateGpuPreflight) {
+            api.docker
+              .validateGpuPreflight()
+              .then((p: typeof gpuPreflight) => setGpuPreflight(p))
+              .catch(() => setGpuPreflight(null));
+          }
+```
+
+- [ ] **Step 3: Subscribe to backend GPU error from the existing admin status poll**
+
+Find where the component already polls `/api/admin/status` or reads `app.state.gpu_error` (search for `gpu_error` or `containerStatus`). Wherever the parsed status comes back, branch:
+
+```typescript
+  // Pseudo-location: in whatever effect already consumes admin status JSON
+  useEffect(() => {
+    const api = (window as any).electronAPI;
+    if (!api?.server?.getAdminStatus) return;
+    let cancelled = false;
+    const tick = (): void => {
+      api.server
+        .getAdminStatus()
+        .then((s: { gpu_error?: { status: string; error: string; recovery_hint?: string } }) => {
+          if (cancelled) return;
+          if (s.gpu_error && s.gpu_error.status === 'unrecoverable') {
+            setGpuBackendError({
+              status: 'unrecoverable',
+              error: s.gpu_error.error,
+              recovery_hint: s.gpu_error.recovery_hint,
+            });
+          } else {
+            setGpuBackendError(null);
+          }
+        })
+        .catch(() => {});
+    };
+    tick();
+    const id = window.setInterval(tick, 10000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, []);
+```
+
+If the project already has an existing admin-status hook/store, prefer reusing it. Search for the canonical source with: `grep -rn "gpu_error\|admin.*status" dashboard/src/ dashboard/components/ | head`. The exact wiring may differ — the rule is: when the unrecoverable backend status arrives, set `gpuBackendError`; when it does not, set `null`.
+
+- [ ] **Step 4: Define the run-diagnostic handler**
+
+Inside the `ServerView` component body, add:
+
+```typescript
+  const handleRunGpuDiagnostic = (): void => {
+    const api = (window as any).electronAPI;
+    if (!api?.docker?.runGpuDiagnostic) return;
+    api.docker
+      .runGpuDiagnostic()
+      .then((res: { status: string; logPath?: string; manualCommand?: string }) => {
+        if (res.status === 'started' && res.logPath) {
+          // Show the log path so the user can tail/inspect it.
+          window.alert(
+            `GPU diagnostic started.\n\nLog file: ${res.logPath}\n\nTail it with:\n  tail -f "${res.logPath}"`,
+          );
+        } else if (res.status === 'script-missing' && res.manualCommand) {
+          window.alert(
+            `Diagnostic script not bundled. Run it manually:\n\n  ${res.manualCommand}`,
+          );
+        } else if (res.status === 'unsupported') {
+          window.alert('GPU diagnostic is for Linux NVIDIA hosts only.');
+        }
+      })
+      .catch(() => {
+        window.alert('Failed to start GPU diagnostic — see console.');
+      });
+  };
+```
+
+(`window.alert` is the simplest first cut. A later iteration can replace it with a proper modal if the UX needs it — but it satisfies the spec's "surface the log path" requirement.)
+
+- [ ] **Step 5: Render the card**
+
+Find the JSX section where the existing setup checklist or system-status area lives (around the same area where `setupChecks` is rendered). Add the card adjacent to it, gated on Linux + NVIDIA:
+
+```tsx
+        {process.platform === 'linux' && (gpuInfo?.gpu ?? false) && (
+          <GpuHealthCard
+            gpuDetected={true}
+            preflight={gpuPreflight}
+            backendError={gpuBackendError}
+            onRunDiagnostic={handleRunGpuDiagnostic}
+          />
+        )}
+```
+
+- [ ] **Step 6: Type-check the dashboard**
+
+```bash
+cd dashboard
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Run the full dashboard test suite**
+
+```bash
+cd dashboard
+npx vitest run
+```
+
+Expected: all tests pass (the new `GpuHealthCard.test.tsx` already covered the component; the integration into `ServerView.tsx` doesn't add new tests since the card is gated on a runtime condition).
+
+- [ ] **Step 8: UI contract check (per project CLAUDE.md)**
+
+```bash
+cd dashboard
+npm run ui:contract:extract && npm run ui:contract:build && \
+  node scripts/ui-contract/validate-contract.mjs --update-baseline && \
+  npm run ui:contract:check
+```
+
+Expected: passes; baseline updated to reflect the new card classes.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add dashboard/components/views/ServerView.tsx dashboard/ui-contract/
+git commit -m "feat(dashboard, server-view): mount GpuHealthCard with backend recovery_hint and full-diagnostic action
+
+* feat(dashboard, server-view): ServerView.tsx now fetches docker.validateGpuPreflight() after checkGpu resolves and polls /api/admin/status for app.state.gpu_error; the result drives the new GpuHealthCard in three states. Card is gated on process.platform === 'linux' && gpuInfo.gpu so AMD/Intel/Apple Silicon installs never see it.
+
+* feat(dashboard, server-view): 'Run Full Diagnostic' button calls docker.runGpuDiagnostic() and surfaces the log path / manual command via a window.alert (placeholder UI; can be promoted to a modal later)
+
+* chore(ui-contract): refresh contract baseline for the new GpuHealthCard classes"
+```
+
+---
+
+# Phase 2 — Verification
+
+## Task 14: End-to-end verification
+
+- [ ] **Step 1: Run the full backend test suite**
+
+```bash
+cd server/backend
+../../build/.venv/bin/pytest tests/ -v --tb=short
+```
+
+Expected: all tests pass; no regressions in `test_audio_utils.py` or elsewhere.
+
+- [ ] **Step 2: Run the full dashboard test suite**
+
+```bash
+cd dashboard
+npx vitest run
+```
+
+Expected: all tests pass — including the new `dockerManagerGpuPreflight.test.ts` and `GpuHealthCard.test.tsx`.
+
+- [ ] **Step 3: Run the diagnostic script on the developer's own machine**
+
+```bash
+bash scripts/diagnose-gpu.sh
+```
+
+Expected: 11 checks complete; the user inspects the `gpu-diagnostic-<timestamp>.log` file and applies any indicated host fix.
+
+- [ ] **Step 4: Manual UI smoke test (Linux + NVIDIA only)**
+
+```bash
+cd dashboard
+npm run dev:electron
+```
+
+Expected:
+- The Server tab shows the **GPU Health (NVIDIA)** card.
+- On a healthy host: card is green.
+- After artificially deleting `/dev/char` symlinks (e.g., `sudo rm /dev/char/195:*` — only do this in a disposable VM), restart the dashboard: card turns yellow with the `nvidia-ctk system create-dev-char-symlinks` command shown in a copyable code block.
+- Clicking **Run Full Diagnostic**: an alert appears with the log path; the file `/tmp/gpu-diagnostic-<ts>.log` exists and contains the script's output.
+
+- [ ] **Step 5: Verify the card does NOT appear on non-NVIDIA setups**
+
+Boot the dashboard on macOS or a Linux machine without an NVIDIA GPU. Confirm: the GpuHealthCard is not rendered at all (no element with title "GPU Health (NVIDIA)" exists).
+
+- [ ] **Step 6: Verify the unrecoverable error log now includes `recovery_hint`**
+
+Trigger an artificial unrecoverable state (mock `torch.cuda.init` to raise `"CUDA unknown error"` repeatedly, or simulate by running on a host where the container cannot see the GPU) and grep the server log:
+
+```bash
+docker logs transcriptionsuite-container 2>&1 | grep -A 2 'recovery_hint'
+```
+
+Expected: the line `recovery_hint=GPU init failed with error 999 (CUDA unknown). … Run scripts/diagnose-gpu.sh on the host …` appears in the structured log output.
+
+---
+
+## Self-review checklist
+
+(Worker should run this checklist after completing all tasks.)
+
+- [ ] **Spec coverage** — every section of the design doc maps to a task:
+  - Spec §3 (Phase 1 script + README) → Tasks 1–2.
+  - Spec §4.1 (backend `recovery_hint`) → Tasks 3–5.
+  - Spec §4.2 (`validateGpuPreflight` preflight) → Tasks 6–8.
+  - Spec §4.3 (`GpuHealthCard` on Server tab + Run Full Diagnostic) → Tasks 9–13.
+  - Spec §4.4 (cross-platform: card hidden on macOS/Windows) → covered by gating in Task 13 step 5 + tests in Task 11.
+  - Spec §4.5 (acceptance criteria) → Task 14 covers each.
+- [ ] **No placeholders** — every task contains the actual code; no "TBD" / "see other task" / "implement appropriate" phrasing.
+- [ ] **Type consistency** — `GpuPreflightResult` shape is identical in `dockerManager.ts` (Task 7), `preload.ts` (Task 8 step 3), and `GpuHealthCard.tsx` (Tasks 11–12). `RunGpuDiagnosticResult` shape is identical between `dockerManager.ts` (Task 10 step 1) and `preload.ts` (Task 10 step 3).
+- [ ] **Commit cadence** — every task ends with a commit; commit messages follow the project style in `CLAUDE.md` (lowercase scope, `feat/fix/chore/etc(area)` prefix).

--- a/docs/superpowers/specs/2026-04-29-cuda-error-999-recovery-design.md
+++ b/docs/superpowers/specs/2026-04-29-cuda-error-999-recovery-design.md
@@ -1,0 +1,261 @@
+# Design — CUDA Error 999 Diagnosis & In-App GPU Health
+
+**Date:** 2026-04-29
+**Status:** Draft (pending implementation plan)
+**Topic:** Diagnose and harden the project against the recurring "CUDA unknown error / error 999" Docker GPU initialization failure that surfaces in the dashboard as *"Please restart your computer to reset the GPU."*
+
+---
+
+## 1. Problem statement
+
+When the unified server container starts, `torch.cuda.init()` in `server/backend/core/audio_utils.py:cuda_health_check()` intermittently raises:
+
+```
+RuntimeError: CUDA unknown error - this may be due to an incorrectly set up environment,
+e.g. changing env variable CUDA_VISIBLE_DEVICES after program start.
+Setting the available devices to be zero.
+```
+
+This is CUDA error code 999 (`cudaErrorUnknown`). Existing retry logic (1s/2s/4s exponential backoff, three attempts) catches transient cases. When all three retries fail, the server marks the GPU `_cuda_probe_failed = True` and falls back to CPU transcription.
+
+In one observed failure case (host: Arch Linux, Zen kernel 6.19.14, NVIDIA driver 595.58.03, RTX 3060, PyTorch cu129), the standard remediations all failed:
+
+- Host reboot
+- Fresh Docker image rebuild
+- Deletion of the `transcriptionsuite-runtime` volume
+
+`nvidia-smi` continued to succeed on the host throughout. The container could not initialize CUDA. CPU fallback works but is too slow to be useful for non-trivial transcription on a 12 GB-class GPU.
+
+This design covers two phases:
+
+- **Phase 1** — A reusable host-side diagnostic that captures the structural signals needed to identify the actual root cause from a small set of well-documented candidates, plus the host fix to apply once identified.
+- **Phase 2** — Modest in-app changes (backend hint message + dashboard preflight + Server-tab GPU Health card) so future occurrences self-diagnose at startup and the user never sees the misleading "restart your computer" instruction without an explanation.
+
+Out-of-scope intentionally: any path that runs `sudo`/`pkexec` from the dashboard, automatic retry-after-N-seconds, per-distro fix recipes beyond generic NVIDIA-doc commands.
+
+---
+
+## 2. Background — why error 999 happens (research summary)
+
+The PyTorch warning text always blames `CUDA_VISIBLE_DEVICES`, but error 999 is the driver's generic "I cannot enumerate any GPU." Documented candidate root causes for this failure mode in containerized PyTorch on Linux, in order of likelihood for a system that previously worked and where `nvidia-smi` succeeds on the host:
+
+1. **Missing `/dev/char` symlinks for NVIDIA devices** — recent `runc` requires `/dev/char/<major>:<minor>` symlinks for every device node injected into a container; the NVIDIA driver does not create them. On systems with the systemd cgroup driver (Arch default), any `systemctl daemon-reload` (which `pacman` invokes after most package updates) revokes GPU access from running containers and breaks new-container startup.
+   - Fix: `sudo nvidia-ctk system create-dev-char-symlinks --create-all` plus persistent udev rule at `/lib/udev/rules.d/71-nvidia-dev-char.rules`.
+   - References: [NVIDIA Container Toolkit Troubleshooting](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/troubleshooting.html), [NVIDIA/nvidia-container-toolkit#48](https://github.com/NVIDIA/nvidia-container-toolkit/issues/48).
+
+2. **Stale CDI spec at `/etc/cdi/nvidia.yaml`** — the spec is a static snapshot of driver state; after a driver update it advertises stale library paths and an outdated NVRM version, causing CDI injection to silently produce a broken container.
+   - Fix: `sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml`.
+
+3. **`nvidia_uvm` kernel module not loaded** — classic suspend-resume bug; also occurs after `nvidia-utils` package updates without module reload. `nvidia-smi` does not load `nvidia_uvm` (only CUDA does), so it can succeed while CUDA fails.
+   - Fix: `sudo rmmod nvidia_uvm && sudo modprobe nvidia_uvm`. Sometimes flaky, in which case driver reinstall is needed.
+   - Reference: [PyTorch issue #115340](https://github.com/pytorch/pytorch/issues/115340), [PyTorch forums thread](https://discuss.pytorch.org/t/cuda-runtime-error-999/69658/12).
+
+4. **Docker `cgroupdriver` mismatch** — `native.cgroupdriver=systemd` (Arch default for newer Docker) makes GPU access fragile. NVIDIA documents `cgroupfs` as the safer choice for GPU workloads.
+   - Fix: set `"exec-opts": ["native.cgroupdriver=cgroupfs"]` in `/etc/docker/daemon.json`, then `systemctl restart docker`.
+
+5. **PyTorch wheel / driver mismatch** — lowest priority; CUDA 12.9 wheels with a 13.x-capable driver are forward-compatible in practice.
+
+The dashboard already auto-detects CDI vs legacy nvidia-runtime mode in `dashboard/electron/dockerManager.ts:detectGpuMode()` (line ~2508) and selects `docker-compose.gpu-cdi.yml` or `docker-compose.gpu.yml` accordingly. Both paths are vulnerable to candidates 1, 3, and 4; only the CDI path is vulnerable to candidate 2.
+
+---
+
+## 3. Phase 1 — Host diagnostic + host fix
+
+### 3.1 Deliverable
+
+A self-contained shell script `scripts/diagnose-gpu.sh` (committed to the repository), plus a companion `scripts/README-gpu-diagnostic.md` documenting what each check measures and the recommended remediation for each failure mode.
+
+The script is **observation-only** — no `sudo`, no mutations, no package operations. Output is written to both stdout and a timestamped log file (`gpu-diagnostic-<UTC-timestamp>.log` in the current directory) so it can be pasted back without loss.
+
+### 3.2 Checks (in order)
+
+| # | Check | Purpose |
+|---|---|---|
+| 1 | `uname -r`, `cat /etc/os-release`, NVIDIA driver version from `nvidia-smi` | Baseline host identification. |
+| 2 | `nvidia-ctk --version`, `nvidia-container-cli --version` | Container-toolkit installed and ≥ 1.14 (CDI required). |
+| 3 | `ls -la /etc/cdi/nvidia.yaml`, `nvidia-ctk cdi list` | CDI spec exists; what devices it advertises. |
+| 4 | mtime of `/etc/cdi/nvidia.yaml` vs mtime of `/usr/lib/modules/$(uname -r)/extramodules/nvidia.ko.zst` (or distro equivalent) | CDI spec drift after driver update — root cause #2. |
+| 5 | `ls -la /dev/char \| grep -E 'nvidia\|195:'` | `/dev/char` symlinks present — root cause #1. |
+| 6 | `lsmod \| grep -E '^nvidia'` | `nvidia`, `nvidia_modeset`, `nvidia_uvm`, `nvidia_drm` all loaded — root cause #3. |
+| 7 | `cat /etc/docker/daemon.json` (if present); `cat /etc/nvidia-container-runtime/config.toml` (if present) | Cgroup driver, `no-cgroups`, registered runtimes — root cause #4. |
+| 8 | `docker info --format '{{json .}}'`, filtered to `Runtimes`, `CgroupDriver`, `DefaultRuntime` | What Docker uses at runtime. |
+| 9 | Smoke test: `docker run --rm --gpus all <small NVIDIA base image> nvidia-smi` (illustrative tag: `nvidia/cuda:12.6.0-base-ubuntu24.04`; implementation picks a stable, small, currently-published tag) | Isolates host-side breakage (test fails) from project-specific issues (test passes). |
+| 10 | If smoke passes: same image, `bash -c "ls /dev/nvidia* && cat /proc/driver/nvidia/version"` | Container actually sees NVIDIA proc files. |
+| 11 | PASS / WARN / FAIL summary block | Quick-read at the end. |
+
+### 3.3 Decision tree (output → fix)
+
+```
+Smoke test (#9) FAIL
+├── /dev/char NVIDIA symlinks missing (#5)        → sudo nvidia-ctk system create-dev-char-symlinks --create-all
+│                                                    plus udev rule for persistence
+├── CDI spec stale (#4) or missing (#3)           → sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+├── nvidia_uvm not in lsmod (#6)                  → sudo rmmod nvidia_uvm && sudo modprobe nvidia_uvm
+│                                                    if fails: driver reinstall
+├── Docker cgroup driver = systemd (#7, #8)       → /etc/docker/daemon.json native.cgroupdriver=cgroupfs
+└── (none of above match)                         → escalate; capture full container logs
+
+Smoke test (#9) PASS
+└── Issue is project-internal                     → inspect /runtime/.venv, PyTorch wheels, LD_LIBRARY_PATH
+                                                    inside the actual container
+```
+
+### 3.4 Companion README content
+
+The companion `scripts/README-gpu-diagnostic.md` covers:
+
+- What the script does and what it does *not* do (no mutations, no sudo).
+- How to run it: `bash scripts/diagnose-gpu.sh > gpu-diagnostic.log 2>&1`.
+- A table mapping each check number to (a) what failure looks like in the log and (b) the canonical fix command from NVIDIA documentation.
+- Links to the NVIDIA Container Toolkit troubleshooting page and the GitHub issues referenced in §2.
+- Platform note: script is Linux-only; on macOS/Windows it should print a friendly "this diagnostic is for Linux NVIDIA installs only" message and exit 0.
+
+### 3.5 Acceptance criteria for Phase 1
+
+- Script runs end-to-end on Arch with no errors when all checks pass (healthy GPU host).
+- Script produces clear `FAIL: <check>` lines when each individual check is artificially broken.
+- Smoke test (#9) tolerates a missing/unpullable image: prints WARN with the pull command, does not crash.
+- README enables a new user to read the log and find the fix without external help in the four documented failure modes.
+
+---
+
+## 4. Phase 2 — App-side hardening
+
+### 4.1 Backend — `recovery_hint` in CUDA health result
+
+**File:** `server/backend/core/audio_utils.py`
+
+`cuda_health_check()` already returns a dict with `status`, `error`, `nvidia_smi`. Add an optional `recovery_hint: str | None` field, populated only when `status == "unrecoverable"` and the error string matches the error-999 fingerprint (`"unknown error" in err_lower or "error 999" in err_lower`).
+
+The hint is one short line, host-platform-aware where the platform is detectable inside the container (Linux always; we can read `/etc/os-release` from the container's view of the host root, but in practice the container *is* on Linux when this code runs):
+
+```python
+recovery_hint = (
+    "GPU init failed with error 999 (CUDA unknown). This is almost always "
+    "host-side: missing /dev/char symlinks, stale CDI spec, or nvidia_uvm "
+    "not loaded. Run scripts/diagnose-gpu.sh on the host for details."
+)
+```
+
+The hint surfaces through whatever endpoint already exposes `cuda_health_check` results to the dashboard (the existing `/health` or admin status routes already include CUDA status).
+
+**Change scope:** ~10 lines + 1 unit test for the heuristic.
+
+### 4.2 Dashboard preflight — `validateGpuPreflight()`
+
+**File:** `dashboard/electron/dockerManager.ts`
+
+Add `validateGpuPreflight()` that runs after `detectGpuMode()` (~line 2510) and returns a structured result. Only the *cheap* subset of the script's checks runs at preflight (no `docker pull`, no container run):
+
+| Check | Implementation | Failure surface |
+|---|---|---|
+| CDI spec exists | `fs.existsSync('/etc/cdi/nvidia.yaml')` | Yellow |
+| CDI spec mtime newer than driver install | compare to `/usr/lib/modules/$(uname -r)/...` mtime via `stat` | Yellow |
+| `/dev/char` NVIDIA symlinks | `fs.readdirSync('/dev/char')` filtered for `195:*` | Yellow |
+| `nvidia_uvm` loaded | shell out to `lsmod \| grep -q nvidia_uvm` | Yellow |
+
+Result shape (typed):
+
+```typescript
+interface GpuPreflightResult {
+  status: 'healthy' | 'warning' | 'unknown';
+  checks: Array<{
+    name: string;
+    pass: boolean;
+    fixCommand?: string;
+    docsUrl?: string;
+  }>;
+}
+```
+
+**Platform gating:** `validateGpuPreflight()` returns `{ status: 'unknown', checks: [] }` immediately when `process.platform !== 'linux'` or when `detectGpuMode()` returned `null` (no NVIDIA GPU detected). All checks are no-ops outside the Linux + NVIDIA happy path.
+
+**Change scope:** ~80 lines + a unit test mirroring the existing `dockerManager` test layout (`dashboard/electron/__tests__/`).
+
+### 4.3 Dashboard UI — GPU Health card on the Server tab
+
+**File:** `dashboard/components/views/ServerView.tsx`
+
+A new card, placed in the existing system-status area of `ServerView.tsx`. The card is **rendered only when an NVIDIA GPU is detected** (`cachedGpuInfo.gpu === true`). On Apple Silicon / AMD / Intel-only systems the card does not appear at all, removing any chance of confusing a non-NVIDIA user.
+
+When rendered, the card displays a top-line label that explicitly scopes it: **"GPU Health (NVIDIA)"**.
+
+Three states:
+
+- **Green — "GPU healthy — CUDA operational"** when all preflight checks pass *and* the most recent backend health probe reported `status: healthy`.
+- **Yellow — "GPU may be misconfigured"** when one or more preflight checks fail but the backend has not yet reported an error. Each failed check renders a row with: short description, the documented fix command in a copyable `<code>` block, and a "More info" link to NVIDIA docs.
+- **Red — "GPU unavailable — fell back to CPU"** when the backend reported `status: unrecoverable`. The `recovery_hint` from §4.1 is shown verbatim. Below it: the same fix-command rows from the yellow state for any check that is currently failing.
+
+Below the state block: a **"Run Full Diagnostic"** button. Clicking it:
+- On Linux: invokes the diagnostic script and surfaces the log path. The script must be reachable from both a source checkout (`<repo>/scripts/diagnose-gpu.sh`) *and* a packaged Electron app — the implementation plan will decide whether to bundle it as an `extraResource` at build time or fall back to printing the path/command to a copy-paste modal when the script is not bundled (e.g. dev builds without the bundling step).
+- On non-Linux NVIDIA setups (theoretically WSL2): shows the literal command to run in a copy-paste modal, no auto-execute.
+
+The card includes a single explanatory line near the title:
+
+> *"This card appears only on systems with an NVIDIA GPU. AMD / Intel / Apple Silicon setups do not need it."*
+
+**Change scope:** ~150 lines for the card component + integration in `ServerView.tsx`. A snapshot test or render test covering green/yellow/red states.
+
+### 4.4 Cross-platform handling
+
+| Platform | Card shown? | Behaviour |
+|---|---|---|
+| Linux + NVIDIA | Yes | Full preflight + Run Diagnostic button. |
+| Linux + AMD/Intel (Vulkan path) | No | Card hidden. Vulkan health surfaced through existing Vulkan profile UI. |
+| Linux + no GPU | No | Card hidden. |
+| Windows | Stub card | "GPU preflight is Linux-only; ensure WSL2 NVIDIA support is configured." Plus docs link. No checks run. |
+| macOS | No | Card hidden entirely. The macOS path uses MLX bare-metal, not Docker CUDA. |
+
+### 4.5 Acceptance criteria for Phase 2
+
+- Backend: when `cuda_health_check` returns `unrecoverable` with an error-999 string, the result dict includes a non-empty `recovery_hint`.
+- Backend: unit test asserts the heuristic does not produce a hint for non-error-999 failures.
+- Dashboard: `validateGpuPreflight()` returns `status: 'unknown'` on macOS and Windows without invoking any host commands.
+- Dashboard: on a healthy Linux+NVIDIA host, the card renders green with all checks passing.
+- Dashboard: when `/dev/char` NVIDIA symlinks are deleted (simulated), the card renders yellow with the correct fix command shown.
+- Dashboard: when the backend reports `unrecoverable`, the card renders red with the `recovery_hint` text visible.
+- Dashboard: card is not rendered on a system reporting no NVIDIA GPU.
+- "Run Full Diagnostic" button executes the script and surfaces the log path.
+
+---
+
+## 5. Explicitly out of scope
+
+| Idea | Why not |
+|---|---|
+| One-click `pkexec nvidia-ctk cdi generate` button in the dashboard | Touches host root from a GUI app; one wrong call rewrites system config. The dashboard remains an *advisor* about the host, not an *agent* that mutates it. |
+| Automatic retry-after-N-seconds with optimistic restart of the container | The existing 3-attempt 1s/2s/4s retry already covers transient cases. Adding more retries papers over structural bugs. |
+| Per-distro fix recipes (Arch / Ubuntu / Fedora / NixOS-specific commands in the UI) | Generic NVIDIA-doc commands cover all distros for the four documented root causes. Per-distro hints can be added later if a real user asks. |
+| Backend auto-recovery (e.g. exec into host to reload nvidia_uvm) | Container has no host root. Even with privileged mode this would be a security regression. |
+| Replacing the existing `_cuda_probe_failed` flag mechanism | Out of scope; the existing CPU fallback works correctly and is not the subject of this design. |
+
+---
+
+## 6. Risks & open questions
+
+- **Smoke-test image pull cost.** The diagnostic script's step #9 pulls `nvidia/cuda:12.6.0-base-ubuntu24.04` (~150 MB) the first time. Mitigation: print a one-line warning before attempting the pull, and skip with a WARN if the user has no internet. Acceptable for a one-shot diagnostic.
+- **CDI spec mtime comparison heuristic.** Comparing `/etc/cdi/nvidia.yaml` mtime to driver-install mtime requires guessing the right driver path (`/usr/lib/modules/$(uname -r)/...`, or `/lib/modules/...`, or distro-specific). The check should be conservative: if the driver path cannot be located, skip the check rather than warn falsely.
+- **Card placement on the Server tab.** `ServerView.tsx` is large; we should pick a location that does not push existing controls below the fold. Final placement to be confirmed during implementation.
+- **`Run Full Diagnostic` UX on Linux without a default terminal app.** Some headless or minimal Linux setups have no `x-terminal-emulator`. The fallback should be: write the log path and command to a modal that the user can copy-paste into their own terminal.
+
+---
+
+## 7. Sequencing
+
+Phase 1 ships first and is self-contained — script + README, no app changes, no test infrastructure changes. The user runs it once, fixes the host, and the immediate problem is resolved.
+
+Phase 2 ships as a follow-up. The preflight checks in §4.2 are derived directly from the script's checks in §3.2 — Phase 1 is the *spec* for Phase 2's preflight. This means Phase 1 work is not throwaway: it both unblocks the user *and* validates which checks are worth promoting into the dashboard.
+
+---
+
+## 8. References
+
+- [NVIDIA Container Toolkit Troubleshooting](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/troubleshooting.html)
+- [NVIDIA/nvidia-container-toolkit Issue #48 — Containers losing access to GPUs](https://github.com/NVIDIA/nvidia-container-toolkit/issues/48)
+- [Arch Linux forum — Docker with GPU NVML Unknown Error](https://bbs.archlinux.org/viewtopic.php?id=266915)
+- [PyTorch issue #115340 — modprobe reload isn't always enough](https://github.com/pytorch/pytorch/issues/115340)
+- [PyTorch forums — CUDA initialization unknown error](https://discuss.pytorch.org/t/userwarning-cuda-initialization-cuda-unknown-error-this-may-be-due-to-an-incorrectly-set-up-environment-e-g-changing-env-variable-cuda-visible-devices-after-program-start-setting-the-available-devices-to-be-zero/129335)
+- [PyTorch forums — `rmmod nvidia_uvm` workaround](https://discuss.pytorch.org/t/cuda-runtime-error-999/69658/12)
+- Internal: `server/backend/core/audio_utils.py:cuda_health_check()` (existing retry logic)
+- Internal: `dashboard/electron/dockerManager.ts:detectGpuMode()` (existing CDI/legacy detection)
+- Internal: `server/docker/docker-compose.gpu.yml` and `server/docker/docker-compose.gpu-cdi.yml` (the two GPU runtime overlays)

--- a/scripts/README-gpu-diagnostic.md
+++ b/scripts/README-gpu-diagnostic.md
@@ -1,0 +1,54 @@
+# `diagnose-gpu.sh` — GPU host diagnostic
+
+Runs 11 read-only checks against a Linux NVIDIA host to identify why a Docker
+container can fail to initialise CUDA (PyTorch error 999, "CUDA unknown error")
+even when `nvidia-smi` succeeds on the host.
+
+The script is **observation-only**: no `sudo`, no package operations, no
+mutations to your system. Output is tee'd to both stdout and a timestamped
+`gpu-diagnostic-<UTC>.log` file in the current directory so it can be pasted
+back without loss.
+
+## When to run it
+
+- The TranscriptionSuite server logs `CUDA health check failed — GPU
+  transcription disabled for this session`.
+- The dashboard's GPU Health card shows yellow or red.
+- A fresh container start hangs at GPU init or falls back to CPU
+  unexpectedly.
+- After any `pacman -Syu` / `apt upgrade` / `dnf upgrade` that bumped
+  `nvidia-utils`, `nvidia-dkms`, `nvidia-container-toolkit`, or the kernel.
+
+## Usage
+
+```
+bash scripts/diagnose-gpu.sh
+```
+
+The script exits 0 on every platform — on macOS / Windows it prints a friendly
+"Linux only" message and returns. On Linux it always completes the 11 checks
+even if some fail.
+
+## What each check measures and how to fix it
+
+| # | Check | What it measures | If it fails |
+|---|---|---|---|
+| 1 | `nvidia-smi present` | NVIDIA userspace driver tool is installed | Install the NVIDIA driver from your distro (e.g. `sudo pacman -S nvidia` on Arch). |
+| 2 | `nvidia-ctk installed` | NVIDIA Container Toolkit is installed | `sudo pacman -S nvidia-container-toolkit` (or distro equivalent). Required for both CDI and legacy modes. |
+| 3 | `CDI spec at /etc/cdi/nvidia.yaml` | The CDI spec file exists | Only matters if the dashboard auto-detected CDI mode. Generate with `sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml`. |
+| 4 | `CDI spec vs driver mtime` | The CDI spec is newer than the installed driver | The spec is a static snapshot. Regenerate after any driver update: `sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml`. |
+| 5 | `/dev/char NVIDIA symlinks` | Symlinks under `/dev/char/195:*` exist for the NVIDIA char devices | This is the most common Phase-1 root cause. Run `sudo nvidia-ctk system create-dev-char-symlinks --create-all`. To make it persistent across reboots, install the udev rule from [NVIDIA/nvidia-container-toolkit issue #48](https://github.com/NVIDIA/nvidia-container-toolkit/issues/48). |
+| 6 | NVIDIA kernel modules loaded | `nvidia`, `nvidia_modeset`, `nvidia_uvm`, `nvidia_drm` are loaded | `sudo modprobe nvidia_uvm` (replace with the missing module). After suspend/resume you may need `sudo rmmod nvidia_uvm && sudo modprobe nvidia_uvm`. If `modprobe` fails, your DKMS module did not rebuild for the running kernel — reboot, or rebuild via `sudo dkms autoinstall`. |
+| 7 | Docker daemon config | `/etc/docker/daemon.json` does not force the systemd cgroup driver | Add `"exec-opts": ["native.cgroupdriver=cgroupfs"]` to `/etc/docker/daemon.json`, then `sudo systemctl restart docker`. NVIDIA documents this for GPU workloads. |
+| 8 | `docker info` | Docker is reachable and reports its runtimes / cgroup driver | Confirm Docker is running: `sudo systemctl status docker`. |
+| 9 | Container smoke test | `docker run --rm --gpus all <NVIDIA base image> nvidia-smi` succeeds | If checks 5/6/3 are clean and this still fails, capture the exact docker error — it usually names the missing piece (`failed to inject CDI devices`, `unknown runtime: nvidia`, etc.). |
+| 10 | NVIDIA proc files inside container | `/dev/nvidia*` and `/proc/driver/nvidia/version` are readable inside the container | Same fixes as check 9. |
+| 11 | Summary | PASS / WARN / FAIL totals | — |
+
+## References
+
+- [NVIDIA Container Toolkit Troubleshooting](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/troubleshooting.html)
+- [NVIDIA/nvidia-container-toolkit Issue #48](https://github.com/NVIDIA/nvidia-container-toolkit/issues/48)
+- [Arch Linux forum — Docker with GPU NVML Unknown Error](https://bbs.archlinux.org/viewtopic.php?id=266915)
+- [PyTorch issue #115340](https://github.com/pytorch/pytorch/issues/115340)
+- Internal spec: `docs/superpowers/specs/2026-04-29-cuda-error-999-recovery-design.md`

--- a/scripts/diagnose-gpu.sh
+++ b/scripts/diagnose-gpu.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# diagnose-gpu.sh — observation-only host diagnostic for the recurring
+# "CUDA unknown error / error 999" Docker GPU initialization failure.
+#
+# Usage:
+#   bash scripts/diagnose-gpu.sh
+#   bash scripts/diagnose-gpu.sh > my-log.txt 2>&1
+#
+# Writes both to stdout and to ./gpu-diagnostic-<UTC-timestamp>.log so the
+# output can be pasted back without loss.
+#
+# Performs 11 read-only checks (no sudo, no mutations, no package operations)
+# and prints PASS / WARN / FAIL for each. See scripts/README-gpu-diagnostic.md
+# for the fix corresponding to each FAIL.
+
+set -u
+
+# ── Setup ─────────────────────────────────────────────────────────────────
+TIMESTAMP="$(date -u '+%Y%m%dT%H%M%SZ')"
+LOGFILE="gpu-diagnostic-${TIMESTAMP}.log"
+PASS_COUNT=0
+WARN_COUNT=0
+FAIL_COUNT=0
+
+# Tee everything to the log file from this point on.
+exec > >(tee -a "$LOGFILE") 2>&1
+
+print_header() {
+  echo
+  echo "============================================================"
+  echo "$1"
+  echo "============================================================"
+}
+
+print_check() {
+  # $1 = check number, $2 = title, $3 = status (PASS|WARN|FAIL|INFO), $4 = detail
+  local num="$1" title="$2" status="$3" detail="$4"
+  printf '[%s] #%-2s %-50s %s\n' "$status" "$num" "$title" "$detail"
+  case "$status" in
+    PASS) PASS_COUNT=$((PASS_COUNT + 1));;
+    WARN) WARN_COUNT=$((WARN_COUNT + 1));;
+    FAIL) FAIL_COUNT=$((FAIL_COUNT + 1));;
+  esac
+}
+
+# ── Linux gate ────────────────────────────────────────────────────────────
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "diagnose-gpu.sh is for Linux NVIDIA installs only."
+  echo "Detected: $(uname -s). Exiting cleanly."
+  exit 0
+fi
+
+print_header "TranscriptionSuite GPU Diagnostic — ${TIMESTAMP}"
+echo "Log file: $LOGFILE"
+
+# ── #1 baseline ───────────────────────────────────────────────────────────
+print_header "#1 Host baseline"
+echo "Kernel: $(uname -r)"
+if [ -r /etc/os-release ]; then
+  # shellcheck disable=SC1091
+  . /etc/os-release
+  echo "Distro: ${PRETTY_NAME:-unknown}"
+fi
+DRIVER_VERSION=""
+if command -v nvidia-smi >/dev/null 2>&1; then
+  DRIVER_VERSION="$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -n1 || true)"
+  echo "NVIDIA driver: ${DRIVER_VERSION:-unknown}"
+  print_check 1 "nvidia-smi present" PASS "driver=${DRIVER_VERSION:-unknown}"
+else
+  print_check 1 "nvidia-smi present" FAIL "nvidia-smi not in PATH — install NVIDIA driver first"
+fi
+
+# ── #2 nvidia-container-toolkit ──────────────────────────────────────────
+print_header "#2 NVIDIA Container Toolkit"
+if command -v nvidia-ctk >/dev/null 2>&1; then
+  CTK_VERSION="$(nvidia-ctk --version 2>/dev/null | head -n1 || true)"
+  print_check 2 "nvidia-ctk installed" PASS "${CTK_VERSION:-unknown version}"
+else
+  print_check 2 "nvidia-ctk installed" FAIL "nvidia-container-toolkit not installed"
+fi
+if command -v nvidia-container-cli >/dev/null 2>&1; then
+  CLI_VERSION="$(nvidia-container-cli --version 2>/dev/null | head -n1 || true)"
+  echo "nvidia-container-cli: ${CLI_VERSION:-unknown}"
+fi
+
+# ── #3 CDI spec exists ───────────────────────────────────────────────────
+print_header "#3 CDI spec presence"
+CDI_PATH="/etc/cdi/nvidia.yaml"
+if [ -f "$CDI_PATH" ]; then
+  CDI_SIZE="$(stat -c '%s' "$CDI_PATH" 2>/dev/null || echo '?')"
+  CDI_MTIME="$(stat -c '%y' "$CDI_PATH" 2>/dev/null || echo '?')"
+  print_check 3 "CDI spec at $CDI_PATH" PASS "size=${CDI_SIZE}B mtime=${CDI_MTIME}"
+  if command -v nvidia-ctk >/dev/null 2>&1; then
+    echo "--- nvidia-ctk cdi list ---"
+    nvidia-ctk cdi list 2>&1 || true
+    echo "---------------------------"
+  fi
+else
+  print_check 3 "CDI spec at $CDI_PATH" WARN "missing — only matters if dashboard selected CDI mode (regenerate with: sudo nvidia-ctk cdi generate --output=$CDI_PATH)"
+fi
+
+# ── #4 CDI spec drift after driver update ────────────────────────────────
+print_header "#4 CDI spec freshness vs. driver"
+if [ -f "$CDI_PATH" ]; then
+  CDI_EPOCH="$(stat -c '%Y' "$CDI_PATH" 2>/dev/null || echo 0)"
+  # Heuristic: locate any nvidia.ko* under /lib/modules or /usr/lib/modules; take newest mtime.
+  DRIVER_NEWEST_EPOCH=0
+  while IFS= read -r f; do
+    mt="$(stat -c '%Y' "$f" 2>/dev/null || echo 0)"
+    if [ "$mt" -gt "$DRIVER_NEWEST_EPOCH" ]; then
+      DRIVER_NEWEST_EPOCH="$mt"
+    fi
+  done < <(find /lib/modules /usr/lib/modules -maxdepth 6 -name 'nvidia*.ko*' 2>/dev/null)
+  if [ "$DRIVER_NEWEST_EPOCH" -eq 0 ]; then
+    print_check 4 "CDI spec vs driver mtime" INFO "driver module path not located on this distro — skipped"
+  elif [ "$CDI_EPOCH" -lt "$DRIVER_NEWEST_EPOCH" ]; then
+    print_check 4 "CDI spec vs driver mtime" WARN "CDI spec is older than driver modules — regenerate with: sudo nvidia-ctk cdi generate --output=$CDI_PATH"
+  else
+    print_check 4 "CDI spec vs driver mtime" PASS "spec newer or equal to driver modules"
+  fi
+else
+  print_check 4 "CDI spec vs driver mtime" INFO "skipped — no CDI spec to compare"
+fi
+
+# ── #5 /dev/char NVIDIA symlinks ─────────────────────────────────────────
+print_header "#5 /dev/char NVIDIA symlinks"
+if [ -d /dev/char ]; then
+  CHAR_NV_COUNT="$(ls -1 /dev/char 2>/dev/null | grep -c '^195:' || true)"
+  if [ "$CHAR_NV_COUNT" -gt 0 ]; then
+    print_check 5 "/dev/char NVIDIA symlinks" PASS "found $CHAR_NV_COUNT entries with major 195"
+  else
+    print_check 5 "/dev/char NVIDIA symlinks" FAIL "missing — fix: sudo nvidia-ctk system create-dev-char-symlinks --create-all (also add udev rule per nvidia-container-toolkit issue #48)"
+  fi
+else
+  print_check 5 "/dev/char NVIDIA symlinks" WARN "/dev/char does not exist on this host"
+fi
+
+# ── #6 NVIDIA kernel modules ─────────────────────────────────────────────
+print_header "#6 NVIDIA kernel modules"
+LSMOD_OUTPUT="$(lsmod 2>/dev/null | awk '{print $1}' || true)"
+for mod in nvidia nvidia_modeset nvidia_uvm nvidia_drm; do
+  if echo "$LSMOD_OUTPUT" | grep -qx "$mod"; then
+    print_check 6 "module $mod loaded" PASS ""
+  else
+    if [ "$mod" = "nvidia_uvm" ]; then
+      print_check 6 "module $mod loaded" FAIL "fix: sudo modprobe $mod (or sudo rmmod $mod && sudo modprobe $mod after suspend/resume)"
+    else
+      print_check 6 "module $mod loaded" WARN "fix: sudo modprobe $mod"
+    fi
+  fi
+done
+
+# ── #7 Docker daemon config ──────────────────────────────────────────────
+print_header "#7 Docker daemon config"
+DAEMON_JSON="/etc/docker/daemon.json"
+if [ -r "$DAEMON_JSON" ]; then
+  echo "--- $DAEMON_JSON ---"
+  cat "$DAEMON_JSON"
+  echo "--------------------"
+  if grep -q 'native.cgroupdriver=systemd' "$DAEMON_JSON" 2>/dev/null; then
+    print_check 7 "Docker cgroup driver" WARN "uses systemd cgroups — NVIDIA recommends cgroupfs for GPU workloads (set exec-opts native.cgroupdriver=cgroupfs and restart docker)"
+  else
+    print_check 7 "Docker cgroup driver" PASS "no systemd cgroupdriver override detected in daemon.json"
+  fi
+else
+  print_check 7 "Docker daemon.json" INFO "no daemon.json present (Docker uses defaults)"
+fi
+NCT_CONFIG="/etc/nvidia-container-runtime/config.toml"
+if [ -r "$NCT_CONFIG" ]; then
+  echo "--- $NCT_CONFIG ---"
+  grep -E 'no-cgroups|^\[' "$NCT_CONFIG" || true
+  echo "-------------------"
+fi
+
+# ── #8 Docker runtime info ───────────────────────────────────────────────
+print_header "#8 Docker runtime info"
+if command -v docker >/dev/null 2>&1; then
+  DOCKER_INFO="$(docker info --format '{{json .}}' 2>/dev/null || echo '{}')"
+  echo "Runtimes: $(echo "$DOCKER_INFO" | grep -oP '"Runtimes":\{[^}]*\}' || echo 'unparseable')"
+  echo "DefaultRuntime: $(echo "$DOCKER_INFO" | grep -oP '"DefaultRuntime":"[^"]*"' || echo 'unknown')"
+  echo "CgroupDriver: $(echo "$DOCKER_INFO" | grep -oP '"CgroupDriver":"[^"]*"' || echo 'unknown')"
+  print_check 8 "docker info readable" PASS ""
+else
+  print_check 8 "docker present" FAIL "docker CLI not in PATH"
+fi
+
+# ── #9 Smoke test: --gpus all in a small NVIDIA base image ──────────────
+print_header "#9 Container smoke test"
+SMOKE_IMAGE="nvidia/cuda:12.6.0-base-ubuntu24.04"
+if ! command -v docker >/dev/null 2>&1; then
+  print_check 9 "container --gpus all smoke test" INFO "skipped — docker not present"
+elif ! docker image inspect "$SMOKE_IMAGE" >/dev/null 2>&1; then
+  echo "Image $SMOKE_IMAGE not present locally; this check would pull ~150MB."
+  echo "Skipping the pull. To run manually: docker pull $SMOKE_IMAGE"
+  print_check 9 "container --gpus all smoke test" INFO "skipped — image not pulled (would pull ~150MB)"
+else
+  echo "Running: docker run --rm --gpus all $SMOKE_IMAGE nvidia-smi"
+  if SMOKE_OUT="$(docker run --rm --gpus all "$SMOKE_IMAGE" nvidia-smi 2>&1)"; then
+    echo "$SMOKE_OUT" | head -n 20
+    print_check 9 "container --gpus all smoke test" PASS "GPU visible inside a fresh NVIDIA base container"
+  else
+    echo "$SMOKE_OUT"
+    print_check 9 "container --gpus all smoke test" FAIL "GPU NOT visible inside container — host-side breakage confirmed; see checks #5/#6/#3 for the most likely fix"
+  fi
+fi
+
+# ── #10 NVIDIA proc files inside a container (only if smoke passed) ─────
+print_header "#10 NVIDIA proc files inside container"
+if docker image inspect "$SMOKE_IMAGE" >/dev/null 2>&1; then
+  if PROC_OUT="$(docker run --rm --gpus all "$SMOKE_IMAGE" bash -c 'ls /dev/nvidia* 2>&1; echo ---; cat /proc/driver/nvidia/version 2>&1' 2>&1)"; then
+    echo "$PROC_OUT"
+    print_check 10 "container can read /dev/nvidia* and /proc/driver/nvidia" PASS ""
+  else
+    echo "$PROC_OUT"
+    print_check 10 "container can read /dev/nvidia* and /proc/driver/nvidia" FAIL "container has --gpus all but cannot read NVIDIA proc files"
+  fi
+else
+  print_check 10 "container can read NVIDIA proc files" INFO "skipped — image not pulled"
+fi
+
+# ── #11 Summary ─────────────────────────────────────────────────────────
+print_header "#11 Summary"
+echo "PASS: $PASS_COUNT   WARN: $WARN_COUNT   FAIL: $FAIL_COUNT"
+echo
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "RESULT: One or more FAIL checks. See scripts/README-gpu-diagnostic.md"
+  echo "        for the recommended fix per failure mode."
+elif [ "$WARN_COUNT" -gt 0 ]; then
+  echo "RESULT: Some WARN checks — host is likely operational but not optimally"
+  echo "        configured. Review WARN entries above."
+else
+  echo "RESULT: All checks PASS — host GPU/Docker setup looks healthy."
+fi
+echo
+echo "Full log: $LOGFILE"
+exit 0

--- a/server/backend/api/main.py
+++ b/server/backend/api/main.py
@@ -514,6 +514,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
             extra={
                 "error": gpu_health["error"],
                 "nvidia_smi": gpu_health.get("nvidia_smi", "N/A"),
+                "recovery_hint": gpu_health.get("recovery_hint"),
             },
         )
         app.state.gpu_error = gpu_health

--- a/server/backend/api/routes/health.py
+++ b/server/backend/api/routes/health.py
@@ -94,5 +94,12 @@ async def get_status(request: Request) -> dict[str, Any]:
     if gpu_error is not None:
         response["gpu_error"] = gpu_error.get("error", "Unknown GPU error")
         response["gpu_error_action"] = "Please restart your computer to reset the GPU driver."
+        # Surface the diagnostic recovery_hint (added by Task 4) so the
+        # dashboard's GpuHealthCard can display it verbatim in the red state.
+        # Optional — only present for the error-999 unrecoverable fingerprint;
+        # absent for other failure modes. Backward compatible (additive only).
+        recovery_hint = gpu_error.get("recovery_hint")
+        if recovery_hint:
+            response["gpu_error_recovery_hint"] = recovery_hint
 
     return response

--- a/server/backend/core/audio_utils.py
+++ b/server/backend/core/audio_utils.py
@@ -251,17 +251,25 @@ def cuda_health_check(device_index: int = 0) -> dict[str, Any]:
             # All retries exhausted — mark as unrecoverable.
             _cuda_probe_failed = True
             smi_output = _capture_nvidia_smi()
+            recovery_hint = (
+                "GPU init failed with error 999 (CUDA unknown). This is "
+                "almost always host-side: missing /dev/char symlinks, stale "
+                "CDI spec, nvidia_uvm not loaded, or systemd cgroup driver "
+                "interference. Run scripts/diagnose-gpu.sh on the host for "
+                "details and the recommended fix."
+            )
             logger.error(
                 "CUDA health check: unrecoverable GPU state after %d retries",
                 len(_error_999_delays),
                 exc_info=last_exc,
-                extra={"nvidia_smi": smi_output},
+                extra={"nvidia_smi": smi_output, "recovery_hint": recovery_hint},
             )
             return {
                 "status": "unrecoverable",
                 "error": str(last_exc),
                 "nvidia_smi": smi_output,
                 "attempts": len(_error_999_delays) + 1,
+                "recovery_hint": recovery_hint,
             }
 
         # Non-999 transient error — single retry after a short delay.

--- a/server/backend/tests/test_audio_utils.py
+++ b/server/backend/tests/test_audio_utils.py
@@ -220,6 +220,57 @@ class TestCudaHealthCheck:
         mock_time.sleep.assert_called_once_with(0.5)
         assert mock_torch.cuda.init.call_count == 2
 
+    def test_error_999_unrecoverable_includes_recovery_hint(self):
+        """When error 999 fails all retries, result includes a recovery_hint."""
+        mock_torch = MagicMock()
+        mock_torch.cuda.init.side_effect = RuntimeError("CUDA unknown error")
+
+        with (
+            patch.object(au, "torch", mock_torch),
+            patch.object(au, "HAS_TORCH", True),
+            patch.object(au, "_capture_nvidia_smi", return_value="ok"),
+            patch.object(au, "time"),
+        ):
+            result = au.cuda_health_check()
+
+        assert result["status"] == "unrecoverable"
+        hint = result.get("recovery_hint")
+        assert hint is not None
+        assert "error 999" in hint.lower() or "cuda unknown" in hint.lower()
+        assert "diagnose-gpu.sh" in hint
+
+    def test_error_999_recovered_omits_recovery_hint(self):
+        """If error 999 recovers on retry, no recovery_hint is added."""
+        mock_props = MagicMock()
+        mock_props.name = "NVIDIA RTX 3060"
+        mock_props.total_mem = 12 * 1024**3
+
+        mock_torch = MagicMock()
+        mock_torch.cuda.init.side_effect = [RuntimeError("CUDA unknown error"), None]
+        mock_torch.cuda.get_device_properties.return_value = mock_props
+
+        with (
+            patch.object(au, "torch", mock_torch),
+            patch.object(au, "HAS_TORCH", True),
+            patch.object(au, "time"),
+        ):
+            result = au.cuda_health_check()
+
+        assert result["status"] == "healthy"
+        assert "recovery_hint" not in result
+
+    def test_non_999_unrecoverable_omits_recovery_hint(self):
+        """A non-999 error path that still yields a non-healthy status must not
+        carry the error-999-specific recovery_hint."""
+        mock_torch = MagicMock()
+        mock_torch.cuda.init.side_effect = RuntimeError("no CUDA-capable device")
+
+        with patch.object(au, "torch", mock_torch), patch.object(au, "HAS_TORCH", True):
+            result = au.cuda_health_check()
+
+        assert result["status"] == "no_cuda"
+        assert "recovery_hint" not in result
+
 
 # ── check_cuda_available with probe flag ─────────────────────────────────
 

--- a/server/backend/tests/test_health_routes.py
+++ b/server/backend/tests/test_health_routes.py
@@ -126,3 +126,48 @@ def test_status_no_gpu_error_when_healthy(test_client_local):
     body = response.json()
     assert "gpu_error" not in body
     assert "gpu_error_action" not in body
+
+
+def test_status_includes_recovery_hint_when_set(test_client_local):
+    """
+    GET /api/status surfaces gpu_error_recovery_hint when the backend's
+    cuda_health_check populated it (error-999 unrecoverable fingerprint).
+    The field is consumed by the dashboard's GpuHealthCard red state.
+    """
+    hint = (
+        "GPU init failed with error 999 (CUDA unknown). Run "
+        "scripts/diagnose-gpu.sh on the host for details."
+    )
+    test_client_local.app.state.gpu_error = {
+        "error": "CUDA unknown error",
+        "status": "unrecoverable",
+        "recovery_hint": hint,
+    }
+    try:
+        response = test_client_local.get("/api/status")
+    finally:
+        del test_client_local.app.state.gpu_error
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body.get("gpu_error_recovery_hint") == hint
+
+
+def test_status_omits_recovery_hint_when_absent(test_client_local):
+    """
+    GET /api/status does NOT include gpu_error_recovery_hint when the
+    backend did not populate it (non-error-999 failure mode).
+    """
+    test_client_local.app.state.gpu_error = {
+        "error": "Some other CUDA error",
+        "status": "unrecoverable",
+    }
+    try:
+        response = test_client_local.get("/api/status")
+    finally:
+        del test_client_local.app.state.gpu_error
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "gpu_error" in body
+    assert "gpu_error_recovery_hint" not in body


### PR DESCRIPTION
## Summary

- **Phase 1: Host diagnostic.** New `scripts/diagnose-gpu.sh` — observation-only, 11 read-only checks for the recurring "CUDA unknown error / error 999" Docker GPU init failure on Linux NVIDIA hosts. Identifies the four documented root causes (missing `/dev/char` symlinks, stale `/etc/cdi/nvidia.yaml`, `nvidia_uvm` not loaded, systemd cgroup driver) and prints the canonical NVIDIA fix per failure. Exits cleanly on macOS/Windows. Companion `scripts/README-gpu-diagnostic.md` documents each check.
- **Phase 2: App-side hardening.** Backend `cuda_health_check()` now attaches a `recovery_hint` string on the error-999 unrecoverable branch; surfaced through the lifespan log, `/api/status`, `useServerStatus`, and a new NVIDIA-only **GPU Health** card on the Server tab (three states: green / yellow / red). Card reads cheap host signals via `dockerManager.ts:validateGpuPreflight()` and offers a "Run Full Diagnostic" button that spawns the bundled Phase 1 script and surfaces the log path.
- **No `sudo` from the dashboard, no auto-fix, no per-distro recipes.** The dashboard is an *advisor* about the host, not an *agent* that mutates it. All fix commands are copy-pasteable via the project's `writeToClipboard` helper (Flatpak/AppImage safe).

Driven by the spec at [`docs/superpowers/specs/2026-04-29-cuda-error-999-recovery-design.md`](docs/superpowers/specs/2026-04-29-cuda-error-999-recovery-design.md) and the implementation plan at [`docs/superpowers/plans/2026-04-29-cuda-error-999-recovery.md`](docs/superpowers/plans/2026-04-29-cuda-error-999-recovery.md).
TDD throughout — every behavioural change is paired with a failing-tests commit followed by the implementation that makes them pass.

## What this looks like for users

| Host state | Card state | What you see |
|---|---|---|
| Linux + NVIDIA, all checks pass | Green | "GPU healthy — CUDA operational" |
| Linux + NVIDIA, e.g. `/dev/char` symlinks missing | Yellow | "GPU may be misconfigured" + copyable fix command + docs link |
| Linux + NVIDIA, backend reported error-999 unrecoverable | Red | "GPU unavailable" + `recovery_hint` rendered verbatim + same fix-command rows |
| macOS, Linux/AMD, Linux/Intel, Linux/no-GPU, Windows | Hidden | Card not rendered at all |

## Validation by smoke test

Running `bash scripts/diagnose-gpu.sh` on the dev host during Task 1 immediately surfaced a real misconfiguration (CDI spec mtime older than the installed driver modules) — the same class of issue that motivated the research in the first place. The fix in that case is: `sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml`.

## Test plan

- [ ] Backend: `cd server/backend && ../../build/.venv/bin/pytest tests/test_audio_utils.py tests/test_health_routes.py -v` — 77 pass.
- [ ] Dashboard: `cd dashboard && npx vitest run` — 986 pass across 53 files.
- [ ] Type-check: `cd dashboard && npx tsc --noEmit` — clean.
- [ ] UI contract: `cd dashboard && npm run ui:contract:check` — 16/16 pass at spec_version 1.0.30.
- [ ] On a Linux + NVIDIA host with a working setup: launch the dashboard, navigate to the Server tab, confirm the **GPU Health (NVIDIA)** card renders and is green.
- [ ] Click "Run Full Diagnostic": confirm an alert shows `/tmp/gpu-diagnostic-<ts>.log`, and tailing that file shows all 11 checks running.
- [ ] On a non-NVIDIA host (or with `gpuInfo.gpu === false` mocked): confirm the card is not rendered.
- [ ] Force a yellow state by deleting `/dev/char/195:*` symlinks in a disposable VM — confirm the card flips to yellow with the `nvidia-ctk system create-dev-char-symlinks` command shown copyable.
- [ ] Force a red state by simulating an unrecoverable container start — confirm the card shows the `recovery_hint` text from `audio_utils.py` verbatim.

## Out of scope (intentional, may be follow-ups)

- One-click `pkexec nvidia-ctk` from the dashboard (would need root from a GUI app — too risky for a hobbyist tool).
- Auto-retry-after-N-seconds beyond the existing 1s/2s/4s backoff in `cuda_health_check`.
- Per-distro fix recipes (Arch / Ubuntu / Fedora / NixOS specific commands in the UI). Generic NVIDIA-doc commands cover all distros.
- Future refactor: extract preflight functions from `dockerManager.ts` (now 3,300 lines) into a sibling `dashboard/electron/gpuPreflight.ts`.
- Promote `Run Full Diagnostic` from `window.alert` to a proper modal (alert text isn't always selectable on KDE Wayland).
- Trivial: add `import '@testing-library/jest-dom'` to fix the `toBeInTheDocument` LSP-only type warning in `GpuHealthCard.test.tsx` (tests already pass at runtime).