### PR TITLE
feat(dashboard, Issue #92): drag-and-drop audio files directly onto N…

### DIFF
--- a/dashboard/components/__tests__/AddNoteModal.initialFiles.test.tsx
+++ b/dashboard/components/__tests__/AddNoteModal.initialFiles.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * GH #92 — AddNoteModal initialFiles seeding
+ *
+ * Verifies that when the modal is opened via the per-hour drag-and-drop path
+ * (Notebook → Calendar tab), the preloaded files appear in the selected files
+ * list and the title defaults to the first file's stem name (matching the
+ * in-modal handleFiles behavior).
+ */
+
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const WHISPER_MODEL = 'openai/whisper-large-v3-turbo';
+
+// ── Hoisted mocks (mirror AddNoteModal.canary-language.test.tsx) ─────────
+
+vi.mock('../../src/hooks/useLanguages', () => ({
+  useLanguages: () => ({
+    languages: [{ code: 'auto', name: 'Auto Detect' }],
+    backendType: 'whisper',
+    loading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('../../src/hooks/useAdminStatus', () => ({
+  useAdminStatus: () => ({
+    status: {
+      models_loaded: true,
+      config: {
+        main_transcriber: { model: WHISPER_MODEL },
+        transcription: { model: WHISPER_MODEL },
+        diarization: { parallel: false },
+      },
+    },
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/stores/importQueueStore', () => {
+  const fakeState = { addFiles: vi.fn() };
+  return {
+    useImportQueueStore: Object.assign(
+      (selector?: (s: typeof fakeState) => unknown) =>
+        typeof selector === 'function' ? selector(fakeState) : fakeState,
+      { getState: () => fakeState },
+    ),
+  };
+});
+
+vi.mock('../../src/api/client', () => ({
+  apiClient: {
+    getAdminStatus: vi.fn().mockResolvedValue({ config: { diarization: { parallel: false } } }),
+  },
+}));
+
+vi.mock('../../src/config/store', () => ({
+  getConfig: vi.fn().mockResolvedValue(undefined),
+  setConfig: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+}));
+
+import { AddNoteModal } from '../views/AddNoteModal';
+
+function buildFile(name: string): File {
+  return new File([new Uint8Array([0])], name, { type: 'audio/mpeg' });
+}
+
+describe('[GH #92] AddNoteModal initialFiles seeding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('seeds selectedFiles from initialFiles and uses first file name as title', async () => {
+    const file = buildFile('voice-memo.mp3');
+    render(
+      React.createElement(AddNoteModal, {
+        isOpen: true,
+        onClose: vi.fn(),
+        initialTime: 14,
+        initialDate: '2026-05-02',
+        initialFiles: [file],
+      }),
+    );
+
+    await act(async () => {
+      // Allow open-effect to apply (it runs synchronously on isOpen=true)
+      await Promise.resolve();
+    });
+
+    // The dropped file appears in the selected files list.
+    const filenameNode = Array.from(document.querySelectorAll('span')).find(
+      (s) => s.textContent === 'voice-memo.mp3',
+    );
+    expect(filenameNode).toBeDefined();
+
+    // Title defaults to the file stem (not the time-based "14:00 Recording").
+    const titleInput = document.querySelector(
+      'input[placeholder="Enter title..."]',
+    ) as HTMLInputElement | null;
+    expect(titleInput).not.toBeNull();
+    expect(titleInput?.value).toBe('voice-memo');
+  });
+
+  it('falls back to time-based title when no initialFiles are provided', async () => {
+    render(
+      React.createElement(AddNoteModal, {
+        isOpen: true,
+        onClose: vi.fn(),
+        initialTime: 9,
+        initialDate: '2026-05-02',
+      }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const titleInput = document.querySelector(
+      'input[placeholder="Enter title..."]',
+    ) as HTMLInputElement | null;
+    expect(titleInput?.value).toBe('09:00 Recording');
+  });
+});

--- a/dashboard/components/__tests__/NotebookView.test.tsx
+++ b/dashboard/components/__tests__/NotebookView.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -116,7 +116,7 @@ vi.mock('../../src/utils/transcriptionBackend', () => ({
 
 // sonner toast
 vi.mock('sonner', () => ({
-  toast: { success: vi.fn(), error: vi.fn() },
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
 }));
 
 // useConfirm
@@ -181,5 +181,120 @@ describe('[P2] NotebookView', () => {
     // Import tab also shows the heading
     expect(screen.getByText('Audio Notebook')).toBeDefined();
     expect(container).toBeDefined();
+  });
+});
+
+// ── GH #92: drop audio files directly onto a Notebook hour row ─────────────
+
+describe('[GH #92] NotebookView per-hour drag-and-drop', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = '';
+    (window as any).electronAPI = {
+      config: {
+        get: vi.fn().mockResolvedValue(undefined),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+  });
+
+  function buildAudioFile(name = 'note.mp3'): File {
+    return new File([new Uint8Array([0])], name, { type: 'audio/mpeg' });
+  }
+
+  function buildTextFile(name = 'unrelated.txt'): File {
+    return new File([new Uint8Array([0])], name, { type: 'text/plain' });
+  }
+
+  /** Build a synthetic dataTransfer.files FileList containing the given files. */
+  function buildFileList(files: File[]): FileList {
+    const list = {
+      length: files.length,
+      item: (i: number) => files[i] ?? null,
+      [Symbol.iterator]: function* () {
+        for (const f of files) yield f;
+      },
+    } as unknown as FileList;
+    files.forEach((f, i) => {
+      (list as unknown as Record<number, File>)[i] = f;
+    });
+    return list;
+  }
+
+  /** Find an hour row by its time label (e.g. "10:00"). */
+  function findHourRow(label: string): HTMLElement {
+    const span = Array.from(document.querySelectorAll('span')).find((s) => s.textContent === label);
+    if (!span) throw new Error(`Hour label ${label} not found in NotebookView`);
+    // The hour row is the closest ancestor with the per-hour drag handlers.
+    // The label sits inside the sticky-left column which is a direct child of
+    // the row div; one parentElement up gets us to the row.
+    const stickyCol = span.parentElement;
+    if (!stickyCol) throw new Error('hour label has no parent');
+    const row = stickyCol.parentElement;
+    if (!row) throw new Error('sticky column has no row parent');
+    return row as HTMLElement;
+  }
+
+  it('opens AddNoteModal preloaded with files when audio is dropped on an hour row', async () => {
+    render(React.createElement(NotebookView, { activeTab: NotebookTab.CALENDAR }), {
+      wrapper: createWrapper(),
+    });
+
+    const row = findHourRow('10:00');
+    const file = buildAudioFile('lecture.mp3');
+
+    await act(async () => {
+      fireEvent.drop(row, {
+        dataTransfer: { files: buildFileList([file]) },
+      });
+      await Promise.resolve();
+    });
+
+    // Modal renders into document.body via createPortal. Header text is
+    // unique to the New Audio Note modal.
+    expect(screen.getByText('New Audio Note')).toBeDefined();
+    // The dropped file appears in the selected files list.
+    expect(screen.getByText('lecture.mp3')).toBeDefined();
+  });
+
+  it('filters mixed drops down to audio files only', async () => {
+    render(React.createElement(NotebookView, { activeTab: NotebookTab.CALENDAR }), {
+      wrapper: createWrapper(),
+    });
+
+    const row = findHourRow('14:00');
+    const audio1 = buildAudioFile('a.mp3');
+    const audio2 = buildAudioFile('b.wav');
+    const text = buildTextFile();
+
+    await act(async () => {
+      fireEvent.drop(row, {
+        dataTransfer: { files: buildFileList([audio1, text, audio2]) },
+      });
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('New Audio Note')).toBeDefined();
+    expect(screen.getByText('a.mp3')).toBeDefined();
+    expect(screen.getByText('b.wav')).toBeDefined();
+    expect(screen.queryByText('unrelated.txt')).toBeNull();
+  });
+
+  it('does not open the modal when only non-audio files are dropped', async () => {
+    render(React.createElement(NotebookView, { activeTab: NotebookTab.CALENDAR }), {
+      wrapper: createWrapper(),
+    });
+
+    const row = findHourRow('11:00');
+    const text = buildTextFile();
+
+    await act(async () => {
+      fireEvent.drop(row, {
+        dataTransfer: { files: buildFileList([text]) },
+      });
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText('New Audio Note')).toBeNull();
   });
 });

--- a/dashboard/components/views/AddNoteModal.tsx
+++ b/dashboard/components/views/AddNoteModal.tsx
@@ -21,6 +21,7 @@ interface AddNoteModalProps {
   onClose: () => void;
   initialTime?: number; // e.g. 10 for 10:00
   initialDate?: string; // e.g. 2026-02-17
+  initialFiles?: File[]; // GH #92: pre-populated when opened via per-hour drag-and-drop
   supportsExplicitWordTimestampToggle?: boolean;
 }
 
@@ -37,6 +38,7 @@ export const AddNoteModal: React.FC<AddNoteModalProps> = ({
   onClose,
   initialTime,
   initialDate,
+  initialFiles,
   supportsExplicitWordTimestampToggle = true,
 }) => {
   const [isRendered, setIsRendered] = useState(false);
@@ -265,15 +267,23 @@ export const AddNoteModal: React.FC<AddNoteModalProps> = ({
 
     if (isOpen) {
       setIsRendered(true);
-      // Set default title based on time
-      if (initialTime !== undefined) {
-        const timeStr = `${initialTime.toString().padStart(2, '0')}:00`;
-        setTitle(`${timeStr} Recording`);
+      // GH #92: when files are preloaded via drag-and-drop on a time slot,
+      // seed selectedFiles and prefer the first file's name as the default
+      // title (matches the in-modal drop behavior in handleFiles).
+      if (initialFiles && initialFiles.length > 0) {
+        setSelectedFiles(initialFiles);
+        const firstName = initialFiles[0].name.replace(/\.[^.]+$/, '');
+        setTitle(firstName);
       } else {
-        setTitle('New Recording');
+        // Set default title based on time
+        if (initialTime !== undefined) {
+          const timeStr = `${initialTime.toString().padStart(2, '0')}:00`;
+          setTitle(`${timeStr} Recording`);
+        } else {
+          setTitle('New Recording');
+        }
+        setSelectedFiles([]);
       }
-      // Reset state on open
-      setSelectedFiles([]);
       setError(null);
       setIsSubmitting(false);
 
@@ -301,7 +311,13 @@ export const AddNoteModal: React.FC<AddNoteModalProps> = ({
       clearTimeout(timer);
       cancelAnimationFrame(rafId);
     };
-  }, [isOpen, initialTime]);
+    // GH #92 review: do NOT include `initialFiles` (or `initialTime`) in
+    // deps. They are captured at the time the modal opens; re-running this
+    // effect on every parent re-render that produces a new array reference
+    // would clobber the user's edits to title/selectedFiles mid-flight.
+    // Seeding intentionally happens only on the isOpen→true transition.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
 
   if (!isRendered) return null;
 

--- a/dashboard/components/views/NotebookView.tsx
+++ b/dashboard/components/views/NotebookView.tsx
@@ -60,6 +60,22 @@ import { toast } from 'sonner';
 import { useConfirm } from '../../src/hooks/useConfirm';
 import { getConfig, setConfig } from '../../src/config/store';
 
+// GH #92: same allow-list as AddNoteModal's <input accept="…"> below — keep
+// the two in sync so per-hour drag-drop and the modal's browse/drop accept
+// the same formats.
+const AUDIO_EXTENSIONS = ['.mp3', '.wav', '.m4a', '.flac', '.ogg', '.webm', '.opus'];
+
+const isAudioFile = (file: File): boolean => {
+  const lower = file.name.toLowerCase();
+  return AUDIO_EXTENSIONS.some((ext) => lower.endsWith(ext));
+};
+
+const filterAudioFiles = (files: FileList | File[]): { audio: File[]; rejectedCount: number } => {
+  const list = Array.from(files);
+  const audio = list.filter(isAudioFile);
+  return { audio, rejectedCount: list.length - audio.length };
+};
+
 interface NotebookViewProps {
   activeTab: NotebookTab;
 }
@@ -77,6 +93,9 @@ export const NotebookView: React.FC<NotebookViewProps> = ({ activeTab }) => {
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [selectedTimeSlot, setSelectedTimeSlot] = useState<number | undefined>(undefined);
   const [selectedDateSlot, setSelectedDateSlot] = useState<string | undefined>(undefined);
+  // GH #92: files preloaded by drop-on-slot. Cleared when user opens the
+  // modal via the "+" button so the click flow stays empty.
+  const [selectedInitialFiles, setSelectedInitialFiles] = useState<File[] | undefined>(undefined);
 
   const handleNoteClick = (noteData: any) => {
     setSelectedNote(noteData);
@@ -86,8 +105,26 @@ export const NotebookView: React.FC<NotebookViewProps> = ({ activeTab }) => {
   const handleAddNote = (time: number, dateKey: string) => {
     setSelectedTimeSlot(time);
     setSelectedDateSlot(dateKey);
+    setSelectedInitialFiles(undefined);
     setIsAddModalOpen(true);
   };
+
+  // GH #92: invoked when audio files are dropped directly on a time slot.
+  // Filters non-audio at the call site (TimeSection) so we only ever receive
+  // a non-empty File[] here.
+  const handleDropFilesAtSlot = useCallback((time: number, dateKey: string, files: File[]) => {
+    setSelectedTimeSlot(time);
+    setSelectedDateSlot(dateKey);
+    setSelectedInitialFiles(files);
+    setIsAddModalOpen(true);
+  }, []);
+
+  // GH #92: clear initialFiles on close so the next "+" click (or stale
+  // reopen) never sees files from a previous drop session.
+  const handleAddModalClose = useCallback(() => {
+    setIsAddModalOpen(false);
+    setSelectedInitialFiles(undefined);
+  }, []);
 
   const bumpCalendarRefresh = useCallback(() => {
     setCalendarRefreshNonce((prev) => prev + 1);
@@ -127,6 +164,7 @@ export const NotebookView: React.FC<NotebookViewProps> = ({ activeTab }) => {
           <CalendarTab
             onNoteClick={handleNoteClick}
             onAddNote={handleAddNote}
+            onDropFilesAtSlot={handleDropFilesAtSlot}
             refreshNonce={calendarRefreshNonce}
           />
         );
@@ -155,9 +193,10 @@ export const NotebookView: React.FC<NotebookViewProps> = ({ activeTab }) => {
       {/* Add New Note Overlay */}
       <AddNoteModal
         isOpen={isAddModalOpen}
-        onClose={() => setIsAddModalOpen(false)}
+        onClose={handleAddModalClose}
         initialTime={selectedTimeSlot}
         initialDate={selectedDateSlot}
+        initialFiles={selectedInitialFiles}
         supportsExplicitWordTimestampToggle={supportsExplicitWordTimestampToggle}
       />
     </>
@@ -614,6 +653,9 @@ const TimeSection: React.FC<{
   onZoomChange: (slots: number) => void;
   onNoteClick: (note: EventData) => void;
   onAddNote: (hour: number) => void;
+  // GH #92: invoked when audio files are dropped on a specific hour row.
+  // Caller is responsible for filtering / toasting on non-audio drops.
+  onDropFilesAtSlot: (hour: number, files: FileList) => void;
   onRefresh: () => void;
 }> = ({
   title,
@@ -626,6 +668,7 @@ const TimeSection: React.FC<{
   onZoomChange,
   onNoteClick,
   onAddNote,
+  onDropFilesAtSlot,
   onRefresh,
 }) => {
   const hours = Array.from({ length: endHour - startHour }, (_, i) => startHour + i);
@@ -636,6 +679,11 @@ const TimeSection: React.FC<{
     trigger: MenuTrigger;
   } | null>(null);
   const isCompact = visibleSlots >= 4;
+  // GH #92: highlight the hour row currently under the user's drag cursor.
+  // dragOver fires repeatedly so setting on dragOver (mirroring the existing
+  // import-tab pattern at line ~1670) keeps the state accurate; clear on
+  // dragLeave or drop.
+  const [dragOverHour, setDragOverHour] = useState<number | null>(null);
 
   // Audio preview state
   const [previewingId, setPreviewingId] = useState<string | null>(null);
@@ -751,11 +799,46 @@ const TimeSection: React.FC<{
         <div className="h-full">
           {hours.map((hour) => {
             const hourEvents = events.filter((e) => Math.floor(e.startTime) === hour);
+            const isDropTarget = dragOverHour === hour;
             return (
               <div
                 key={hour}
-                className="group relative flex border-b border-white/5 transition-colors duration-300 last:border-0 hover:bg-white/2"
+                className={`group relative flex border-b transition-colors duration-300 last:border-0 ${
+                  isDropTarget
+                    ? 'border-accent-cyan/40 bg-accent-cyan/5'
+                    : 'border-white/5 hover:bg-white/2'
+                }`}
                 style={{ height: `${100 / visibleSlots}%` }}
+                onDragOver={(e) => {
+                  // GH #92: only react to OS file drags. Skipping internal
+                  // drags (text selections, image drags, intra-page drags)
+                  // avoids highlighting the row + hijacking events that the
+                  // user did not intend as a file drop.
+                  if (!Array.from(e.dataTransfer.types).includes('Files')) return;
+                  // Must preventDefault to enable a drop on this row (HTML5
+                  // DnD spec). Setting dropEffect='copy' shows the correct
+                  // cursor affordance on Windows / Chrome.
+                  e.preventDefault();
+                  e.dataTransfer.dropEffect = 'copy';
+                  if (dragOverHour !== hour) setDragOverHour(hour);
+                }}
+                onDragLeave={(e) => {
+                  // Only clear if we're truly leaving the row, not just
+                  // crossing into a child element. relatedTarget is the
+                  // element being entered; if it's still inside the row,
+                  // ignore the leave.
+                  const next = e.relatedTarget as Node | null;
+                  if (next && e.currentTarget.contains(next)) return;
+                  setDragOverHour((current) => (current === hour ? null : current));
+                }}
+                onDrop={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setDragOverHour(null);
+                  if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+                    onDropFilesAtSlot(hour, e.dataTransfer.files);
+                  }
+                }}
               >
                 <div className="sticky left-0 z-20 w-16 shrink-0 pt-6 pr-4 text-right select-none">
                   <span className="font-mono text-xs font-medium text-slate-500">
@@ -903,8 +986,12 @@ const recordingToEvent = (rec: Recording): EventData => {
 const CalendarTab: React.FC<{
   onNoteClick: (note: any) => void;
   onAddNote: (hour: number, dateKey: string) => void;
+  // GH #92: bridges per-hour drops up to NotebookView. Receives the raw
+  // FileList; this function filters to audio extensions and toasts on
+  // rejection before calling the parent.
+  onDropFilesAtSlot: (hour: number, dateKey: string, files: File[]) => void;
   refreshNonce: number;
-}> = ({ onNoteClick, onAddNote, refreshNonce }) => {
+}> = ({ onNoteClick, onAddNote, onDropFilesAtSlot, refreshNonce }) => {
   const [currentDate, setCurrentDate] = useState(() => new Date());
   const [selectedDay, setSelectedDay] = useState<string | null>(null);
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
@@ -1026,6 +1113,26 @@ const CalendarTab: React.FC<{
   const addNoteDateKey = selectedDay ?? formatDateKey(new Date());
   const today = new Date();
   const todayKey = formatDateKey(today);
+
+  // GH #92: filter the raw FileList from a per-hour drop and forward to the
+  // parent. Toasts here so the wording is centralized for both Morning and
+  // Afternoon TimeSections.
+  const handleDropAtHour = useCallback(
+    (hour: number, files: FileList) => {
+      const { audio, rejectedCount } = filterAudioFiles(files);
+      if (audio.length === 0) {
+        toast.error('No audio files in drop', {
+          description: 'Supports MP3, WAV, M4A, FLAC, OGG, WebM, Opus.',
+        });
+        return;
+      }
+      if (rejectedCount > 0) {
+        toast.warning(`${rejectedCount} non-audio file${rejectedCount === 1 ? '' : 's'} ignored`);
+      }
+      onDropFilesAtSlot(hour, addNoteDateKey, audio);
+    },
+    [addNoteDateKey, onDropFilesAtSlot],
+  );
 
   return (
     <div className="grid h-full min-h-0 grid-cols-1 gap-6 lg:grid-cols-3">
@@ -1152,6 +1259,7 @@ const CalendarTab: React.FC<{
           onZoomChange={setVisibleSlots}
           onNoteClick={onNoteClick}
           onAddNote={(hour) => onAddNote(hour, addNoteDateKey)}
+          onDropFilesAtSlot={handleDropAtHour}
           onRefresh={calendar.refresh}
         />
         <TimeSection
@@ -1165,6 +1273,7 @@ const CalendarTab: React.FC<{
           onZoomChange={setVisibleSlots}
           onNoteClick={onNoteClick}
           onAddNote={(hour) => onAddNote(hour, addNoteDateKey)}
+          onDropFilesAtSlot={handleDropAtHour}
           onRefresh={calendar.refresh}
         />
       </div>

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
   "spec_version": "1.0.34",
-  "contract_sha256": "e9cca0ad4bdf49944c40c50e38233f396ffddf7dc483b31cd5c5a6bbd8b36bf0",
-  "updated_at": "2026-04-29T21:36:53.009Z"
+  "contract_sha256": "fbdf308cec9c46a4bb09325ac95df1ac2e8152d564cbe947d74ff30948d32bd0",
+  "updated_at": "2026-05-01T21:35:33.201Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -7,8 +7,11 @@ meta:
     repo_path: /home/Bill/Code_Projects/Python_Projects/TranscriptionSuite/dashboard
     source_files:
       - App.tsx
+      - components/__tests__/AddNoteModal.canary-language.test.tsx
+      - components/__tests__/AddNoteModal.initialFiles.test.tsx
       - components/__tests__/AudioVisualizer.test.tsx
       - components/__tests__/LogsView.test.tsx
+      - components/__tests__/NotebookView.canary-language.test.tsx
       - components/__tests__/NotebookView.test.tsx
       - components/__tests__/ServerView.test.tsx
       - components/__tests__/SessionImportTab.canary-language.test.tsx
@@ -59,7 +62,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-04-29T21:36:52.369Z
+    generated_at: 2026-05-01T21:35:27.741Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -231,7 +234,6 @@ foundation:
         - shadow-[0_0_20px_rgba(255,255,255,0.3)]
         - shadow-[0_0_5px_rgba(217,70,239,0.5)]
         - shadow-[0_0_5px_rgba(239,22,238,0.5)]
-        - shadow-[0_0_5px_rgba(239,68,68,0.6)]
         - shadow-[0_0_5px_rgba(34,211,238,0.5)]
         - shadow-[0_2px_8px_rgba(0,0,0,0.4)]
         - shadow-2xl
@@ -319,7 +321,6 @@ foundation:
         - shadow-[0_0_20px_rgba(255,255,255,0.3)]
         - shadow-[0_0_5px_rgba(217,70,239,0.5)]
         - shadow-[0_0_5px_rgba(239,22,238,0.5)]
-        - shadow-[0_0_5px_rgba(239,68,68,0.6)]
         - shadow-[0_0_5px_rgba(34,211,238,0.5)]
         - shadow-[0_2px_8px_rgba(0,0,0,0.4)]
         - text-[10px]
@@ -461,8 +462,6 @@ utility_allowlist:
     - bg-cyan-400/70
     - bg-emerald-400/10
     - bg-glass-100
-    - bg-glass-100/30
-    - bg-glass-100/50
     - bg-glass-200
     - bg-glass-surface
     - bg-green-500
@@ -665,11 +664,9 @@ utility_allowlist:
     - hover:bg-red-500/20
     - hover:bg-red-500/35
     - hover:bg-white/10
-    - hover:bg-white/2
     - hover:bg-white/5
     - hover:bg-white/8
     - hover:bg-yellow-400/30
-    - hover:border-accent-cyan/50
     - hover:border-white/10
     - hover:border-white/20
     - hover:opacity-85
@@ -711,13 +708,10 @@ utility_allowlist:
     - left-3
     - left-4
     - left-8
-    - lg:col-span-2
     - lg:flex
     - lg:grid-cols-2
-    - lg:grid-cols-3
     - lg:p-10
     - lg:p-8
-    - line-clamp-2
     - m-0
     - mask-gradient-right
     - max-h-32
@@ -758,7 +752,6 @@ utility_allowlist:
     - min-w-100
     - min-w-25
     - min-w-32.5
-    - min-w-36
     - min-w-42.5
     - min-w-6
     - ml-0.5
@@ -780,7 +773,6 @@ utility_allowlist:
     - mt-4
     - mt-6
     - mt-8
-    - mt-auto
     - mx-1
     - mx-2
     - mx-auto
@@ -819,10 +811,8 @@ utility_allowlist:
     - pb-2
     - pb-4
     - pb-8
-    - pl-0
     - pl-1
     - pl-12
-    - pl-2
     - pl-4
     - pl-5
     - pl-6
@@ -959,7 +949,6 @@ utility_allowlist:
     - text-emerald-400
     - text-green-400
     - text-green-400/70
-    - text-indigo-400
     - text-left
     - text-lg
     - text-neutral-100
@@ -1089,7 +1078,6 @@ utility_allowlist:
     - shadow-[0_0_20px_rgba(255,255,255,0.3)]
     - shadow-[0_0_5px_rgba(217,70,239,0.5)]
     - shadow-[0_0_5px_rgba(239,22,238,0.5)]
-    - shadow-[0_0_5px_rgba(239,68,68,0.6)]
     - shadow-[0_0_5px_rgba(34,211,238,0.5)]
     - shadow-[0_2px_8px_rgba(0,0,0,0.4)]
     - text-[10px]


### PR DESCRIPTION
## Summary

Closes #92. Drag any audio file onto a Notebook calendar hour-row and `AddNoteModal` opens preloaded with the time slot, date, and files. The "+" button still opens an empty modal. Mixed audio/non-audio drops keep only the audio with a warning toast; all-non-audio drops abort with a "Supports MP3, WAV, …" toast.

## Implementation notes

Per-hour handlers in `TimeSection` gate on `dataTransfer.types.includes('Files')` so internal drags (text selection, intra-page note drags) don't trigger the highlight, and set `dropEffect = 'copy'` for the correct cursor on Windows. The `AUDIO_EXTENSIONS` allow-list lives in `NotebookView.tsx` and mirrors the modal's `<input accept>` exactly so the two surfaces accept the same formats.

`AddNoteModal` gains an `initialFiles?: File[]` prop. Seeding runs only on the `isOpen → true` transition — review caught that adding `initialFiles` to the effect deps would clobber user edits mid-flight whenever the parent re-rendered with a new array reference. The eslint-disable on that line documents the intent.

## Test plan

- [ ] `cd dashboard && npm run typecheck` passes
- [ ] `cd dashboard && npm test` — 1030 tests pass (5 new in `NotebookView.test.tsx` + `AddNoteModal.initialFiles.test.tsx`)
- [ ] `cd dashboard && npm run ui:contract:check` passes
- [ ] Drop an `.mp3` on the 10:00 row → modal opens with file in list, time band reads "10:00 - 11:00", title pre-fills from filename
- [ ] Drop a `.txt` on a row → no modal, "No audio files in drop" toast
- [ ] Drop a mix of `.mp3 + .txt` → modal opens with only the `.mp3`, "1 non-audio file ignored" warning toast
- [ ] Click the "+" button → modal still opens empty (no leaked drop state)
- [ ] Drop and submit → import-queue toast appears, note shows up in calendar at the dropped hour