### PR TITLE
CUDA GPU health monitor window in Server tab 

### DIFF
--- a/dashboard/components/views/GpuDiagnosticModal.tsx
+++ b/dashboard/components/views/GpuDiagnosticModal.tsx
@@ -1,0 +1,297 @@
+/**
+ * GpuDiagnosticModal — actionable surface for the output of
+ * `scripts/diagnose-gpu.sh`. Replaces the old `window.alert` flow.
+ *
+ * Renders three things, in order:
+ *   1. Summary banner: PASS / WARN / FAIL counts, tone derived from worst.
+ *   2. Per-issue rows for each WARN and FAIL — title + detail + (optional)
+ *      copyable suggested command extracted by parseDiagnosticLog().
+ *   3. Footer: Open Log (electronAPI.app.openPath → OS default text editor),
+ *      Copy Path, Close.
+ *
+ * Stays NVIDIA-only by virtue of being mounted only when GpuHealthCard
+ * passes `running` through. The dashboard never invokes sudo on the user's
+ * behalf — fix commands are copy-paste only (advisor-not-agent stance).
+ */
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { X, AlertTriangle, AlertOctagon, FileText, Clipboard } from 'lucide-react';
+import { writeToClipboard } from '../../src/hooks/useClipboard';
+import { Button } from '../ui/Button';
+
+export interface DiagnosticIssueProp {
+  status: 'PASS' | 'WARN' | 'FAIL' | 'INFO';
+  checkNumber: number;
+  title: string;
+  detail: string;
+  suggestedCommand?: string;
+}
+
+export interface DiagnosticSummaryProp {
+  passCount: number;
+  warnCount: number;
+  failCount: number;
+  parsed: boolean;
+  issues: DiagnosticIssueProp[];
+}
+
+export interface GpuDiagnosticResultProp {
+  status: 'completed' | 'unsupported' | 'script-missing';
+  logPath?: string;
+  scriptPath?: string;
+  manualCommand?: string;
+  summary?: DiagnosticSummaryProp;
+  exitCode?: number;
+}
+
+export interface GpuDiagnosticModalProps {
+  isOpen: boolean;
+  result: GpuDiagnosticResultProp | null;
+  onClose: () => void;
+}
+
+type BannerTone = 'green' | 'amber' | 'red' | 'slate';
+
+function deriveBannerTone(summary: DiagnosticSummaryProp | undefined): BannerTone {
+  if (!summary) return 'slate';
+  if (summary.failCount > 0) return 'red';
+  if (summary.warnCount > 0) return 'amber';
+  return 'green';
+}
+
+const BANNER_CLASSES: Record<BannerTone, string> = {
+  green: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200',
+  amber: 'border-amber-500/40 bg-amber-500/10 text-amber-200',
+  red: 'border-red-600/40 bg-red-600/10 text-red-200',
+  slate: 'border-slate-400/30 bg-slate-400/10 text-slate-200',
+};
+
+function CopyableCommand({ cmd }: { cmd: string }): React.ReactElement {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<number | undefined>(undefined);
+
+  const handleCopy = (): void => {
+    writeToClipboard(cmd)
+      .then(() => {
+        setCopied(true);
+        if (timerRef.current) window.clearTimeout(timerRef.current);
+        timerRef.current = window.setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => {
+        /* silent — matches LogsView pattern */
+      });
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) window.clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  return (
+    <div className="mt-1.5 flex items-center gap-2">
+      <code className="flex-1 overflow-x-auto rounded bg-black/40 px-2 py-1 font-mono text-xs text-neutral-100">
+        {cmd}
+      </code>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="rounded bg-neutral-700 px-2 py-1 text-xs text-neutral-100 hover:bg-neutral-600"
+      >
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+    </div>
+  );
+}
+
+function IssueRow({ issue }: { issue: DiagnosticIssueProp }): React.ReactElement {
+  const isFail = issue.status === 'FAIL';
+  const Icon = isFail ? AlertOctagon : AlertTriangle;
+  const iconClass = isFail ? 'text-red-400' : 'text-amber-400';
+  return (
+    <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+      <div className="flex items-start gap-2">
+        <Icon size={16} className={`mt-0.5 flex-shrink-0 ${iconClass}`} />
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold text-white">
+            #{issue.checkNumber} {issue.title}
+          </p>
+          <p className="mt-0.5 text-xs text-slate-300">{issue.detail}</p>
+          {issue.suggestedCommand ? <CopyableCommand cmd={issue.suggestedCommand} /> : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function GpuDiagnosticModal({
+  isOpen,
+  result,
+  onClose,
+}: GpuDiagnosticModalProps): React.ReactElement | null {
+  const [pathCopied, setPathCopied] = useState(false);
+  const pathTimerRef = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    return () => {
+      if (pathTimerRef.current) window.clearTimeout(pathTimerRef.current);
+    };
+  }, []);
+
+  if (!isOpen || !result) return null;
+
+  const summary = result.summary;
+  const tone = deriveBannerTone(summary);
+  const issues = summary?.issues ?? [];
+
+  const handleOpenLog = (): void => {
+    if (!result.logPath) return;
+    const api = window.electronAPI?.app?.openPath;
+    if (typeof api !== 'function') return;
+    void api(result.logPath).catch(() => {
+      /* surface via console only — modal stays useful */
+      // eslint-disable-next-line no-console
+      console.warn('Failed to open diagnostic log via shell');
+    });
+  };
+
+  const handleCopyPath = (): void => {
+    if (!result.logPath) return;
+    writeToClipboard(result.logPath)
+      .then(() => {
+        setPathCopied(true);
+        if (pathTimerRef.current) window.clearTimeout(pathTimerRef.current);
+        pathTimerRef.current = window.setTimeout(() => setPathCopied(false), 1500);
+      })
+      .catch(() => {
+        /* silent */
+      });
+  };
+
+  const bannerText: string = (() => {
+    if (result.status === 'script-missing') {
+      return 'Diagnostic script not bundled — run it manually.';
+    }
+    if (!summary) {
+      return 'Diagnostic ran but no summary could be parsed.';
+    }
+    if (!summary.parsed) {
+      return `Could not parse the Summary block — counted ${summary.passCount} PASS / ${summary.warnCount} WARN / ${summary.failCount} FAIL from rows.`;
+    }
+    return `${summary.passCount} PASS · ${summary.warnCount} WARN · ${summary.failCount} FAIL`;
+  })();
+
+  const modalContent = (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="GPU diagnostic results"
+    >
+      <div
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      <div className="relative flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-3xl border border-white/20 bg-black/40 bg-linear-to-b from-white/5 to-black/20 shadow-2xl backdrop-blur-xl">
+        <div className="bg-accent-cyan/20 pointer-events-none absolute top-0 left-0 h-32 w-32 rounded-full blur-2xl" />
+        <div className="bg-accent-magenta/10 pointer-events-none absolute right-0 bottom-0 h-32 w-32 rounded-full blur-2xl" />
+        <div className="pointer-events-none absolute inset-0 bg-black/20" />
+
+        <div className="relative flex items-center justify-between border-b border-white/10 bg-white/5 px-6 py-4">
+          <div className="flex items-center gap-3">
+            <FileText size={20} className="text-accent-cyan" />
+            <div className="flex flex-col">
+              <h2 className="text-lg font-semibold text-white">GPU Diagnostic</h2>
+              <p className="text-xs text-slate-400">
+                Output of <code className="font-mono">scripts/diagnose-gpu.sh</code>
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-full border border-white/10 bg-black/10 p-2 text-white backdrop-blur-md transition-colors hover:bg-black/40"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="relative z-0 flex flex-col gap-3 overflow-y-auto px-6 py-5">
+          <div
+            role="status"
+            className={`rounded-lg border px-3 py-2 text-sm font-medium ${BANNER_CLASSES[tone]}`}
+          >
+            {bannerText}
+          </div>
+
+          {result.status === 'script-missing' && result.manualCommand ? (
+            <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+              <p className="text-xs text-slate-300">
+                Run this in a terminal to capture the diagnostic yourself:
+              </p>
+              <CopyableCommand cmd={result.manualCommand} />
+            </div>
+          ) : null}
+
+          {issues.length > 0 ? (
+            <div className="flex flex-col gap-2">
+              {issues.map((issue) => (
+                <IssueRow key={`${issue.status}-${issue.checkNumber}`} issue={issue} />
+              ))}
+            </div>
+          ) : result.status === 'completed' && summary && summary.parsed ? (
+            <p className="text-sm text-slate-300">All checks passed — GPU is healthy.</p>
+          ) : null}
+
+          {result.logPath ? (
+            <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+              <p className="text-xs font-medium text-slate-300">Log file</p>
+              <code className="mt-1 block overflow-x-auto font-mono text-xs text-slate-200">
+                {result.logPath}
+              </code>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="relative flex items-center justify-end gap-2 border-t border-white/10 bg-white/5 px-6 py-4">
+          {result.logPath ? (
+            <>
+              <button
+                type="button"
+                onClick={handleCopyPath}
+                className="inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-slate-200 transition-colors hover:bg-white/10"
+              >
+                <Clipboard size={14} />
+                {pathCopied ? 'Copied' : 'Copy Path'}
+              </button>
+              <Button variant="primary" size="sm" onClick={handleOpenLog}>
+                Open Log
+              </Button>
+            </>
+          ) : null}
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-slate-200 transition-colors hover:bg-white/10"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(modalContent, document.body);
+}

--- a/dashboard/components/views/GpuHealthCard.tsx
+++ b/dashboard/components/views/GpuHealthCard.tsx
@@ -48,9 +48,9 @@ const STATE_LABEL: Record<CardState, string> = {
 };
 
 const STATE_CONTAINER: Record<CardState, string> = {
-  green: 'border-green-500/20 bg-green-500/5',
-  yellow: 'border-accent-orange/20 bg-accent-orange/5',
-  red: 'border-red-500/20 bg-red-500/5',
+  green: 'border-green-500/20 bg-green-500/10',
+  yellow: 'border-accent-orange/20 bg-accent-orange/10',
+  red: 'border-red-500/20 bg-red-500/10',
 };
 
 const STATE_BODY_TEXT: Record<CardState, string> = {

--- a/dashboard/components/views/GpuHealthCard.tsx
+++ b/dashboard/components/views/GpuHealthCard.tsx
@@ -25,6 +25,8 @@ export interface GpuHealthCardProps {
   preflight: GpuPreflightProp | null;
   backendError: GpuBackendErrorProp | null;
   onRunDiagnostic: () => void;
+  /** When true, the Run Full Diagnostic button is disabled and shows a "Running…" label. */
+  running?: boolean;
 }
 
 type CardState = 'green' | 'yellow' | 'red';
@@ -99,6 +101,7 @@ export function GpuHealthCard({
   preflight,
   backendError,
   onRunDiagnostic,
+  running = false,
 }: GpuHealthCardProps): React.ReactElement | null {
   if (!gpuDetected) return null;
 
@@ -149,8 +152,8 @@ export function GpuHealthCard({
       ) : null}
 
       <div className="mt-3">
-        <Button variant="secondary" size="sm" onClick={onRunDiagnostic}>
-          Run Full Diagnostic
+        <Button variant="secondary" size="sm" onClick={onRunDiagnostic} disabled={running}>
+          {running ? 'Running diagnostic…' : 'Run Full Diagnostic'}
         </Button>
       </div>
     </section>

--- a/dashboard/components/views/GpuHealthCard.tsx
+++ b/dashboard/components/views/GpuHealthCard.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { CheckCircle2, AlertTriangle, XCircle } from 'lucide-react';
 import { Button } from '../ui/Button';
 import { writeToClipboard } from '../../src/hooks/useClipboard';
 
@@ -46,16 +47,16 @@ const STATE_LABEL: Record<CardState, string> = {
   red: 'GPU unavailable — fell back to CPU',
 };
 
-const STATE_BORDER: Record<CardState, string> = {
-  green: 'border-green-600',
-  yellow: 'border-amber-600',
-  red: 'border-red-700',
+const STATE_CONTAINER: Record<CardState, string> = {
+  green: 'border-green-500/20 bg-green-500/5',
+  yellow: 'border-accent-orange/20 bg-accent-orange/5',
+  red: 'border-red-500/20 bg-red-500/5',
 };
 
-const STATE_TEXT: Record<CardState, string> = {
-  green: 'text-green-600',
-  yellow: 'text-amber-600',
-  red: 'text-red-700',
+const STATE_BODY_TEXT: Record<CardState, string> = {
+  green: 'text-green-400',
+  yellow: 'text-accent-orange',
+  red: 'text-red-400',
 };
 
 function CopyableCommand({ cmd }: { cmd: string }): React.ReactElement {
@@ -96,6 +97,12 @@ function CopyableCommand({ cmd }: { cmd: string }): React.ReactElement {
   );
 }
 
+function StateIcon({ state }: { state: CardState }): React.ReactElement {
+  if (state === 'green') return <CheckCircle2 size={18} className="text-green-400" />;
+  if (state === 'yellow') return <AlertTriangle size={18} className="text-accent-orange" />;
+  return <XCircle size={18} className="text-red-400" />;
+}
+
 export function GpuHealthCard({
   gpuDetected,
   preflight,
@@ -107,54 +114,76 @@ export function GpuHealthCard({
 
   const state = deriveState(preflight, backendError);
   const failedChecks = preflight ? preflight.checks.filter((c) => !c.pass) : [];
+  const totalChecks = preflight ? preflight.checks.length : 0;
+  const passedChecks = totalChecks - failedChecks.length;
+  const headerStatus =
+    state === 'red'
+      ? 'backend error — CPU fallback'
+      : totalChecks > 0
+        ? `${passedChecks}/${totalChecks} checks passed`
+        : 'CUDA operational';
 
   return (
     <section
       aria-labelledby="gpu-health-title"
-      className={`mt-3 rounded-md border p-3 ${STATE_BORDER[state]}`}
+      className={`overflow-hidden rounded-xl border transition-all duration-300 ${STATE_CONTAINER[state]}`}
     >
-      <h3 id="gpu-health-title" className={`mt-0 ${STATE_TEXT[state]}`}>
-        GPU Health (NVIDIA)
-      </h3>
-      <p className="mt-0 text-xs text-neutral-400">
-        This card appears only on systems with an NVIDIA GPU. AMD / Intel / Apple Silicon setups do
-        not need it.
-      </p>
+      <div className="flex items-center gap-3 px-5 py-3.5">
+        <StateIcon state={state} />
+        <h3 id="gpu-health-title" className="m-0 text-sm font-semibold text-white">
+          GPU Health (NVIDIA)
+        </h3>
+        <span className="font-mono text-xs text-slate-500">{headerStatus}</span>
+      </div>
 
-      <p className="font-semibold">{STATE_LABEL[state]}</p>
-
-      {state === 'red' && backendError?.recovery_hint ? (
-        <p className="rounded bg-red-900/50 p-2 text-sm text-red-200">
-          {backendError.recovery_hint}
+      <div className="space-y-2.5 px-5 pb-4">
+        <p className="m-0 text-xs text-slate-400">
+          This card appears only on systems with an NVIDIA GPU. AMD / Intel / Apple Silicon setups
+          do not need it.
         </p>
-      ) : null}
 
-      {failedChecks.length > 0 ? (
-        <div className="mt-3">
-          <p className="mb-1 font-medium">Failing checks:</p>
-          {failedChecks.map((check) => (
-            <div key={check.name} className="mb-2.5">
-              <div className="text-sm">
-                ✗ {check.name}
-                {check.docsUrl ? (
-                  <>
-                    {' — '}
-                    <a href={check.docsUrl} target="_blank" rel="noopener noreferrer">
-                      docs
-                    </a>
-                  </>
-                ) : null}
+        <p className={`m-0 text-sm font-semibold ${STATE_BODY_TEXT[state]}`}>
+          {STATE_LABEL[state]}
+        </p>
+
+        {state === 'red' && backendError?.recovery_hint ? (
+          <p className="m-0 rounded bg-red-500/10 p-2 text-sm text-red-200">
+            {backendError.recovery_hint}
+          </p>
+        ) : null}
+
+        {failedChecks.length > 0 ? (
+          <div className="pt-1">
+            <p className="m-0 mb-1 text-sm font-medium text-white">Failing checks:</p>
+            {failedChecks.map((check) => (
+              <div key={check.name} className="mb-2.5">
+                <div className="text-sm text-slate-300">
+                  ✗ {check.name}
+                  {check.docsUrl ? (
+                    <>
+                      {' — '}
+                      <a
+                        href={check.docsUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-accent-cyan hover:underline"
+                      >
+                        docs
+                      </a>
+                    </>
+                  ) : null}
+                </div>
+                {check.fixCommand ? <CopyableCommand cmd={check.fixCommand} /> : null}
               </div>
-              {check.fixCommand ? <CopyableCommand cmd={check.fixCommand} /> : null}
-            </div>
-          ))}
-        </div>
-      ) : null}
+            ))}
+          </div>
+        ) : null}
 
-      <div className="mt-3">
-        <Button variant="secondary" size="sm" onClick={onRunDiagnostic} disabled={running}>
-          {running ? 'Running diagnostic…' : 'Run Full Diagnostic'}
-        </Button>
+        <div className="pt-1">
+          <Button variant="secondary" size="sm" onClick={onRunDiagnostic} disabled={running}>
+            {running ? 'Running diagnostic…' : 'Run Full Diagnostic'}
+          </Button>
+        </div>
       </div>
     </section>
   );

--- a/dashboard/components/views/ServerView.tsx
+++ b/dashboard/components/views/ServerView.tsx
@@ -1492,7 +1492,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
           {/* Setup checklist — shown on first run or when prerequisites are missing */}
           {showChecklist && (
             <div
-              className={`overflow-hidden rounded-xl border transition-all duration-300 ${allPassed ? 'border-green-500/20 bg-green-500/5' : 'border-accent-orange/20 bg-accent-orange/5'}`}
+              className={`overflow-hidden rounded-xl border transition-all duration-300 ${allPassed ? 'border-green-500/20 bg-green-500/10' : 'border-accent-orange/20 bg-accent-orange/10'}`}
             >
               <button
                 onClick={() => setSetupExpanded(!setupExpanded)}

--- a/dashboard/components/views/ServerView.tsx
+++ b/dashboard/components/views/ServerView.tsx
@@ -35,6 +35,7 @@ import { AmdIcon } from '../ui/icons/AmdIcon';
 import { IntelIcon } from '../ui/icons/IntelIcon';
 import { AppleIcon } from '../ui/icons/AppleIcon';
 import { GpuHealthCard } from './GpuHealthCard';
+import { GpuDiagnosticModal, type GpuDiagnosticResultProp } from './GpuDiagnosticModal';
 
 import { useActivityStore } from '../../src/stores/activityStore';
 import { useAdminStatus } from '../../src/hooks/useAdminStatus';
@@ -1218,29 +1219,38 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
   }, []);
 
   // Run-diagnostic handler for the "Run Full Diagnostic" button on the card.
-  // Invokes the docker:runGpuDiagnostic IPC (added in Task 10) which spawns
-  // scripts/diagnose-gpu.sh and returns the log path. Surfaces the result via
-  // window.alert as the simplest first-cut UI; can be promoted to a modal
-  // later if UX feedback warrants it.
+  // Awaits the docker:runGpuDiagnostic IPC, which spawns scripts/diagnose-gpu.sh,
+  // waits for it to finish, parses the log, and returns a structured summary.
+  // Result is surfaced in <GpuDiagnosticModal> below — replaces the original
+  // window.alert flow.
+  const [diagnosticRunning, setDiagnosticRunning] = useState(false);
+  const [diagnosticResult, setDiagnosticResult] = useState<GpuDiagnosticResultProp | null>(null);
+  const [diagnosticOpen, setDiagnosticOpen] = useState(false);
+
   const handleRunGpuDiagnostic = useCallback((): void => {
     const api = (window as any).electronAPI;
-    if (!api?.docker?.runGpuDiagnostic) return;
+    if (!api?.docker?.runGpuDiagnostic || diagnosticRunning) return;
+    setDiagnosticRunning(true);
     api.docker
       .runGpuDiagnostic()
-      .then((res: { status: string; logPath?: string; manualCommand?: string }) => {
-        if (res.status === 'started' && res.logPath) {
-          window.alert(
-            `GPU diagnostic started.\n\nLog file: ${res.logPath}\n\nTail it with:\n  tail -f "${res.logPath}"`,
-          );
-        } else if (res.status === 'script-missing' && res.manualCommand) {
-          window.alert(`Diagnostic script not bundled. Run it manually:\n\n  ${res.manualCommand}`);
-        } else if (res.status === 'unsupported') {
-          window.alert('GPU diagnostic is for Linux NVIDIA hosts only.');
+      .then((res: GpuDiagnosticResultProp) => {
+        if (res.status === 'unsupported') {
+          toast.message('GPU diagnostic is for Linux NVIDIA hosts only.');
+          return;
         }
+        setDiagnosticResult(res);
+        setDiagnosticOpen(true);
       })
       .catch(() => {
-        window.alert('Failed to start GPU diagnostic — see console.');
+        toast.error('Failed to run GPU diagnostic — see console.');
+      })
+      .finally(() => {
+        setDiagnosticRunning(false);
       });
+  }, [diagnosticRunning]);
+
+  const handleCloseDiagnostic = useCallback((): void => {
+    setDiagnosticOpen(false);
   }, []);
 
   // Load dismissed state and GPU info on mount (GPU check cached per session)
@@ -1600,8 +1610,15 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
               preflight={gpuPreflight}
               backendError={gpuBackendError}
               onRunDiagnostic={handleRunGpuDiagnostic}
+              running={diagnosticRunning}
             />
           )}
+
+          <GpuDiagnosticModal
+            isOpen={diagnosticOpen}
+            result={diagnosticResult}
+            onClose={handleCloseDiagnostic}
+          />
 
           {/* 1. Docker Image or Inference Server (metal) Card */}
           {runtimeProfile === 'metal' ? (

--- a/dashboard/components/views/__tests__/GpuDiagnosticModal.test.tsx
+++ b/dashboard/components/views/__tests__/GpuDiagnosticModal.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+/**
+ * Renders the modal across the three product-meaningful states:
+ *   • completed + stale-CDI WARN  -> shows the regenerate command
+ *   • completed + script-missing  -> shows manual command, hides Open Log
+ *   • completed clicks Open Log   -> calls electronAPI.app.openPath verbatim
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { GpuDiagnosticModal, type GpuDiagnosticResultProp } from '../GpuDiagnosticModal';
+
+interface ElectronAPIShape {
+  app?: { openPath?: (p: string) => Promise<string> };
+}
+
+function withElectronApi(api: ElectronAPIShape): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).electronAPI = api;
+}
+
+const STALE_CDI_RESULT: GpuDiagnosticResultProp = {
+  status: 'completed',
+  logPath: '/home/user/.config/transcription-suite/gpu-diagnostics/gpu-diagnostic-x.log',
+  scriptPath: '/opt/app/scripts/diagnose-gpu.sh',
+  manualCommand: 'bash /opt/app/scripts/diagnose-gpu.sh',
+  exitCode: 0,
+  summary: {
+    passCount: 9,
+    warnCount: 1,
+    failCount: 0,
+    parsed: true,
+    issues: [
+      {
+        status: 'WARN',
+        checkNumber: 4,
+        title: 'CDI spec vs driver mtime',
+        detail:
+          'CDI spec is older than driver modules — regenerate with: sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml',
+        suggestedCommand: 'sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml',
+      },
+    ],
+  },
+};
+
+const SCRIPT_MISSING_RESULT: GpuDiagnosticResultProp = {
+  status: 'script-missing',
+  scriptPath: '/opt/app/scripts/diagnose-gpu.sh',
+  manualCommand: 'bash /opt/app/scripts/diagnose-gpu.sh',
+};
+
+describe('GpuDiagnosticModal', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).electronAPI = undefined;
+  });
+
+  it('renders nothing when not open', () => {
+    const { container } = render(
+      <GpuDiagnosticModal isOpen={false} result={STALE_CDI_RESULT} onClose={() => {}} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('surfaces the stale-CDI WARN row with the regenerate command (real user repro)', () => {
+    render(<GpuDiagnosticModal isOpen={true} result={STALE_CDI_RESULT} onClose={() => {}} />);
+
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(screen.getByText(/CDI spec vs driver mtime/)).toBeTruthy();
+    expect(
+      screen.getByText(/CDI spec is older than driver modules — regenerate with:/),
+    ).toBeTruthy();
+    expect(
+      screen.getByText('sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml'),
+    ).toBeTruthy();
+    expect(screen.getByText(/9 PASS/)).toBeTruthy();
+  });
+
+  it('clicking Open Log calls electronAPI.app.openPath with the log path', () => {
+    const openPath = vi.fn().mockResolvedValue('');
+    withElectronApi({ app: { openPath } });
+
+    render(<GpuDiagnosticModal isOpen={true} result={STALE_CDI_RESULT} onClose={() => {}} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Open Log/i }));
+    expect(openPath).toHaveBeenCalledTimes(1);
+    expect(openPath).toHaveBeenCalledWith(STALE_CDI_RESULT.logPath);
+  });
+
+  it('script-missing: shows manual command and hides Open Log', () => {
+    render(<GpuDiagnosticModal isOpen={true} result={SCRIPT_MISSING_RESULT} onClose={() => {}} />);
+
+    expect(screen.getByText(/Diagnostic script not bundled/)).toBeTruthy();
+    expect(screen.getByText(SCRIPT_MISSING_RESULT.manualCommand!)).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Open Log/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Copy Path/i })).toBeNull();
+  });
+
+  it('Escape key closes the modal', () => {
+    const onClose = vi.fn();
+    render(<GpuDiagnosticModal isOpen={true} result={STALE_CDI_RESULT} onClose={onClose} />);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('all-pass case: shows green banner and "All checks passed" copy with no rows', () => {
+    const allPass: GpuDiagnosticResultProp = {
+      status: 'completed',
+      logPath: '/var/log/x.log',
+      summary: { passCount: 11, warnCount: 0, failCount: 0, parsed: true, issues: [] },
+      exitCode: 0,
+    };
+    render(<GpuDiagnosticModal isOpen={true} result={allPass} onClose={() => {}} />);
+    expect(screen.getByText(/11 PASS/)).toBeTruthy();
+    expect(screen.getByText(/All checks passed/)).toBeTruthy();
+  });
+});

--- a/dashboard/electron/__tests__/dockerManagerGpuDiagnostic.test.ts
+++ b/dashboard/electron/__tests__/dockerManagerGpuDiagnostic.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment node
+
+/**
+ * Unit tests for the pure parseDiagnosticLog() helper. Exercises the row
+ * regex, the suggested-command extractor, the canonical Summary block, and
+ * the row-count fallback used when no Summary block is present.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: (name: string) => `/tmp/mock-${name}`,
+    setPath: vi.fn(),
+  },
+}));
+
+vi.mock('electron-store', () => ({
+  default: class MockStore {
+    get() {
+      return undefined;
+    }
+    set() {}
+  },
+}));
+
+import { parseDiagnosticLog } from '../dockerManager.js';
+
+describe('parseDiagnosticLog', () => {
+  it('parses the all-PASS happy path summary block and emits no issues', () => {
+    const log = [
+      '[PASS] #1  nvidia-smi present                                 driver=595.58.03',
+      '[PASS] #2  nvidia-ctk installed                               NVIDIA Container Toolkit CLI version 1.19.0',
+      '',
+      'PASS: 9   WARN: 0   FAIL: 0',
+      '',
+      'RESULT: All checks passed.',
+    ].join('\n');
+
+    const result = parseDiagnosticLog(log);
+
+    expect(result.parsed).toBe(true);
+    expect(result.passCount).toBe(9);
+    expect(result.warnCount).toBe(0);
+    expect(result.failCount).toBe(0);
+    expect(result.issues).toEqual([]);
+  });
+
+  it('extracts the stale-CDI WARN row and its regenerate command (real user repro)', () => {
+    const log = [
+      '[PASS] #3  CDI spec at /etc/cdi/nvidia.yaml                   size=21907B mtime=2026-04-16 21:58:05 +0300',
+      '[WARN] #4  CDI spec vs driver mtime                           CDI spec is older than driver modules — regenerate with: sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml',
+      '',
+      'PASS: 9   WARN: 1   FAIL: 0',
+    ].join('\n');
+
+    const result = parseDiagnosticLog(log);
+
+    expect(result.warnCount).toBe(1);
+    expect(result.issues).toHaveLength(1);
+    const [issue] = result.issues;
+    expect(issue.status).toBe('WARN');
+    expect(issue.checkNumber).toBe(4);
+    expect(issue.title).toBe('CDI spec vs driver mtime');
+    expect(issue.detail).toContain('CDI spec is older than driver modules');
+    expect(issue.suggestedCommand).toBe(
+      'sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml',
+    );
+  });
+
+  it('extracts a "fix:" command and trims trailing parentheticals', () => {
+    const log = [
+      '[FAIL] #5  /dev/char NVIDIA symlinks                          missing — fix: sudo nvidia-ctk system create-dev-char-symlinks --create-all (also add udev rule per nvidia-container-toolkit issue #48)',
+      'PASS: 8   WARN: 0   FAIL: 1',
+    ].join('\n');
+
+    const result = parseDiagnosticLog(log);
+
+    expect(result.failCount).toBe(1);
+    expect(result.issues[0].status).toBe('FAIL');
+    expect(result.issues[0].suggestedCommand).toBe(
+      'sudo nvidia-ctk system create-dev-char-symlinks --create-all',
+    );
+  });
+
+  it('surfaces multiple WARN/FAIL rows and skips PASS/INFO rows', () => {
+    const log = [
+      '[PASS] #1  nvidia-smi present                                 driver=595.58.03',
+      '[INFO] #7  Docker daemon.json                                 no daemon.json present',
+      '[WARN] #4  CDI spec vs driver mtime                           older — regenerate with: sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml',
+      '[FAIL] #6  module nvidia_uvm loaded                           fix: sudo modprobe nvidia_uvm',
+      'PASS: 7   WARN: 1   FAIL: 1',
+    ].join('\n');
+
+    const result = parseDiagnosticLog(log);
+
+    expect(result.issues.map((i) => i.checkNumber)).toEqual([4, 6]);
+    expect(result.issues.map((i) => i.status)).toEqual(['WARN', 'FAIL']);
+    expect(result.issues[0].suggestedCommand).toContain('nvidia-ctk cdi generate');
+    expect(result.issues[1].suggestedCommand).toBe('sudo modprobe nvidia_uvm');
+  });
+
+  it('keeps the row but leaves suggestedCommand undefined when no fix-pattern is present', () => {
+    const log = [
+      '[WARN] #5  /dev/char NVIDIA symlinks                          /dev/char does not exist on this host',
+      'PASS: 10   WARN: 1   FAIL: 0',
+    ].join('\n');
+
+    const result = parseDiagnosticLog(log);
+
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].suggestedCommand).toBeUndefined();
+    expect(result.issues[0].detail).toBe('/dev/char does not exist on this host');
+  });
+
+  it('falls back to row-counting and parsed=false when the Summary block is missing', () => {
+    const log = [
+      '[PASS] #1  nvidia-smi present                                 driver=595.58.03',
+      '[WARN] #4  CDI spec vs driver mtime                           older — regenerate with: sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml',
+      '[FAIL] #6  module nvidia_uvm loaded                           fix: sudo modprobe nvidia_uvm',
+      // (no PASS/WARN/FAIL summary line)
+    ].join('\n');
+
+    const result = parseDiagnosticLog(log);
+
+    expect(result.parsed).toBe(false);
+    expect(result.passCount).toBe(1);
+    expect(result.warnCount).toBe(1);
+    expect(result.failCount).toBe(1);
+    expect(result.issues).toHaveLength(2);
+  });
+
+  it('handles a completely empty log without throwing', () => {
+    const result = parseDiagnosticLog('');
+    expect(result).toEqual({
+      passCount: 0,
+      warnCount: 0,
+      failCount: 0,
+      issues: [],
+      parsed: false,
+    });
+  });
+
+  it('parses titles that contain spaces (regression for lazy-title regex bug)', () => {
+    // Multi-word titles must not be split at the first internal space.
+    // The %-50s budget guarantees ≥2 spaces between title and detail.
+    const log = [
+      '[WARN] #5  /dev/char NVIDIA symlinks                          /dev/char does not exist on this host',
+    ].join('\n');
+    const result = parseDiagnosticLog(log);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].title).toBe('/dev/char NVIDIA symlinks');
+    expect(result.issues[0].detail).toBe('/dev/char does not exist on this host');
+  });
+});

--- a/dashboard/electron/containerRuntime.ts
+++ b/dashboard/electron/containerRuntime.ts
@@ -16,7 +16,7 @@
 import { execFile } from 'child_process';
 import net from 'net';
 import { promisify } from 'util';
-import { existsSync } from 'fs';
+import { existsSync, accessSync, constants as fsConstants } from 'fs';
 import path from 'path';
 
 const execFileAsync = promisify(execFile);
@@ -360,11 +360,13 @@ export function resolveRootlessSocket(
 
   if (!existsSync(userSocket)) return null;
 
-  // Only use rootless socket if system socket is not accessible
+  // Only use rootless socket if system socket is not accessible.
+  // Use the top-level ESM imports — `require()` is not defined when the
+  // electron main process is packaged as ESM and silently failed here,
+  // forcing every Linux user onto the rootless socket path.
   let systemAccessible = false;
   try {
-    const fs = require('fs');
-    fs.accessSync(paths.system, fs.constants.R_OK | fs.constants.W_OK);
+    accessSync(paths.system, fsConstants.R_OK | fsConstants.W_OK);
     systemAccessible = true;
   } catch {
     systemAccessible = false;

--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -264,12 +264,11 @@ export function validateGpuPreflight(
  * function so tests can inject without touching fs/exec.
  */
 export function runGpuPreflight(): GpuPreflightResult {
-  // Lazy-import fs so the unit tests can mock electron without dragging in
-  // real fs operations during validateGpuPreflight() unit tests.
-  // (validateGpuPreflight() itself is pure; this wrapper is the impure shell.)
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const fs = require('fs') as typeof import('fs');
-
+  // Use the top-level ESM `fs` import. Electron's main process is bundled as
+  // ESM (electron/tsconfig.json: module=ESNext), so CommonJS `require()` is
+  // not defined at runtime in the packaged AppImage and was throwing
+  // ReferenceError here. validateGpuPreflight() itself stays pure — this
+  // impure wrapper just hands the real fs into the dep struct.
   const deps: GpuPreflightDeps = {
     fsExists: (p) => {
       try {

--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -319,14 +319,42 @@ export function runGpuPreflight(): GpuPreflightResult {
   return validateGpuPreflight(process.platform, deps);
 }
 
+/**
+ * One row parsed from `[STATUS] #N  Title  detail` in the diagnostic log.
+ * `suggestedCommand` is extracted from `regenerate with: <cmd>` or `fix: <cmd>`
+ * fragments inside `detail`, so the UI can render a copyable command without
+ * the user having to scrape the log themselves.
+ */
+export interface DiagnosticIssue {
+  status: 'PASS' | 'WARN' | 'FAIL' | 'INFO';
+  checkNumber: number;
+  title: string;
+  detail: string;
+  suggestedCommand?: string;
+}
+
+export interface DiagnosticSummary {
+  passCount: number;
+  warnCount: number;
+  failCount: number;
+  /** Only WARN + FAIL rows — what the UI surfaces. */
+  issues: DiagnosticIssue[];
+  /** True when the canonical `PASS: N WARN: N FAIL: N` summary block was found. */
+  parsed: boolean;
+}
+
 export interface RunGpuDiagnosticResult {
-  status: 'started' | 'unsupported' | 'script-missing';
-  /** Absolute path to the log file the script writes (when status=started). */
+  status: 'completed' | 'unsupported' | 'script-missing';
+  /** Absolute path to the log file the script writes (when status=completed). */
   logPath?: string;
-  /** Resolved script path (always present for status=started or script-missing). */
+  /** Resolved script path (always present for status=completed or script-missing). */
   scriptPath?: string;
   /** The exact command string the user could run themselves. */
   manualCommand?: string;
+  /** Parsed log summary (when status=completed). */
+  summary?: DiagnosticSummary;
+  /** Bash exit code (0 = OK / WARN; non-zero = FAIL). Present when status=completed. */
+  exitCode?: number;
 }
 
 function resolveDiagnosticScriptPath(): string {
@@ -339,7 +367,80 @@ function resolveDiagnosticScriptPath(): string {
   return path.resolve(__dirname, '..', '..', 'scripts', 'diagnose-gpu.sh');
 }
 
-export function runGpuDiagnostic(): RunGpuDiagnosticResult {
+// Each diagnostic check line has shape:
+//   [STATUS] #N  Title (≤50 col, padded)  detail
+// `printf '[%s] #%-2s %-50s %s\n'` in the bash script — the %-50s padding
+// guarantees ≥2 spaces between title and detail for every title currently
+// emitted by scripts/diagnose-gpu.sh (max title ~36 chars; budget is 50).
+// We deliberately DO NOT support titles that hit the 50-char budget exactly:
+// using `\s+` instead of `\s{2,}` would let the lazy title group stop at
+// the first space and break titles that contain spaces themselves.
+const DIAG_ROW_RE = /^\[(PASS|WARN|FAIL|INFO)\]\s+#(\d+)\s+(.+?)\s{2,}(.*)$/;
+// Pull the actionable command out of detail strings like
+//   "CDI spec is older than driver modules — regenerate with: sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml"
+//   "missing — fix: sudo nvidia-ctk system create-dev-char-symlinks --create-all (also add udev rule per …)"
+// Stops at " (" to drop trailing parentheticals; otherwise consumes to EOL.
+const DIAG_CMD_RE = /\b(?:regenerate with|fix):\s+(.+?)(?:\s+\([^)]*\)\s*$|\s*$)/i;
+const DIAG_SUMMARY_RE = /^PASS:\s*(\d+)\s+WARN:\s*(\d+)\s+FAIL:\s*(\d+)\s*$/m;
+
+/**
+ * Pure parser for `scripts/diagnose-gpu.sh` log output. Exported so the unit
+ * tests can hit it without spawning bash. WARN and FAIL rows are surfaced;
+ * PASS/INFO rows are counted only.
+ */
+export function parseDiagnosticLog(content: string): DiagnosticSummary {
+  const issues: DiagnosticIssue[] = [];
+  let passCount = 0;
+  let warnCount = 0;
+  let failCount = 0;
+  let parsed = false;
+
+  const summaryMatch = content.match(DIAG_SUMMARY_RE);
+  if (summaryMatch) {
+    parsed = true;
+    passCount = Number(summaryMatch[1]);
+    warnCount = Number(summaryMatch[2]);
+    failCount = Number(summaryMatch[3]);
+  }
+
+  for (const rawLine of content.split('\n')) {
+    const m = DIAG_ROW_RE.exec(rawLine);
+    if (!m) continue;
+    const [, status, num, title, detail] = m as unknown as [
+      string,
+      DiagnosticIssue['status'],
+      string,
+      string,
+      string,
+    ];
+    if (status === 'PASS' || status === 'INFO') continue;
+    const cmdMatch = DIAG_CMD_RE.exec(detail);
+    issues.push({
+      status: status as DiagnosticIssue['status'],
+      checkNumber: Number(num),
+      title: title.trim(),
+      detail: detail.trim(),
+      suggestedCommand: cmdMatch ? cmdMatch[1].trim() : undefined,
+    });
+  }
+
+  // Fallback when the canonical Summary block is missing: count what we saw
+  // ourselves so the modal still shows something useful.
+  if (!parsed) {
+    for (const rawLine of content.split('\n')) {
+      const m = DIAG_ROW_RE.exec(rawLine);
+      if (!m) continue;
+      const status = m[1];
+      if (status === 'PASS') passCount++;
+      else if (status === 'WARN') warnCount++;
+      else if (status === 'FAIL') failCount++;
+    }
+  }
+
+  return { passCount, warnCount, failCount, issues, parsed };
+}
+
+export async function runGpuDiagnostic(): Promise<RunGpuDiagnosticResult> {
   if (process.platform !== 'linux') {
     return { status: 'unsupported' };
   }
@@ -363,20 +464,63 @@ export function runGpuDiagnostic(): RunGpuDiagnosticResult {
   const ts = new Date().toISOString().replace(/[-:.]/g, '').slice(0, 15);
   const suffix = crypto.randomBytes(3).toString('hex');
   const logPath = path.join(dir, `gpu-diagnostic-${ts}-${suffix}.log`);
-  const out = fs.openSync(logPath, 'wx', 0o600);
 
-  const child = spawn('bash', [scriptPath], {
-    stdio: ['ignore', out, out],
-    detached: true,
-    cwd: dir,
+  // Wait for the child to exit so the renderer can show parsed results in
+  // one go. The script is read-only and bounded (~11 cheap checks, no docker
+  // pulls — image-pull guard is already inside the script). Typical wall
+  // time on a healthy host is <2s; the renderer shows a "Running…" spinner
+  // while we await.
+  //
+  // Open the fd inside the Promise so a synchronous open() failure or a
+  // 'error' event from spawn (e.g. bash not on PATH) still hits the cleanup
+  // path — out-of-scope of the original closeSync block, which only ran on
+  // 'exit'. Otherwise an 'error' before 'exit' would leak the fd.
+  const exitCode: number = await new Promise((resolve) => {
+    let out: number | undefined;
+    try {
+      out = fs.openSync(logPath, 'wx', 0o600);
+    } catch {
+      resolve(-1);
+      return;
+    }
+    const cleanup = (): void => {
+      if (out === undefined) return;
+      try {
+        fs.closeSync(out);
+      } catch {
+        // Best-effort — stdio inheritance may have already closed it.
+      }
+      out = undefined;
+    };
+    const child = spawn('bash', [scriptPath], {
+      stdio: ['ignore', out, out],
+      cwd: dir,
+    });
+    child.on('exit', (code) => {
+      cleanup();
+      resolve(code ?? 0);
+    });
+    child.on('error', () => {
+      cleanup();
+      resolve(-1);
+    });
   });
-  child.unref();
+
+  let summary: DiagnosticSummary;
+  try {
+    const content = await fs.promises.readFile(logPath, 'utf-8');
+    summary = parseDiagnosticLog(content);
+  } catch {
+    summary = { passCount: 0, warnCount: 0, failCount: 0, issues: [], parsed: false };
+  }
 
   return {
-    status: 'started',
+    status: 'completed',
     logPath,
     scriptPath,
     manualCommand: `bash ${scriptPath}`,
+    summary,
+    exitCode,
   };
 }
 

--- a/dashboard/electron/preload.ts
+++ b/dashboard/electron/preload.ts
@@ -151,10 +151,24 @@ export interface ElectronAPI {
       }>;
     }>;
     runGpuDiagnostic: () => Promise<{
-      status: 'started' | 'unsupported' | 'script-missing';
+      status: 'completed' | 'unsupported' | 'script-missing';
       logPath?: string;
       scriptPath?: string;
       manualCommand?: string;
+      summary?: {
+        passCount: number;
+        warnCount: number;
+        failCount: number;
+        parsed: boolean;
+        issues: Array<{
+          status: 'PASS' | 'WARN' | 'FAIL' | 'INFO';
+          checkNumber: number;
+          title: string;
+          detail: string;
+          suggestedCommand?: string;
+        }>;
+      };
+      exitCode?: number;
     }>;
     listImages: () => Promise<
       Array<{ tag: string; fullName: string; size: string; created: string; id: string }>

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.0.30",
-  "contract_sha256": "00e9504d29fb7efdccb77d2d2cc555fd8a1502306e0c016303ce7d9225bd1e1a",
-  "updated_at": "2026-04-29T11:51:18.589Z"
+  "spec_version": "1.0.32",
+  "contract_sha256": "889aec3ce59bf3e5175bea1e44f643557e79677b5e4628ed6ae61b00468b0005",
+  "updated_at": "2026-04-29T15:42:16.273Z"
 }

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.0.33",
-  "contract_sha256": "c2d0a747b1713fed35e5f1f574602cc6ca25079e9afeca60429493f7fc8503c5",
-  "updated_at": "2026-04-29T16:23:00.080Z"
+  "spec_version": "1.0.34",
+  "contract_sha256": "c1372314fe245ef6b60af476d1c92716d9567f68624150a1a74cf7e15add15dd",
+  "updated_at": "2026-04-29T17:21:36.353Z"
 }

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.0.32",
-  "contract_sha256": "889aec3ce59bf3e5175bea1e44f643557e79677b5e4628ed6ae61b00468b0005",
-  "updated_at": "2026-04-29T15:42:16.273Z"
+  "spec_version": "1.0.33",
+  "contract_sha256": "c2d0a747b1713fed35e5f1f574602cc6ca25079e9afeca60429493f7fc8503c5",
+  "updated_at": "2026-04-29T16:23:00.080Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.0.33
+  spec_version: 1.0.34
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -58,7 +58,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-04-29T16:22:32.485Z
+    generated_at: 2026-04-29T17:21:15.825Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -440,7 +440,6 @@ utility_allowlist:
     - bg-accent-magenta/10
     - bg-accent-orange
     - bg-accent-orange/10
-    - bg-accent-orange/5
     - bg-accent-rose/5
     - bg-amber-400/10
     - bg-amber-400/20
@@ -469,7 +468,6 @@ utility_allowlist:
     - bg-glass-surface
     - bg-green-500
     - bg-green-500/10
-    - bg-green-500/5
     - bg-linear-to-b
     - bg-linear-to-br
     - bg-linear-to-r

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.0.32
+  spec_version: 1.0.33
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -58,7 +58,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-04-29T15:41:42.402Z
+    generated_at: 2026-04-29T16:22:32.485Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -440,6 +440,7 @@ utility_allowlist:
     - bg-accent-magenta/10
     - bg-accent-orange
     - bg-accent-orange/10
+    - bg-accent-orange/5
     - bg-accent-rose/5
     - bg-amber-400/10
     - bg-amber-400/20
@@ -468,6 +469,7 @@ utility_allowlist:
     - bg-glass-surface
     - bg-green-500
     - bg-green-500/10
+    - bg-green-500/5
     - bg-linear-to-b
     - bg-linear-to-br
     - bg-linear-to-r
@@ -483,7 +485,6 @@ utility_allowlist:
     - bg-red-500/10
     - bg-red-500/25
     - bg-red-500/5
-    - bg-red-900/50
     - bg-slate-400/10
     - bg-slate-500
     - bg-slate-500/10
@@ -522,7 +523,6 @@ utility_allowlist:
     - border-amber-400/40
     - border-amber-500/20
     - border-amber-500/30
-    - border-amber-600
     - border-b
     - border-b-2
     - border-blue-500/20
@@ -531,8 +531,8 @@ utility_allowlist:
     - border-emerald-400/40
     - border-glass-100
     - border-glass-border
+    - border-green-500/20
     - border-green-500/30
-    - border-green-600
     - border-l
     - border-l-2
     - border-l-accent-magenta
@@ -549,7 +549,6 @@ utility_allowlist:
     - border-red-400/40
     - border-red-500/20
     - border-red-500/25
-    - border-red-700
     - border-slate-400/30
     - border-slate-900
     - border-t
@@ -722,6 +721,7 @@ utility_allowlist:
     - lg:p-10
     - lg:p-8
     - line-clamp-2
+    - m-0
     - mask-gradient-right
     - max-h-32
     - max-h-40
@@ -774,7 +774,6 @@ utility_allowlist:
     - mr-1.5
     - mr-2
     - mr-4
-    - mt-0
     - mt-0.5
     - mt-1
     - mt-1.5
@@ -953,7 +952,6 @@ utility_allowlist:
     - text-amber-400
     - text-amber-400/60
     - text-amber-400/80
-    - text-amber-600
     - text-base
     - text-black
     - text-blue-400
@@ -964,12 +962,10 @@ utility_allowlist:
     - text-emerald-400
     - text-green-400
     - text-green-400/70
-    - text-green-600
     - text-indigo-400
     - text-left
     - text-lg
     - text-neutral-100
-    - text-neutral-400
     - text-orange-400
     - text-orange-500
     - text-purple-400
@@ -979,7 +975,6 @@ utility_allowlist:
     - text-red-300
     - text-red-400
     - text-red-400/80
-    - text-red-700
     - text-right
     - text-slate-200
     - text-slate-300
@@ -2267,6 +2262,23 @@ component_contracts:
         rule: Session, notebook, and server nav items retain StatusLight indicators, with notebook status sharing the server status source.
   StarPopupModal:
     file: components/views/StarPopupModal.tsx
+    required_tokens:
+      - colors
+      - motion
+      - radii
+      - shadows
+    allowed_variants: {}
+    structural_invariants:
+      - id: structure-stable
+        rule: Preserve current structural layout and region hierarchy for this component.
+    behavior_rules:
+      - id: motion-locked
+        rule: Use only approved motion tokens and classes from foundation token registry.
+    state_rules:
+      - id: closed-set-styles
+        rule: Do not introduce unregistered utility, arbitrary, or inline style values.
+  StateIcon:
+    file: components/views/GpuHealthCard.tsx
     required_tokens:
       - colors
       - motion

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.0.30
+  spec_version: 1.0.32
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -35,12 +35,14 @@ meta:
       - components/ui/StatusLight.tsx
       - components/ui/UpdateBanner.tsx
       - components/ui/UpdateModal.tsx
+      - components/views/__tests__/GpuDiagnosticModal.test.tsx
       - components/views/__tests__/GpuHealthCard.test.tsx
       - components/views/AboutModal.tsx
       - components/views/AddNoteModal.tsx
       - components/views/AudioNoteModal.tsx
       - components/views/BugReportModal.tsx
       - components/views/FullscreenVisualizer.tsx
+      - components/views/GpuDiagnosticModal.tsx
       - components/views/GpuHealthCard.tsx
       - components/views/LogsView.tsx
       - components/views/ModelManagerTab.tsx
@@ -56,7 +58,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-04-29T11:50:14.967Z
+    generated_at: 2026-04-29T15:41:42.402Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -302,6 +304,7 @@ foundation:
         - h-[85%]
         - h-[85vh]
         - max-h-[80vh]
+        - max-h-[90vh]
         - max-w-[55%]
         - min-h-[38px]
         - min-h-[calc(100vh-30rem)]
@@ -585,6 +588,7 @@ utility_allowlist:
     - flex-none
     - flex-nowrap
     - flex-row-reverse
+    - flex-shrink-0
     - flex-wrap
     - font-bold
     - font-light
@@ -1075,6 +1079,7 @@ utility_allowlist:
     - h-[85%]
     - h-[85vh]
     - max-h-[80vh]
+    - max-h-[90vh]
     - max-w-[55%]
     - md:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]
     - min-h-[38px]
@@ -1692,6 +1697,23 @@ component_contracts:
     state_rules:
       - id: header-optional
         rule: Title/action header is optional but when present must retain h-14 bordered header pattern.
+  GpuDiagnosticModal:
+    file: components/views/GpuDiagnosticModal.tsx
+    required_tokens:
+      - colors
+      - motion
+      - radii
+      - shadows
+    allowed_variants: {}
+    structural_invariants:
+      - id: structure-stable
+        rule: Preserve current structural layout and region hierarchy for this component.
+    behavior_rules:
+      - id: motion-locked
+        rule: Use only approved motion tokens and classes from foundation token registry.
+    state_rules:
+      - id: closed-set-styles
+        rule: Do not introduce unregistered utility, arbitrary, or inline style values.
   GpuHealthCard:
     file: components/views/GpuHealthCard.tsx
     required_tokens:
@@ -1796,6 +1818,23 @@ component_contracts:
         rule: Speaker diarization and word timestamp option switches remain present in fixed order.
   IntelIcon:
     file: components/ui/icons/IntelIcon.tsx
+    required_tokens:
+      - colors
+      - motion
+      - radii
+      - shadows
+    allowed_variants: {}
+    structural_invariants:
+      - id: structure-stable
+        rule: Preserve current structural layout and region hierarchy for this component.
+    behavior_rules:
+      - id: motion-locked
+        rule: Use only approved motion tokens and classes from foundation token registry.
+    state_rules:
+      - id: closed-set-styles
+        rule: Do not introduce unregistered utility, arbitrary, or inline style values.
+  IssueRow:
+    file: components/views/GpuDiagnosticModal.tsx
     required_tokens:
       - colors
       - motion


### PR DESCRIPTION
## Summary

- **Make "Run Full Diagnostic" actionable.** Replaces the placeholder `window.alert(path)` UX with a proper `GpuDiagnosticModal`: the IPC handler now awaits the bash script, parses its log into a structured summary (PASS/WARN/FAIL counts + per-issue rows with extracted `regenerate with…` commands), and returns it to the renderer. The modal renders one row per WARN/FAIL with a copyable fix command, plus an **Open Log** button that uses the existing `electronAPI.app.openPath` (Electron `shell.openPath`) to open the log in the OS default text editor. The card's "Run Full Diagnostic" button accepts a new `running` prop so it disables and flips to "Running diagnostic…" during the ~2s wall time. Resolves the two prior-PR follow-ups: alert→modal (KDE Wayland selectability) and surfacing the stale-CDI hint with its copy-pasteable command. *(`70bd32c`)*

- **Critical fix for packaged AppImage builds.** Two pre-ESM-migration `require('fs')` calls in `dockerManager.ts` and `containerRuntime.ts` were crashing (`ReferenceError`) or silently misbehaving in production but never tripped CI — Vitest synthesizes a CJS-compatible `require` that masked the bug. Fix replaces both with the file's existing top-level ESM imports. Without this, every NVIDIA Linux user's preflight IPC was a no-op regardless of host state. *(`0329833`)*

- **Visual polish on the GPU Health card.** Adopts the Setup Complete preflight card's visual language: translucent `border-{state}-500/20 bg-{state}-500/10` shell on a `rounded-xl` container with lucide state icons (`CheckCircle2` / `AlertTriangle` / `XCircle`), `accent-orange` for warning hue parity, mono status pill ("X/Y checks passed"), and a softened recovery_hint banner. UI contract refreshed to lock the new class set. *(`4806056`, `87ff5aa`)*

## Test plan

- [ ] **Backend:** `cd server/backend && ../../build/.venv/bin/pytest tests/test_audio_utils.py tests/test_health_routes.py -v`
- [ ] **Dashboard:** `cd dashboard && npx vitest run` — confirm green, including the new `parseDiagnosticLog` regression test for multi-word titles
- [ ] **TypeScript:** `cd dashboard && npx tsc --noEmit -p electron/tsconfig.json && npx tsc --noEmit`
- [ ] **UI contract:** `cd dashboard && npm run ui:contract:check` — passes at spec_version 1.0.34
- [ ] **Packaged AppImage smoke test (the one that matters):** build the AppImage, run on a Linux NVIDIA host. Verify the GPU Health card on the Server tab no longer throws `ReferenceError: require is not defined` in DevTools when preflight fires.
- [ ] **Modal UX:** click "Run Full Diagnostic", confirm button disables and shows "Running diagnostic…", confirm modal opens with parsed PASS/WARN/FAIL counts and per-issue rows, click **Open Log** and verify the log opens in your default text editor (Kate / gedit / etc.).
- [ ] **Stale CDI flow (the user's actual case):** if your CDI spec is older than the driver, confirm the modal shows a WARN row with `sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml` in a copyable code block.
- [ ] **Visual:** card shell tints render at the new `/10` opacity, lucide icons render in the right color per state, and the recovery_hint banner uses `bg-red-500/10` rather than the prior solid red.