### PR TITLE
Issue #102 follow up

### DIFF
--- a/dashboard/components/__tests__/AddNoteModal.canary-language.test.tsx
+++ b/dashboard/components/__tests__/AddNoteModal.canary-language.test.tsx
@@ -1,0 +1,328 @@
+/**
+ * AddNoteModal — Canary language plumbing (gh-102 followup #2)
+ *
+ * Verifies the notebook-upload modal honors the persisted `session.mainLanguage`
+ * (and translation-target keys when Canary bidi is active). Mirrors the
+ * SessionImportTab pattern shipped in gh-102-followup-1:
+ *
+ *   1. Canary + Source Language = Spanish, submit → addFiles called with
+ *      options.language="es".
+ *   2. Canary + Auto Detect (or empty/unresolvable), submit → addFiles NOT
+ *      called; toast.error shown with the same wording the live-recording /
+ *      session-import guard uses ("Source language required").
+ *   3. Canary + bidi translation active (English source, target = French),
+ *      submit → addFiles called with language="en", translation_enabled=true,
+ *      translation_target_language="fr".
+ *   4. Whisper + Auto Detect → addFiles called with options.language=undefined
+ *      (regression check on the auto-detect happy path).
+ *   5. Languages still loading when user submits (Canary active) →
+ *      refuse-with-toast using "loading languages — please try again in a
+ *      moment." wording.
+ */
+
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const CANARY_MODEL = 'nvidia/canary-1b-v2';
+const WHISPER_MODEL = 'openai/whisper-large-v3-turbo';
+
+// ── Hoisted mock state ────────────────────────────────────────────────────
+
+interface MockLanguageSet {
+  languages: Array<{ code: string; name: string }>;
+  loading: boolean;
+  backendType: string;
+}
+
+let mockActiveModel: string | null = CANARY_MODEL;
+
+let mockLanguageSet: MockLanguageSet = {
+  languages: [{ code: 'auto', name: 'Auto Detect' }],
+  loading: true,
+  backendType: 'canary',
+};
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+const mockGetConfig = vi.fn();
+const mockAddFiles = vi.fn();
+
+vi.mock('../../src/hooks/useLanguages', () => ({
+  useLanguages: () => ({
+    languages: mockLanguageSet.languages,
+    backendType: mockLanguageSet.backendType,
+    loading: mockLanguageSet.loading,
+    error: null,
+  }),
+}));
+
+vi.mock('../../src/hooks/useAdminStatus', () => ({
+  useAdminStatus: () => ({
+    status: {
+      models_loaded: true,
+      config: {
+        main_transcriber: { model: mockActiveModel },
+        transcription: { model: mockActiveModel },
+        diarization: { parallel: false },
+      },
+    },
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/stores/importQueueStore', () => {
+  const fakeState = {
+    addFiles: (...args: unknown[]) => mockAddFiles(...args),
+  };
+  return {
+    useImportQueueStore: Object.assign(
+      (selector?: (s: typeof fakeState) => unknown) =>
+        typeof selector === 'function' ? selector(fakeState) : fakeState,
+      { getState: () => fakeState },
+    ),
+  };
+});
+
+vi.mock('../../src/api/client', () => ({
+  apiClient: {
+    getAdminStatus: vi.fn().mockResolvedValue({ config: { diarization: { parallel: false } } }),
+  },
+}));
+
+vi.mock('../../src/config/store', () => ({
+  getConfig: (...args: unknown[]) => mockGetConfig(...args),
+  setConfig: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Real modelCapabilities — we want the real `supportsAutoDetect`,
+// `isCanaryModel`, and `supportsTranslation` so the picker→code resolution is
+// end-to-end.
+vi.mock('../../src/services/modelCapabilities', async () => {
+  const actual = await vi.importActual<typeof import('../../src/services/modelCapabilities')>(
+    '../../src/services/modelCapabilities',
+  );
+  return actual;
+});
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+import { AddNoteModal } from '../views/AddNoteModal';
+
+const NEMO_LANGUAGES_FOR_TEST: Array<{ code: string; name: string }> = [
+  { code: 'auto', name: 'Auto Detect' },
+  { code: 'en', name: 'English' },
+  { code: 'es', name: 'Spanish' },
+  { code: 'fr', name: 'French' },
+  { code: 'de', name: 'German' },
+];
+
+const WHISPER_LANGUAGES_FOR_TEST: Array<{ code: string; name: string }> = [
+  { code: 'auto', name: 'Auto Detect' },
+  { code: 'en', name: 'English' },
+  { code: 'es', name: 'Spanish' },
+];
+
+function buildFile(name = 'sample.mp3'): File {
+  return new File([new Uint8Array([0])], name, { type: 'audio/mpeg' });
+}
+
+/** Populate the modal's selectedFiles by changing the hidden file input. */
+async function attachFile(file: File): Promise<void> {
+  const input = document.querySelector('input[type="file"]') as HTMLInputElement | null;
+  if (!input) throw new Error('file input not found in AddNoteModal');
+  Object.defineProperty(input, 'files', {
+    value: {
+      0: file,
+      length: 1,
+      item: (i: number) => (i === 0 ? file : null),
+      [Symbol.iterator]: function* () {
+        yield file;
+      },
+    },
+    configurable: true,
+  });
+  await act(async () => {
+    fireEvent.change(input);
+  });
+}
+
+/** Click the modal's Create Note submit button. */
+async function clickCreateNote(): Promise<void> {
+  const buttons = Array.from(document.querySelectorAll('button')) as HTMLButtonElement[];
+  const createButton = buttons.find((b) => /create note|queueing/i.test(b.textContent ?? ''));
+  if (!createButton) throw new Error('Create Note button not found in AddNoteModal');
+  await act(async () => {
+    fireEvent.click(createButton);
+    await Promise.resolve();
+  });
+}
+
+describe('AddNoteModal — Canary language plumbing (gh-102 followup #2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockToastError.mockReset();
+    mockToastSuccess.mockReset();
+    mockAddFiles.mockReset();
+    mockGetConfig.mockReset();
+    mockGetConfig.mockResolvedValue(undefined);
+
+    mockActiveModel = CANARY_MODEL;
+    mockLanguageSet = {
+      languages: NEMO_LANGUAGES_FOR_TEST,
+      loading: false,
+      backendType: 'canary',
+    };
+
+    // Modal renders into document.body via createPortal. Reset between tests
+    // to avoid stale DOM bleeding across cases.
+    document.body.innerHTML = '';
+  });
+
+  it('Canary + Spanish persisted: submit enqueues with options.language="es"', async () => {
+    mockGetConfig.mockImplementation(async (key: string) => {
+      if (key === 'session.mainLanguage') return 'Spanish';
+      return undefined;
+    });
+
+    render(React.createElement(AddNoteModal, { isOpen: true, onClose: vi.fn() }));
+
+    await act(async () => {
+      // Allow hydrate useEffect's Promise.all to resolve
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await attachFile(buildFile());
+    await clickCreateNote();
+
+    expect(mockToastError).not.toHaveBeenCalled();
+    expect(mockAddFiles).toHaveBeenCalledTimes(1);
+    const [, , options] = mockAddFiles.mock.calls[0] as [unknown, unknown, Record<string, unknown>];
+    expect(options.language).toBe('es');
+    expect(options.translation_enabled).toBeUndefined();
+    expect(options.translation_target_language).toBeUndefined();
+  });
+
+  it('Canary + Auto Detect: submit refuses with toast.error and does not enqueue', async () => {
+    mockGetConfig.mockImplementation(async (key: string) => {
+      if (key === 'session.mainLanguage') return 'Auto Detect';
+      return undefined;
+    });
+
+    render(React.createElement(AddNoteModal, { isOpen: true, onClose: vi.fn() }));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await attachFile(buildFile());
+    await clickCreateNote();
+
+    expect(mockAddFiles).not.toHaveBeenCalled();
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+    const [title, opts] = mockToastError.mock.calls[0] as [string, { description?: string }];
+    // Strict equality enforces the spec's "wording-grep parity" Always:
+    // invariant — any future copy drift between AddNoteModal,
+    // NotebookView.ImportTab, and SessionImportTab.handleFiles will fail
+    // tests instead of silently succeeding.
+    expect(title).toBe('Source language required');
+    expect(opts?.description).toBe(
+      '"Auto Detect" is not a valid source language for the active model. Pick a language from the Source Language dropdown.',
+    );
+  });
+
+  it('Canary + bidi (English source, French target): submit enqueues with translation fields', async () => {
+    mockGetConfig.mockImplementation(async (key: string) => {
+      if (key === 'session.mainLanguage') return 'English';
+      if (key === 'session.mainBidiTarget') return 'French';
+      return undefined;
+    });
+
+    render(React.createElement(AddNoteModal, { isOpen: true, onClose: vi.fn() }));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await attachFile(buildFile());
+    await clickCreateNote();
+
+    expect(mockToastError).not.toHaveBeenCalled();
+    expect(mockAddFiles).toHaveBeenCalledTimes(1);
+    const [, , options] = mockAddFiles.mock.calls[0] as [unknown, unknown, Record<string, unknown>];
+    expect(options.language).toBe('en');
+    expect(options.translation_enabled).toBe(true);
+    expect(options.translation_target_language).toBe('fr');
+  });
+
+  it('Whisper + Auto Detect: submit enqueues with options.language=undefined (regression check)', async () => {
+    mockActiveModel = WHISPER_MODEL;
+    mockLanguageSet = {
+      languages: WHISPER_LANGUAGES_FOR_TEST,
+      loading: false,
+      backendType: 'whisper',
+    };
+    mockGetConfig.mockImplementation(async (key: string) => {
+      if (key === 'session.mainLanguage') return 'Auto Detect';
+      return undefined;
+    });
+
+    render(React.createElement(AddNoteModal, { isOpen: true, onClose: vi.fn() }));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await attachFile(buildFile());
+    await clickCreateNote();
+
+    expect(mockToastError).not.toHaveBeenCalled();
+    expect(mockAddFiles).toHaveBeenCalledTimes(1);
+    const [, , options] = mockAddFiles.mock.calls[0] as [unknown, unknown, Record<string, unknown>];
+    expect(options.language).toBeUndefined();
+    expect(options.translation_enabled).toBeUndefined();
+    expect(options.translation_target_language).toBeUndefined();
+  });
+
+  it('Canary + languages still loading: submit refuses with "loading languages" wording', async () => {
+    mockLanguageSet = {
+      languages: [{ code: 'auto', name: 'Auto Detect' }],
+      loading: true,
+      backendType: 'canary',
+    };
+    mockGetConfig.mockImplementation(async (key: string) => {
+      if (key === 'session.mainLanguage') return 'Spanish';
+      return undefined;
+    });
+
+    render(React.createElement(AddNoteModal, { isOpen: true, onClose: vi.fn() }));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await attachFile(buildFile());
+    await clickCreateNote();
+
+    expect(mockAddFiles).not.toHaveBeenCalled();
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+    const [title, opts] = mockToastError.mock.calls[0] as [string, { description?: string }];
+    // Strict equality enforces wording-grep parity for the loading branch
+    // tail ("please try again in a moment.") — see comment in the
+    // Auto-Detect refuse case above.
+    expect(title).toBe('Source language required');
+    expect(opts?.description).toBe('Loading languages — please try again in a moment.');
+  });
+});

--- a/dashboard/components/__tests__/NotebookView.canary-language.test.tsx
+++ b/dashboard/components/__tests__/NotebookView.canary-language.test.tsx
@@ -128,6 +128,7 @@ vi.mock('../../src/stores/importQueueStore', () => {
     resumeQueue: vi.fn(),
     updateNotebookCallbacks: vi.fn(),
     updateNotebookConfig: vi.fn(),
+    setLanguagesCache: vi.fn(),
     clearWatchLog: vi.fn(),
   };
   return {

--- a/dashboard/components/__tests__/NotebookView.canary-language.test.tsx
+++ b/dashboard/components/__tests__/NotebookView.canary-language.test.tsx
@@ -1,0 +1,433 @@
+/**
+ * NotebookView ImportTab — Canary language plumbing (gh-102 followup #2)
+ *
+ * Verifies the inline ImportTab inside NotebookView (lines 1302–1480) honors
+ * the persisted `session.mainLanguage` (and translation-target keys when
+ * Canary bidi is active). Mirrors the SessionImportTab pattern shipped in
+ * gh-102-followup-1 and the parallel AddNoteModal coverage:
+ *
+ *   1. Canary + Source Language = Spanish, drop file → addFiles called with
+ *      options.language="es".
+ *   2. Canary + Auto Detect (or empty/unresolvable), drop file → addFiles NOT
+ *      called; toast.error shown with the same wording the live-recording /
+ *      session-import guard uses ("Source language required").
+ *   3. Canary + bidi translation active (English source, target = French),
+ *      drop file → addFiles called with language="en", translation_enabled=true,
+ *      translation_target_language="fr".
+ *   4. Whisper + Auto Detect → addFiles called with options.language=undefined
+ *      (regression check on the auto-detect happy path).
+ *   5. Languages still loading when user drops a file (Canary active) →
+ *      refuse-with-toast using "loading languages — please try again in a
+ *      moment." wording.
+ */
+
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const CANARY_MODEL = 'nvidia/canary-1b-v2';
+const WHISPER_MODEL = 'openai/whisper-large-v3-turbo';
+
+// ── Hoisted mock state ────────────────────────────────────────────────────
+
+interface MockLanguageSet {
+  languages: Array<{ code: string; name: string }>;
+  loading: boolean;
+  backendType: string;
+}
+
+let mockActiveModel: string | null = CANARY_MODEL;
+
+let mockLanguageSet: MockLanguageSet = {
+  languages: [{ code: 'auto', name: 'Auto Detect' }],
+  loading: true,
+  backendType: 'canary',
+};
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+const mockGetConfig = vi.fn();
+const mockAddFiles = vi.fn();
+
+// ── Mocks (mirror NotebookView.test.tsx isolation pattern) ────────────────
+
+vi.mock('../../src/hooks/useCalendar', () => ({
+  useCalendar: () => ({
+    days: {},
+    totalRecordings: 0,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/hooks/useSearch', () => ({
+  useSearch: () => ({
+    results: [],
+    count: 0,
+    loading: false,
+    error: null,
+    search: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/hooks/useLanguages', () => ({
+  useLanguages: () => ({
+    languages: mockLanguageSet.languages,
+    backendType: mockLanguageSet.backendType,
+    loading: mockLanguageSet.loading,
+    error: null,
+  }),
+}));
+
+vi.mock('../../src/hooks/useAdminStatus', () => ({
+  useAdminStatus: () => ({
+    status: {
+      models_loaded: true,
+      config: {
+        main_transcriber: { model: mockActiveModel },
+        transcription: { model: mockActiveModel },
+        diarization: { parallel: false },
+      },
+    },
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/hooks/useNotebookWatcher', () => ({
+  useNotebookWatcher: () => ({
+    notebookWatchPath: '',
+    notebookWatchActive: false,
+    notebookWatchAccessible: true,
+    setNotebookWatchPath: vi.fn(),
+    setWatchPath: vi.fn(),
+    setNotebookWatchActive: vi.fn(),
+    toggleNotebookWatch: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/stores/importQueueStore', () => {
+  const fakeState: Record<string, unknown> = {
+    jobs: [],
+    isPaused: false,
+    notebookCallbacks: {},
+    notebookWatchPath: '',
+    notebookWatchActive: false,
+    sessionWatchPath: '',
+    watcherServerConnected: true,
+    watchLog: [],
+    avgProcessingMs: 0,
+    addFiles: (...args: unknown[]) => mockAddFiles(...args),
+    removeJob: vi.fn(),
+    retryJob: vi.fn(),
+    clearFinished: vi.fn(),
+    pauseQueue: vi.fn(),
+    resumeQueue: vi.fn(),
+    updateNotebookCallbacks: vi.fn(),
+    updateNotebookConfig: vi.fn(),
+    clearWatchLog: vi.fn(),
+  };
+  return {
+    useImportQueueStore: (selector?: (s: Record<string, unknown>) => unknown) =>
+      typeof selector === 'function' ? selector(fakeState) : fakeState,
+    selectNotebookJobs: () => [],
+    selectPendingCount: () => 0,
+    selectCompletedCount: () => 0,
+    selectErrorCount: () => 0,
+    selectIsProcessing: () => false,
+  };
+});
+
+vi.mock('../../src/api/client', () => ({
+  apiClient: {
+    getCalendar: vi.fn().mockResolvedValue({ days: {}, total_recordings: 0 }),
+    getAdminStatus: vi.fn().mockResolvedValue({ config: { diarization: { parallel: false } } }),
+    search: vi.fn().mockResolvedValue({ results: [], count: 0 }),
+    updateRecordingTitle: vi.fn(),
+    deleteRecording: vi.fn(),
+    getExportUrl: vi.fn().mockReturnValue('http://localhost:9786/api/notebook/recordings/1/export'),
+  },
+}));
+
+vi.mock('../../src/config/store', () => ({
+  getConfig: (...args: unknown[]) => mockGetConfig(...args),
+  setConfig: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/utils/transcriptionBackend', () => ({
+  supportsExplicitWordTimestampToggle: () => true,
+}));
+
+vi.mock('../../src/services/modelCapabilities', async () => {
+  const actual = await vi.importActual<typeof import('../../src/services/modelCapabilities')>(
+    '../../src/services/modelCapabilities',
+  );
+  return actual;
+});
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+vi.mock('../../src/hooks/useConfirm', () => ({
+  useConfirm: () => ({
+    confirm: vi.fn().mockResolvedValue(true),
+    dialog: null,
+  }),
+}));
+
+vi.mock('zustand/react/shallow', () => ({
+  useShallow: (selector: unknown) => selector,
+}));
+
+// ── Import after mocks ────────────────────────────────────────────────────
+
+import { NotebookView } from '../views/NotebookView';
+import { NotebookTab } from '../../types';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const NEMO_LANGUAGES_FOR_TEST: Array<{ code: string; name: string }> = [
+  { code: 'auto', name: 'Auto Detect' },
+  { code: 'en', name: 'English' },
+  { code: 'es', name: 'Spanish' },
+  { code: 'fr', name: 'French' },
+  { code: 'de', name: 'German' },
+];
+
+const WHISPER_LANGUAGES_FOR_TEST: Array<{ code: string; name: string }> = [
+  { code: 'auto', name: 'Auto Detect' },
+  { code: 'en', name: 'English' },
+  { code: 'es', name: 'Spanish' },
+];
+
+function buildFile(name = 'sample.mp3'): File {
+  return new File([new Uint8Array([0])], name, { type: 'audio/mpeg' });
+}
+
+function dropFile(file: File): { dataTransfer: { files: FileList } } {
+  const list = {
+    0: file,
+    length: 1,
+    item: (i: number) => (i === 0 ? file : null),
+    [Symbol.iterator]: function* () {
+      yield file;
+    },
+  } as unknown as FileList;
+  return { dataTransfer: { files: list } };
+}
+
+function createWrapper(): ({ children }: { children: React.ReactNode }) => React.ReactElement {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children) as React.ReactElement;
+}
+
+/** Find the ImportTab dropzone — the cursor-pointer div with the upload icon. */
+function findDropZone(container: HTMLElement): Element {
+  // ImportTab's dropzone has the same cursor-pointer + border-dashed shape as
+  // SessionImportTab's. Filter for "Drag & Drop Audio Files" heading nearby
+  // to disambiguate from the watch-folder drag area (which also has cursor
+  // styling on its inner buttons).
+  const candidates = Array.from(container.querySelectorAll<HTMLElement>('.cursor-pointer'));
+  const dropZone = candidates.find((el) => /drag.*drop/i.test(el.textContent ?? ''));
+  if (!dropZone) throw new Error('ImportTab dropzone not found');
+  return dropZone;
+}
+
+describe('NotebookView ImportTab — Canary language plumbing (gh-102 followup #2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockToastError.mockReset();
+    mockToastSuccess.mockReset();
+    mockAddFiles.mockReset();
+    mockGetConfig.mockReset();
+    mockGetConfig.mockResolvedValue(undefined);
+
+    mockActiveModel = CANARY_MODEL;
+    mockLanguageSet = {
+      languages: NEMO_LANGUAGES_FOR_TEST,
+      loading: false,
+      backendType: 'canary',
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as unknown as { electronAPI?: any }).electronAPI = {
+      fileIO: {
+        getDownloadsPath: vi.fn().mockResolvedValue('/tmp'),
+        selectFolder: vi.fn().mockResolvedValue(null),
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+  });
+
+  it('Canary + Spanish persisted: drop enqueues with options.language="es"', async () => {
+    mockGetConfig.mockImplementation(async (key: string) => {
+      if (key === 'session.mainLanguage') return 'Spanish';
+      return undefined;
+    });
+
+    const { container } = render(
+      React.createElement(NotebookView, { activeTab: NotebookTab.IMPORT }),
+      { wrapper: createWrapper() },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const dropZone = findDropZone(container);
+    await act(async () => {
+      fireEvent.drop(dropZone, dropFile(buildFile()));
+    });
+
+    expect(mockToastError).not.toHaveBeenCalled();
+    expect(mockAddFiles).toHaveBeenCalledTimes(1);
+    const [, , options] = mockAddFiles.mock.calls[0] as [unknown, unknown, Record<string, unknown>];
+    expect(options.language).toBe('es');
+    expect(options.translation_enabled).toBeUndefined();
+    expect(options.translation_target_language).toBeUndefined();
+  });
+
+  it('Canary + Auto Detect: drop refuses with toast.error and does not enqueue', async () => {
+    mockGetConfig.mockImplementation(async (key: string) => {
+      if (key === 'session.mainLanguage') return 'Auto Detect';
+      return undefined;
+    });
+
+    const { container } = render(
+      React.createElement(NotebookView, { activeTab: NotebookTab.IMPORT }),
+      { wrapper: createWrapper() },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const dropZone = findDropZone(container);
+    await act(async () => {
+      fireEvent.drop(dropZone, dropFile(buildFile()));
+    });
+
+    expect(mockAddFiles).not.toHaveBeenCalled();
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+    const [title, opts] = mockToastError.mock.calls[0] as [string, { description?: string }];
+    // Strict equality enforces the spec's "wording-grep parity" Always:
+    // invariant — any future copy drift between NotebookView.ImportTab,
+    // AddNoteModal, and SessionImportTab.handleFiles will fail tests
+    // instead of silently succeeding.
+    expect(title).toBe('Source language required');
+    expect(opts?.description).toBe(
+      '"Auto Detect" is not a valid source language for the active model. Pick a language from the Source Language dropdown.',
+    );
+  });
+
+  it('Canary + bidi (English source, French target): drop enqueues with translation fields', async () => {
+    mockGetConfig.mockImplementation(async (key: string) => {
+      if (key === 'session.mainLanguage') return 'English';
+      if (key === 'session.mainBidiTarget') return 'French';
+      return undefined;
+    });
+
+    const { container } = render(
+      React.createElement(NotebookView, { activeTab: NotebookTab.IMPORT }),
+      { wrapper: createWrapper() },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const dropZone = findDropZone(container);
+    await act(async () => {
+      fireEvent.drop(dropZone, dropFile(buildFile()));
+    });
+
+    expect(mockToastError).not.toHaveBeenCalled();
+    expect(mockAddFiles).toHaveBeenCalledTimes(1);
+    const [, , options] = mockAddFiles.mock.calls[0] as [unknown, unknown, Record<string, unknown>];
+    expect(options.language).toBe('en');
+    expect(options.translation_enabled).toBe(true);
+    expect(options.translation_target_language).toBe('fr');
+  });
+
+  it('Whisper + Auto Detect: drop enqueues with options.language=undefined (regression check)', async () => {
+    mockActiveModel = WHISPER_MODEL;
+    mockLanguageSet = {
+      languages: WHISPER_LANGUAGES_FOR_TEST,
+      loading: false,
+      backendType: 'whisper',
+    };
+    mockGetConfig.mockImplementation(async (key: string) => {
+      if (key === 'session.mainLanguage') return 'Auto Detect';
+      return undefined;
+    });
+
+    const { container } = render(
+      React.createElement(NotebookView, { activeTab: NotebookTab.IMPORT }),
+      { wrapper: createWrapper() },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const dropZone = findDropZone(container);
+    await act(async () => {
+      fireEvent.drop(dropZone, dropFile(buildFile()));
+    });
+
+    expect(mockToastError).not.toHaveBeenCalled();
+    expect(mockAddFiles).toHaveBeenCalledTimes(1);
+    const [, , options] = mockAddFiles.mock.calls[0] as [unknown, unknown, Record<string, unknown>];
+    expect(options.language).toBeUndefined();
+    expect(options.translation_enabled).toBeUndefined();
+    expect(options.translation_target_language).toBeUndefined();
+  });
+
+  it('Canary + languages still loading: drop refuses with "loading languages" wording', async () => {
+    mockLanguageSet = {
+      languages: [{ code: 'auto', name: 'Auto Detect' }],
+      loading: true,
+      backendType: 'canary',
+    };
+    mockGetConfig.mockImplementation(async (key: string) => {
+      if (key === 'session.mainLanguage') return 'Spanish';
+      return undefined;
+    });
+
+    const { container } = render(
+      React.createElement(NotebookView, { activeTab: NotebookTab.IMPORT }),
+      { wrapper: createWrapper() },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const dropZone = findDropZone(container);
+    await act(async () => {
+      fireEvent.drop(dropZone, dropFile(buildFile()));
+    });
+
+    expect(mockAddFiles).not.toHaveBeenCalled();
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+    const [title, opts] = mockToastError.mock.calls[0] as [string, { description?: string }];
+    // Strict equality enforces wording-grep parity for the loading branch
+    // tail ("please try again in a moment.") — see comment in the
+    // Auto-Detect refuse case above.
+    expect(title).toBe('Source language required');
+    expect(opts?.description).toBe('Loading languages — please try again in a moment.');
+  });
+});

--- a/dashboard/components/__tests__/NotebookView.test.tsx
+++ b/dashboard/components/__tests__/NotebookView.test.tsx
@@ -78,6 +78,7 @@ vi.mock('../../src/stores/importQueueStore', () => ({
       notebookWatchActive: false,
       updateNotebookCallbacks: vi.fn(),
       updateNotebookConfig: vi.fn(),
+      setLanguagesCache: vi.fn(),
     };
     return typeof selector === 'function' ? selector(state) : state;
   },

--- a/dashboard/components/__tests__/SessionImportTab.canary-language.test.tsx
+++ b/dashboard/components/__tests__/SessionImportTab.canary-language.test.tsx
@@ -1,0 +1,374 @@
+/**
+ * SessionImportTab — Canary language plumbing (gh-102 followup, issue 102 reopened)
+ *
+ * Verifies the file-import surface honors the persisted `session.mainLanguage`
+ * (and translation-target keys when Canary bidi is active). Mirrors the
+ * live-recording guard pattern at SessionView.handleStartRecording (gh-102):
+ *
+ *   1. Canary + Source Language = Spanish, drop file → addFiles called with
+ *      options.language="es".
+ *   2. Canary + Auto Detect (or empty/unresolvable), drop file → addFiles NOT
+ *      called; toast.error shown with the same wording the live-recording
+ *      guard uses ("Source language required").
+ *   3. Canary + bidi translation active (English source, target = French),
+ *      drop file → addFiles called with language="en",
+ *      translation_enabled=true, translation_target_language="fr".
+ *   4. Whisper + Auto Detect → addFiles called with options.language=undefined
+ *      (regression check on the auto-detect happy path).
+ *   5. Languages still loading when user drops a file (Canary active) →
+ *      refuse-with-toast using "loading languages — please try again in a
+ *      moment." wording (mirrors handleStartRecording's loading branch).
+ */
+
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const CANARY_MODEL = 'nvidia/canary-1b-v2';
+const WHISPER_MODEL = 'openai/whisper-large-v3-turbo';
+
+// ── Hoisted mock state ────────────────────────────────────────────────────
+//
+// Tests flip the language list, the active model, and the persisted config
+// per-case. Mocks read from module-level mutable state and tests reset it in
+// beforeEach.
+
+interface MockLanguageSet {
+  languages: Array<{ code: string; name: string }>;
+  loading: boolean;
+  backendType: string;
+}
+
+let mockActiveModel: string | null = CANARY_MODEL;
+
+let mockLanguageSet: MockLanguageSet = {
+  languages: [{ code: 'auto', name: 'Auto Detect' }],
+  loading: true,
+  backendType: 'canary',
+};
+
+const mockToastError = vi.fn();
+const mockGetConfig = vi.fn();
+const mockAddFiles = vi.fn();
+
+vi.mock('../../src/hooks/useLanguages', () => ({
+  useLanguages: () => ({
+    languages: mockLanguageSet.languages,
+    backendType: mockLanguageSet.backendType,
+    loading: mockLanguageSet.loading,
+    error: null,
+  }),
+}));
+
+vi.mock('../../src/hooks/useAdminStatus', () => ({
+  useAdminStatus: () => ({
+    status: {
+      models_loaded: true,
+      config: {
+        main_transcriber: { model: mockActiveModel },
+        transcription: { model: mockActiveModel },
+      },
+    },
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/hooks/useSessionWatcher', () => ({
+  useSessionWatcher: () => ({
+    sessionWatchPath: '',
+    sessionWatchActive: false,
+    setSessionWatchActive: vi.fn(),
+    setWatchPath: vi.fn(),
+    sessionWatchAccessible: true,
+  }),
+}));
+
+vi.mock('../../src/stores/importQueueStore', () => {
+  const fakeState: Record<string, unknown> = {
+    jobs: [],
+    isPaused: false,
+    sessionConfig: {
+      outputDir: '',
+      diarizedFormat: 'srt',
+      hideTimestamps: false,
+      enableDiarization: true,
+      enableWordTimestamps: true,
+      parallelDiarization: false,
+      multitrack: false,
+    },
+    sessionWatchPath: '',
+    sessionWatchActive: false,
+    notebookWatchPath: '',
+    notebookWatchActive: false,
+    watcherServerConnected: true,
+    watchLog: [],
+    avgProcessingMs: 0,
+    addFiles: (...args: unknown[]) => mockAddFiles(...args),
+    removeJob: vi.fn(),
+    retryJob: vi.fn(),
+    clearFinished: vi.fn(),
+    pauseQueue: vi.fn(),
+    resumeQueue: vi.fn(),
+    updateSessionConfig: vi.fn(),
+    clearWatchLog: vi.fn(),
+  };
+  return {
+    useImportQueueStore: (selector?: (s: Record<string, unknown>) => unknown) =>
+      typeof selector === 'function' ? selector(fakeState) : fakeState,
+    selectSessionJobs: () => [],
+    selectPendingCount: () => 0,
+    selectCompletedCount: () => 0,
+    selectErrorCount: () => 0,
+    selectIsProcessing: () => false,
+  };
+});
+
+vi.mock('../../src/api/client', () => ({
+  apiClient: {
+    getAdminStatus: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock('../../src/config/store', () => ({
+  getConfig: (...args: unknown[]) => mockGetConfig(...args),
+  setConfig: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/utils/transcriptionBackend', () => ({
+  supportsExplicitWordTimestampToggle: () => true,
+}));
+
+// Real modelCapabilities — we want the real `supportsAutoDetect`,
+// `isCanaryModel`, and `supportsTranslation` so the picker→code resolution
+// is end-to-end.
+vi.mock('../../src/services/modelCapabilities', async () => {
+  const actual = await vi.importActual<typeof import('../../src/services/modelCapabilities')>(
+    '../../src/services/modelCapabilities',
+  );
+  return actual;
+});
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+import { SessionImportTab } from '../views/SessionImportTab';
+
+// NEMO Canary language list (canary-1b-v2 supports 25 EU languages).
+const NEMO_LANGUAGES_FOR_TEST: Array<{ code: string; name: string }> = [
+  { code: 'auto', name: 'Auto Detect' }, // synthetic prepend; filter drops for canary
+  { code: 'en', name: 'English' },
+  { code: 'es', name: 'Spanish' },
+  { code: 'fr', name: 'French' },
+  { code: 'de', name: 'German' },
+];
+
+// Whisper auto-detect-capable list.
+const WHISPER_LANGUAGES_FOR_TEST: Array<{ code: string; name: string }> = [
+  { code: 'auto', name: 'Auto Detect' },
+  { code: 'en', name: 'English' },
+  { code: 'es', name: 'Spanish' },
+];
+
+function buildFile(name = 'sample.mp3'): File {
+  return new File([new Uint8Array([0])], name, { type: 'audio/mpeg' });
+}
+
+function dropFile(file: File): { dataTransfer: { files: FileList } } {
+  // Construct a FileList-like object since jsdom doesn't expose a constructor.
+  const list = {
+    0: file,
+    length: 1,
+    item: (i: number) => (i === 0 ? file : null),
+    [Symbol.iterator]: function* () {
+      yield file;
+    },
+  } as unknown as FileList;
+  return { dataTransfer: { files: list } };
+}
+
+describe('SessionImportTab — Canary language plumbing (gh-102 followup)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockToastError.mockReset();
+    mockAddFiles.mockReset();
+    mockGetConfig.mockReset();
+
+    // Default: no persisted config keys.
+    mockGetConfig.mockResolvedValue(undefined);
+
+    mockActiveModel = CANARY_MODEL;
+    mockLanguageSet = {
+      languages: NEMO_LANGUAGES_FOR_TEST,
+      loading: false,
+      backendType: 'canary',
+    };
+
+    // jsdom electronAPI shim — SessionImportTab reads downloadsPath on mount.
+    // The fileIO surface is wider than what we exercise here, so use `any`
+    // (with eslint-disable) instead of the full IpcFileIO type.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as unknown as { electronAPI?: any }).electronAPI = {
+      fileIO: {
+        getDownloadsPath: vi.fn().mockResolvedValue('/tmp'),
+        selectFolder: vi.fn().mockResolvedValue(null),
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+  });
+
+  it('Canary + Spanish persisted: drop file enqueues with options.language="es"', async () => {
+    mockGetConfig.mockImplementation(async (key: string) => {
+      if (key === 'session.mainLanguage') return 'Spanish';
+      return undefined;
+    });
+
+    const { container } = render(React.createElement(SessionImportTab));
+
+    // Wait for mount-time getConfig promises to resolve.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const dropZone = container.querySelector('.cursor-pointer');
+    expect(dropZone).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.drop(dropZone as Element, dropFile(buildFile()));
+    });
+
+    expect(mockToastError).not.toHaveBeenCalled();
+    expect(mockAddFiles).toHaveBeenCalledTimes(1);
+    const [, , options] = mockAddFiles.mock.calls[0] as [unknown, unknown, Record<string, unknown>];
+    expect(options.language).toBe('es');
+    // Whisper-like translation fields must NOT be present on a non-translation
+    // path — only emit them for Canary bidi.
+    expect(options.translation_enabled).toBeUndefined();
+    expect(options.translation_target_language).toBeUndefined();
+  });
+
+  it('Canary + Auto Detect: drop refuses with toast.error and does not enqueue', async () => {
+    mockGetConfig.mockImplementation(async (key: string) => {
+      if (key === 'session.mainLanguage') return 'Auto Detect';
+      return undefined;
+    });
+
+    const { container } = render(React.createElement(SessionImportTab));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const dropZone = container.querySelector('.cursor-pointer');
+    await act(async () => {
+      fireEvent.drop(dropZone as Element, dropFile(buildFile()));
+    });
+
+    expect(mockAddFiles).not.toHaveBeenCalled();
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+    const [title, opts] = mockToastError.mock.calls[0] as [string, { description?: string }];
+    expect(title).toMatch(/source language required/i);
+    expect(String(opts?.description ?? '')).toMatch(
+      /not a valid source language|no source language/i,
+    );
+  });
+
+  it('Canary + bidi (English source, French target): drop enqueues with translation fields', async () => {
+    mockGetConfig.mockImplementation(async (key: string) => {
+      if (key === 'session.mainLanguage') return 'English';
+      if (key === 'session.mainBidiTarget') return 'French';
+      // mainTranslate is irrelevant when bidi is active (Canary path uses
+      // mainBidiTarget !== 'Off' as the activation signal — same shape
+      // SessionView.handleStartRecording produces).
+      return undefined;
+    });
+
+    const { container } = render(React.createElement(SessionImportTab));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const dropZone = container.querySelector('.cursor-pointer');
+    await act(async () => {
+      fireEvent.drop(dropZone as Element, dropFile(buildFile()));
+    });
+
+    expect(mockToastError).not.toHaveBeenCalled();
+    expect(mockAddFiles).toHaveBeenCalledTimes(1);
+    const [, , options] = mockAddFiles.mock.calls[0] as [unknown, unknown, Record<string, unknown>];
+    expect(options.language).toBe('en');
+    expect(options.translation_enabled).toBe(true);
+    expect(options.translation_target_language).toBe('fr');
+  });
+
+  it('Whisper + Auto Detect: drop enqueues with options.language=undefined (regression check)', async () => {
+    mockActiveModel = WHISPER_MODEL;
+    mockLanguageSet = {
+      languages: WHISPER_LANGUAGES_FOR_TEST,
+      loading: false,
+      backendType: 'whisper',
+    };
+    mockGetConfig.mockImplementation(async (key: string) => {
+      if (key === 'session.mainLanguage') return 'Auto Detect';
+      return undefined;
+    });
+
+    const { container } = render(React.createElement(SessionImportTab));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const dropZone = container.querySelector('.cursor-pointer');
+    await act(async () => {
+      fireEvent.drop(dropZone as Element, dropFile(buildFile()));
+    });
+
+    expect(mockToastError).not.toHaveBeenCalled();
+    expect(mockAddFiles).toHaveBeenCalledTimes(1);
+    const [, , options] = mockAddFiles.mock.calls[0] as [unknown, unknown, Record<string, unknown>];
+    expect(options.language).toBeUndefined();
+    expect(options.translation_enabled).toBeUndefined();
+    expect(options.translation_target_language).toBeUndefined();
+  });
+
+  it('Canary + languages still loading: drop refuses with "loading languages" wording', async () => {
+    mockLanguageSet = {
+      languages: [{ code: 'auto', name: 'Auto Detect' }],
+      loading: true,
+      backendType: 'canary',
+    };
+    mockGetConfig.mockImplementation(async (key: string) => {
+      if (key === 'session.mainLanguage') return 'Spanish';
+      return undefined;
+    });
+
+    const { container } = render(React.createElement(SessionImportTab));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const dropZone = container.querySelector('.cursor-pointer');
+    await act(async () => {
+      fireEvent.drop(dropZone as Element, dropFile(buildFile()));
+    });
+
+    expect(mockAddFiles).not.toHaveBeenCalled();
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+    const [title, opts] = mockToastError.mock.calls[0] as [string, { description?: string }];
+    expect(title).toMatch(/source language required/i);
+    expect(String(opts?.description ?? '')).toMatch(/loading languages/i);
+  });
+});

--- a/dashboard/components/__tests__/SessionImportTab.canary-language.test.tsx
+++ b/dashboard/components/__tests__/SessionImportTab.canary-language.test.tsx
@@ -112,6 +112,7 @@ vi.mock('../../src/stores/importQueueStore', () => {
     pauseQueue: vi.fn(),
     resumeQueue: vi.fn(),
     updateSessionConfig: vi.fn(),
+    setLanguagesCache: vi.fn(),
     clearWatchLog: vi.fn(),
   };
   return {

--- a/dashboard/components/views/AddNoteModal.tsx
+++ b/dashboard/components/views/AddNoteModal.tsx
@@ -6,6 +6,14 @@ import { AppleSwitch } from '../ui/AppleSwitch';
 import { GlassCard } from '../ui/GlassCard';
 import { useImportQueueStore } from '../../src/stores/importQueueStore';
 import { apiClient } from '../../src/api/client';
+import { useAdminStatus } from '../../src/hooks/useAdminStatus';
+import { useLanguages } from '../../src/hooks/useLanguages';
+import { getConfig } from '../../src/config/store';
+import {
+  isCanaryModel,
+  supportsAutoDetect,
+  supportsTranslation,
+} from '../../src/services/modelCapabilities';
 import { toast } from 'sonner';
 
 interface AddNoteModalProps {
@@ -45,6 +53,27 @@ export const AddNoteModal: React.FC<AddNoteModalProps> = ({
   const [isDragOver, setIsDragOver] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // gh-102 followup #2: notebook-upload surface honors the same Source
+  // Language and translation selection persisted by SessionView. Mirrors the
+  // SessionImportTab load pattern (SessionImportTab.tsx:122–183 / 163–183) —
+  // the persisted picker is the single source of truth, no duplicate UI here.
+  const [mainLanguage, setMainLanguage] = useState<string>('Auto Detect');
+  const [mainTranslate, setMainTranslate] = useState<boolean>(false);
+  const [mainBidiTarget, setMainBidiTarget] = useState<string>('Off');
+
+  const admin = useAdminStatus();
+  const activeModel: string | null =
+    admin.status?.config?.main_transcriber?.model ??
+    admin.status?.config?.transcription?.model ??
+    null;
+  const { languages, loading: languagesLoading } = useLanguages(activeModel);
+  // Mirror SessionImportTab.tsx:129–130 — same predicate shape so the
+  // notebook surface produces the same translation envelope handleFiles
+  // produces for live recording / session-import.
+  const isCanaryMainBidi = isCanaryModel(activeModel) && mainLanguage === 'English';
+  const canTranslate = supportsTranslation(activeModel);
+
   const selectedDateKey =
     initialDate && DATE_KEY_RE.test(initialDate) ? initialDate : formatDateKey(new Date());
   const selectedDateLabel = new Date(`${selectedDateKey}T00:00:00`).toLocaleDateString([], {
@@ -78,6 +107,43 @@ export const AddNoteModal: React.FC<AddNoteModalProps> = ({
     }
   }, [supportsExplicitWordTimestampToggle]);
 
+  // gh-102 followup #2: hydrate the persisted Source Language picker
+  // selection (and Canary bidi state) from config. Mirrors
+  // SessionImportTab.tsx:163–183 so all import surfaces converge on the same
+  // source-of-truth on every mount and every config change driven by setConfig
+  // writes from SessionView.
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      const [savedMainLanguage, savedMainTranslate, savedMainBidiTarget] = await Promise.all([
+        getConfig<string>('session.mainLanguage'),
+        getConfig<boolean>('session.mainTranslate'),
+        getConfig<string>('session.mainBidiTarget'),
+      ]);
+      if (!active) return;
+      if (typeof savedMainLanguage === 'string' && savedMainLanguage) {
+        setMainLanguage(savedMainLanguage);
+      }
+      if (typeof savedMainTranslate === 'boolean') setMainTranslate(savedMainTranslate);
+      if (typeof savedMainBidiTarget === 'string' && savedMainBidiTarget) {
+        setMainBidiTarget(savedMainBidiTarget);
+      }
+    })().catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // Resolve language code from display name. Mirrors SessionImportTab.tsx:270–277.
+  const resolveLanguage = useCallback(
+    (name: string): string | undefined => {
+      if (name === 'Auto Detect') return undefined;
+      const match = languages.find((l) => l.name === name);
+      return match?.code;
+    },
+    [languages],
+  );
+
   const handleFiles = useCallback((files: FileList | null) => {
     if (!files || files.length === 0) return;
     const fileArray = Array.from(files);
@@ -108,6 +174,36 @@ export const AddNoteModal: React.FC<AddNoteModalProps> = ({
       setError('Please select at least one audio file.');
       return;
     }
+
+    // gh-102 followup #2: mirror SessionImportTab.handleFiles guard
+    // (SessionImportTab.tsx:291–301). The Canary backend (canary_backend.py:79)
+    // raises ValueError when `language` is missing. Without this guard,
+    // submitting a notebook upload on Canary with an unresolvable picker
+    // (Auto Detect, languages still loading, stale display name) round-trips
+    // to the backend fail-loud path. Wording matches the live-recording /
+    // session-import guard verbatim so future copy changes propagate via grep.
+    const resolvedLang = resolveLanguage(mainLanguage);
+    if (resolvedLang === undefined && !supportsAutoDetect(activeModel)) {
+      toast.error('Source language required', {
+        description: languagesLoading
+          ? 'Loading languages — please try again in a moment.'
+          : mainLanguage
+            ? `"${mainLanguage}" is not a valid source language for the active model. Pick a language from the Source Language dropdown.`
+            : 'No source language is selected. Pick a language from the Source Language dropdown.',
+      });
+      return;
+    }
+
+    // Translation parity: mirror SessionImportTab.tsx:308–313 so the notebook
+    // surface produces the same envelope live recording / session-import
+    // produce. Canary bidi (English source + non-Off target) drives
+    // translate=true; the regular Whisper translate-to-English toggle is only
+    // honored when the active model supports translation.
+    const mainTranslateActive = isCanaryMainBidi
+      ? mainBidiTarget !== 'Off'
+      : mainTranslate && canTranslate;
+    const mainTranslateTarget = isCanaryMainBidi ? (resolveLanguage(mainBidiTarget) ?? 'en') : 'en';
+
     setIsSubmitting(true);
     setError(null);
 
@@ -120,6 +216,9 @@ export const AddNoteModal: React.FC<AddNoteModalProps> = ({
       const enableWordTimestamps = supportsExplicitWordTimestampToggle ? isTimestampsEnabled : true;
 
       useImportQueueStore.getState().addFiles(selectedFiles, 'notebook-normal', {
+        language: resolvedLang,
+        translation_enabled: mainTranslateActive ? true : undefined,
+        translation_target_language: mainTranslateActive ? mainTranslateTarget : undefined,
         enable_diarization: isDiarizationEnabled,
         enable_word_timestamps: enableWordTimestamps,
         parallel_diarization: isDiarizationEnabled ? parallelDiarization : undefined,
@@ -150,6 +249,14 @@ export const AddNoteModal: React.FC<AddNoteModalProps> = ({
     selectedDateKey,
     supportsExplicitWordTimestampToggle,
     title,
+    activeModel,
+    mainLanguage,
+    mainTranslate,
+    mainBidiTarget,
+    isCanaryMainBidi,
+    canTranslate,
+    languagesLoading,
+    resolveLanguage,
   ]);
 
   useEffect(() => {

--- a/dashboard/components/views/NotebookView.tsx
+++ b/dashboard/components/views/NotebookView.tsx
@@ -51,6 +51,11 @@ import { useNotebookWatcher } from '../../src/hooks/useNotebookWatcher';
 import { apiClient } from '../../src/api/client';
 import type { AdminStatus, Recording } from '../../src/api/types';
 import { supportsExplicitWordTimestampToggle as supportsExplicitWordTimestampToggleForModel } from '../../src/utils/transcriptionBackend';
+import {
+  isCanaryModel,
+  supportsAutoDetect,
+  supportsTranslation,
+} from '../../src/services/modelCapabilities';
 import { toast } from 'sonner';
 import { useConfirm } from '../../src/hooks/useConfirm';
 import { getConfig, setConfig } from '../../src/config/store';
@@ -1401,11 +1406,65 @@ const ImportTab = ({
   const [parallelDefault, setParallelDefault] = useState<boolean>(false);
   const [isDragOver, setIsDragOver] = useState(false);
 
+  // gh-102 followup #2: notebook-upload surface honors the persisted Source
+  // Language and translation selection from SessionView. Mirrors the
+  // SessionImportTab load pattern (SessionImportTab.tsx:122–183 / 163–183) —
+  // the persisted picker is the single source of truth, no duplicate UI here.
+  const [mainLanguage, setMainLanguage] = useState<string>('Auto Detect');
+  const [mainTranslate, setMainTranslate] = useState<boolean>(false);
+  const [mainBidiTarget, setMainBidiTarget] = useState<string>('Off');
+
+  // Derive activeModel from the existing adminStatus prop (parent already
+  // computes the same thing; we re-derive locally to avoid prop-drilling
+  // the model name).
+  const activeModel: string | null =
+    adminStatus?.config?.main_transcriber?.model ??
+    adminStatus?.config?.transcription?.model ??
+    null;
+  const { languages, loading: languagesLoading } = useLanguages(activeModel);
+  const isCanaryMainBidi = isCanaryModel(activeModel) && mainLanguage === 'English';
+  const canTranslate = supportsTranslation(activeModel);
+
   useEffect(() => {
     if (!supportsExplicitWordTimestampToggle) {
       setWordTimestamps(true);
     }
   }, [supportsExplicitWordTimestampToggle]);
+
+  // gh-102 followup #2: hydrate the persisted Source Language picker selection
+  // (and Canary bidi state) from config. Mirrors SessionImportTab.tsx:163–183
+  // so all import surfaces converge on the same source-of-truth.
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      const [savedMainLanguage, savedMainTranslate, savedMainBidiTarget] = await Promise.all([
+        getConfig<string>('session.mainLanguage'),
+        getConfig<boolean>('session.mainTranslate'),
+        getConfig<string>('session.mainBidiTarget'),
+      ]);
+      if (!active) return;
+      if (typeof savedMainLanguage === 'string' && savedMainLanguage) {
+        setMainLanguage(savedMainLanguage);
+      }
+      if (typeof savedMainTranslate === 'boolean') setMainTranslate(savedMainTranslate);
+      if (typeof savedMainBidiTarget === 'string' && savedMainBidiTarget) {
+        setMainBidiTarget(savedMainBidiTarget);
+      }
+    })().catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // Resolve language code from display name. Mirrors SessionImportTab.tsx:270–277.
+  const resolveLanguage = useCallback(
+    (name: string): string | undefined => {
+      if (name === 'Auto Detect') return undefined;
+      const match = languages.find((l) => l.name === name);
+      return match?.code;
+    },
+    [languages],
+  );
 
   useEffect(() => {
     apiClient
@@ -1451,7 +1510,38 @@ const ImportTab = ({
   const handleFiles = useCallback(
     (files: FileList | null) => {
       if (!files || files.length === 0) return;
+
+      // gh-102 followup #2: mirror SessionImportTab.handleFiles guard
+      // (SessionImportTab.tsx:291–301). The Canary backend
+      // (canary_backend.py:79) raises ValueError when `language` is missing.
+      // Without this guard, dropping a file on Canary with an unresolvable
+      // picker round-trips to the backend fail-loud path. Wording matches the
+      // live-recording / session-import guard verbatim so future copy changes
+      // propagate via grep.
+      const resolvedLang = resolveLanguage(mainLanguage);
+      if (resolvedLang === undefined && !supportsAutoDetect(activeModel)) {
+        toast.error('Source language required', {
+          description: languagesLoading
+            ? 'Loading languages — please try again in a moment.'
+            : mainLanguage
+              ? `"${mainLanguage}" is not a valid source language for the active model. Pick a language from the Source Language dropdown.`
+              : 'No source language is selected. Pick a language from the Source Language dropdown.',
+        });
+        return;
+      }
+
+      // Translation parity: mirror SessionImportTab.tsx:308–313.
+      const mainTranslateActive = isCanaryMainBidi
+        ? mainBidiTarget !== 'Off'
+        : mainTranslate && canTranslate;
+      const mainTranslateTarget = isCanaryMainBidi
+        ? (resolveLanguage(mainBidiTarget) ?? 'en')
+        : 'en';
+
       addFiles(Array.from(files), 'notebook-normal', {
+        language: resolvedLang,
+        translation_enabled: mainTranslateActive ? true : undefined,
+        translation_target_language: mainTranslateActive ? mainTranslateTarget : undefined,
         enable_diarization: diarization,
         enable_word_timestamps: supportsExplicitWordTimestampToggle ? wordTimestamps : true,
         parallel_diarization: diarization ? parallelDiarization : undefined,
@@ -1475,6 +1565,14 @@ const ImportTab = ({
       wordTimestamps,
       notebookWatchPath,
       showWatchHint,
+      activeModel,
+      mainLanguage,
+      mainTranslate,
+      mainBidiTarget,
+      isCanaryMainBidi,
+      canTranslate,
+      languagesLoading,
+      resolveLanguage,
     ],
   );
 

--- a/dashboard/components/views/NotebookView.tsx
+++ b/dashboard/components/views/NotebookView.tsx
@@ -1329,6 +1329,7 @@ const ImportTab = ({
   const watchLog = useImportQueueStore((s) => s.watchLog);
   const clearWatchLog = useImportQueueStore((s) => s.clearWatchLog);
   const updateNotebookConfig = useImportQueueStore((s) => s.updateNotebookConfig);
+  const setLanguagesCache = useImportQueueStore((s) => s.setLanguagesCache);
 
   const {
     notebookWatchPath,
@@ -1478,15 +1479,29 @@ const ImportTab = ({
   }, []);
 
   // Sync toggle state to the unified store so notebook-auto (Folder Watch)
-  // jobs honor these UI selections (Issue #93). Manual notebook-normal jobs
-  // still pass options directly via handleFiles.
+  // jobs honor these UI selections (Issue #93) and the source language picker
+  // (gh-102 #3). Manual notebook-normal jobs still pass options directly via
+  // handleFiles.
   useEffect(() => {
     updateNotebookConfig({
       enableDiarization: diarization,
       enableWordTimestamps: wordTimestamps,
       parallelDiarization,
+      language: mainLanguage,
     });
-  }, [diarization, wordTimestamps, parallelDiarization, updateNotebookConfig]);
+  }, [diarization, wordTimestamps, parallelDiarization, mainLanguage, updateNotebookConfig]);
+
+  // gh-102 #3 — push useLanguages() results into the global languagesCache so
+  // handleFilesDetected (a non-React store action) can resolve display name →
+  // code. Mirror of the SessionImportTab effect; React Query dedupes the
+  // underlying fetch since both views use the same activeModel cache key.
+  useEffect(() => {
+    setLanguagesCache({
+      model: activeModel,
+      languages,
+      loading: languagesLoading,
+    });
+  }, [activeModel, languages, languagesLoading, setLanguagesCache]);
 
   // Constraint: diarization ON → force timestamps ON
   const handleDiarizationChange = useCallback((enabled: boolean) => {

--- a/dashboard/components/views/SessionImportTab.tsx
+++ b/dashboard/components/views/SessionImportTab.tsx
@@ -68,6 +68,7 @@ export const SessionImportTab: React.FC = () => {
   const pauseQueue = useImportQueueStore((s) => s.pauseQueue);
   const resumeQueue = useImportQueueStore((s) => s.resumeQueue);
   const updateSessionConfig = useImportQueueStore((s) => s.updateSessionConfig);
+  const setLanguagesCache = useImportQueueStore((s) => s.setLanguagesCache);
   const watcherServerConnected = useImportQueueStore((s) => s.watcherServerConnected);
   const avgProcessingMs = useImportQueueStore((s) => s.avgProcessingMs);
   const watchLog = useImportQueueStore((s) => s.watchLog);
@@ -210,8 +211,9 @@ export const SessionImportTab: React.FC = () => {
 
   // Sync per-tab settings to the unified Zustand store. Folder Watch jobs read
   // these in handleFilesDetected so auto-imported files honor the user's UI
-  // toggles (Issue #93). Raw values are stored — derivation rules
-  // (multitrack ? false : enableDiarization, etc.) live in the store handler.
+  // toggles (Issue #93) and source language picker (gh-102 #3). Raw values
+  // are stored — derivation rules (multitrack ? false : enableDiarization,
+  // etc.) live in the store handler.
   useEffect(() => {
     updateSessionConfig({
       outputDir,
@@ -221,6 +223,7 @@ export const SessionImportTab: React.FC = () => {
       enableWordTimestamps: wordTimestamps,
       parallelDiarization,
       multitrack,
+      language: mainLanguage,
     });
   }, [
     outputDir,
@@ -230,8 +233,22 @@ export const SessionImportTab: React.FC = () => {
     wordTimestamps,
     parallelDiarization,
     multitrack,
+    mainLanguage,
     updateSessionConfig,
   ]);
+
+  // gh-102 #3 — push useLanguages() results into the global languagesCache so
+  // handleFilesDetected (a non-React store action) can resolve display name →
+  // code. Both this view and NotebookView ImportTab call useLanguages with the
+  // same activeModel, so React Query dedupes; either consumer's write produces
+  // an idempotent cache state.
+  useEffect(() => {
+    setLanguagesCache({
+      model: activeModel,
+      languages,
+      loading: languagesLoading,
+    });
+  }, [activeModel, languages, languagesLoading, setLanguagesCache]);
 
   useEffect(() => {
     if (!supportsExplicitWordTimestampToggle) {

--- a/dashboard/components/views/SessionImportTab.tsx
+++ b/dashboard/components/views/SessionImportTab.tsx
@@ -36,6 +36,12 @@ import { apiClient } from '../../src/api/client';
 import { supportsExplicitWordTimestampToggle as supportsExplicitWordTimestampToggleForModel } from '../../src/utils/transcriptionBackend';
 import { getConfig, setConfig } from '../../src/config/store';
 import { useSessionWatcher } from '../../src/hooks/useSessionWatcher';
+import {
+  supportsAutoDetect,
+  supportsTranslation,
+  isCanaryModel,
+} from '../../src/services/modelCapabilities';
+import { toast } from 'sonner';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -101,10 +107,27 @@ export const SessionImportTab: React.FC = () => {
     admin.status?.config?.main_transcriber?.model ??
     admin.status?.config?.transcription?.model ??
     null;
-  const { backendType } = useLanguages(activeModel);
+  const { backendType, languages, loading: languagesLoading } = useLanguages(activeModel);
   const supportsExplicitWordTimestampToggle = activeModel
     ? supportsExplicitWordTimestampToggleForModel(activeModel)
     : backendType !== 'vibevoice_asr';
+
+  // gh-102 followup: file-import surface honors the same language /
+  // translation selection the live-recording surface persists from
+  // SessionView. We mirror the SessionView load pattern (SessionView.tsx:393–
+  // 412): read session.mainLanguage + session.mainTranslate +
+  // session.mainBidiTarget on mount, then plumb them through addFiles options
+  // in handleFiles. The persisted picker is the single source of truth — no
+  // duplicate UI here.
+  const [mainLanguage, setMainLanguage] = useState<string>('Auto Detect');
+  const [mainTranslate, setMainTranslate] = useState<boolean>(false);
+  const [mainBidiTarget, setMainBidiTarget] = useState<string>('Off');
+
+  // Canary bidirectional mode mirrors SessionView.tsx:376 — same predicate
+  // shape so the import surface produces the same translation envelope as
+  // handleStartRecording (English source + non-Off bidi target → translate).
+  const isCanaryMainBidi = isCanaryModel(activeModel) && mainLanguage === 'English';
+  const canTranslate = supportsTranslation(activeModel);
 
   // Fetch downloads path and hideTimestamps setting on mount
   useEffect(() => {
@@ -131,6 +154,32 @@ export const SessionImportTab: React.FC = () => {
       }
     };
     init();
+  }, []);
+
+  // gh-102 followup: hydrate the persisted Source Language picker selection
+  // (and Canary bidi state) from config. Mirrors SessionView.tsx:393–412 so
+  // both surfaces converge on the same source-of-truth on every mount and
+  // every config change driven by setConfig writes from SessionView.
+  useEffect(() => {
+    let active = true;
+    void (async () => {
+      const [savedMainLanguage, savedMainTranslate, savedMainBidiTarget] = await Promise.all([
+        getConfig<string>('session.mainLanguage'),
+        getConfig<boolean>('session.mainTranslate'),
+        getConfig<string>('session.mainBidiTarget'),
+      ]);
+      if (!active) return;
+      if (typeof savedMainLanguage === 'string' && savedMainLanguage) {
+        setMainLanguage(savedMainLanguage);
+      }
+      if (typeof savedMainTranslate === 'boolean') setMainTranslate(savedMainTranslate);
+      if (typeof savedMainBidiTarget === 'string' && savedMainBidiTarget) {
+        setMainBidiTarget(savedMainBidiTarget);
+      }
+    })().catch(() => {});
+    return () => {
+      active = false;
+    };
   }, []);
 
   // 4.6 — load manual import count and hint state on mount
@@ -217,10 +266,56 @@ export const SessionImportTab: React.FC = () => {
     [supportsExplicitWordTimestampToggle],
   );
 
+  // Resolve language code from display name. Mirrors SessionView.tsx:680.
+  const resolveLanguage = useCallback(
+    (name: string): string | undefined => {
+      if (name === 'Auto Detect') return undefined;
+      const match = languages.find((l) => l.name === name);
+      return match?.code;
+    },
+    [languages],
+  );
+
   const handleFiles = useCallback(
     (files: FileList | null) => {
       if (!files || files.length === 0) return;
+
+      // gh-102 followup: mirror SessionView.handleStartRecording (SessionView.tsx:705–715).
+      // The Canary backend (canary_backend.py:79) raises ValueError when
+      // `language` is missing. Without this guard, dropping a file on Canary
+      // with an unresolvable picker (Auto Detect, languages still loading,
+      // stale display name) round-trips to the backend fail-loud path and
+      // surfaces the cryptic toast the issue 102 reporter screenshotted.
+      // Wording matches the live-recording guard verbatim so future copy
+      // changes propagate via grep.
+      const resolvedLang = resolveLanguage(mainLanguage);
+      if (resolvedLang === undefined && !supportsAutoDetect(activeModel)) {
+        toast.error('Source language required', {
+          description: languagesLoading
+            ? 'Loading languages — please try again in a moment.'
+            : mainLanguage
+              ? `"${mainLanguage}" is not a valid source language for the active model. Pick a language from the Source Language dropdown.`
+              : 'No source language is selected. Pick a language from the Source Language dropdown.',
+        });
+        return;
+      }
+
+      // Translation parity: mirror SessionView.tsx:718–719 so the import
+      // surface produces the same envelope handleStartRecording produces for
+      // live recording. Canary bidi (English source + non-Off target) drives
+      // translate=true; the regular Whisper translate-to-English toggle is
+      // only honored when the active model supports translation.
+      const mainTranslateActive = isCanaryMainBidi
+        ? mainBidiTarget !== 'Off'
+        : mainTranslate && canTranslate;
+      const mainTranslateTarget = isCanaryMainBidi
+        ? (resolveLanguage(mainBidiTarget) ?? 'en')
+        : 'en';
+
       addFiles(Array.from(files), 'session-normal', {
+        language: resolvedLang,
+        translation_enabled: mainTranslateActive ? true : undefined,
+        translation_target_language: mainTranslateActive ? mainTranslateTarget : undefined,
         enable_diarization: multitrack ? false : diarization,
         enable_word_timestamps: supportsExplicitWordTimestampToggle ? wordTimestamps : true,
         parallel_diarization: diarization && !multitrack ? parallelDiarization : undefined,
@@ -246,6 +341,14 @@ export const SessionImportTab: React.FC = () => {
       wordTimestamps,
       sessionWatchPath,
       showWatchHint,
+      activeModel,
+      mainLanguage,
+      mainTranslate,
+      mainBidiTarget,
+      isCanaryMainBidi,
+      canTranslate,
+      languagesLoading,
+      resolveLanguage,
     ],
   );
 

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -359,9 +359,9 @@ export const SessionView: React.FC<SessionViewProps> = ({
 
   // Main Transcription State
   const [mainLanguage, setMainLanguage] = useState('Auto Detect');
-  const [mainTranslate, setMainTranslate] = useState(false);
+  const [mainTranslate, setMainTranslateRaw] = useState(false);
   // Bidirectional translation target (used when Canary + source=English)
-  const [mainBidiTarget, setMainBidiTarget] = useState('Off');
+  const [mainBidiTarget, setMainBidiTargetRaw] = useState('Off');
 
   // Output formatting
   const [hideTimestamps, setHideTimestamps] = useState(false);
@@ -371,6 +371,21 @@ export const SessionView: React.FC<SessionViewProps> = ({
   const [liveTranslate, setLiveTranslate] = useState(false);
   // Bidirectional translation target (used when Canary + source=English)
   const [liveBidiTarget, setLiveBidiTarget] = useState('Off');
+
+  // gh-102 followup: persist mainTranslate / mainBidiTarget so the file-import
+  // surface (SessionImportTab) can read the same source-of-truth as the
+  // live-recording leg. Without persistence the import POST would never see
+  // the translation parity that handleStartRecording produces from in-memory
+  // state.
+  const setMainTranslate = useCallback((value: boolean) => {
+    setMainTranslateRaw(value);
+    void setConfig('session.mainTranslate', value).catch(() => {});
+  }, []);
+
+  const setMainBidiTarget = useCallback((value: string) => {
+    setMainBidiTargetRaw(value);
+    void setConfig('session.mainBidiTarget', value).catch(() => {});
+  }, []);
 
   // Canary bidirectional mode: when Canary model + source=English, show target dropdown
   const isCanaryMainBidi = isCanaryModel(activeModel) && mainLanguage === 'English';
@@ -386,6 +401,8 @@ export const SessionView: React.FC<SessionViewProps> = ({
         savedMainLanguage,
         savedLiveLanguage,
         savedHideTimestamps,
+        savedMainTranslate,
+        savedMainBidiTarget,
       ] = await Promise.all([
         getConfig<'mic' | 'system'>('session.audioSource'),
         getConfig<string>('session.micDevice'),
@@ -393,6 +410,8 @@ export const SessionView: React.FC<SessionViewProps> = ({
         getConfig<string>('session.mainLanguage'),
         getConfig<string>('session.liveLanguage'),
         getConfig<boolean>('output.hideTimestamps'),
+        getConfig<boolean>('session.mainTranslate'),
+        getConfig<string>('session.mainBidiTarget'),
       ]);
       if (!active) return;
 
@@ -417,6 +436,13 @@ export const SessionView: React.FC<SessionViewProps> = ({
         setLiveLanguage(savedLiveLanguage);
       }
       if (savedHideTimestamps != null) setHideTimestamps(savedHideTimestamps);
+      // gh-102 followup: rehydrate translate/bidi state so the file-import
+      // surface and the live-recording surface always see the same selection
+      // after reload. Use the raw setters here to avoid re-persisting on hydrate.
+      if (typeof savedMainTranslate === 'boolean') setMainTranslateRaw(savedMainTranslate);
+      if (typeof savedMainBidiTarget === 'string' && savedMainBidiTarget) {
+        setMainBidiTargetRaw(savedMainBidiTarget);
+      }
     })().catch(() => {});
 
     return () => {
@@ -483,9 +509,12 @@ export const SessionView: React.FC<SessionViewProps> = ({
     void setConfig('session.liveLanguage', language).catch(() => {});
   }, []);
 
-  // Reset translate toggles when model changes to one that doesn't support it
+  // Reset translate toggles when model changes to one that does not support it.
+  // Uses the raw setter so a model-driven reset stays in-memory only — calling
+  // the persisting wrapper here would clobber the user-saved preference on
+  // every swap through a non-translation backend (Parakeet, Whisper turbo, …).
   useEffect(() => {
-    if (!canTranslate) setMainTranslate(false);
+    if (!canTranslate) setMainTranslateRaw(false);
   }, [canTranslate]);
 
   useEffect(() => {

--- a/dashboard/src/stores/importQueueStore.test.ts
+++ b/dashboard/src/stores/importQueueStore.test.ts
@@ -21,12 +21,24 @@ vi.mock('../services/transcriptionFormatters', () => ({
   })),
 }));
 
+// Mock sonner so the new gh-102 #3 tests can assert on toast.warning calls
+// without rendering. Existing tests don't assert on toast and stay unaffected.
+vi.mock('sonner', () => ({
+  toast: {
+    warning: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
 // Stub window.electronAPI
 Object.defineProperty(globalThis, 'window', {
   value: globalThis,
   writable: true,
 });
 
+import { toast } from 'sonner';
 import {
   useImportQueueStore,
   selectPendingCount,
@@ -65,6 +77,18 @@ function resetStore() {
     watcherServerConnected: true,
     watchLog: [],
     avgProcessingMs: 0,
+    // gh-102 #3 — default to a "ready" cache with a Whisper model so the
+    // language-resolution branch in handleFilesDetected falls through (no
+    // pause, no explicit-required) and pre-existing tests stay green. Tests
+    // that exercise the new behavior override this with setLanguagesCache.
+    languagesCache: {
+      model: 'large-v3',
+      languages: [
+        { code: 'en', name: 'English' },
+        { code: 'es', name: 'Spanish' },
+      ],
+      loading: false,
+    },
   });
 }
 
@@ -86,6 +110,14 @@ describe('importQueueStore', () => {
   beforeEach(() => {
     resetStore();
     vi.useFakeTimers();
+    // Clear sonner mock counts at the suite level so toast assertions never
+    // bleed across describe blocks (e.g. the watcherServerConnected guard
+    // emits toast.warning, which would otherwise contaminate the gh-102 #3
+    // tests' toHaveBeenCalledWith checks).
+    vi.mocked(toast.warning).mockClear();
+    vi.mocked(toast.success).mockClear();
+    vi.mocked(toast.error).mockClear();
+    vi.mocked(toast.info).mockClear();
   });
 
   afterEach(() => {
@@ -433,6 +465,214 @@ describe('importQueueStore', () => {
         fileMeta: [],
       });
       expect(getState().jobs).toHaveLength(0);
+    });
+  });
+
+  // ── handleFilesDetected — gh-102 #3 language resolution ────────────────
+  //
+  // Folder-watch auto-imports must honor the user's persisted Source Language
+  // picker. The handler resolves the snapshotted display name → code via the
+  // languagesCache (populated by useLanguages consumers in SessionImportTab
+  // and NotebookView ImportTab) and pauses the entire detection batch when
+  // languages haven't loaded or the active model lacks auto-detect and the
+  // resolve fails. Each test pre-seeds sessionConfig/notebookConfig and
+  // languagesCache, then asserts on jobs[] (enqueue) or watchLog + toast.warning
+  // (pause).
+
+  describe('handleFilesDetected — gh-102 #3 language resolution', () => {
+    function lastJobOptions() {
+      const { jobs } = getState();
+      return jobs[jobs.length - 1].options;
+    }
+    function lastWatchLogMessage() {
+      const { watchLog } = getState();
+      return watchLog[watchLog.length - 1]?.message;
+    }
+
+    it('session: Canary + Spanish loaded → enqueues with language=es', () => {
+      getState().updateSessionConfig({ language: 'Spanish' });
+      getState().setLanguagesCache({
+        model: 'nvidia/canary-1b-v2',
+        languages: [
+          { code: 'en', name: 'English' },
+          { code: 'es', name: 'Spanish' },
+        ],
+        loading: false,
+      });
+      getState().handleFilesDetected({
+        type: 'session',
+        files: ['/watch/spanish.wav'],
+        count: 1,
+        fileMeta: [],
+      });
+      expect(getState().jobs).toHaveLength(1);
+      expect(lastJobOptions()?.language).toBe('es');
+    });
+
+    it('session: Canary + Auto Detect → pauses, no enqueue, "Source Language required" warn', () => {
+      getState().updateSessionConfig({ language: 'Auto Detect' });
+      getState().setLanguagesCache({
+        model: 'nvidia/canary-1b-v2',
+        languages: [{ code: 'es', name: 'Spanish' }],
+        loading: false,
+      });
+      getState().handleFilesDetected({
+        type: 'session',
+        files: ['/watch/auto.wav'],
+        count: 1,
+        fileMeta: [],
+      });
+      expect(getState().jobs).toHaveLength(0);
+      expect(lastWatchLogMessage()).toBe(
+        'Folder Watch paused — Source Language required for the active model',
+      );
+      expect(toast.warning).toHaveBeenCalledWith(
+        'Folder Watch paused — Source Language required for the active model',
+      );
+    });
+
+    it('session: Canary + Spanish but languages loading → pauses, "languages still loading" warn', () => {
+      getState().updateSessionConfig({ language: 'Spanish' });
+      getState().setLanguagesCache({
+        model: 'nvidia/canary-1b-v2',
+        languages: [],
+        loading: true,
+      });
+      getState().handleFilesDetected({
+        type: 'session',
+        files: ['/watch/early.wav'],
+        count: 1,
+        fileMeta: [],
+      });
+      expect(getState().jobs).toHaveLength(0);
+      expect(lastWatchLogMessage()).toBe('Folder Watch paused — languages still loading');
+      expect(toast.warning).toHaveBeenCalledWith('Folder Watch paused — languages still loading');
+    });
+
+    it('session: Whisper + Auto Detect → enqueues with language=undefined (auto-detect)', () => {
+      getState().updateSessionConfig({ language: 'Auto Detect' });
+      getState().setLanguagesCache({
+        model: 'large-v3',
+        languages: [{ code: 'es', name: 'Spanish' }],
+        loading: false,
+      });
+      getState().handleFilesDetected({
+        type: 'session',
+        files: ['/watch/whisper-auto.wav'],
+        count: 1,
+        fileMeta: [],
+      });
+      expect(getState().jobs).toHaveLength(1);
+      expect(lastJobOptions()?.language).toBeUndefined();
+    });
+
+    it('session: Whisper + Spanish → enqueues with language=es', () => {
+      getState().updateSessionConfig({ language: 'Spanish' });
+      getState().setLanguagesCache({
+        model: 'large-v3',
+        languages: [{ code: 'es', name: 'Spanish' }],
+        loading: false,
+      });
+      getState().handleFilesDetected({
+        type: 'session',
+        files: ['/watch/whisper-es.wav'],
+        count: 1,
+        fileMeta: [],
+      });
+      expect(getState().jobs).toHaveLength(1);
+      expect(lastJobOptions()?.language).toBe('es');
+    });
+
+    it('notebook: Canary + Spanish loaded → enqueues with language=es', () => {
+      getState().updateNotebookConfig({ language: 'Spanish' });
+      getState().setLanguagesCache({
+        model: 'nvidia/canary-1b-v2',
+        languages: [{ code: 'es', name: 'Spanish' }],
+        loading: false,
+      });
+      getState().handleFilesDetected({
+        type: 'notebook',
+        files: ['/watch/notebook-es.wav'],
+        count: 1,
+        fileMeta: [{ path: '/watch/notebook-es.wav', createdAt: '2026-04-30T10:00:00Z' }],
+      });
+      expect(getState().jobs).toHaveLength(1);
+      expect(lastJobOptions()?.language).toBe('es');
+      expect(lastJobOptions()?.file_created_at).toBe('2026-04-30T10:00:00Z');
+    });
+
+    it('notebook: Canary + Auto Detect → pauses, no enqueue, "Source Language required" warn', () => {
+      getState().updateNotebookConfig({ language: 'Auto Detect' });
+      getState().setLanguagesCache({
+        model: 'nvidia/canary-1b-v2',
+        languages: [{ code: 'es', name: 'Spanish' }],
+        loading: false,
+      });
+      getState().handleFilesDetected({
+        type: 'notebook',
+        files: ['/watch/notebook-auto.wav'],
+        count: 1,
+        fileMeta: [{ path: '/watch/notebook-auto.wav', createdAt: '2026-04-30T11:00:00Z' }],
+      });
+      expect(getState().jobs).toHaveLength(0);
+      expect(lastWatchLogMessage()).toBe(
+        'Folder Watch paused — Source Language required for the active model',
+      );
+      expect(toast.warning).toHaveBeenCalledWith(
+        'Folder Watch paused — Source Language required for the active model',
+      );
+    });
+
+    it('notebook: Canary + Spanish but languages loading → pauses, "languages still loading" warn', () => {
+      getState().updateNotebookConfig({ language: 'Spanish' });
+      getState().setLanguagesCache({
+        model: 'nvidia/canary-1b-v2',
+        languages: [],
+        loading: true,
+      });
+      getState().handleFilesDetected({
+        type: 'notebook',
+        files: ['/watch/notebook-early.wav'],
+        count: 1,
+        fileMeta: [{ path: '/watch/notebook-early.wav', createdAt: '2026-04-30T12:00:00Z' }],
+      });
+      expect(getState().jobs).toHaveLength(0);
+      expect(lastWatchLogMessage()).toBe('Folder Watch paused — languages still loading');
+      expect(toast.warning).toHaveBeenCalledWith('Folder Watch paused — languages still loading');
+    });
+
+    it('notebook: Whisper + Auto Detect → enqueues with language=undefined (auto-detect)', () => {
+      getState().updateNotebookConfig({ language: 'Auto Detect' });
+      getState().setLanguagesCache({
+        model: 'large-v3',
+        languages: [{ code: 'es', name: 'Spanish' }],
+        loading: false,
+      });
+      getState().handleFilesDetected({
+        type: 'notebook',
+        files: ['/watch/notebook-whisper-auto.wav'],
+        count: 1,
+        fileMeta: [{ path: '/watch/notebook-whisper-auto.wav', createdAt: '2026-04-30T13:00:00Z' }],
+      });
+      expect(getState().jobs).toHaveLength(1);
+      expect(lastJobOptions()?.language).toBeUndefined();
+    });
+
+    it('notebook: Whisper + Spanish → enqueues with language=es', () => {
+      getState().updateNotebookConfig({ language: 'Spanish' });
+      getState().setLanguagesCache({
+        model: 'large-v3',
+        languages: [{ code: 'es', name: 'Spanish' }],
+        loading: false,
+      });
+      getState().handleFilesDetected({
+        type: 'notebook',
+        files: ['/watch/notebook-whisper-es.wav'],
+        count: 1,
+        fileMeta: [{ path: '/watch/notebook-whisper-es.wav', createdAt: '2026-04-30T14:00:00Z' }],
+      });
+      expect(getState().jobs).toHaveLength(1);
+      expect(lastJobOptions()?.language).toBe('es');
     });
   });
 

--- a/dashboard/src/stores/importQueueStore.ts
+++ b/dashboard/src/stores/importQueueStore.ts
@@ -16,6 +16,7 @@ import type {
   UploadResponse,
 } from '../api/types';
 import { resolveTranscriptionOutput } from '../services/transcriptionFormatters';
+import { supportsAutoDetect } from '../services/modelCapabilities';
 import { getConfig } from '../config/store';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -49,6 +50,9 @@ export interface SessionConfig {
   enableWordTimestamps: boolean;
   parallelDiarization: boolean;
   multitrack: boolean;
+  /** Source-language display name (e.g. "Spanish", "Auto Detect") bridged from
+   *  SessionImportTab so Folder Watch jobs honor the user's picker (gh-102 #3) */
+  language?: string;
 }
 
 export interface NotebookConfig {
@@ -56,6 +60,16 @@ export interface NotebookConfig {
   enableDiarization: boolean;
   enableWordTimestamps: boolean;
   parallelDiarization: boolean;
+  /** Source-language display name bridged from NotebookView ImportTab (gh-102 #3) */
+  language?: string;
+}
+
+export interface LanguagesCacheState {
+  /** Active main transcriber model from the most recent useLanguages() push. */
+  model: string | null;
+  languages: Array<{ code: string; name: string }>;
+  /** True until useLanguages() resolves real server data the first time. */
+  loading: boolean;
 }
 
 export interface NotebookCallbacks {
@@ -92,6 +106,9 @@ interface ImportQueueState extends WatcherState {
   sessionConfig: SessionConfig;
   notebookConfig: NotebookConfig;
   notebookCallbacks: NotebookCallbacks;
+  /** Languages cache pushed by useLanguages() consumers so handleFilesDetected
+   *  can resolve a display name → code without calling a hook (gh-102 #3) */
+  languagesCache: LanguagesCacheState;
 
   // Actions
   addFiles: (
@@ -116,6 +133,9 @@ interface ImportQueueState extends WatcherState {
   updateSessionConfig: (patch: Partial<SessionConfig>) => void;
   updateNotebookConfig: (patch: Partial<NotebookConfig>) => void;
   updateNotebookCallbacks: (callbacks: NotebookCallbacks) => void;
+  /** gh-102 #3 — pushed by useLanguages() consumers in SessionImportTab and
+   *  NotebookView ImportTab so non-React store actions can resolve language. */
+  setLanguagesCache: (cache: LanguagesCacheState) => void;
 
   // Watcher actions
   setSessionWatchPath: (path: string) => void;
@@ -449,6 +469,15 @@ export const useImportQueueStore = create<ImportQueueState>()((set) => ({
   watchLog: [],
   avgProcessingMs: 0,
 
+  // gh-102 #3 — initial cache is "loading" with empty list. Populated by
+  // useLanguages() consumers (SessionImportTab, NotebookView ImportTab) via
+  // setLanguagesCache. Folder Watch pauses while loading or pre-populated.
+  languagesCache: {
+    model: null,
+    languages: [],
+    loading: true,
+  },
+
   // ─── Queue Actions ───────────────────────────────────────────────────────
 
   addFiles: (files, type, options) => {
@@ -536,6 +565,10 @@ export const useImportQueueStore = create<ImportQueueState>()((set) => ({
     set({ notebookCallbacks: callbacks });
   },
 
+  setLanguagesCache: (cache) => {
+    set({ languagesCache: cache });
+  },
+
   // ─── Watcher Actions ──────────────────────────────────────────────────────
 
   setSessionWatchPath: (_path) => {
@@ -578,6 +611,42 @@ export const useImportQueueStore = create<ImportQueueState>()((set) => ({
     // SessionImportTab.handleFiles / NotebookImportTab.handleFiles (Issue #93).
     const state = useImportQueueStore.getState();
 
+    // gh-102 #3 — resolve persisted Source Language display name → code via
+    // the languages cache. Pause the entire detection batch when languages
+    // haven't loaded yet, OR when the active model lacks auto-detect (Canary,
+    // MLX-Canary) and the resolve fails. Reuses the folder-watch warn-toast +
+    // appendWatchLog channel established by the watcherServerConnected guard.
+    const cfg = type === 'session' ? state.sessionConfig : state.notebookConfig;
+    const cache = state.languagesCache;
+
+    // Pause when the cache is unpopulated. `cache.model === null` covers both
+    // the initial state and any window before a useLanguages() consumer has
+    // pushed real data. Using model-identity (not languages.length) avoids a
+    // false "loaded-but-empty" misclassification: empty list with loading=false
+    // would be a server contract violation, not a loading state, and should
+    // fall through to the explicit-required guard below where Canary still
+    // pauses (correct behavior) and Whisper proceeds with auto-detect.
+    if (cache.loading || cache.model === null) {
+      const msg = 'Folder Watch paused — languages still loading';
+      toast.warning(msg);
+      useImportQueueStore.getState().appendWatchLog({ message: msg, level: 'warn' });
+      return;
+    }
+
+    const requestedDisplayName = cfg.language;
+    const isAutoDetect = !requestedDisplayName || requestedDisplayName === 'Auto Detect';
+    const resolvedCode = isAutoDetect
+      ? undefined
+      : cache.languages.find((l) => l.name === requestedDisplayName)?.code;
+    const requiresExplicit = cache.model !== null && !supportsAutoDetect(cache.model);
+
+    if (requiresExplicit && resolvedCode === undefined) {
+      const msg = 'Folder Watch paused — Source Language required for the active model';
+      toast.warning(msg);
+      useImportQueueStore.getState().appendWatchLog({ message: msg, level: 'warn' });
+      return;
+    }
+
     if (type === 'notebook') {
       const { enableDiarization, enableWordTimestamps, parallelDiarization } = state.notebookConfig;
       // Add each notebook file individually so we can attach its creation timestamp.
@@ -588,6 +657,7 @@ export const useImportQueueStore = create<ImportQueueState>()((set) => ({
           enable_diarization: enableDiarization,
           enable_word_timestamps: enableWordTimestamps,
           parallel_diarization: enableDiarization ? parallelDiarization : undefined,
+          language: resolvedCode,
         });
       }
     } else {
@@ -598,6 +668,7 @@ export const useImportQueueStore = create<ImportQueueState>()((set) => ({
         enable_word_timestamps: enableWordTimestamps,
         parallel_diarization: enableDiarization && !multitrack ? parallelDiarization : undefined,
         multitrack: multitrack || undefined,
+        language: resolvedCode,
       });
     }
 

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
   "spec_version": "1.0.34",
-  "contract_sha256": "c1372314fe245ef6b60af476d1c92716d9567f68624150a1a74cf7e15add15dd",
-  "updated_at": "2026-04-29T17:21:36.353Z"
+  "contract_sha256": "e9cca0ad4bdf49944c40c50e38233f396ffddf7dc483b31cd5c5a6bbd8b36bf0",
+  "updated_at": "2026-04-29T21:36:53.009Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -11,6 +11,7 @@ meta:
       - components/__tests__/LogsView.test.tsx
       - components/__tests__/NotebookView.test.tsx
       - components/__tests__/ServerView.test.tsx
+      - components/__tests__/SessionImportTab.canary-language.test.tsx
       - components/__tests__/SessionView.canary-language.test.tsx
       - components/__tests__/SessionView.test.tsx
       - components/AudioVisualizer.tsx
@@ -58,7 +59,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-04-29T17:21:15.825Z
+    generated_at: 2026-04-29T21:36:52.369Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -233,7 +234,6 @@ foundation:
         - shadow-[0_0_5px_rgba(239,68,68,0.6)]
         - shadow-[0_0_5px_rgba(34,211,238,0.5)]
         - shadow-[0_2px_8px_rgba(0,0,0,0.4)]
-        - shadow-[inset_0_2px_4px_rgba(0,0,0,0.3)]
         - shadow-2xl
         - shadow-accent-cyan/20
         - shadow-accent-cyan/40
@@ -308,7 +308,6 @@ foundation:
         - max-w-[55%]
         - min-h-[38px]
         - min-h-[calc(100vh-30rem)]
-        - min-w-[3ch]
         - min-w-[5rem]
         - p-[3px]
         - shadow-[0_0_10px_#22d3ee]
@@ -323,7 +322,6 @@ foundation:
         - shadow-[0_0_5px_rgba(239,68,68,0.6)]
         - shadow-[0_0_5px_rgba(34,211,238,0.5)]
         - shadow-[0_2px_8px_rgba(0,0,0,0.4)]
-        - shadow-[inset_0_2px_4px_rgba(0,0,0,0.3)]
         - text-[10px]
         - text-[11px]
         - text-[8px]
@@ -441,6 +439,7 @@ utility_allowlist:
     - bg-accent-orange
     - bg-accent-orange/10
     - bg-accent-rose/5
+    - bg-accent-violet/15
     - bg-amber-400/10
     - bg-amber-400/20
     - bg-amber-400/5
@@ -777,13 +776,11 @@ utility_allowlist:
     - mt-1.5
     - mt-10
     - mt-2
-    - mt-2.5
     - mt-3
     - mt-4
     - mt-6
     - mt-8
     - mt-auto
-    - mx-0.5
     - mx-1
     - mx-2
     - mx-auto
@@ -803,7 +800,6 @@ utility_allowlist:
     - outline-none
     - overflow-auto
     - overflow-hidden
-    - overflow-visible
     - overflow-x-auto
     - overflow-y-auto
     - p-0.5
@@ -930,6 +926,7 @@ utility_allowlist:
     - space-y-2.5
     - space-y-3
     - space-y-4
+    - space-y-5
     - space-y-6
     - space-y-8
     - sticky
@@ -942,10 +939,12 @@ utility_allowlist:
     - text-accent-orange
     - text-accent-rose
     - text-accent-violet
+    - text-accent-violet/80
     - text-amber-100
     - text-amber-200
     - text-amber-300
     - text-amber-300/60
+    - text-amber-300/70
     - text-amber-300/80
     - text-amber-400
     - text-amber-400/60
@@ -1014,6 +1013,7 @@ utility_allowlist:
     - transition-opacity
     - transition-shadow
     - transition-transform
+    - translate-to-English
     - translate-x-4
     - translate-x-5
     - truncate
@@ -1071,13 +1071,13 @@ utility_allowlist:
     - ease-[cubic-bezier(0.33,1,0.68,1)]
     - h-[85%]
     - h-[85vh]
+    - lg:grid-cols-[minmax(480px,5fr)_minmax(300px,7fr)]
     - max-h-[80vh]
     - max-h-[90vh]
     - max-w-[55%]
     - md:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]
     - min-h-[38px]
     - min-h-[calc(100vh-30rem)]
-    - min-w-[3ch]
     - min-w-[5rem]
     - p-[3px]
     - shadow-[0_0_10px_#22d3ee]
@@ -1092,7 +1092,6 @@ utility_allowlist:
     - shadow-[0_0_5px_rgba(239,68,68,0.6)]
     - shadow-[0_0_5px_rgba(34,211,238,0.5)]
     - shadow-[0_2px_8px_rgba(0,0,0,0.4)]
-    - shadow-[inset_0_2px_4px_rgba(0,0,0,0.3)]
     - text-[10px]
     - text-[11px]
     - text-[8px]


### PR DESCRIPTION
## Summary

Closes the Issue #102 / Issue #81 Canary source-language footgun across every import surface. Issue #102's reporter saw it on Session Import, but the same root cause (no `language` field plumbed into `addFiles` / `apiClient.importAndTranscribe` / `apiClient.uploadAndTranscribe`) existed on three more surfaces. The Canary backend's `ValueError("Canary requires an explicit source language; received None")` remains the last line of defense for non-dashboard clients.

- **`425d33c`** — Session Import tab (file drops). First surface beyond live recording. Establishes the canonical `useLanguages` + `getConfig` + `resolveLanguage` + refuse-with-toast pattern.
- **`75418c7`** — AddNoteModal + NotebookView's inline ImportTab. Two notebook upload entry points. Wording-grep parity with Session Import is locked in via strict-equality test assertions.
- **`487c271`** — Folder-watch auto-imports (`handleFilesDetected`). Snapshot + cache pattern: React views push `useLanguages` results into a global `languagesCache`; the non-React store action resolves against it. Cold-start and load-pending detection events pause cleanly with the existing watcher's `toast.warning` + `appendWatchLog({level:'warn'})` channel. 11 store-level tests cover the I/O matrix.

`session.mainLanguage` is the single source of truth for all four surfaces — no surface-specific config keys, no duplicate pickers. Whisper auto-detect path is bit-for-bit unchanged on every surface.

## Test plan

- [ ] **Live recording (regression):** Canary + Spanish source → record → transcript in Spanish.
- [ ] **Session Import:** Canary + Spanish persisted, drag file → transcribes in Spanish. Auto Detect → toast "Source language required". Whisper + Auto Detect → transcribes normally.
- [ ] **AddNoteModal:** same checks via the calendar +-button modal.
- [ ] **NotebookView ImportTab:** same checks via the inline drag-drop.
- [ ] **Folder watch (Session):** Canary + Spanish → enqueues with explicit Spanish. Auto Detect → log/toast "Folder Watch paused — Source Language required for the active model". Cold-start (drop before any import tab mounts) → "Folder Watch paused — languages still loading".
- [ ] **Folder watch (Notebook):** same three checks via notebook watcher path.
- [ ] **Canary bidi** (English source + French target): each surface produces `translation_enabled=true`, `translation_target_language='fr'` in the upload envelope.
- [ ] **Whisper regression:** Auto Detect on each surface → enqueues with no `language` field; backend auto-detects.
- [ ] Suite green: `cd dashboard && npm run test` (1025 passing), `npm run typecheck`, `npm run ui:contract:check`.

## Deferred (out of scope, tracked locally)

- **carve-out no. 3** (LOW) — backend route-layer 400 guards at `/api/transcribe/import` and `/api/notebook/transcribe/upload` for non-dashboard clients. No current symptom; the Canary `ValueError` remains the loud failure for third-party callers.
- **followup no. 2 review** (LOW-MED) — `onStopLiveMode` tray callback in `useTraySync` bypasses `handleLiveToggle(false)`. Severity uncertain pending investigation of `handleLiveToggle(false)`'s body.