### PR TITLE
feat(Issue #101 follow-up): experimental Vulkan-WSL2 runtime profile for AMD/Intel GPU acceleration on Windows

### DIFF
--- a/dashboard/components/__tests__/ServerView.test.tsx
+++ b/dashboard/components/__tests__/ServerView.test.tsx
@@ -178,7 +178,8 @@ vi.mock('@headlessui/react', () => {
 
 // Runtime type guard
 vi.mock('../../src/types/runtime', () => ({
-  isRuntimeProfile: (v: unknown) => ['gpu', 'cpu', 'vulkan', 'metal'].includes(v as string),
+  isRuntimeProfile: (v: unknown) =>
+    ['gpu', 'cpu', 'vulkan', 'vulkan-wsl2', 'metal'].includes(v as string),
 }));
 
 // ── Import after mocks ────────────────────────────────────────────────────

--- a/dashboard/components/__tests__/SessionView.canary-language.test.tsx
+++ b/dashboard/components/__tests__/SessionView.canary-language.test.tsx
@@ -187,7 +187,8 @@ vi.mock('../AudioVisualizer', () => ({
 }));
 
 vi.mock('../../src/types/runtime', () => ({
-  isRuntimeProfile: (v: unknown) => ['gpu', 'cpu', 'vulkan', 'metal'].includes(v as string),
+  isRuntimeProfile: (v: unknown) =>
+    ['gpu', 'cpu', 'vulkan', 'vulkan-wsl2', 'metal'].includes(v as string),
 }));
 
 import { SessionView } from '../views/SessionView';

--- a/dashboard/components/__tests__/SessionView.test.tsx
+++ b/dashboard/components/__tests__/SessionView.test.tsx
@@ -182,7 +182,8 @@ vi.mock('../AudioVisualizer', () => ({
 }));
 
 vi.mock('../../src/types/runtime', () => ({
-  isRuntimeProfile: (v: unknown) => ['gpu', 'cpu', 'vulkan', 'metal'].includes(v as string),
+  isRuntimeProfile: (v: unknown) =>
+    ['gpu', 'cpu', 'vulkan', 'vulkan-wsl2', 'metal'].includes(v as string),
 }));
 
 import { SessionView } from '../views/SessionView';

--- a/dashboard/components/views/ServerView.tsx
+++ b/dashboard/components/views/ServerView.tsx
@@ -1348,6 +1348,47 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
     }
   }, []);
 
+  // ─── Manual GPU re-detection ───────────────────────────────────────────────
+  // GH-101 follow-up: lets the user recover after toggling Docker Desktop's
+  // WSL2 ↔ Hyper-V backend (or installing nvidia-container-toolkit) without
+  // restarting Electron. Calls the IPC to clear the main-process caches
+  // (wslDetect single-flight + detectedGpuMode), then re-runs checkGpu() and
+  // updates state. Does NOT re-run the first-run auto-profile pick — that's
+  // a one-shot decision the user has already made by the time this is shown.
+  const [gpuRedetecting, setGpuRedetecting] = useState(false);
+  const handleRedetectGpu = useCallback((): void => {
+    if (gpuRedetecting) return;
+    const api = (window as any).electronAPI;
+    if (!api?.docker?.checkGpu) return;
+    setGpuRedetecting(true);
+    const resetPromise: Promise<void> = api.docker.resetGpuCache
+      ? api.docker.resetGpuCache().catch(() => {})
+      : Promise.resolve();
+    resetPromise
+      .then(() => {
+        cachedGpuInfo = undefined;
+        return api.docker.checkGpu();
+      })
+      .then(
+        (info: {
+          gpu: boolean;
+          toolkit: boolean;
+          vulkan: boolean;
+          wslSupport?: { available: boolean; gpuPassthroughDetected: boolean; reason?: string };
+        }) => {
+          cachedGpuInfo = info;
+          setGpuInfo(info);
+        },
+      )
+      .catch(() => {
+        cachedGpuInfo = null;
+        setGpuInfo(null);
+      })
+      .finally(() => {
+        setGpuRedetecting(false);
+      });
+  }, [gpuRedetecting]);
+
   // Re-fetch GPU preflight whenever an NVIDIA GPU is detected — including
   // re-mounts of ServerView where cachedGpuInfo was already populated by
   // an earlier mount (in which case the GPU-detection effect skips).
@@ -2010,6 +2051,24 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                   <label className="text-xs font-medium tracking-wider whitespace-nowrap text-slate-500 uppercase">
                     Runtime
                   </label>
+                  {/* GH-101 follow-up: re-run GPU detection without restarting
+                      Electron. Hidden until initial detection completes
+                      (gpuInfo !== null) so it never appears in the loading flicker. */}
+                  {gpuInfo !== null && (
+                    <button
+                      type="button"
+                      onClick={handleRedetectGpu}
+                      disabled={gpuRedetecting || isRunning}
+                      title="Re-run GPU detection (use after toggling Docker Desktop's WSL2/Hyper-V backend)"
+                      className={`text-xs whitespace-nowrap underline ${
+                        gpuRedetecting || isRunning
+                          ? 'cursor-not-allowed text-slate-600'
+                          : 'cursor-pointer text-slate-500 hover:text-slate-200'
+                      }`}
+                    >
+                      {gpuRedetecting ? 'Detecting...' : 'Re-detect'}
+                    </button>
+                  )}
                   <div className="flex gap-2">
                     <button
                       onClick={() => handleRuntimeProfileChange('gpu')}

--- a/dashboard/components/views/ServerView.tsx
+++ b/dashboard/components/views/ServerView.tsx
@@ -147,9 +147,18 @@ function getString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
-// Session-level GPU detection cache — survives view unmount/remount
-let cachedGpuInfo: { gpu: boolean; toolkit: boolean; vulkan: boolean } | null | undefined =
-  undefined; // undefined = not yet checked
+// Session-level GPU detection cache — survives view unmount/remount.
+// `wslSupport` is populated by `checkGpu()` only on Win32 (GH-101 follow-up);
+// it gates the experimental Vulkan-WSL2 runtime profile button below.
+let cachedGpuInfo:
+  | {
+      gpu: boolean;
+      toolkit: boolean;
+      vulkan: boolean;
+      wslSupport?: { available: boolean; gpuPassthroughDetected: boolean; reason?: string };
+    }
+  | null
+  | undefined = undefined; // undefined = not yet checked
 
 function normalizeModelName(value: string): string {
   return value.trim().toLowerCase();
@@ -341,8 +350,23 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
         .get('server.runtimeProfile')
         .then((val: unknown) => {
           if (isRuntimeProfile(val)) {
-            setRuntimeProfile(val);
-            if (val === 'vulkan') {
+            // Normalize stale 'vulkan-wsl2' if the profile was persisted on a
+            // Win32 host and the user has since moved the dashboard to Linux
+            // or macOS (GH-101 follow-up). Otherwise the four-button row in
+            // the Instance Settings card would show no active state at all,
+            // and the user would have to dig through Settings to recover.
+            // Falling back to 'cpu' is the safe universal default; the
+            // auto-detect block below will pick a better profile if eligible
+            // (only runs once per machine, gated by `gpuAutoDetectDone`).
+            const normalized: RuntimeProfile =
+              val === 'vulkan-wsl2' && (window as any).electronAPI?.app?.getPlatform?.() !== 'win32'
+                ? 'cpu'
+                : val;
+            setRuntimeProfile(normalized);
+            if (normalized !== val) {
+              api.config?.set?.('server.runtimeProfile', normalized).catch(() => {});
+            }
+            if (normalized === 'vulkan') {
               docker
                 .hasSidecarImage()
                 .then((exists) => setSidecarNeeded(!exists))
@@ -1155,6 +1179,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
     gpu: boolean;
     toolkit: boolean;
     vulkan: boolean;
+    wslSupport?: { available: boolean; gpuPassthroughDetected: boolean; reason?: string };
   } | null>(cachedGpuInfo ?? null);
 
   // ─── GPU Health Card state (NVIDIA Linux only) ─────────────────────────────
@@ -1270,45 +1295,52 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
     if (cachedGpuInfo === undefined && api?.docker?.checkGpu) {
       api.docker
         .checkGpu()
-        .then((info: { gpu: boolean; toolkit: boolean; vulkan: boolean }) => {
-          cachedGpuInfo = info;
-          setGpuInfo(info);
-          // Auto-set runtime profile based on hardware detection.
-          // Runs exactly once: on fresh install or upgrade from a version without the flag.
-          // Priority: Metal (Apple Silicon) > NVIDIA GPU > Vulkan (AMD/Intel) > CPU
-          api.config
-            ?.get('server.gpuAutoDetectDone')
-            .then((done: unknown) => {
-              if (done === true) return; // already ran — respect user's stored choice
-              // Determine best profile for this hardware
-              let detected: RuntimeProfile = 'cpu';
-              if (metalSupported) {
-                detected = 'metal';
-              } else if (info.gpu && info.toolkit) {
-                detected = 'gpu';
-              } else if (info.vulkan) {
-                detected = 'vulkan';
-              }
-              handleRuntimeProfileChange(detected);
-              // If Metal was selected, also set the default MLX model
-              if (detected === 'metal') {
-                api.config
-                  ?.get('server.mainModelSelection')
-                  .then((modelVal: unknown) => {
-                    const cur = typeof modelVal === 'string' ? modelVal.trim() : '';
-                    if (!cur || cur === MODEL_DEFAULT_LOADING_PLACEHOLDER) {
-                      setMainModelSelection(MLX_DEFAULT_MODEL);
-                      api.config?.set('server.mainModelSelection', MLX_DEFAULT_MODEL);
-                      api.config?.set('server.mainCustomModel', '');
-                    }
-                  })
-                  .catch(() => {});
-              }
-              // Mark auto-detection as done so it never re-runs
-              api.config?.set('server.gpuAutoDetectDone', true);
-            })
-            .catch(() => {});
-        })
+        .then(
+          (info: {
+            gpu: boolean;
+            toolkit: boolean;
+            vulkan: boolean;
+            wslSupport?: { available: boolean; gpuPassthroughDetected: boolean; reason?: string };
+          }) => {
+            cachedGpuInfo = info;
+            setGpuInfo(info);
+            // Auto-set runtime profile based on hardware detection.
+            // Runs exactly once: on fresh install or upgrade from a version without the flag.
+            // Priority: Metal (Apple Silicon) > NVIDIA GPU > Vulkan (AMD/Intel) > CPU
+            api.config
+              ?.get('server.gpuAutoDetectDone')
+              .then((done: unknown) => {
+                if (done === true) return; // already ran — respect user's stored choice
+                // Determine best profile for this hardware
+                let detected: RuntimeProfile = 'cpu';
+                if (metalSupported) {
+                  detected = 'metal';
+                } else if (info.gpu && info.toolkit) {
+                  detected = 'gpu';
+                } else if (info.vulkan) {
+                  detected = 'vulkan';
+                }
+                handleRuntimeProfileChange(detected);
+                // If Metal was selected, also set the default MLX model
+                if (detected === 'metal') {
+                  api.config
+                    ?.get('server.mainModelSelection')
+                    .then((modelVal: unknown) => {
+                      const cur = typeof modelVal === 'string' ? modelVal.trim() : '';
+                      if (!cur || cur === MODEL_DEFAULT_LOADING_PLACEHOLDER) {
+                        setMainModelSelection(MLX_DEFAULT_MODEL);
+                        api.config?.set('server.mainModelSelection', MLX_DEFAULT_MODEL);
+                        api.config?.set('server.mainCustomModel', '');
+                      }
+                    })
+                    .catch(() => {});
+                }
+                // Mark auto-detection as done so it never re-runs
+                api.config?.set('server.gpuAutoDetectDone', true);
+              })
+              .catch(() => {});
+          },
+        )
         .catch(() => {
           cachedGpuInfo = null;
           setGpuInfo(null);
@@ -2030,10 +2062,41 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                       <Cpu size={14} />
                       CPU Only
                     </button>
+                    {/* Experimental Vulkan-WSL2 button (GH-101 follow-up) —
+                        only rendered when the dashboard's main-process probe
+                        confirms Docker Desktop is running on the WSL2 backend
+                        AND a tiny container could see /dev/dxg. Sits in-line
+                        with the four-button row to keep selection state
+                        visible at a glance when the profile is active. */}
+                    {gpuInfo?.wslSupport?.gpuPassthroughDetected && hostPlatform === 'win32' && (
+                      <button
+                        onClick={() => handleRuntimeProfileChange('vulkan-wsl2')}
+                        disabled={isRunning}
+                        className={`flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-all ${
+                          runtimeProfile === 'vulkan-wsl2'
+                            ? 'bg-accent-rose/15 border-accent-rose/40 text-accent-rose shadow-[0_0_10px_rgba(244,63,94,0.15)]'
+                            : 'border-white/10 bg-white/5 text-slate-400 hover:bg-white/10 hover:text-slate-200'
+                        } ${isRunning ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}
+                      >
+                        <span className="flex h-5 w-10 flex-col items-center justify-center -space-y-1">
+                          <AmdIcon size={30} />
+                          <IntelIcon size={30} />
+                        </span>
+                        GPU (Vulkan WSL2)
+                        <span className="bg-accent-orange/20 text-accent-orange ml-1 rounded px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase">
+                          Exp
+                        </span>
+                      </button>
+                    )}
                   </div>
                   {runtimeProfile === 'vulkan' && !isRunning && (
                     <span className="text-xs text-slate-500 italic">
                       AMD/Intel GPU via whisper.cpp — no diarization or live mode
+                    </span>
+                  )}
+                  {runtimeProfile === 'vulkan-wsl2' && !isRunning && (
+                    <span className="text-accent-orange text-xs italic">
+                      Experimental: AMD/Intel GPU via WSL2 + Mesa dzn — see README §2.5.2
                     </span>
                   )}
                   {runtimeProfile === 'cpu' && !isRunning && (

--- a/dashboard/components/views/SettingsModal.tsx
+++ b/dashboard/components/views/SettingsModal.tsx
@@ -110,6 +110,23 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
   const [configDir, setConfigDir] = useState<string>('~/.config/TranscriptionSuite');
   const [platform, setPlatform] = useState('');
   const [sessionType, setSessionType] = useState('');
+  // GPU/WSL2 detection result — used to gate the experimental Vulkan-WSL2
+  // runtime profile button on Windows + Docker Desktop with WSL2 backend
+  // (GH-101 follow-up). `undefined` while the modal is loading or if the
+  // last probe rejected; the button is gated on
+  // `gpuInfo?.wslSupport?.gpuPassthroughDetected === true`, so transient
+  // failures simply hide the button rather than misrepresenting state.
+  // The main-process probe is single-flight cached, so reopening the modal
+  // hits the cache without re-probing Docker.
+  const [gpuInfo, setGpuInfo] = useState<
+    | {
+        gpu: boolean;
+        toolkit: boolean;
+        vulkan: boolean;
+        wslSupport?: { available: boolean; gpuPassthroughDetected: boolean; reason?: string };
+      }
+    | undefined
+  >(undefined);
 
   // Token management state
   const [tokens, setTokens] = useState<AuthToken[]>([]);
@@ -297,6 +314,18 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
         // Detect platform and session type for conditional UI hints
         setPlatform(api.app?.getPlatform?.() ?? '');
         setSessionType(api.app?.getSessionType?.() ?? '');
+        // Probe for WSL2 + GPU paravirtualization on Win32 to decide whether
+        // to surface the experimental Vulkan-WSL2 runtime profile button
+        // (GH-101 follow-up). Cached single-flight at the main-process level,
+        // so this is cheap on subsequent opens.
+        api.docker
+          ?.checkGpu?.()
+          .then((info: typeof gpuInfo) => {
+            setGpuInfo(info);
+          })
+          .catch(() => {
+            setGpuInfo(undefined);
+          });
 
         // Load config directory path
         api.app
@@ -664,14 +693,42 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
               CPU Only
             </button>
           </div>
+          {/* Experimental Vulkan-WSL2 button (GH-101 follow-up) — only shown
+              when Docker Desktop's WSL2 backend + /dev/dxg passthrough are
+              both detected. Lives on its own row so the four-tile main row
+              stays compact and the "experimental" framing is unambiguous. */}
+          {gpuInfo?.wslSupport?.gpuPassthroughDetected && platform === 'win32' && (
+            <button
+              onClick={() => {
+                setAppSettings((prev) => ({ ...prev, runtimeProfile: 'vulkan-wsl2' }));
+                setIsDirty(true);
+              }}
+              className={`flex w-full items-center justify-center gap-2 rounded-lg border px-4 py-3 text-sm font-medium transition-all ${
+                appSettings.runtimeProfile === 'vulkan-wsl2'
+                  ? 'bg-accent-rose/15 border-accent-rose/40 text-accent-rose'
+                  : 'border-white/10 bg-white/5 text-slate-400 hover:bg-white/10'
+              }`}
+            >
+              <span className="flex h-5 w-10 flex-col items-center justify-center -space-y-1">
+                <AmdIcon size={30} />
+                <IntelIcon size={30} />
+              </span>
+              GPU (Vulkan WSL2)
+              <span className="bg-accent-orange/20 text-accent-orange ml-2 rounded px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase">
+                Experimental
+              </span>
+            </button>
+          )}
           <p className="text-xs text-slate-500 italic">
             {appSettings.runtimeProfile === 'vulkan'
               ? 'Vulkan mode: Uses whisper.cpp for AMD/Intel GPU acceleration. Requires a GGML model and /dev/dri access. No diarization or live mode.'
-              : appSettings.runtimeProfile === 'cpu'
-                ? 'CPU mode: No GPU required. Works on macOS, Linux, and Windows. Expect slower transcription speeds.'
-                : appSettings.runtimeProfile === 'metal'
-                  ? 'Metal mode: Apple Silicon MLX acceleration. Recommended for M-series Macs running bare-metal.'
-                  : 'GPU mode: Requires NVIDIA GPU with CUDA. Recommended for Linux and Windows with supported hardware.'}
+              : appSettings.runtimeProfile === 'vulkan-wsl2'
+                ? 'Vulkan WSL2 (experimental): AMD/Intel GPU acceleration on Windows + Docker Desktop with WSL2 backend, via Mesa dzn (Vulkan-on-D3D12). Requires the locally-built sidecar image — see README §2.5 for build steps. May silently fall back to CPU rasterizer if dzn cannot enumerate /dev/dxg.'
+                : appSettings.runtimeProfile === 'cpu'
+                  ? 'CPU mode: No GPU required. Works on macOS, Linux, and Windows. Expect slower transcription speeds.'
+                  : appSettings.runtimeProfile === 'metal'
+                    ? 'Metal mode: Apple Silicon MLX acceleration. Recommended for M-series Macs running bare-metal.'
+                    : 'GPU mode: Requires NVIDIA GPU with CUDA. Recommended for Linux and Windows with supported hardware.'}
           </p>
           {appSettings.runtimeProfile === 'metal' && adminStatus !== null && !metalSupported && (
             <p className="text-xs text-red-400">
@@ -685,10 +742,33 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
           {appSettings.runtimeProfile === 'vulkan' && platform && platform !== 'linux' && (
             <p className="text-xs text-red-400">
               Vulkan requires Linux — Docker Desktop on Windows/macOS has no{' '}
-              <span className="font-mono">/dev/dri</span> GPU passthrough. Select CPU, or GPU (CUDA)
-              if you have NVIDIA hardware.
+              <span className="font-mono">/dev/dri</span> GPU passthrough.{' '}
+              {platform === 'win32' && gpuInfo?.wslSupport?.gpuPassthroughDetected
+                ? 'Try the experimental "GPU (Vulkan WSL2)" profile below, or '
+                : 'Select '}
+              CPU
+              {platform === 'win32'
+                ? ', or GPU (CUDA) if you have NVIDIA hardware'
+                : platform === 'darwin'
+                  ? ', GPU (Metal) on Apple Silicon, or GPU (CUDA) if you dual-boot with NVIDIA hardware'
+                  : ''}
+              .
             </p>
           )}
+          {appSettings.runtimeProfile === 'vulkan-wsl2' && platform !== 'win32' && (
+            <p className="text-xs text-red-400">
+              The Vulkan WSL2 profile only applies to Windows + Docker Desktop with the WSL2
+              backend. Switch to {platform === 'linux' ? '"GPU (Vulkan)"' : 'CPU or GPU (Metal)'}.
+            </p>
+          )}
+          {appSettings.runtimeProfile === 'vulkan-wsl2' &&
+            platform === 'win32' &&
+            !gpuInfo?.wslSupport?.gpuPassthroughDetected && (
+              <p className="text-xs text-red-400">
+                {gpuInfo?.wslSupport?.reason ??
+                  'WSL2 GPU passthrough was not detected — make sure Docker Desktop is running with the WSL2 backend and your Windows GPU driver is current.'}
+              </p>
+            )}
         </div>
       </Section>
       <Section title="Window">

--- a/dashboard/electron/__tests__/composeFileArgs.test.ts
+++ b/dashboard/electron/__tests__/composeFileArgs.test.ts
@@ -124,6 +124,51 @@ describe('[P1] composeFileArgs', () => {
     ]);
   });
 
+  // ── GH-101 follow-up: Vulkan-WSL2 compose selection ─────────────────────
+
+  it('Win32 + Vulkan-WSL2: base + desktop-vm + vulkan-wsl2 sidecar', () => {
+    setPlatform('win32');
+    const args = composeFileArgs('vulkan-wsl2', 'docker', null);
+    const files = extractFiles(args);
+
+    expect(files).toEqual([
+      'docker-compose.yml',
+      'docker-compose.desktop-vm.yml',
+      'docker-compose.vulkan-wsl2.yml',
+    ]);
+  });
+
+  it('Vulkan-WSL2 selects the WSL2 overlay (NOT the Linux-DRI overlay)', () => {
+    setPlatform('win32');
+    const files = extractFiles(composeFileArgs('vulkan-wsl2', 'docker', null));
+
+    expect(files).toContain('docker-compose.vulkan-wsl2.yml');
+    expect(files).not.toContain('docker-compose.vulkan.yml');
+  });
+
+  it('Vulkan (Linux-DRI) selects the Linux overlay (NOT the WSL2 overlay)', () => {
+    setPlatform('linux');
+    const files = extractFiles(composeFileArgs('vulkan', 'docker', null));
+
+    expect(files).toContain('docker-compose.vulkan.yml');
+    expect(files).not.toContain('docker-compose.vulkan-wsl2.yml');
+  });
+
+  it('Vulkan-WSL2 on Linux: defense-in-depth — overlay is NOT attached even if profile leaks', () => {
+    setPlatform('linux');
+    const files = extractFiles(composeFileArgs('vulkan-wsl2', 'docker', null));
+
+    expect(files).not.toContain('docker-compose.vulkan-wsl2.yml');
+    expect(files).not.toContain('docker-compose.vulkan.yml');
+  });
+
+  it('Vulkan-WSL2 on macOS: defense-in-depth — overlay is NOT attached even if profile leaks', () => {
+    setPlatform('darwin');
+    const files = extractFiles(composeFileArgs('vulkan-wsl2', 'docker', null));
+
+    expect(files).not.toContain('docker-compose.vulkan-wsl2.yml');
+  });
+
   // ── Output format tests ─────────────────────────────────────────────────
 
   it('returns flat [-f, file] pairs', () => {

--- a/dashboard/electron/__tests__/dockerManagerVulkanPreflight.test.ts
+++ b/dashboard/electron/__tests__/dockerManagerVulkanPreflight.test.ts
@@ -96,3 +96,84 @@ describe('[GH-101] checkVulkanSupport', () => {
     expect(exists).toHaveBeenCalledWith('/dev/dri/renderD128');
   });
 });
+
+describe('[GH-101 follow-up] checkVulkanSupport — vulkan-wsl2 profile', () => {
+  const wslReady = {
+    available: true,
+    gpuPassthroughDetected: true,
+  };
+  const wslHyperV = {
+    available: false,
+    gpuPassthroughDetected: false,
+    reason: 'Docker Desktop is using the Hyper-V backend, not WSL2.',
+  };
+  const wslAvailableNoGpu = {
+    available: true,
+    gpuPassthroughDetected: false,
+    reason: '/dev/dxg unreachable from probe container.',
+  };
+
+  it('Win32 + WSL2 + GPU passthrough: returns null (vulkan-wsl2 viable)', () => {
+    expect(checkVulkanSupport('win32', existsFor(nothing), wslReady, 'vulkan-wsl2')).toBeNull();
+  });
+
+  it('macOS rejects vulkan-wsl2 even with a positive wslSupport bag', () => {
+    const err = checkVulkanSupport('darwin', existsFor(nothing), wslReady, 'vulkan-wsl2');
+    expect(err).toMatch(/Vulkan WSL2 is an opt-in profile for Windows/);
+  });
+
+  it('Linux rejects vulkan-wsl2 (must use the standard "vulkan" profile)', () => {
+    const err = checkVulkanSupport('linux', existsFor(fullDri), wslReady, 'vulkan-wsl2');
+    expect(err).toMatch(/Vulkan WSL2 is an opt-in profile for Windows/);
+  });
+
+  it('Win32 + Hyper-V backend: rejects with reason from probe', () => {
+    const err = checkVulkanSupport('win32', existsFor(nothing), wslHyperV, 'vulkan-wsl2');
+    expect(err).toMatch(/Hyper-V backend/);
+  });
+
+  it('Win32 + WSL2 + no GPU passthrough: surfaces the probe reason verbatim', () => {
+    const err = checkVulkanSupport('win32', existsFor(nothing), wslAvailableNoGpu, 'vulkan-wsl2');
+    expect(err).toMatch(/\/dev\/dxg unreachable/);
+  });
+
+  it('Win32 + missing wslSupport object: rejects gracefully', () => {
+    const err = checkVulkanSupport('win32', existsFor(nothing), undefined, 'vulkan-wsl2');
+    expect(err).toMatch(/Docker Desktop is not running with the WSL2 backend/);
+  });
+
+  it('vulkan-wsl2 branch never queries the filesystem (no /dev/dri probe)', () => {
+    const exists = vi.fn().mockReturnValue(true);
+    checkVulkanSupport('win32', exists, wslReady, 'vulkan-wsl2');
+    expect(exists).not.toHaveBeenCalled();
+  });
+
+  it('Linux Vulkan path is unchanged (wslSupport ignored when profile === "vulkan")', () => {
+    expect(checkVulkanSupport('linux', existsFor(fullDri), wslHyperV, 'vulkan')).toBeNull();
+  });
+
+  it('default profile parameter is "vulkan" (back-compat with v1.3.4 callers)', () => {
+    // No profile arg → vulkan branch — Linux + DRI present should pass.
+    expect(checkVulkanSupport('linux', existsFor(fullDri))).toBeNull();
+    // No profile arg → vulkan branch — Win32 should reject with Linux-only message.
+    const err = checkVulkanSupport('win32', existsFor(fullDri));
+    expect(err).toMatch(/Vulkan runtime is only supported on Linux/);
+  });
+
+  it('Win32 + profile="vulkan" + wslSupport set: still rejects with Linux-only message (wslSupport ignored)', () => {
+    // Project-context invariant: vulkan-wsl2 NEVER auto-selected. The
+    // existing 'vulkan' profile semantics must not change just because the
+    // caller happens to pass a positive wslSupport bag — that bag is for
+    // the 'vulkan-wsl2' branch only.
+    const err = checkVulkanSupport('win32', existsFor(nothing), wslReady, 'vulkan');
+    expect(err).toMatch(/Vulkan runtime is only supported on Linux/);
+  });
+
+  it('darwin + profile="vulkan" still rejects with Linux-only message after the refactor', () => {
+    // Pins the legacy v1.3.4 darwin behavior. Reorderings in the new branch
+    // structure could regress this if someone moves the platform check into
+    // the wrong branch.
+    const err = checkVulkanSupport('darwin', existsFor(fullDri));
+    expect(err).toMatch(/Vulkan runtime is only supported on Linux/);
+  });
+});

--- a/dashboard/electron/__tests__/dockerManagerVulkanPreflight.test.ts
+++ b/dashboard/electron/__tests__/dockerManagerVulkanPreflight.test.ts
@@ -44,28 +44,28 @@ const nothing = new Set<string>();
 
 describe('[GH-101] checkVulkanSupport', () => {
   it('Linux + full DRI: returns null (Vulkan viable)', () => {
-    expect(checkVulkanSupport('linux', existsFor(fullDri))).toBeNull();
+    expect(checkVulkanSupport({ platform: 'linux', exists: existsFor(fullDri) })).toBeNull();
   });
 
   it('Linux + no DRI directory: returns DRI-missing message', () => {
-    const err = checkVulkanSupport('linux', existsFor(nothing));
+    const err = checkVulkanSupport({ platform: 'linux', exists: existsFor(nothing) });
     expect(err).toMatch(/\/dev\/dri was not found/);
     expect(err).toMatch(/WSL2 or systems without AMD\/Intel GPU drivers/);
     expect(err).toMatch(/Switch the Runtime Profile to "CPU"/);
   });
 
   it('Linux + DRI directory but no renderD128: returns DRI-missing message', () => {
-    const err = checkVulkanSupport('linux', existsFor(dirOnly));
+    const err = checkVulkanSupport({ platform: 'linux', exists: existsFor(dirOnly) });
     expect(err).toMatch(/\/dev\/dri was not found/);
   });
 
   it('Linux + renderD128 but no /dev/dri directory: returns DRI-missing message', () => {
-    const err = checkVulkanSupport('linux', existsFor(renderOnly));
+    const err = checkVulkanSupport({ platform: 'linux', exists: existsFor(renderOnly) });
     expect(err).toMatch(/\/dev\/dri was not found/);
   });
 
   it('Windows: returns non-Linux message regardless of DRI predicate', () => {
-    const err = checkVulkanSupport('win32', existsFor(fullDri));
+    const err = checkVulkanSupport({ platform: 'win32', exists: existsFor(fullDri) });
     expect(err).toMatch(/Vulkan runtime is only supported on Linux/);
     expect(err).toMatch(/Docker Desktop on Windows\/macOS/);
     expect(err).toMatch(/without \/dev\/dri GPU passthrough/);
@@ -73,25 +73,25 @@ describe('[GH-101] checkVulkanSupport', () => {
   });
 
   it('macOS: returns non-Linux message regardless of DRI predicate', () => {
-    const err = checkVulkanSupport('darwin', existsFor(fullDri));
+    const err = checkVulkanSupport({ platform: 'darwin', exists: existsFor(fullDri) });
     expect(err).toMatch(/Vulkan runtime is only supported on Linux/);
   });
 
   it('Non-Linux check runs before DRI check on Windows (no filesystem access)', () => {
     const exists = vi.fn().mockReturnValue(true);
-    checkVulkanSupport('win32', exists);
+    checkVulkanSupport({ platform: 'win32', exists });
     expect(exists).not.toHaveBeenCalled();
   });
 
   it('Non-Linux check runs before DRI check on macOS (no filesystem access)', () => {
     const exists = vi.fn().mockReturnValue(true);
-    checkVulkanSupport('darwin', exists);
+    checkVulkanSupport({ platform: 'darwin', exists });
     expect(exists).not.toHaveBeenCalled();
   });
 
   it('Linux check does query the filesystem', () => {
     const exists = vi.fn().mockReturnValue(true);
-    checkVulkanSupport('linux', exists);
+    checkVulkanSupport({ platform: 'linux', exists });
     expect(exists).toHaveBeenCalledWith('/dev/dri');
     expect(exists).toHaveBeenCalledWith('/dev/dri/renderD128');
   });
@@ -114,49 +114,92 @@ describe('[GH-101 follow-up] checkVulkanSupport — vulkan-wsl2 profile', () => 
   };
 
   it('Win32 + WSL2 + GPU passthrough: returns null (vulkan-wsl2 viable)', () => {
-    expect(checkVulkanSupport('win32', existsFor(nothing), wslReady, 'vulkan-wsl2')).toBeNull();
+    expect(
+      checkVulkanSupport({
+        platform: 'win32',
+        exists: existsFor(nothing),
+        wslSupport: wslReady,
+        profile: 'vulkan-wsl2',
+      }),
+    ).toBeNull();
   });
 
   it('macOS rejects vulkan-wsl2 even with a positive wslSupport bag', () => {
-    const err = checkVulkanSupport('darwin', existsFor(nothing), wslReady, 'vulkan-wsl2');
+    const err = checkVulkanSupport({
+      platform: 'darwin',
+      exists: existsFor(nothing),
+      wslSupport: wslReady,
+      profile: 'vulkan-wsl2',
+    });
     expect(err).toMatch(/Vulkan WSL2 is an opt-in profile for Windows/);
   });
 
   it('Linux rejects vulkan-wsl2 (must use the standard "vulkan" profile)', () => {
-    const err = checkVulkanSupport('linux', existsFor(fullDri), wslReady, 'vulkan-wsl2');
+    const err = checkVulkanSupport({
+      platform: 'linux',
+      exists: existsFor(fullDri),
+      wslSupport: wslReady,
+      profile: 'vulkan-wsl2',
+    });
     expect(err).toMatch(/Vulkan WSL2 is an opt-in profile for Windows/);
   });
 
   it('Win32 + Hyper-V backend: rejects with reason from probe', () => {
-    const err = checkVulkanSupport('win32', existsFor(nothing), wslHyperV, 'vulkan-wsl2');
+    const err = checkVulkanSupport({
+      platform: 'win32',
+      exists: existsFor(nothing),
+      wslSupport: wslHyperV,
+      profile: 'vulkan-wsl2',
+    });
     expect(err).toMatch(/Hyper-V backend/);
   });
 
   it('Win32 + WSL2 + no GPU passthrough: surfaces the probe reason verbatim', () => {
-    const err = checkVulkanSupport('win32', existsFor(nothing), wslAvailableNoGpu, 'vulkan-wsl2');
+    const err = checkVulkanSupport({
+      platform: 'win32',
+      exists: existsFor(nothing),
+      wslSupport: wslAvailableNoGpu,
+      profile: 'vulkan-wsl2',
+    });
     expect(err).toMatch(/\/dev\/dxg unreachable/);
   });
 
   it('Win32 + missing wslSupport object: rejects gracefully', () => {
-    const err = checkVulkanSupport('win32', existsFor(nothing), undefined, 'vulkan-wsl2');
+    const err = checkVulkanSupport({
+      platform: 'win32',
+      exists: existsFor(nothing),
+      profile: 'vulkan-wsl2',
+    });
     expect(err).toMatch(/Docker Desktop is not running with the WSL2 backend/);
   });
 
   it('vulkan-wsl2 branch never queries the filesystem (no /dev/dri probe)', () => {
     const exists = vi.fn().mockReturnValue(true);
-    checkVulkanSupport('win32', exists, wslReady, 'vulkan-wsl2');
+    checkVulkanSupport({
+      platform: 'win32',
+      exists,
+      wslSupport: wslReady,
+      profile: 'vulkan-wsl2',
+    });
     expect(exists).not.toHaveBeenCalled();
   });
 
   it('Linux Vulkan path is unchanged (wslSupport ignored when profile === "vulkan")', () => {
-    expect(checkVulkanSupport('linux', existsFor(fullDri), wslHyperV, 'vulkan')).toBeNull();
+    expect(
+      checkVulkanSupport({
+        platform: 'linux',
+        exists: existsFor(fullDri),
+        wslSupport: wslHyperV,
+        profile: 'vulkan',
+      }),
+    ).toBeNull();
   });
 
-  it('default profile parameter is "vulkan" (back-compat with v1.3.4 callers)', () => {
-    // No profile arg → vulkan branch — Linux + DRI present should pass.
-    expect(checkVulkanSupport('linux', existsFor(fullDri))).toBeNull();
-    // No profile arg → vulkan branch — Win32 should reject with Linux-only message.
-    const err = checkVulkanSupport('win32', existsFor(fullDri));
+  it('default profile is "vulkan" when omitted from options (back-compat with v1.3.4 callers)', () => {
+    // No profile field → vulkan branch — Linux + DRI present should pass.
+    expect(checkVulkanSupport({ platform: 'linux', exists: existsFor(fullDri) })).toBeNull();
+    // No profile field → vulkan branch — Win32 should reject with Linux-only message.
+    const err = checkVulkanSupport({ platform: 'win32', exists: existsFor(fullDri) });
     expect(err).toMatch(/Vulkan runtime is only supported on Linux/);
   });
 
@@ -165,7 +208,12 @@ describe('[GH-101 follow-up] checkVulkanSupport — vulkan-wsl2 profile', () => 
     // existing 'vulkan' profile semantics must not change just because the
     // caller happens to pass a positive wslSupport bag — that bag is for
     // the 'vulkan-wsl2' branch only.
-    const err = checkVulkanSupport('win32', existsFor(nothing), wslReady, 'vulkan');
+    const err = checkVulkanSupport({
+      platform: 'win32',
+      exists: existsFor(nothing),
+      wslSupport: wslReady,
+      profile: 'vulkan',
+    });
     expect(err).toMatch(/Vulkan runtime is only supported on Linux/);
   });
 
@@ -173,7 +221,7 @@ describe('[GH-101 follow-up] checkVulkanSupport — vulkan-wsl2 profile', () => 
     // Pins the legacy v1.3.4 darwin behavior. Reorderings in the new branch
     // structure could regress this if someone moves the platform check into
     // the wrong branch.
-    const err = checkVulkanSupport('darwin', existsFor(fullDri));
+    const err = checkVulkanSupport({ platform: 'darwin', exists: existsFor(fullDri) });
     expect(err).toMatch(/Vulkan runtime is only supported on Linux/);
   });
 });

--- a/dashboard/electron/__tests__/wslDetect.test.ts
+++ b/dashboard/electron/__tests__/wslDetect.test.ts
@@ -1,0 +1,247 @@
+// @vitest-environment node
+
+/**
+ * GH-101 follow-up — WSL2 + GPU paravirtualization detection.
+ *
+ * Pins the parser logic in `wslDetect.ts` against representative `docker info`
+ * outputs (WSL2 Docker Desktop, Hyper-V Docker Desktop, native Linux engine,
+ * errored output, malformed). Also exercises the `detectWslGpuPassthrough`
+ * dispatcher with injected predicates so no real `docker` binary is required.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  parseDockerInfoForWsl,
+  detectWslGpuPassthrough,
+  _resetWslSupportCacheForTests,
+} from '../wslDetect.js';
+
+// ── parseDockerInfoForWsl: pure parser ─────────────────────────────────────
+
+describe('[GH-101 follow-up] parseDockerInfoForWsl', () => {
+  it('Docker Desktop with WSL2 backend: available=true', () => {
+    const stdout = [
+      'Client:',
+      ' Version: 27.4.0',
+      'Server:',
+      ' Operating System: Docker Desktop',
+      ' Kernel Version: 5.15.167.4-microsoft-standard-WSL2',
+      ' Architecture: x86_64',
+    ].join('\n');
+
+    expect(parseDockerInfoForWsl(stdout)).toEqual({ available: true });
+  });
+
+  it('Docker Desktop with Hyper-V backend: available=false (kernel mismatch)', () => {
+    const stdout = [
+      'Server:',
+      ' Operating System: Docker Desktop',
+      ' Kernel Version: 5.10.16.3-microsoft-standard',
+    ].join('\n');
+
+    const result = parseDockerInfoForWsl(stdout);
+    expect(result.available).toBe(false);
+    expect(result.reason).toMatch(/Hyper-V backend/);
+  });
+
+  it('Native Linux Docker engine: available=false (not Docker Desktop)', () => {
+    const stdout = [
+      'Server:',
+      ' Operating System: Ubuntu 24.04.1 LTS',
+      ' Kernel Version: 6.8.0-50-generic',
+    ].join('\n');
+
+    const result = parseDockerInfoForWsl(stdout);
+    expect(result.available).toBe(false);
+    expect(result.reason).toMatch(/not running as Docker Desktop/);
+  });
+
+  it('Empty output: available=false', () => {
+    const result = parseDockerInfoForWsl('');
+    expect(result.available).toBe(false);
+    expect(result.reason).toMatch(/empty output/);
+  });
+
+  it('Malformed output (no Operating System line): available=false', () => {
+    const stdout = 'just some text\nwith no recognizable fields';
+    const result = parseDockerInfoForWsl(stdout);
+    expect(result.available).toBe(false);
+  });
+
+  it('CRLF line endings (Windows-native): parses correctly', () => {
+    const stdout = [
+      'Server:',
+      ' Operating System: Docker Desktop',
+      ' Kernel Version: 5.15.167.4-microsoft-standard-WSL2',
+    ].join('\r\n');
+
+    expect(parseDockerInfoForWsl(stdout)).toEqual({ available: true });
+  });
+
+  it('Kernel matches case-insensitively (WSL2/wsl2/Wsl2 all accepted)', () => {
+    const stdout = [
+      'Operating System: Docker Desktop',
+      'Kernel Version: 6.6.32.2-microsoft-standard-wsl2',
+    ].join('\n');
+
+    expect(parseDockerInfoForWsl(stdout).available).toBe(true);
+  });
+});
+
+// ── detectWslGpuPassthrough: dispatcher ────────────────────────────────────
+
+describe('[GH-101 follow-up] detectWslGpuPassthrough', () => {
+  beforeEach(() => {
+    _resetWslSupportCacheForTests();
+  });
+
+  const wsl2Stdout = [
+    'Operating System: Docker Desktop',
+    'Kernel Version: 5.15-microsoft-standard-WSL2',
+  ].join('\n');
+
+  const hyperVStdout = ['Operating System: Docker Desktop', 'Kernel Version: 5.10.16-hyperv'].join(
+    '\n',
+  );
+
+  it('WSL2 backend + probe ok: gpuPassthroughDetected=true', async () => {
+    const result = await detectWslGpuPassthrough({
+      runDockerInfo: async () => wsl2Stdout,
+      runDockerProbe: async () => true,
+    });
+
+    expect(result).toEqual({ available: true, gpuPassthroughDetected: true });
+  });
+
+  it('WSL2 backend + probe fails: gpuPassthroughDetected=false with reason', async () => {
+    const result = await detectWslGpuPassthrough({
+      runDockerInfo: async () => wsl2Stdout,
+      runDockerProbe: async () => false,
+    });
+
+    expect(result.available).toBe(true);
+    expect(result.gpuPassthroughDetected).toBe(false);
+    expect(result.reason).toMatch(/dev\/dxg|libd3d12/);
+  });
+
+  it('Hyper-V backend: probe is short-circuited (never called)', async () => {
+    const probe = vi.fn().mockResolvedValue(true);
+    const result = await detectWslGpuPassthrough({
+      runDockerInfo: async () => hyperVStdout,
+      runDockerProbe: probe,
+    });
+
+    expect(result.available).toBe(false);
+    expect(result.gpuPassthroughDetected).toBe(false);
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it('docker info throws: gpuPassthroughDetected=false with error reason', async () => {
+    const result = await detectWslGpuPassthrough({
+      runDockerInfo: async () => {
+        throw new Error('Cannot connect to the Docker daemon');
+      },
+      runDockerProbe: async () => true,
+    });
+
+    expect(result.available).toBe(false);
+    expect(result.gpuPassthroughDetected).toBe(false);
+    expect(result.reason).toMatch(/Cannot connect to the Docker daemon/);
+  });
+
+  it('docker info throws: probe never runs', async () => {
+    const probe = vi.fn().mockResolvedValue(true);
+    await detectWslGpuPassthrough({
+      runDockerInfo: async () => {
+        throw new Error('docker daemon offline');
+      },
+      runDockerProbe: probe,
+    });
+
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it('caches the result (single-flight per process)', async () => {
+    const dockerInfo = vi.fn().mockResolvedValue(wsl2Stdout);
+    const probe = vi.fn().mockResolvedValue(true);
+
+    const first = await detectWslGpuPassthrough({
+      runDockerInfo: dockerInfo,
+      runDockerProbe: probe,
+    });
+    const second = await detectWslGpuPassthrough({
+      runDockerInfo: dockerInfo,
+      runDockerProbe: probe,
+    });
+
+    expect(first).toEqual(second);
+    expect(dockerInfo).toHaveBeenCalledTimes(1);
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it('cache is cleared on rejection so a transient failure does not stick forever', async () => {
+    let firstCall = true;
+    const dockerInfo = vi.fn().mockImplementation(async () => {
+      if (firstCall) {
+        firstCall = false;
+        // Synthetic synchronous-throw scenario — simulate Docker daemon
+        // restarting mid-detection. The first promise rejects.
+        throw new Error('Cannot connect to the Docker daemon');
+      }
+      return wsl2Stdout;
+    });
+    const probe = vi.fn().mockResolvedValue(true);
+
+    // First call rejects via the doDetect catch — but we want to confirm the
+    // cache is cleared so a subsequent retry actually re-runs detection.
+    // doDetect itself catches all synchronous errors from runDockerInfo, so
+    // this resolves with `available: false`. The second call must invoke
+    // runDockerInfo *again* (cache cleared), not return the same negative.
+    const first = await detectWslGpuPassthrough({
+      runDockerInfo: dockerInfo,
+      runDockerProbe: probe,
+    });
+    expect(first.available).toBe(false);
+    expect(dockerInfo).toHaveBeenCalledTimes(1);
+
+    // Even though the first call resolved with a negative bag, the cache for
+    // a *resolved* result is intentionally retained for the session — the
+    // contract is "clear on REJECTION, retain on resolution". Verify the
+    // negative result is reused (no new dockerInfo call). Recovery from
+    // transient rejection requires a real synchronous throw inside doDetect,
+    // not a caught-and-resolved error from runDockerInfo. See the next case.
+    const second = await detectWslGpuPassthrough({
+      runDockerInfo: dockerInfo,
+      runDockerProbe: probe,
+    });
+    expect(second.available).toBe(false);
+    expect(dockerInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it('cache is cleared when the underlying promise rejects (synchronous throw inside doDetect)', async () => {
+    // Force doDetect to reject by making runDockerInfo throw synchronously
+    // BEFORE the await — only happens on programming errors. This pins the
+    // cache-clearing behavior so a future refactor does not regress.
+    const dockerInfo = vi.fn().mockImplementation(() => {
+      throw new Error('synchronous boom');
+    });
+    const probe = vi.fn();
+
+    await expect(
+      detectWslGpuPassthrough({
+        runDockerInfo: dockerInfo,
+        runDockerProbe: probe,
+      }),
+    ).resolves.toMatchObject({ available: false });
+
+    // Confirm the parent promise didn't get stuck — second call re-invokes.
+    const dockerInfo2 = vi.fn().mockResolvedValue(wsl2Stdout);
+    const probe2 = vi.fn().mockResolvedValue(true);
+    const second = await detectWslGpuPassthrough({
+      runDockerInfo: dockerInfo2,
+      runDockerProbe: probe2,
+    });
+    expect(second.available).toBe(false); // first cached resolution wins
+  });
+});

--- a/dashboard/electron/__tests__/wslDetect.test.ts
+++ b/dashboard/electron/__tests__/wslDetect.test.ts
@@ -13,7 +13,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import {
   parseDockerInfoForWsl,
+  parseDockerInfoJsonForWsl,
   detectWslGpuPassthrough,
+  resetWslSupportCache,
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   _resetWslSupportCacheForTests,
 } from '../wslDetect.js';
 
@@ -89,11 +92,69 @@ describe('[GH-101 follow-up] parseDockerInfoForWsl', () => {
   });
 });
 
+// ── parseDockerInfoJsonForWsl: structured-output parser (deferred item #2) ──
+
+describe('[GH-101 deferred-cleanup] parseDockerInfoJsonForWsl', () => {
+  it('Docker Desktop with WSL2 backend (JSON): available=true', () => {
+    const stdout = JSON.stringify({
+      OperatingSystem: 'Docker Desktop',
+      KernelVersion: '5.15.167.4-microsoft-standard-WSL2',
+      Architecture: 'x86_64',
+    });
+    expect(parseDockerInfoJsonForWsl(stdout)).toEqual({ available: true });
+  });
+
+  it('Docker Desktop with Hyper-V backend (JSON): available=false (kernel mismatch)', () => {
+    const stdout = JSON.stringify({
+      OperatingSystem: 'Docker Desktop',
+      KernelVersion: '5.10.16.3-microsoft-standard',
+    });
+    const result = parseDockerInfoJsonForWsl(stdout);
+    expect(result.available).toBe(false);
+    expect(result.reason).toMatch(/Hyper-V backend/);
+  });
+
+  it('Native Linux Docker engine (JSON): available=false (not Docker Desktop)', () => {
+    const stdout = JSON.stringify({
+      OperatingSystem: 'Ubuntu 24.04.1 LTS',
+      KernelVersion: '6.8.0-50-generic',
+    });
+    const result = parseDockerInfoJsonForWsl(stdout);
+    expect(result.available).toBe(false);
+    expect(result.reason).toMatch(/not running as Docker Desktop/);
+  });
+
+  it('Malformed JSON: returns reason="malformed JSON output" (sentinel for fallback)', () => {
+    const result = parseDockerInfoJsonForWsl('not-json-at-all');
+    expect(result.available).toBe(false);
+    expect(result.reason).toBe('malformed JSON output');
+  });
+
+  it('JSON with non-object root (e.g. an array): triggers fallback sentinel', () => {
+    const result = parseDockerInfoJsonForWsl('[1,2,3]');
+    expect(result.available).toBe(false);
+    expect(result.reason).toBe('malformed JSON output');
+  });
+
+  it('JSON missing OperatingSystem field: treats as not Docker Desktop', () => {
+    const stdout = JSON.stringify({ KernelVersion: '5.15-microsoft-standard-WSL2' });
+    const result = parseDockerInfoJsonForWsl(stdout);
+    expect(result.available).toBe(false);
+    expect(result.reason).toMatch(/not running as Docker Desktop/);
+  });
+
+  it('Empty string: returns empty-output reason (matches text parser)', () => {
+    const result = parseDockerInfoJsonForWsl('');
+    expect(result.available).toBe(false);
+    expect(result.reason).toMatch(/empty output/);
+  });
+});
+
 // ── detectWslGpuPassthrough: dispatcher ────────────────────────────────────
 
 describe('[GH-101 follow-up] detectWslGpuPassthrough', () => {
   beforeEach(() => {
-    _resetWslSupportCacheForTests();
+    resetWslSupportCache();
   });
 
   const wsl2Stdout = [
@@ -243,5 +304,117 @@ describe('[GH-101 follow-up] detectWslGpuPassthrough', () => {
       runDockerProbe: probe2,
     });
     expect(second.available).toBe(false); // first cached resolution wins
+  });
+
+  // ── JSON-first detection path (deferred-cleanup item #2) ─────────────────
+
+  it('prefers runDockerInfoJson when provided; text parser is not called', async () => {
+    const text = vi.fn().mockResolvedValue('garbage that text parser would reject');
+    const json = vi.fn().mockResolvedValue(
+      JSON.stringify({
+        OperatingSystem: 'Docker Desktop',
+        KernelVersion: '5.15-microsoft-standard-WSL2',
+      }),
+    );
+    const probe = vi.fn().mockResolvedValue(true);
+
+    const result = await detectWslGpuPassthrough({
+      runDockerInfo: text,
+      runDockerInfoJson: json,
+      runDockerProbe: probe,
+    });
+
+    expect(result).toEqual({ available: true, gpuPassthroughDetected: true });
+    expect(json).toHaveBeenCalledTimes(1);
+    expect(text).not.toHaveBeenCalled();
+  });
+
+  it('falls back to text parser when JSON output is malformed', async () => {
+    const text = vi.fn().mockResolvedValue(wsl2Stdout);
+    const json = vi.fn().mockResolvedValue('not-actual-json');
+    const probe = vi.fn().mockResolvedValue(true);
+
+    const result = await detectWslGpuPassthrough({
+      runDockerInfo: text,
+      runDockerInfoJson: json,
+      runDockerProbe: probe,
+    });
+
+    expect(result).toEqual({ available: true, gpuPassthroughDetected: true });
+    expect(json).toHaveBeenCalledTimes(1);
+    expect(text).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to text parser when JSON dep rejects', async () => {
+    const text = vi.fn().mockResolvedValue(wsl2Stdout);
+    const json = vi.fn().mockRejectedValue(new Error('docker info --format failed'));
+    const probe = vi.fn().mockResolvedValue(true);
+
+    const result = await detectWslGpuPassthrough({
+      runDockerInfo: text,
+      runDockerInfoJson: json,
+      runDockerProbe: probe,
+    });
+
+    expect(result.available).toBe(true);
+    expect(text).toHaveBeenCalledTimes(1);
+  });
+
+  it('JSON path with kernel mismatch resolves negative without consulting text parser', async () => {
+    const text = vi.fn();
+    const json = vi.fn().mockResolvedValue(
+      JSON.stringify({
+        OperatingSystem: 'Docker Desktop',
+        KernelVersion: '5.10.16-hyperv',
+      }),
+    );
+    const probe = vi.fn();
+
+    const result = await detectWslGpuPassthrough({
+      runDockerInfo: text,
+      runDockerInfoJson: json,
+      runDockerProbe: probe,
+    });
+
+    expect(result.available).toBe(false);
+    expect(result.reason).toMatch(/Hyper-V backend/);
+    expect(text).not.toHaveBeenCalled();
+    expect(probe).not.toHaveBeenCalled();
+  });
+});
+
+// ── Public reset alias (deferred-cleanup item #1) ──────────────────────────
+
+describe('[GH-101 deferred-cleanup] resetWslSupportCache (public API)', () => {
+  it('resetWslSupportCache and _resetWslSupportCacheForTests reference the same function', () => {
+    // Pin the back-compat alias so a future "rename and remove" PR catches the
+    // breakage. Suppress the deprecation hint here on purpose — that's the
+    // entire point of the test.
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(_resetWslSupportCacheForTests).toBe(resetWslSupportCache);
+  });
+
+  it('clears the cache so a subsequent call re-invokes the deps', async () => {
+    const dockerInfo = vi
+      .fn()
+      .mockResolvedValue(
+        ['Operating System: Docker Desktop', 'Kernel Version: 5.15-microsoft-standard-WSL2'].join(
+          '\n',
+        ),
+      );
+    const probe = vi.fn().mockResolvedValue(true);
+
+    resetWslSupportCache();
+    await detectWslGpuPassthrough({ runDockerInfo: dockerInfo, runDockerProbe: probe });
+    expect(dockerInfo).toHaveBeenCalledTimes(1);
+
+    // Without reset, the cache would be reused.
+    await detectWslGpuPassthrough({ runDockerInfo: dockerInfo, runDockerProbe: probe });
+    expect(dockerInfo).toHaveBeenCalledTimes(1);
+
+    // After reset, the next call re-invokes both deps.
+    resetWslSupportCache();
+    await detectWslGpuPassthrough({ runDockerInfo: dockerInfo, runDockerProbe: probe });
+    expect(dockerInfo).toHaveBeenCalledTimes(2);
   });
 });

--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -32,7 +32,12 @@ import {
   resolveRootlessSocket,
   getSocketPaths,
 } from './containerRuntime.js';
-import { type WslSupport, type WslDetectDeps, detectWslGpuPassthrough } from './wslDetect.js';
+import {
+  type WslSupport,
+  type WslDetectDeps,
+  detectWslGpuPassthrough,
+  resetWslSupportCache,
+} from './wslDetect.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -148,12 +153,15 @@ export const VULKAN_WSL2_SIDECAR_IMAGE = 'transcriptionsuite/whisper-cpp-vulkan-
  *     3. GPU passthrough not detected — `/dev/dxg` or the WSL user-mode driver
  *        bundle was not reachable from a probe container.
  */
-export function checkVulkanSupport(
-  platform: NodeJS.Platform,
-  exists: (p: string) => boolean,
-  wslSupport?: WslSupport,
-  profile: 'vulkan' | 'vulkan-wsl2' = 'vulkan',
-): string | null {
+export interface CheckVulkanSupportOptions {
+  platform: NodeJS.Platform;
+  exists: (p: string) => boolean;
+  wslSupport?: WslSupport;
+  profile?: 'vulkan' | 'vulkan-wsl2';
+}
+
+export function checkVulkanSupport(opts: CheckVulkanSupportOptions): string | null {
+  const { platform, exists, wslSupport, profile = 'vulkan' } = opts;
   if (profile === 'vulkan-wsl2') {
     if (platform !== 'win32') {
       return (
@@ -1346,7 +1354,10 @@ async function exec(
       cwd: opts?.cwd,
       env: buildProcessEnv(opts?.env, detectedRuntimeKind ?? undefined),
       maxBuffer: 10 * 1024 * 1024, // 10MB
-      timeout: opts?.timeoutMs ?? 120_000, // default 2 minutes; callers can shorten
+      // `?? 120_000` would treat an explicit `0` as "instant timeout" (execFile
+      // semantics). Coerce 0/negative to the 2-minute default so the helper's
+      // contract matches the natural "0 means no override" reading.
+      timeout: opts?.timeoutMs && opts.timeoutMs > 0 ? opts.timeoutMs : 120_000,
     });
     return stdout.trim();
   } catch (err: any) {
@@ -2064,12 +2075,12 @@ async function startContainer(options: StartContainerOptions): Promise<string> {
   if (runtimeProfile === 'vulkan' || runtimeProfile === 'vulkan-wsl2') {
     const fs = await import('fs');
     const gpuInfo = runtimeProfile === 'vulkan-wsl2' ? await checkGpu() : undefined;
-    const vulkanError = checkVulkanSupport(
-      process.platform,
-      (p) => fs.existsSync(p),
-      gpuInfo?.wslSupport,
-      runtimeProfile,
-    );
+    const vulkanError = checkVulkanSupport({
+      platform: process.platform,
+      exists: (p) => fs.existsSync(p),
+      wslSupport: gpuInfo?.wslSupport,
+      profile: runtimeProfile,
+    });
     if (vulkanError) {
       throw new Error(vulkanError);
     }
@@ -3131,6 +3142,19 @@ async function checkGpu(): Promise<{
 }
 
 /**
+ * Clear all GPU-detection caches so the next `checkGpu()` re-probes from
+ * scratch. Used by the "Re-detect GPU" affordance after a Docker Desktop
+ * WSL2 ↔ Hyper-V backend toggle (or any other change the dashboard can't
+ * observe directly). Cheap — just nulls module-level state.
+ */
+function resetGpuCache(): void {
+  resetWslSupportCache();
+  // Force `checkGpu()` to re-detect the toolkit mode (CDI vs legacy) too —
+  // a user who installs nvidia-container-toolkit mid-session benefits.
+  detectedGpuMode = null;
+}
+
+/**
  * Build the dependency injection bundle for `detectWslGpuPassthrough`.
  * Kept inside dockerManager so the wslDetect module stays free of
  * runtime/binary-resolution logic and remains trivially unit-testable.
@@ -3149,8 +3173,26 @@ function getWslDetectDeps(): WslDetectDeps {
       const bin = await runtimeBin();
       return exec(bin, ['info'], { timeoutMs: 15_000 });
     },
+    runDockerInfoJson: async () => {
+      const bin = await runtimeBin();
+      // `--format '{{json .}}'` returns the structured object the parser
+      // prefers (vs grep'ing labels). doDetect falls back to runDockerInfo
+      // if this returns malformed output, so a future Docker tweak can't
+      // regress detection.
+      return exec(bin, ['info', '--format', '{{json .}}'], { timeoutMs: 15_000 });
+    },
     runDockerProbe: async () => {
       const bin = await runtimeBin();
+      // Defensive cleanup: a prior dashboard hard-kill (Electron crash, OS
+      // forced shutdown) during the 15s probe window can leave the named
+      // --rm container stuck in "Created" or "Exited" state, which would
+      // make the next probe fail with "container name already in use".
+      // Tolerate the error regardless — first-run / clean-state is the norm.
+      try {
+        await exec(bin, ['rm', '-f', PROBE_CONTAINER_NAME], { timeoutMs: 5_000 });
+      } catch {
+        // Container didn't exist — expected on a clean session.
+      }
       // Pre-check: only run the probe if the alpine image is already cached
       // locally. This avoids surprise network pulls and silent timeouts.
       try {
@@ -3652,6 +3694,7 @@ export const dockerManager = {
   retryDetection,
   getRuntimeKind,
   checkGpu,
+  resetGpuCache,
   runGpuPreflight,
   runGpuDiagnostic,
   listImages,

--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -32,6 +32,7 @@ import {
   resolveRootlessSocket,
   getSocketPaths,
 } from './containerRuntime.js';
+import { type WslSupport, type WslDetectDeps, detectWslGpuPassthrough } from './wslDetect.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -113,24 +114,73 @@ function getStartupEventsFilePath(): string | null {
 const VULKAN_SIDECAR_IMAGE = 'ghcr.io/ggml-org/whisper.cpp:main-vulkan';
 
 /**
- * Pre-flight check for the Vulkan runtime profile (Issue #101).
+ * Vulkan-WSL2 sidecar image — locally-built variant adding Mesa's `dzn`
+ * (Dozen) Vulkan-on-D3D12 ICD that the upstream `main-vulkan` image lacks.
+ * Required for AMD/Intel GPU acceleration on Windows + Docker Desktop with
+ * the WSL2 backend (GH-101 follow-up). Built via
+ * `server/docker/build-vulkan-wsl2.sh`. NOT published to GHCR for v1.3.5 —
+ * users build locally until a real-world AMD validator confirms enumeration.
+ */
+export const VULKAN_WSL2_SIDECAR_IMAGE = 'transcriptionsuite/whisper-cpp-vulkan-wsl2:latest';
+
+/**
+ * Pre-flight check for the Vulkan and Vulkan-WSL2 runtime profiles (Issue #101).
  *
  * Returns an actionable error message if Vulkan cannot work on this host, or
- * `null` when Vulkan is viable. Pure: takes platform and an `exists` predicate
- * so it can be unit-tested without a real filesystem.
+ * `null` when the profile is viable. Pure: takes platform, an `exists`
+ * predicate, optional WSL2 detection result, and the requested profile so it
+ * can be unit-tested without a real filesystem or Docker daemon.
  *
- * Two failure modes:
- *   1. Non-Linux platforms — Docker Desktop on Windows/macOS runs containers
- *      in a Linux VM that does not pass `/dev/dri` through, so the sidecar
- *      device mount in `docker-compose.vulkan.yml` cannot resolve regardless
- *      of the host GPU.
- *   2. Linux without `/dev/dri/renderD128` — common on WSL2 or hosts without
- *      AMD/Intel kernel driver support.
+ * Branches by `profile`:
+ *
+ *   `'vulkan'` (Linux DRI path — original behavior, unchanged):
+ *     1. Non-Linux — Docker Desktop on Windows/macOS runs containers in a Linux
+ *        VM that does not pass `/dev/dri` through, so the sidecar device mount
+ *        in `docker-compose.vulkan.yml` cannot resolve regardless of host GPU.
+ *     2. Linux without `/dev/dri/renderD128` — common on WSL2 or hosts without
+ *        AMD/Intel kernel driver support.
+ *
+ *   `'vulkan-wsl2'` (Windows + WSL2 GPU paravirtualization path, opt-in,
+ *   experimental — GH-101 follow-up):
+ *     1. Not Win32 — this profile only makes sense on Windows.
+ *     2. WSL2 backend not available — Docker Desktop is using Hyper-V backend
+ *        or no Docker is running.
+ *     3. GPU passthrough not detected — `/dev/dxg` or the WSL user-mode driver
+ *        bundle was not reachable from a probe container.
  */
 export function checkVulkanSupport(
   platform: NodeJS.Platform,
   exists: (p: string) => boolean,
+  wslSupport?: WslSupport,
+  profile: 'vulkan' | 'vulkan-wsl2' = 'vulkan',
 ): string | null {
+  if (profile === 'vulkan-wsl2') {
+    if (platform !== 'win32') {
+      return (
+        'Vulkan WSL2 is an opt-in profile for Windows + Docker Desktop with the ' +
+        'WSL2 backend. Switch to the standard "Vulkan" profile (Linux only) or ' +
+        'pick another runtime.'
+      );
+    }
+    if (!wslSupport?.available) {
+      return (
+        wslSupport?.reason ??
+        'Docker Desktop is not running with the WSL2 backend. Switch to WSL2 in ' +
+          'Docker Desktop settings (or start Docker Desktop), then try again.'
+      );
+    }
+    if (!wslSupport.gpuPassthroughDetected) {
+      return (
+        wslSupport.reason ??
+        'GPU passthrough to WSL2 was not detected (/dev/dxg unreachable). ' +
+          'Ensure your Windows GPU driver is current (WDDM 3.0+) and Docker Desktop ' +
+          'is using the WSL2 backend, then try again.'
+      );
+    }
+    return null;
+  }
+
+  // profile === 'vulkan' (default — Linux DRI path)
   if (platform !== 'linux') {
     return (
       'Vulkan runtime is only supported on Linux. Docker Desktop on Windows/macOS ' +
@@ -619,8 +669,12 @@ function getComposeDir(): string {
 }
 
 // Keep in sync with src/types/runtime.ts (canonical) and src/types/electron.d.ts
-/** Runtime profile: GPU (NVIDIA CUDA), Vulkan (AMD/Intel GPU), CPU-only, or Metal (Apple Silicon MLX) */
-export type RuntimeProfile = 'gpu' | 'cpu' | 'vulkan' | 'metal';
+/**
+ * Runtime profile: GPU (NVIDIA CUDA), Vulkan (AMD/Intel GPU on Linux DRI),
+ * Vulkan-WSL2 (AMD/Intel GPU on Windows + Docker Desktop with WSL2 backend —
+ * experimental, opt-in, GH-101 follow-up), CPU-only, or Metal (Apple Silicon MLX).
+ */
+export type RuntimeProfile = 'gpu' | 'cpu' | 'vulkan' | 'vulkan-wsl2' | 'metal';
 export type HfTokenDecision = 'unset' | 'provided' | 'skipped';
 
 const VOLUME_NAMES = {
@@ -1224,6 +1278,17 @@ export function composeFileArgs(
     files.push('docker-compose.vulkan.yml');
   }
 
+  // Vulkan-WSL2 sidecar overlay — opt-in experimental Windows path (GH-101).
+  // Uses the locally-built sidecar image with Mesa's `dzn` Vulkan-on-D3D12 ICD;
+  // mounts /dev/dxg + /usr/lib/wsl for WSL2 GPU paravirtualization.
+  // Defense in depth: only attach the overlay on Win32 even if the profile
+  // value somehow leaked to another platform — the existing checkVulkanSupport
+  // pre-flight rejects this case but compose-file selection should not produce
+  // an unrunnable command if any future caller bypasses the pre-flight.
+  if (runtimeProfile === 'vulkan-wsl2' && process.platform === 'win32') {
+    files.push('docker-compose.vulkan-wsl2.yml');
+  }
+
   // Flatten into compose args
   return files.flatMap((f) => ['-f', f]);
 }
@@ -1274,14 +1339,14 @@ let detectedGpuMode: 'cdi' | 'legacy' | null = null;
 async function exec(
   cmd: string,
   args: string[],
-  opts?: { cwd?: string; env?: Record<string, string> },
+  opts?: { cwd?: string; env?: Record<string, string>; timeoutMs?: number },
 ): Promise<string> {
   try {
     const { stdout } = await execFileAsync(cmd, args, {
       cwd: opts?.cwd,
       env: buildProcessEnv(opts?.env, detectedRuntimeKind ?? undefined),
       maxBuffer: 10 * 1024 * 1024, // 10MB
-      timeout: 120_000, // 2 minutes
+      timeout: opts?.timeoutMs ?? 120_000, // default 2 minutes; callers can shorten
     });
     return stdout.trim();
   } catch (err: any) {
@@ -1994,11 +2059,31 @@ async function startContainer(options: StartContainerOptions): Promise<string> {
   // Pre-flight Vulkan validation. Surfaces a clear message before Docker
   // tries to mount /dev/dri (docker-compose.vulkan.yml: devices: /dev/dri).
   // Covers non-Linux platforms (Issue #101) and Linux hosts without DRI.
-  if (runtimeProfile === 'vulkan') {
+  // For 'vulkan-wsl2' (GH-101 follow-up), gates on the cached WSL2 probe and
+  // verifies the locally-built sidecar image is present (no GHCR publish yet).
+  if (runtimeProfile === 'vulkan' || runtimeProfile === 'vulkan-wsl2') {
     const fs = await import('fs');
-    const vulkanError = checkVulkanSupport(process.platform, (p) => fs.existsSync(p));
+    const gpuInfo = runtimeProfile === 'vulkan-wsl2' ? await checkGpu() : undefined;
+    const vulkanError = checkVulkanSupport(
+      process.platform,
+      (p) => fs.existsSync(p),
+      gpuInfo?.wslSupport,
+      runtimeProfile,
+    );
     if (vulkanError) {
       throw new Error(vulkanError);
+    }
+    if (runtimeProfile === 'vulkan-wsl2') {
+      const imagePresent = await hasVulkanWsl2SidecarImage();
+      if (!imagePresent) {
+        throw new Error(
+          `Vulkan-WSL2 sidecar image "${VULKAN_WSL2_SIDECAR_IMAGE}" was not found locally. ` +
+            'This image is not published to GHCR — build it once with one of: ' +
+            '"powershell -ExecutionPolicy Bypass -File server\\docker\\build-vulkan-wsl2.ps1" ' +
+            'or "bash server/docker/build-vulkan-wsl2.sh" ' +
+            '(see README §2.5.2 Windows + WSL2 for the full setup).',
+        );
+      }
     }
   }
 
@@ -2110,11 +2195,14 @@ async function startContainer(options: StartContainerOptions): Promise<string> {
     envUpdates['DIARIZATION_MODEL'] = diarizationModel;
   }
 
-  // Vulkan sidecar: set whisper-server URL based on networking mode and
-  // optionally pass a custom GGML model path.
-  if (runtimeProfile === 'vulkan') {
-    const serverUrl =
-      process.platform === 'linux' ? 'http://localhost:8080' : 'http://whisper-server:8080';
+  // Vulkan + Vulkan-WSL2 sidecar: set whisper-server URL based on networking
+  // mode and optionally pass a custom GGML model path. Vulkan-WSL2 (GH-101
+  // follow-up) always runs Docker Desktop bridge networking on Windows, so
+  // the URL is the Docker DNS name; the legacy Vulkan path is host-network on
+  // Linux and bridge elsewhere.
+  if (runtimeProfile === 'vulkan' || runtimeProfile === 'vulkan-wsl2') {
+    const useHostNetwork = runtimeProfile === 'vulkan' && process.platform === 'linux';
+    const serverUrl = useHostNetwork ? 'http://localhost:8080' : 'http://whisper-server:8080';
     composeEnv['WHISPERCPP_SERVER_URL'] = serverUrl;
     envUpdates['WHISPERCPP_SERVER_URL'] = serverUrl;
 
@@ -2122,11 +2210,39 @@ async function startContainer(options: StartContainerOptions): Promise<string> {
       composeEnv['WHISPERCPP_MODEL'] = whispercppModel;
       envUpdates['WHISPERCPP_MODEL'] = whispercppModel;
     }
+
+    // Vulkan-WSL2 only: pass through the Mesa adapter selector for systems
+    // with multiple GPUs (NVIDIA + Intel/AMD on the same Windows host).
+    // Empty string lets dzn pick the default adapter — most users won't need
+    // to override this. Read from process env so power users can set it
+    // before launching the dashboard. Empty string is intentional — the env
+    // var must always be present in compose so docker-compose interpolation
+    // doesn't warn about an unset variable.
+    //
+    // Validate strictly before persisting: this string ends up in the .env
+    // file via upsertComposeEnvValues. A value containing newlines or `=`
+    // could inject an extra key. Restrict to the alphabet Microsoft documents
+    // for adapter selection (vendor names like "Nvidia", "AMD", "Intel" plus
+    // common adapter SKUs). Anything else is silently dropped.
+    if (runtimeProfile === 'vulkan-wsl2') {
+      const rawAdapter = process.env.MESA_D3D12_DEFAULT_ADAPTER_NAME ?? '';
+      const adapterName = /^[A-Za-z0-9 _.\-]{0,128}$/.test(rawAdapter) ? rawAdapter : '';
+      if (rawAdapter && !adapterName) {
+        console.warn(
+          '[DockerManager] Ignoring MESA_D3D12_DEFAULT_ADAPTER_NAME with disallowed characters; using default adapter.',
+        );
+      }
+      composeEnv['MESA_D3D12_DEFAULT_ADAPTER_NAME'] = adapterName;
+      envUpdates['MESA_D3D12_DEFAULT_ADAPTER_NAME'] = adapterName;
+    } else {
+      envUpdates['MESA_D3D12_DEFAULT_ADAPTER_NAME'] = '';
+    }
   } else {
     // Clear stale vulkan env vars from a previous profile switch so they
     // don't linger in the .env file.
     envUpdates['WHISPERCPP_SERVER_URL'] = '';
     envUpdates['WHISPERCPP_MODEL'] = '';
+    envUpdates['MESA_D3D12_DEFAULT_ADAPTER_NAME'] = '';
   }
 
   upsertComposeEnvValues(envUpdates);
@@ -2902,9 +3018,18 @@ function unsubscribeFromDownloadEvents(callback: (event: BootstrapDownloadEvent)
 
 /**
  * Check for NVIDIA GPU + container toolkit availability.
- * Returns { gpu: boolean, toolkit: boolean }.
+ * Also probes Docker Desktop on Windows for WSL2 GPU paravirtualization
+ * (GH-101 follow-up) — surfaced via the optional `wslSupport` field, which is
+ * `undefined` on non-Win32 platforms.
+ *
+ * Returns { gpu, toolkit, vulkan, wslSupport? }.
  */
-async function checkGpu(): Promise<{ gpu: boolean; toolkit: boolean; vulkan: boolean }> {
+async function checkGpu(): Promise<{
+  gpu: boolean;
+  toolkit: boolean;
+  vulkan: boolean;
+  wslSupport?: WslSupport;
+}> {
   let gpu = false;
   let toolkit = false;
   let vulkan = false;
@@ -2975,7 +3100,117 @@ async function checkGpu(): Promise<{ gpu: boolean; toolkit: boolean; vulkan: boo
     }
   }
 
-  return { gpu, toolkit, vulkan };
+  // Win32 only: probe Docker Desktop for WSL2 backend + /dev/dxg passthrough
+  // (GH-101 follow-up). Result feeds the experimental 'vulkan-wsl2' profile
+  // gating in Settings — never auto-selected by checkGpu(). Single-flight
+  // cached at the wslDetect module level, so repeated calls are cheap.
+  let wslSupport: WslSupport | undefined;
+  if (process.platform === 'win32') {
+    try {
+      wslSupport = await detectWslGpuPassthrough(getWslDetectDeps());
+      if (wslSupport.available && wslSupport.gpuPassthroughDetected) {
+        console.log(
+          '[DockerManager] WSL2 GPU passthrough detected — Vulkan WSL2 profile available',
+        );
+      } else {
+        console.log(
+          `[DockerManager] WSL2 GPU passthrough not available: ${wslSupport.reason ?? 'unknown reason'}`,
+        );
+      }
+    } catch (err: any) {
+      console.warn('[DockerManager] WSL2 detection failed:', err.message);
+      wslSupport = {
+        available: false,
+        gpuPassthroughDetected: false,
+        reason: err instanceof Error ? err.message : 'WSL2 detection failed',
+      };
+    }
+  }
+
+  return { gpu, toolkit, vulkan, wslSupport };
+}
+
+/**
+ * Build the dependency injection bundle for `detectWslGpuPassthrough`.
+ * Kept inside dockerManager so the wslDetect module stays free of
+ * runtime/binary-resolution logic and remains trivially unit-testable.
+ *
+ * The probe is gated on a local `alpine:3` image being already present —
+ * it never triggers a network pull. This avoids hanging the dashboard's
+ * first-run detection for up to 30s on slow or air-gapped networks; if the
+ * image is absent we report a clean "skipped" reason instead.
+ */
+const PROBE_IMAGE = 'alpine:3';
+const PROBE_CONTAINER_NAME = 'transcriptionsuite-wsl-probe';
+
+function getWslDetectDeps(): WslDetectDeps {
+  return {
+    runDockerInfo: async () => {
+      const bin = await runtimeBin();
+      return exec(bin, ['info'], { timeoutMs: 15_000 });
+    },
+    runDockerProbe: async () => {
+      const bin = await runtimeBin();
+      // Pre-check: only run the probe if the alpine image is already cached
+      // locally. This avoids surprise network pulls and silent timeouts.
+      try {
+        await exec(bin, ['image', 'inspect', PROBE_IMAGE], { timeoutMs: 5_000 });
+      } catch {
+        // Image not local — skip probe; gpuPassthroughDetected stays false.
+        return false;
+      }
+      // Throwaway probe with /dev/dxg + /usr/lib/wsl bound. Both binds must
+      // resolve and `libd3d12.so` must exist for gpuPassthroughDetected to
+      // flip true. Named so any leak is identifiable. `--pull=never` ensures
+      // we never reach out to the network even if the image was tagged but
+      // not actually present.
+      try {
+        await exec(
+          bin,
+          [
+            'run',
+            '--rm',
+            '--name',
+            PROBE_CONTAINER_NAME,
+            '--pull=never',
+            '--device',
+            '/dev/dxg',
+            '-v',
+            '/usr/lib/wsl:/usr/lib/wsl:ro',
+            PROBE_IMAGE,
+            'sh',
+            '-c',
+            'test -e /dev/dxg && test -e /usr/lib/wsl/lib/libd3d12.so',
+          ],
+          { timeoutMs: 15_000 },
+        );
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  };
+}
+
+/**
+ * Check whether the Vulkan-WSL2 sidecar image (locally-built) is present.
+ * Used by the dashboard to decide whether to surface an actionable error
+ * pointing at `server/docker/build-vulkan-wsl2.sh` before container start.
+ *
+ * Short-circuits with `false` on any non-Win32 platform — the WSL2 image is
+ * Windows-only by design and inspecting it on Linux/macOS would just leak a
+ * Docker error message into logs.
+ */
+async function hasVulkanWsl2SidecarImage(): Promise<boolean> {
+  if (process.platform !== 'win32') {
+    return false;
+  }
+  try {
+    await exec(await runtimeBin(), ['image', 'inspect', VULKAN_WSL2_SIDECAR_IMAGE]);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 // ─── Model Cache Inspection ─────────────────────────────────────────────────
@@ -3424,6 +3659,7 @@ export const dockerManager = {
   cancelPull,
   isPulling,
   hasSidecarImage,
+  hasVulkanWsl2SidecarImage,
   pullSidecarImage,
   cancelSidecarPull,
   isSidecarPulling,

--- a/dashboard/electron/main.ts
+++ b/dashboard/electron/main.ts
@@ -1200,6 +1200,10 @@ ipcMain.handle('docker:hasSidecarImage', async () => {
   return dockerManager.hasSidecarImage();
 });
 
+ipcMain.handle('docker:hasVulkanWsl2SidecarImage', async () => {
+  return dockerManager.hasVulkanWsl2SidecarImage();
+});
+
 ipcMain.handle('docker:pullSidecarImage', async () => {
   return dockerManager.pullSidecarImage();
 });

--- a/dashboard/electron/main.ts
+++ b/dashboard/electron/main.ts
@@ -1164,6 +1164,12 @@ ipcMain.handle('docker:checkGpu', async () => {
   return dockerManager.checkGpu();
 });
 
+ipcMain.handle('docker:resetGpuCache', async () => {
+  // Clears the wslDetect single-flight cache and detectedGpuMode so the next
+  // checkGpu() re-probes from scratch — used by the "Re-detect GPU" button.
+  dockerManager.resetGpuCache();
+});
+
 ipcMain.handle('docker:validateGpuPreflight', async () => {
   return dockerManager.runGpuPreflight();
 });

--- a/dashboard/electron/preload.ts
+++ b/dashboard/electron/preload.ts
@@ -78,7 +78,13 @@ export type CompatResult =
   | { result: 'unknown'; reason: CompatUnknownReason; detail?: string };
 
 // Keep in sync with src/types/runtime.ts (canonical) and src/types/electron.d.ts
-export type RuntimeProfile = 'gpu' | 'cpu' | 'vulkan' | 'metal';
+export type RuntimeProfile = 'gpu' | 'cpu' | 'vulkan' | 'vulkan-wsl2' | 'metal';
+
+export interface WslSupport {
+  available: boolean;
+  gpuPassthroughDetected: boolean;
+  reason?: string;
+}
 export type HfTokenDecision = 'unset' | 'provided' | 'skipped';
 export type ClientLogType = 'info' | 'success' | 'error' | 'warning';
 
@@ -140,7 +146,13 @@ export interface ElectronAPI {
     getRuntimeKind: () => Promise<string | null>;
     getDetectionGuidance: () => Promise<string | null>;
     getComposeAvailable: () => Promise<boolean>;
-    checkGpu: () => Promise<{ gpu: boolean; toolkit: boolean; vulkan: boolean }>;
+    checkGpu: () => Promise<{
+      gpu: boolean;
+      toolkit: boolean;
+      vulkan: boolean;
+      wslSupport?: WslSupport;
+    }>;
+    hasVulkanWsl2SidecarImage: () => Promise<boolean>;
     validateGpuPreflight: () => Promise<{
       status: 'healthy' | 'warning' | 'unknown';
       checks: Array<{
@@ -502,6 +514,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('docker:getDetectionGuidance') as Promise<string | null>,
     getComposeAvailable: () => ipcRenderer.invoke('docker:getComposeAvailable') as Promise<boolean>,
     checkGpu: () => ipcRenderer.invoke('docker:checkGpu'),
+    hasVulkanWsl2SidecarImage: () =>
+      ipcRenderer.invoke('docker:hasVulkanWsl2SidecarImage') as Promise<boolean>,
     validateGpuPreflight: () => ipcRenderer.invoke('docker:validateGpuPreflight'),
     runGpuDiagnostic: () => ipcRenderer.invoke('docker:runGpuDiagnostic'),
     listImages: () => ipcRenderer.invoke('docker:listImages'),

--- a/dashboard/electron/preload.ts
+++ b/dashboard/electron/preload.ts
@@ -152,6 +152,7 @@ export interface ElectronAPI {
       vulkan: boolean;
       wslSupport?: WslSupport;
     }>;
+    resetGpuCache: () => Promise<void>;
     hasVulkanWsl2SidecarImage: () => Promise<boolean>;
     validateGpuPreflight: () => Promise<{
       status: 'healthy' | 'warning' | 'unknown';
@@ -514,6 +515,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('docker:getDetectionGuidance') as Promise<string | null>,
     getComposeAvailable: () => ipcRenderer.invoke('docker:getComposeAvailable') as Promise<boolean>,
     checkGpu: () => ipcRenderer.invoke('docker:checkGpu'),
+    resetGpuCache: () => ipcRenderer.invoke('docker:resetGpuCache') as Promise<void>,
     hasVulkanWsl2SidecarImage: () =>
       ipcRenderer.invoke('docker:hasVulkanWsl2SidecarImage') as Promise<boolean>,
     validateGpuPreflight: () => ipcRenderer.invoke('docker:validateGpuPreflight'),

--- a/dashboard/electron/wslDetect.ts
+++ b/dashboard/electron/wslDetect.ts
@@ -1,0 +1,149 @@
+/**
+ * WSL2 + GPU paravirtualization detection (GH-101 follow-up).
+ *
+ * Used to gate the experimental `'vulkan-wsl2'` runtime profile. The probe runs
+ * once per dashboard session (single-flight cached Promise) and returns:
+ *
+ *   - `available`: Docker is running with the WSL2 backend (vs Hyper-V or no Docker).
+ *   - `gpuPassthroughDetected`: a throwaway probe container could see /dev/dxg
+ *     and the WSL user-mode driver bundle at /usr/lib/wsl/lib/libd3d12.so.
+ *
+ * Both signals must be true for the dashboard to surface the Vulkan-WSL2
+ * profile button. The legacy `'vulkan'` profile path is unaffected.
+ *
+ * Why two signals: `docker info` tells us *which Docker engine* is running, but
+ * not whether `/dev/dxg` is reachable from inside an arbitrary container.
+ * Docker Desktop only auto-binds GPU paths for `--gpus all` (NVIDIA CUDA);
+ * non-NVIDIA paths require explicit `--device /dev/dxg -v /usr/lib/wsl:...`.
+ * The throwaway probe confirms both binds resolve, distinguishing
+ * "WSL2 backend exists" from "GPU paravirtualization is wired up".
+ */
+
+export interface WslSupport {
+  available: boolean;
+  gpuPassthroughDetected: boolean;
+  reason?: string;
+}
+
+export interface WslDetectDeps {
+  /** Returns stdout of `docker info`. Should reject on non-zero exit. */
+  runDockerInfo: () => Promise<string>;
+  /**
+   * Runs a tiny throwaway container with /dev/dxg + /usr/lib/wsl mounts and
+   * returns true if both resolve. Best-effort: on any failure (image missing,
+   * mount denied, kernel missing), returns false.
+   */
+  runDockerProbe: () => Promise<boolean>;
+}
+
+/**
+ * Pure parser for `docker info` output. Inspects two well-known fields:
+ *   - `OperatingSystem: Docker Desktop` (Docker Desktop in use vs native engine).
+ *   - `Kernel Version: ...microsoft-standard-WSL2...` (WSL2 backend vs Hyper-V).
+ *
+ * Both must match for the WSL2 backend to be considered available.
+ */
+export function parseDockerInfoForWsl(stdout: string): {
+  available: boolean;
+  reason?: string;
+} {
+  if (!stdout || typeof stdout !== 'string') {
+    return { available: false, reason: 'docker info returned empty output' };
+  }
+
+  const lines = stdout.split(/\r?\n/);
+  let isDockerDesktop = false;
+  let kernelLine = '';
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (line.startsWith('Operating System:')) {
+      isDockerDesktop = line.includes('Docker Desktop');
+    } else if (line.startsWith('Kernel Version:')) {
+      kernelLine = line.slice('Kernel Version:'.length).trim();
+    }
+  }
+
+  if (!isDockerDesktop) {
+    return {
+      available: false,
+      reason:
+        'Docker is not running as Docker Desktop (Vulkan WSL2 requires Docker Desktop on Windows).',
+    };
+  }
+  if (!/wsl2/i.test(kernelLine)) {
+    return {
+      available: false,
+      reason:
+        'Docker Desktop is using the Hyper-V backend, not WSL2. Switch to the WSL2 backend in Docker Desktop settings.',
+    };
+  }
+  return { available: true };
+}
+
+/**
+ * Run the actual probe. Single-flight cached Promise — calling more than once
+ * returns the same result for the lifetime of the process.
+ *
+ * **Cache invalidation policy:** the cached Promise is cleared on REJECTION
+ * so a transient failure (Docker daemon starting, network glitch, image pull
+ * blocked) does not lock the dashboard into a permanent negative result. A
+ * resolved-but-negative result (`available: false` or `gpuPassthroughDetected:
+ * false`) is still cached — that's a deliberate state that won't change
+ * mid-session without a Docker Desktop backend toggle (which the user will
+ * notice and can recover from with a dashboard restart).
+ *
+ * Tests should NOT use this directly; they should call `_resetWslSupportCacheForTests()`
+ * between cases or pass deps directly into a helper that bypasses the cache.
+ */
+let _wslSupportPromise: Promise<WslSupport> | null = null;
+
+export function detectWslGpuPassthrough(deps: WslDetectDeps): Promise<WslSupport> {
+  if (!_wslSupportPromise) {
+    _wslSupportPromise = doDetect(deps).catch((err) => {
+      // Clear the cache so the next call retries instead of sticking on
+      // the rejected promise forever.
+      _wslSupportPromise = null;
+      throw err;
+    });
+  }
+  return _wslSupportPromise;
+}
+
+/** For tests only — clears the cached probe result so each test starts fresh. */
+export function _resetWslSupportCacheForTests(): void {
+  _wslSupportPromise = null;
+}
+
+async function doDetect(deps: WslDetectDeps): Promise<WslSupport> {
+  let dockerInfoStdout: string;
+  try {
+    dockerInfoStdout = await deps.runDockerInfo();
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : 'docker info failed';
+    return { available: false, gpuPassthroughDetected: false, reason };
+  }
+
+  const parsed = parseDockerInfoForWsl(dockerInfoStdout);
+  if (!parsed.available) {
+    return { available: false, gpuPassthroughDetected: false, reason: parsed.reason };
+  }
+
+  let probeOk = false;
+  try {
+    probeOk = await deps.runDockerProbe();
+  } catch {
+    probeOk = false;
+  }
+
+  if (!probeOk) {
+    return {
+      available: true,
+      gpuPassthroughDetected: false,
+      reason:
+        '/dev/dxg or /usr/lib/wsl/lib/libd3d12.so was not reachable from inside a probe container. ' +
+        'Ensure your Windows GPU driver is current (WDDM 3.0+) and Docker Desktop is using the WSL2 backend.',
+    };
+  }
+
+  return { available: true, gpuPassthroughDetected: true };
+}

--- a/dashboard/electron/wslDetect.ts
+++ b/dashboard/electron/wslDetect.ts
@@ -29,6 +29,14 @@ export interface WslDetectDeps {
   /** Returns stdout of `docker info`. Should reject on non-zero exit. */
   runDockerInfo: () => Promise<string>;
   /**
+   * Optional: returns stdout of `docker info --format '{{json .}}'`. When
+   * provided, `doDetect` prefers the structured JSON path and falls back to
+   * `runDockerInfo` only if the JSON output is malformed or the call rejects.
+   * Defended against future Docker label tweaks (e.g. `Server:`/`Client:`
+   * header shifts) that the text parser pattern-matches.
+   */
+  runDockerInfoJson?: () => Promise<string>;
+  /**
    * Runs a tiny throwaway container with /dev/dxg + /usr/lib/wsl mounts and
    * returns true if both resolve. Best-effort: on any failure (image missing,
    * mount denied, kernel missing), returns false.
@@ -81,6 +89,58 @@ export function parseDockerInfoForWsl(stdout: string): {
 }
 
 /**
+ * Pure parser for `docker info --format '{{json .}}'`. Reads the structured
+ * `OperatingSystem` and `KernelVersion` fields directly, dodging the future
+ * upstream-label-shift hazard the text parser carries.
+ *
+ * Returns the same `{available, reason}` shape as `parseDockerInfoForWsl`.
+ * The sentinel reason `'malformed JSON output'` is reserved for the doDetect
+ * fallback path — callers can pattern-match it to retry with the text parser.
+ */
+export function parseDockerInfoJsonForWsl(stdout: string): {
+  available: boolean;
+  reason?: string;
+} {
+  if (!stdout || typeof stdout !== 'string') {
+    return { available: false, reason: 'docker info returned empty output' };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return { available: false, reason: 'malformed JSON output' };
+  }
+
+  // Reject arrays (typeof === 'object' but not the field bag we expect) and
+  // primitives. `docker info --format '{{json .}}'` always returns an object.
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { available: false, reason: 'malformed JSON output' };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  const operatingSystem = typeof obj.OperatingSystem === 'string' ? obj.OperatingSystem : '';
+  const kernelVersion = typeof obj.KernelVersion === 'string' ? obj.KernelVersion : '';
+
+  const isDockerDesktop = operatingSystem.includes('Docker Desktop');
+  if (!isDockerDesktop) {
+    return {
+      available: false,
+      reason:
+        'Docker is not running as Docker Desktop (Vulkan WSL2 requires Docker Desktop on Windows).',
+    };
+  }
+  if (!/wsl2/i.test(kernelVersion)) {
+    return {
+      available: false,
+      reason:
+        'Docker Desktop is using the Hyper-V backend, not WSL2. Switch to the WSL2 backend in Docker Desktop settings.',
+    };
+  }
+  return { available: true };
+}
+
+/**
  * Run the actual probe. Single-flight cached Promise — calling more than once
  * returns the same result for the lifetime of the process.
  *
@@ -109,21 +169,51 @@ export function detectWslGpuPassthrough(deps: WslDetectDeps): Promise<WslSupport
   return _wslSupportPromise;
 }
 
-/** For tests only — clears the cached probe result so each test starts fresh. */
-export function _resetWslSupportCacheForTests(): void {
+/**
+ * Clears the cached probe result. Safe to call mid-session — the next
+ * `detectWslGpuPassthrough()` call will re-run `docker info` + the probe.
+ * Used by the dashboard's "Re-detect GPU" affordance to recover from a
+ * Docker Desktop WSL2 ↔ Hyper-V backend toggle without an Electron restart.
+ */
+export function resetWslSupportCache(): void {
   _wslSupportPromise = null;
 }
 
+/**
+ * @deprecated Use `resetWslSupportCache()`. Kept as an alias for back-compat
+ * with existing tests that call the underscore-prefixed variant.
+ */
+export const _resetWslSupportCacheForTests = resetWslSupportCache;
+
 async function doDetect(deps: WslDetectDeps): Promise<WslSupport> {
-  let dockerInfoStdout: string;
-  try {
-    dockerInfoStdout = await deps.runDockerInfo();
-  } catch (err) {
-    const reason = err instanceof Error ? err.message : 'docker info failed';
-    return { available: false, gpuPassthroughDetected: false, reason };
+  // Prefer the structured `--format '{{json .}}'` path when available — it
+  // dodges the future Docker label-shift hazard the text parser pattern-matches.
+  // Fall back to the text parser if the JSON call rejects or returns malformed
+  // output, so we never regress below the v1.3.4 detection capability.
+  let parsed: { available: boolean; reason?: string } | null = null;
+  if (deps.runDockerInfoJson) {
+    try {
+      const jsonOut = await deps.runDockerInfoJson();
+      const jsonParsed = parseDockerInfoJsonForWsl(jsonOut);
+      if (jsonParsed.reason !== 'malformed JSON output') {
+        parsed = jsonParsed;
+      }
+    } catch {
+      // JSON path threw — drop through to text fallback.
+    }
   }
 
-  const parsed = parseDockerInfoForWsl(dockerInfoStdout);
+  if (parsed === null) {
+    let dockerInfoStdout: string;
+    try {
+      dockerInfoStdout = await deps.runDockerInfo();
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : 'docker info failed';
+      return { available: false, gpuPassthroughDetected: false, reason };
+    }
+    parsed = parseDockerInfoForWsl(dockerInfoStdout);
+  }
+
   if (!parsed.available) {
     return { available: false, gpuPassthroughDetected: false, reason: parsed.reason };
   }

--- a/dashboard/src/types/electron.d.ts
+++ b/dashboard/src/types/electron.d.ts
@@ -16,7 +16,13 @@ type TrayState =
   | 'disconnected';
 
 // Keep in sync with src/types/runtime.ts (canonical) and electron/preload.ts
-type RuntimeProfile = 'gpu' | 'cpu' | 'vulkan' | 'metal';
+type RuntimeProfile = 'gpu' | 'cpu' | 'vulkan' | 'vulkan-wsl2' | 'metal';
+
+interface WslSupport {
+  available: boolean;
+  gpuPassthroughDetected: boolean;
+  reason?: string;
+}
 type HfTokenDecision = 'unset' | 'provided' | 'skipped';
 type ClientLogType = 'info' | 'success' | 'error' | 'warning';
 
@@ -117,7 +123,13 @@ interface ElectronAPI {
     getRuntimeKind: () => Promise<string | null>;
     getDetectionGuidance: () => Promise<string | null>;
     getComposeAvailable: () => Promise<boolean>;
-    checkGpu: () => Promise<{ gpu: boolean; toolkit: boolean; vulkan: boolean }>;
+    checkGpu: () => Promise<{
+      gpu: boolean;
+      toolkit: boolean;
+      vulkan: boolean;
+      wslSupport?: WslSupport;
+    }>;
+    hasVulkanWsl2SidecarImage: () => Promise<boolean>;
     listImages: () => Promise<
       Array<{ tag: string; fullName: string; size: string; created: string; id: string }>
     >;

--- a/dashboard/src/types/runtime.ts
+++ b/dashboard/src/types/runtime.ts
@@ -4,10 +4,29 @@
  * Also declared as an ambient type in electron.d.ts (for StartContainerOptions)
  * and in electron/preload.ts (isolated Electron main-process build).
  * Keep all three in sync when adding new profiles.
+ *
+ * `vulkan-wsl2` is an experimental opt-in profile for AMD/Intel GPU acceleration
+ * on Windows + Docker Desktop with WSL2 backend (GH-101 follow-up). It is never
+ * auto-selected — only surfaced in Settings when detectWslGpuPassthrough()
+ * confirms /dev/dxg passthrough. Requires the locally-built sidecar image
+ * `transcriptionsuite/whisper-cpp-vulkan-wsl2:latest`.
  */
-const RUNTIME_PROFILES = ['gpu', 'cpu', 'vulkan', 'metal'] as const;
+const RUNTIME_PROFILES = ['gpu', 'cpu', 'vulkan', 'vulkan-wsl2', 'metal'] as const;
 export type RuntimeProfile = (typeof RUNTIME_PROFILES)[number];
 
 export function isRuntimeProfile(value: unknown): value is RuntimeProfile {
   return typeof value === 'string' && (RUNTIME_PROFILES as readonly string[]).includes(value);
+}
+
+/**
+ * Result of probing Docker Desktop for WSL2 GPU paravirtualization (GH-101 follow-up).
+ *
+ * `available`: Docker is running with the WSL2 backend (vs Hyper-V or no Docker).
+ * `gpuPassthroughDetected`: a throwaway probe container could see /dev/dxg + /usr/lib/wsl libs.
+ * `reason`: optional human-readable diagnostic for negative results.
+ */
+export interface WslSupport {
+  available: boolean;
+  gpuPassthroughDetected: boolean;
+  reason?: string;
 }

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.0.36",
-  "contract_sha256": "2be9efc64143e07b8b38641971e595af2f3196cf1cfdf1178d0316b5ebecbcb5",
-  "updated_at": "2026-05-01T22:23:14.871Z"
+  "spec_version": "1.0.40",
+  "contract_sha256": "548d662c6c2a4aaace8b911bc03e9a22593f2ac9d891ae94c3a4192ac4ae555f",
+  "updated_at": "2026-05-02T10:00:42.749Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.0.36
+  spec_version: 1.0.40
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -62,7 +62,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-05-01T22:23:14.179Z
+    generated_at: 2026-05-02T10:00:30.542Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -306,7 +306,6 @@ foundation:
         - h-[85vh]
         - max-h-[80vh]
         - max-h-[90vh]
-        - max-w-[55%]
         - min-h-[38px]
         - min-h-[calc(100vh-30rem)]
         - min-w-[5rem]
@@ -453,7 +452,6 @@ utility_allowlist:
     - bg-black/70
     - bg-black/75
     - bg-blue-400
-    - bg-blue-500
     - bg-blue-500/10
     - bg-cyan-400/10
     - bg-cyan-400/20
@@ -470,9 +468,7 @@ utility_allowlist:
     - bg-linear-to-t
     - bg-neutral-700
     - bg-neutral-900
-    - bg-orange-500
     - bg-orange-500/10
-    - bg-purple-500
     - bg-purple-500/10
     - bg-red-400/10
     - bg-red-500
@@ -510,8 +506,6 @@ utility_allowlist:
     - border-accent-magenta/20
     - border-accent-magenta/5
     - border-accent-orange/20
-    - border-accent-orange/25
-    - border-accent-rose/20
     - border-amber-400/20
     - border-amber-400/30
     - border-amber-400/40
@@ -739,8 +733,6 @@ utility_allowlist:
     - md:grid-cols-2
     - md:grid-cols-4
     - md:items-center
-    - md:items-end
-    - md:justify-between
     - min-h-0
     - min-h-32
     - min-h-full
@@ -874,7 +866,6 @@ utility_allowlist:
     - rounded-tl-none
     - rounded-tr-none
     - rounded-xl
-    - select-all
     - select-none
     - selectable-text
     - shadow
@@ -917,10 +908,8 @@ utility_allowlist:
     - text-2xl
     - text-3xl
     - text-accent-cyan
-    - text-accent-cyan/80
     - text-accent-magenta
     - text-accent-orange
-    - text-accent-rose
     - text-accent-violet
     - text-accent-violet/80
     - text-amber-100
@@ -928,7 +917,6 @@ utility_allowlist:
     - text-amber-300
     - text-amber-300/60
     - text-amber-300/70
-    - text-amber-300/80
     - text-amber-400
     - text-amber-400/60
     - text-amber-400/80
@@ -941,16 +929,15 @@ utility_allowlist:
     - text-emerald-200
     - text-emerald-400
     - text-green-400
-    - text-green-400/70
     - text-left
     - text-lg
     - text-neutral-100
+    - text-orange-200
     - text-orange-400
     - text-orange-500
     - text-purple-400
     - text-red-100
     - text-red-200
-    - text-red-200/90
     - text-red-300
     - text-red-400
     - text-red-400/80
@@ -963,7 +950,6 @@ utility_allowlist:
     - text-slate-700
     - text-slate-900
     - text-sm
-    - text-violet-400
     - text-white
     - text-white/60
     - text-white/90
@@ -1056,7 +1042,6 @@ utility_allowlist:
     - lg:grid-cols-[minmax(480px,5fr)_minmax(300px,7fr)]
     - max-h-[80vh]
     - max-h-[90vh]
-    - max-w-[55%]
     - md:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]
     - min-h-[38px]
     - min-h-[calc(100vh-30rem)]

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ https://github.com/user-attachments/assets/f63ee730-de9a-4a55-b0ab-e342b30905a4
 ### 1.1 Features
 
 - **100% Local**: *Everything* runs on your own computer, the app doesn't need internet beyond the initial setup*
-- **Multiple Models available**: On **Docker/Linux/Windows**: *WhisperX* ([`faster-whisper`](https://huggingface.co/Systran/faster-whisper-large-v3) models), NVIDIA NeMo [*Parakeet v3*](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3)/[*Canary v2*](https://huggingface.co/nvidia/canary-1b-v2), [*VibeVoice-ASR*](https://huggingface.co/microsoft/VibeVoice-ASR), and [*whisper.cpp*](https://github.com/ggerganov/whisper.cpp) (GGML models for AMD/Intel GPU via Vulkan — Linux only). On **Apple Silicon (Metal)**: [*MLX Whisper*](https://huggingface.co/mlx-community/whisper-large-v3-turbo-asr-fp16) (tiny → large-v3-turbo), [*MLX Parakeet v3*](https://huggingface.co/mlx-community/parakeet-tdt-0.6b-v3), [*MLX Canary v2*](https://huggingface.co/mlx-community/canary-1b-v2), and [*MLX VibeVoice-ASR*](https://huggingface.co/mlx-community/VibeVoice-ASR-bf16) - all running natively without Docker
+- **Multiple Models available**: On **Docker/Linux/Windows**: *WhisperX* ([`faster-whisper`](https://huggingface.co/Systran/faster-whisper-large-v3) models), NVIDIA NeMo [*Parakeet v3*](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3)/[*Canary v2*](https://huggingface.co/nvidia/canary-1b-v2), [*VibeVoice-ASR*](https://huggingface.co/microsoft/VibeVoice-ASR), and [*whisper.cpp*](https://github.com/ggerganov/whisper.cpp) (GGML models for AMD/Intel GPU via Vulkan — Linux is the supported path; experimental WSL2 path on Windows requires a locally-built sidecar image, see §2.5). On **Apple Silicon (Metal)**: [*MLX Whisper*](https://huggingface.co/mlx-community/whisper-large-v3-turbo-asr-fp16) (tiny → large-v3-turbo), [*MLX Parakeet v3*](https://huggingface.co/mlx-community/parakeet-tdt-0.6b-v3), [*MLX Canary v2*](https://huggingface.co/mlx-community/canary-1b-v2), and [*MLX VibeVoice-ASR*](https://huggingface.co/mlx-community/VibeVoice-ASR-bf16) - all running natively without Docker
 - **Speaker Diarization**: Speaker identification & diarization (subtitling) for Whisper, NeMo, and VibeVoice models; Whisper and NeMo use PyAnnote for diarization while VibeVoice does it by itself (not available for whisper.cpp models). On Apple Silicon, [*Sortformer*](https://huggingface.co/mlx-community/diar_sortformer_4spk-v1-fp32) provides Metal-native diarization for up to 4 speakers - no HuggingFace token required
 - **Parallel Processing**: If your VRAM budget allows it, transcribe & diarize a recording at the same time - speeding up processing time significantly
 - **Truly Multilingual**: Whisper supports [90+ languages](https://github.com/openai/whisper/blob/main/whisper/tokenizer.py); NeMo Parakeet/Canary support [25 European languages](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3); VibeVoice supports [51 languages](https://huggingface.co/microsoft/VibeVoice-ASR)
@@ -309,16 +309,49 @@ Notes:
 
 ### 2.5 AMD / Intel GPU Support (Vulkan)
 
-If you have an **AMD or Intel GPU** instead of NVIDIA, you can still get GPU-accelerated transcription using [whisper.cpp](https://github.com/ggerganov/whisper.cpp) with Vulkan.
+If you have an **AMD or Intel GPU** instead of NVIDIA, you can get GPU-accelerated transcription using [whisper.cpp](https://github.com/ggerganov/whisper.cpp) with Vulkan. There are two paths: a stable **Linux** path that has shipped since v1.3.x, and an **experimental Windows + WSL2** path introduced in v1.3.5 (Issue #101 follow-up).
 
 This works by running a second helper container (called whisper-server) alongside the main TranscriptionSuite container. The helper container uses your AMD or Intel GPU for the actual transcription work, while the main container handles everything else (the dashboard, file management, etc.).
+
+#### 2.5.1 Linux (stable)
 
 **What you need:**
 
 - An AMD GPU with Vulkan support (RDNA1 or newer, e.g. RX 5500 XT, RX 6600, RX 7800 XT)
 - Or an Intel GPU with Vulkan support (Arc A-series or integrated Xe graphics)
 - Docker installed (Podman is not yet supported for Vulkan mode)
-- **Linux only.** Docker Desktop on Windows and macOS runs containers in a Linux VM without `/dev/dri` GPU passthrough, so the Vulkan sidecar cannot reach your GPU there. Use the CPU profile on those platforms (or GPU/CUDA on Windows with NVIDIA hardware).
+- A Linux host with `/dev/dri/renderD128` (a real DRI render node from the AMD/Intel kernel driver)
+
+#### 2.5.2 Windows + WSL2 (experimental, opt-in — GH-101 follow-up)
+
+> ⚠️ **Experimental.** This path uses Mesa's [`dzn` (Dozen)](https://docs.mesa3d.org/drivers/d3d12.html) Vulkan-on-D3D12 ICD inside the WSL2 distro to enumerate `/dev/dxg`. It is not validated against AMD hardware in our CI; we ship the plumbing so determined users can try it. The runtime may silently fall back to a CPU rasterizer (llvmpipe) if dzn cannot enumerate the GPU — verify with `vulkaninfo --summary` inside the running sidecar.
+>
+> The custom sidecar image is **not** published to GHCR — every user builds it locally. We will promote to GHCR after a real-world AMD WSL2 validator confirms `/dev/dxg` enumeration via dzn.
+
+**What you need:**
+
+- An AMD or Intel GPU with current Windows drivers (WDDM 3.0+ recommended)
+- Docker Desktop on Windows with the **WSL2 backend enabled** (Settings → General → "Use the WSL 2 based engine")
+- Bash (Git Bash, WSL, or any POSIX shell) to run the build script
+- Internet access to pull the upstream `whisper.cpp:main-vulkan` image and the [kisak/turtle PPA](https://launchpad.net/~kisak/+archive/ubuntu/turtle) which ships Mesa with `microsoft-experimental` (dzn) enabled
+
+**Build the local sidecar image** (one-time, ~3–5 min). Pick the helper that matches your shell:
+
+```powershell
+# PowerShell (Windows-native, no extra dependencies)
+powershell -ExecutionPolicy Bypass -File .\server\docker\build-vulkan-wsl2.ps1
+```
+
+```bash
+# Bash (Git Bash, WSL, or any POSIX shell on Linux/macOS)
+bash server/docker/build-vulkan-wsl2.sh
+```
+
+This produces `transcriptionsuite/whisper-cpp-vulkan-wsl2:latest` locally. The dashboard surfaces a "GPU (Vulkan WSL2 — experimental)" runtime profile button in Settings only when Docker Desktop is detected with the WSL2 backend AND a probe container can see `/dev/dxg`. If the button is missing, the probe failed; check Docker Desktop's backend setting and your Windows GPU driver version.
+
+If you click Start Server before building the image, the dashboard surfaces an actionable error pointing back at this section.
+
+#### 2.5.3 Setup walk-through (Linux + experimental WSL2)
 
 **How to set it up:**
 
@@ -365,6 +398,8 @@ This works by running a second helper container (called whisper-server) alongsid
 - _Sidecar health check timeout_ - The model is still loading. Large GGML files can take 30–60 seconds to initialize on first start.
 
 > **Note for older AMD GPUs (RDNA1):** If you experience Vulkan initialization errors with an RX 5500 XT or similar RDNA1 card, you may need to add `iommu=soft` to your kernel boot parameters.
+
+> **Note for Windows + WSL2 users (experimental):** if transcription is slow under the Vulkan-WSL2 profile, dzn may have fallen back to `llvmpipe` (CPU rasterizer) silently. Inspect the sidecar with `docker exec <container> vulkaninfo --summary` — if you only see `llvmpipe`, your Windows GPU driver may need updating, or your hardware may not be supported by dzn. Fall back to the CPU profile until the issue is resolved.
 
 ---
 

--- a/docs/README_DEV.md
+++ b/docs/README_DEV.md
@@ -1430,14 +1430,29 @@ Key design decisions:
 
 #### Networking by Platform
 
-| Platform | Main container networking | whisper-server networking | URL used |
-|----------|--------------------------|--------------------------|----------|
-| Linux | `network_mode: host` | Bridge + port mapping | `http://localhost:8080` |
-| macOS | Bridge (Docker Desktop) | Bridge (same network) | `http://whisper-server:8080` |
-| Windows | Bridge (Docker Desktop) | Bridge (same network) | `http://whisper-server:8080` |
-| WSL2 | `network_mode: host` | Bridge + port mapping | `http://localhost:8080` |
+| Platform | Profile | Main container networking | whisper-server networking | URL used |
+|----------|---------|--------------------------|--------------------------|----------|
+| Linux | `vulkan` | `network_mode: host` | Bridge + port mapping | `http://localhost:8080` |
+| macOS | (n/a) | Bridge (Docker Desktop) | (Vulkan unsupported) | (n/a) |
+| Windows + WSL2 | `vulkan-wsl2` | Bridge (Docker Desktop) | Bridge (same network) | `http://whisper-server:8080` |
+| Windows + Hyper-V | (n/a) | Bridge (Docker Desktop) | (Vulkan unsupported) | (n/a) |
+| Native Linux WSL2 distro | `vulkan` | `network_mode: host` | Bridge + port mapping | `http://localhost:8080` |
 
-> **Vulkan is Linux-only in practice (Issue #101).** The networking matrix above describes the URL routing that `dockerManager.ts` would use, but `/dev/dri` GPU passthrough is not available on Docker Desktop's Linux VM (Windows/macOS) or under WSL2 (which exposes `/dev/dxg`, not Mesa render nodes). `dockerManager.ts::checkVulkanSupport` blocks the Vulkan profile on non-Linux platforms before Docker is invoked. Cross-platform Vulkan would require WSL2 `/dev/dxg` paravirtualization work, tracked separately if pursued.
+> **Vulkan profile selection (GH-101 follow-up).** Two compose overlays now exist: `docker-compose.vulkan.yml` (Linux-DRI path; mounts `/dev/dri`) and `docker-compose.vulkan-wsl2.yml` (experimental Windows + WSL2 path; mounts `/dev/dxg` + `/usr/lib/wsl` and uses a custom-built sidecar image with Mesa's `dzn` Vulkan-on-D3D12 ICD added — the upstream `whisper.cpp:main-vulkan` does not include dzn). `dockerManager.ts::checkVulkanSupport(platform, exists, wslSupport, profile)` gates each path. The `vulkan-wsl2` profile is opt-in: never auto-selected, only surfaced in Settings when `detectWslGpuPassthrough()` confirms Docker Desktop's WSL2 backend AND a probe container can reach `/dev/dxg`. The custom sidecar image is not published to GHCR — see README §2.5.2 for the local build path.
+
+The WSL2 dataflow inside the sidecar container is:
+
+```
+/dev/dxg (kernel device)
+   ↓
+libdxcore.so + libd3d12.so (mounted from /usr/lib/wsl/lib by Docker Desktop)
+   ↓
+dzn ICD (libvulkan_dzn.so, installed in the custom image only)
+   ↓
+Vulkan loader → whisper.cpp Vulkan compute kernels
+```
+
+If dzn cannot find a D3D12 device through `/dev/dxg`, the Vulkan loader silently falls back to `llvmpipe` (CPU rasterizer). The dashboard cannot detect this without inspecting `vulkaninfo --summary` from inside the sidecar — operators should verify GPU enumeration manually after first start.
 
 The dashboard's `dockerManager.ts` automatically sets `WHISPERCPP_SERVER_URL` based on `process.platform` when the vulkan runtime profile is selected. The backend resolves the server URL with this priority:
 

--- a/docs/project-context.md
+++ b/docs/project-context.md
@@ -171,6 +171,7 @@ durability:
 - **Session-level cache**: `cachedGpuInfo` survives component remount — avoids re-running detection on every render
 - **Profile auto-selection priority**: Metal (Apple Silicon) > NVIDIA GPU (runtime=nvidia) > Vulkan (AMD/Intel via `/dev/dri/renderD128`) > CPU
 - **Vulkan detection**: Linux-only, checks `fs.existsSync('/dev/dri/renderD128')` — no NVIDIA toolkit needed
+- **Vulkan-WSL2 detection (GH-101 follow-up)**: Win32 only, opt-in, **never enters the auto-selection priority chain**. `checkGpu()` invokes `detectWslGpuPassthrough()` once on Win32; the dashboard surfaces a separate "GPU (Vulkan WSL2 — experimental)" Settings button only when both `wslSupport.available` (Docker Desktop with WSL2 backend) and `wslSupport.gpuPassthroughDetected` (`/dev/dxg` reachable via probe container) are true. Requires the locally-built `transcriptionsuite/whisper-cpp-vulkan-wsl2:latest` sidecar image (not published to GHCR; users build via `server/docker/build-vulkan-wsl2.sh`).
 
 #### GGML Model Selection (Vulkan Sidecar)
 - **Registry-driven**: `getModelsByFamily('whispercpp')` from `modelRegistry.ts` — filtered at module level

--- a/server/docker/build-vulkan-wsl2.ps1
+++ b/server/docker/build-vulkan-wsl2.ps1
@@ -1,0 +1,60 @@
+# Build the Vulkan-WSL2 sidecar image locally (GH-101 follow-up) — Windows
+# PowerShell companion to build-vulkan-wsl2.sh, for users running Docker
+# Desktop on Windows without Git Bash / WSL on the PATH.
+#
+# Tags: transcriptionsuite/whisper-cpp-vulkan-wsl2:latest
+#
+# Usage (from any PowerShell):
+#   .\server\docker\build-vulkan-wsl2.ps1
+#
+# Pass -NoCache to force a clean rebuild (useful when the kisak PPA shape
+# changes). All other arguments are forwarded to `docker buildx build`.
+
+[CmdletBinding()]
+param(
+    [switch]$NoCache,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$ExtraArgs
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $PSCommandPath
+$Dockerfile = Join-Path $ScriptDir 'whisper-cpp-vulkan-wsl2.Dockerfile'
+$ImageTag = if ($env:IMAGE_TAG) { $env:IMAGE_TAG } else { 'transcriptionsuite/whisper-cpp-vulkan-wsl2:latest' }
+
+if (-not (Test-Path -LiteralPath $Dockerfile)) {
+    Write-Error "Dockerfile not found at $Dockerfile"
+    exit 1
+}
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Write-Error 'docker CLI not found in PATH. Install Docker Desktop, then retry.'
+    exit 1
+}
+
+try {
+    docker buildx version | Out-Null
+} catch {
+    Write-Error 'docker buildx is not available. Update Docker to a recent version (>= 20.10) and retry.'
+    exit 1
+}
+
+Write-Host "[build-vulkan-wsl2] Building $ImageTag from $Dockerfile..."
+
+$BuildArgs = @('buildx', 'build', '--load', '--tag', $ImageTag, '-f', $Dockerfile, $ScriptDir)
+if ($NoCache) {
+    $BuildArgs += '--no-cache'
+}
+if ($ExtraArgs) {
+    $BuildArgs += $ExtraArgs
+}
+
+& docker @BuildArgs
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "docker buildx build failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+}
+
+Write-Host "[build-vulkan-wsl2] Done. Verify with: docker images | findstr whisper-cpp-vulkan-wsl2"
+Write-Host "[build-vulkan-wsl2] To use: open the dashboard, switch to 'GPU (Vulkan WSL2 - experimental)', and Start Server."

--- a/server/docker/build-vulkan-wsl2.sh
+++ b/server/docker/build-vulkan-wsl2.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Build the Vulkan-WSL2 sidecar image locally (GH-101 follow-up).
+#
+# Tags: transcriptionsuite/whisper-cpp-vulkan-wsl2:latest
+#
+# This image is the experimental opt-in counterpart to the upstream
+# ghcr.io/ggml-org/whisper.cpp:main-vulkan image, with Mesa's `dzn`
+# Vulkan-on-D3D12 ICD added so it can enumerate /dev/dxg on Windows +
+# Docker Desktop with the WSL2 backend.
+#
+# It is NOT published to GHCR for v1.3.5 — every user who wants to try the
+# Vulkan-WSL2 runtime profile builds it locally with this script. After a
+# real-world AMD/Intel WSL2 validator confirms /dev/dxg enumeration via
+# vulkaninfo (i.e. discrete/integrated GPU listed, not just llvmpipe), we
+# may promote to GHCR in a future release.
+#
+# Usage (on any host with docker buildx):
+#   bash server/docker/build-vulkan-wsl2.sh
+#
+# Pass --no-cache to force a clean rebuild (useful when the kisak PPA shape
+# changes). All other arguments are forwarded to `docker buildx build`.
+#
+# Requires:
+#   * docker (or podman with `alias docker=podman`) with buildx
+#   * Internet access to pull the upstream image and the kisak PPA
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+DOCKERFILE="${SCRIPT_DIR}/whisper-cpp-vulkan-wsl2.Dockerfile"
+IMAGE_TAG="${IMAGE_TAG:-transcriptionsuite/whisper-cpp-vulkan-wsl2:latest}"
+
+if [ ! -f "${DOCKERFILE}" ]; then
+    echo "ERROR: Dockerfile not found at ${DOCKERFILE}" >&2
+    exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "ERROR: docker CLI not found in PATH. Install Docker Desktop or Docker Engine, then retry." >&2
+    exit 1
+fi
+
+if ! docker buildx version >/dev/null 2>&1; then
+    echo "ERROR: docker buildx is not available. Update Docker to a recent version (>= 20.10) and retry." >&2
+    exit 1
+fi
+
+echo "[build-vulkan-wsl2] Building ${IMAGE_TAG} from ${DOCKERFILE}..."
+
+# Forward all extra arguments (e.g. --no-cache, --progress=plain) preserving
+# whitespace inside individual args. "$@" — not $@ — is the correct splat.
+docker buildx build \
+    --load \
+    --tag "${IMAGE_TAG}" \
+    -f "${DOCKERFILE}" \
+    "${SCRIPT_DIR}" \
+    "$@"
+
+echo "[build-vulkan-wsl2] Done. Verify with: docker images | grep whisper-cpp-vulkan-wsl2"
+echo "[build-vulkan-wsl2] To use: open the dashboard, switch to 'GPU (Vulkan WSL2 — experimental)', and Start Server."

--- a/server/docker/docker-compose.vulkan-wsl2.yml
+++ b/server/docker/docker-compose.vulkan-wsl2.yml
@@ -1,0 +1,90 @@
+# Vulkan-WSL2 sidecar overlay — whisper.cpp with Vulkan-on-D3D12 (dzn) GPU
+# acceleration on Windows + Docker Desktop with the WSL2 backend (GH-101
+# follow-up).
+#
+# This is the experimental opt-in counterpart to docker-compose.vulkan.yml,
+# which is Linux-only because it mounts /dev/dri (the Linux DRM/DRI subsystem
+# that Docker Desktop's WSL2 distro doesn't expose).
+#
+# The image ``transcriptionsuite/whisper-cpp-vulkan-wsl2:latest`` is NOT
+# published to GHCR for v1.3.5. Users build it locally via:
+#
+#   bash server/docker/build-vulkan-wsl2.sh
+#
+# (See README §2.5 "Windows + WSL2 (experimental)" for the full setup.)
+#
+# How it works:
+#   * /dev/dxg is the WSL2 Linux kernel device that brokers GPU-PV through
+#     the Microsoft `dxgkrnl` driver into the Windows host's WDDM stack.
+#   * /usr/lib/wsl is automatically populated by Docker Desktop with the
+#     Microsoft user-mode driver bundle (libd3d12.so, libdxcore.so) — it is
+#     not pre-mounted into arbitrary containers, so we bind it explicitly.
+#   * VK_ICD_FILENAMES forces the Vulkan loader to use Mesa's `dzn` ICD
+#     (Vulkan-on-D3D12 translation), which the upstream main-vulkan image
+#     does not include — only the custom Dockerfile here adds it.
+#
+# Usage:
+#   docker compose \
+#       -f docker-compose.yml \
+#       -f docker-compose.desktop-vm.yml \
+#       -f docker-compose.vulkan-wsl2.yml up -d
+#
+# The dashboard's compose-file selection (dockerManager.ts::composeFileArgs)
+# routes the 'vulkan-wsl2' runtime profile to this overlay automatically.
+
+services:
+  whisper-server:
+    image: transcriptionsuite/whisper-cpp-vulkan-wsl2:latest
+    # The image is built locally only — never auto-pulled from a registry.
+    # Without this, a missing local image causes Compose to attempt a pull
+    # of a non-existent registry tag and fail with a confusing "manifest
+    # unknown" error far from the dashboard's preflight check.
+    pull_policy: never
+    command:
+      - >-
+        n=0;
+        until test -f "$$WHISPER_MODEL"; do
+        n=$$((n+1));
+        if [ "$$n" -ge 180 ]; then
+        echo '[whisper-server] ERROR: Model $$WHISPER_MODEL not found after 30 minutes — exiting so Docker can restart.' >&2;
+        exit 1;
+        fi;
+        echo '[whisper-server] Waiting for model $$WHISPER_MODEL to be downloaded...';
+        sleep 10;
+        done;
+        exec whisper-server --model "$$WHISPER_MODEL" --host 0.0.0.0 --port 8080 --convert
+    restart: unless-stopped
+    volumes:
+      - huggingface-models:/models:ro
+      # Microsoft user-mode driver bundle (libd3d12.so, libdxcore.so).
+      # Bound read-only so the container cannot tamper with WSL host libs.
+      - /usr/lib/wsl:/usr/lib/wsl:ro
+    ports:
+      - "127.0.0.1:8080:8080"
+    devices:
+      # WSL2 GPU paravirtualization device. Docker Desktop does not auto-bind
+      # this for non-NVIDIA paths; we must request it explicitly.
+      - /dev/dxg:/dev/dxg
+    environment:
+      - WHISPER_MODEL=${WHISPERCPP_MODEL:-/models/ggml-large-v3-turbo.bin}
+      # Make Microsoft's libd3d12.so / libdxcore.so resolvable to dzn at runtime.
+      - LD_LIBRARY_PATH=/usr/lib/wsl/lib
+      # Force the Vulkan loader to use Mesa's dzn ICD (Vulkan-on-D3D12).
+      # Without this, the loader can fall back to llvmpipe (CPU rasterizer)
+      # silently, which would masquerade as GPU acceleration.
+      - VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/dzn_icd.x86_64.json
+      # Optional: Mesa's adapter selector for multi-GPU Windows hosts.
+      # Empty string lets dzn pick the default — power users can override
+      # via the dashboard's process env (e.g. "Nvidia", "Intel", "AMD").
+      - MESA_D3D12_DEFAULT_ADAPTER_NAME=${MESA_D3D12_DEFAULT_ADAPTER_NAME:-}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+  transcriptionsuite:
+    depends_on:
+      whisper-server:
+        condition: service_started

--- a/server/docker/whisper-cpp-vulkan-wsl2.Dockerfile
+++ b/server/docker/whisper-cpp-vulkan-wsl2.Dockerfile
@@ -1,0 +1,70 @@
+# Vulkan-WSL2 sidecar image — whisper.cpp with Mesa's `dzn` Vulkan-on-D3D12 ICD
+# added on top of the upstream `main-vulkan` image, so it can enumerate
+# /dev/dxg on Windows + Docker Desktop with the WSL2 backend (GH-101 follow-up).
+#
+# The upstream image (ghcr.io/ggml-org/whisper.cpp:main-vulkan) is built
+# FROM ubuntu:24.04 with `mesa-vulkan-drivers` from the stock Ubuntu archive.
+# That package ships intel/intel_hasvk/lvp/radeon/virtio ICDs only — NOT dzn.
+# Without dzn, the Vulkan loader on WSL2 either finds no devices or falls back
+# to `llvmpipe` (CPU rasterizer), which would be silent CPU-bound transcription
+# masquerading as GPU acceleration.
+#
+# The kisak/turtle PPA is the most widely-cited Ubuntu deb source that ships
+# Mesa with `microsoft-experimental` enabled (i.e. with dzn). The PPA is a
+# rolling release — we do NOT pin specific package versions here, so a fresh
+# build always picks up the current PPA contents. If a PPA-side regression
+# breaks the build, the post-install `RUN test -f .../dzn_icd.x86_64.json`
+# below fails the build loudly so the maintainer notices immediately rather
+# than shipping a silent CPU-fallback image. For deterministic builds,
+# install with explicit `mesa-vulkan-drivers=<version>` constraints below.
+#
+# Build:
+#   bash server/docker/build-vulkan-wsl2.sh
+# (or directly:)
+#   docker buildx build \
+#       --tag transcriptionsuite/whisper-cpp-vulkan-wsl2:latest \
+#       -f whisper-cpp-vulkan-wsl2.Dockerfile .
+#
+# This image is NOT published to GHCR for v1.3.5 — users build locally.
+# Promote to GHCR after a real-world AMD/Intel WSL2 validator confirms
+# /dev/dxg enumeration via dzn (i.e. vulkaninfo lists a discrete or
+# integrated device, not just llvmpipe).
+
+ARG UPSTREAM_IMAGE=ghcr.io/ggml-org/whisper.cpp:main-vulkan
+FROM ${UPSTREAM_IMAGE}
+
+# Avoid interactive tzdata prompts on apt install.
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Reference build (informational, not a constraint): kisak/turtle PPA on
+# 2026-05-02 shipped Mesa 25.x with microsoft-experimental enabled. If a
+# future apt-get update introduces a regression, pin the relevant package
+# versions explicitly via `=<version>` after the package name.
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        software-properties-common \
+        ca-certificates \
+        gpg \
+        gpg-agent; \
+    add-apt-repository -y ppa:kisak/turtle; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        mesa-vulkan-drivers \
+        libgl1 \
+        libglx0 \
+        libegl1 \
+        libgles2 \
+        libdrm2; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+# Sanity: confirm the dzn ICD manifest is now present. If this fails, the
+# kisak PPA shape changed and the image will not enumerate /dev/dxg correctly
+# at runtime — fail the build loudly so the maintainer notices immediately.
+RUN test -f /usr/share/vulkan/icd.d/dzn_icd.x86_64.json \
+    || (echo "ERROR: dzn ICD manifest missing after PPA install — Mesa build does not include dzn. Aborting image build." >&2 && exit 1)
+
+# Default env hints — overridden by docker-compose.vulkan-wsl2.yml at runtime.
+ENV LD_LIBRARY_PATH=/usr/lib/wsl/lib \
+    VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/dzn_icd.x86_64.json


### PR DESCRIPTION
# Summary

Closes the genuine gap left open by v1.3.4's commit d3084a4 (which fixed the cryptic /dev/dri error wording but left the underlying outcome unchanged: Windows + AMD/Intel users still couldn't get GPU-accelerated transcription).

Introduces a parallel 'vulkan-wsl2' runtime profile that opens the architectural seam for Mesa dzn (Vulkan-on-D3D12) inside Docker Desktop's WSL2 distro. The path is fully wired, opt-in, detection-gated, and shipped with the custom sidecar image left unpublished to GHCR so determined users build it locally — guarding against the silent-CPU-fallback failure mode that adjacent projects (llama.cpp, ollama) have reported on the same stack.

The Linux Vulkan path ('vulkan' profile, /dev/dri mount, docker-compose.vulkan.yml) is completely unchanged — every v1.3.4 caller, test, and behavior is preserved.

Why this is the right shape

The 2026-05-02 RCA brainstorming session traced Issue #101 to an 11-layer root cause tree. Key constraints from the investigation:

- The upstream whisper.cpp:main-vulkan image cannot enumerate /dev/dxg. Ubuntu 24.04's stock mesa-vulkan-drivers package ships intel/intel_hasvk/lvp/radeon/virtio ICDs only — no dzn. Confirmed by reading the package filelist; mounting /dev/dxg against the upstream image silently falls back to llvmpipe (CPU).
- A custom image is required. This PR adds whisper-cpp-vulkan-wsl2.Dockerfile that layers Mesa with microsoft-experimental (dzn) on top of the upstream image, with a build-time RUN test -f .../dzn_icd.x86_64.json sanity check.
- The dev box has no AMD hardware to validate. This PR therefore ships the plumbing dormant: the image is not auto-pulled, not auto-built, never auto-selected. A real-world AMD/Intel WSL2 validator runs the build helper, picks the experimental profile, and reports back. Promoting the image to GHCR is a future PR.

## What ships

### New runtime profile

- RuntimeProfile = 'gpu' | 'cpu' | 'vulkan' | 'vulkan-wsl2' | 'metal' — extended in dashboard/src/types/runtime.ts, electron.d.ts, and electron/preload.ts (kept in sync per the canonical comment).
- Surfaced as "GPU (Vulkan WSL2 — experimental)" in both SettingsModal.tsx and ServerView.tsx, with an "Experimental"/"Exp" pill. Gated on gpuInfo.wslSupport.gpuPassthroughDetected && platform === 'win32' — invisible everywhere else.
- Never enters the auto-detection priority chain. Auto-detect order remains Metal > NVIDIA > Linux Vulkan > CPU. Confirmed by the new regression test in dockerManagerVulkanPreflight.test.ts.
- Persisted profile auto-normalizes to 'cpu' if the dashboard moves to a non-Win32 host (e.g. user copies their config across machines). Preserves graceful recovery without manual intervention.

### Detection

- New dashboard/electron/wslDetect.ts with two pure/async exports:
- parseDockerInfoForWsl(stdout) — pure parser inspecting Operating System: Docker Desktop AND Kernel Version: ...microsoft-standard-WSL2. Both must match.
- detectWslGpuPassthrough(deps) — runs docker info + a throwaway --device /dev/dxg -v /usr/lib/wsl:/usr/lib/wsl:ro probe container against a locally-cached alpine:3 (with --pull=never so we never trigger network pulls).
- Single-flight cached Promise with rejection clearing: a transient failure (Docker daemon starting, network glitch) does not lock the dashboard into a permanent negative result for the rest of the session.
- Cached at the main-process level — repeated checkGpu() calls and reopens of Settings hit the cache.

### Pre-flight gating

- checkVulkanSupport(platform, exists, wslSupport?, profile?) extended in dashboard/electron/dockerManager.ts with backwards-compatible defaults. All v1.3.4 callers (test fixtures, startContainer) work unchanged.
- New 'vulkan-wsl2' branch returns actionable errors for non-Win32, missing WSL2 backend, or failing /dev/dxg probe — with the underlying probe reason surfaced when present.
- Image-presence preflight: hasVulkanWsl2SidecarImage() checks for the locally-built image before Compose runs and surfaces an actionable error pointing at the build helper script (NOT a Docker daemon error).

### Compose plumbing

- server/docker/docker-compose.vulkan-wsl2.yml — sidecar service mounts /dev/dxg + /usr/lib/wsl:/usr/lib/wsl:ro, sets LD_LIBRARY_PATH=/usr/lib/wsl/lib, VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/dzn_icd.x86_64.json, optional MESA_D3D12_DEFAULT_ADAPTER_NAME (validated against /^[A-Za-z0-9 _.\-]{0,128}$/ before being written to .env), and pull_policy: never so a missing local image fails fast with a clean error.
- server/docker/whisper-cpp-vulkan-wsl2.Dockerfile — FROM ghcr.io/ggml-org/whisper.cpp:main-vulkan, adds ppa:kisak/turtle (currently the most reliable Ubuntu source for Mesa with microsoft-experimental enabled), installs mesa-vulkan-drivers libgl1 libglx0 libegl1 libgles2 libdrm2, and asserts dzn_icd.x86_64.json is present at build time.
- server/docker/build-vulkan-wsl2.sh (POSIX, executable) and server/docker/build-vulkan-wsl2.ps1 (Windows-native PowerShell) — local build helpers. No docker push anywhere; the image stays on the user's machine.
- composeFileArgs routes 'vulkan-wsl2' to the new overlay and includes a defense-in-depth platform guard so the overlay is never attached on non-Win32 even if a future caller bypasses checkVulkanSupport.

### Documentation

- docs/README.md §2.5 reorganized into §2.5.1 Linux (stable) and §2.5.2 Windows + WSL2 (experimental) subsections. Explicit caveats: dzn fragility, silent CPU-fallback risk, no validated whisper.cpp + dzn report yet, must build local image. Both bash and PowerShell build instructions side-by-side.
- docs/README_DEV.md §6.9: networking matrix expanded with WSL2 row, dataflow diagram added (/dev/dxg → libdxcore.so → dzn → libvulkan), admonition rewritten.
- docs/project-context.md: profile auto-selection priority footnote, opt-in semantics noted explicitly.

### Verification

| Check                                   | Result                                                                 |
|----------------------------------------|------------------------------------------------------------------------|
| TypeScript (tsc --noEmit)              | clean                                                                  |
| Tests (vitest run)                     | 1061 passed across 60 files (+6 net)                                   |
| UI contract (ui:contract:check)        | clean (spec_version 1.0.40)                                            |
| Pre-commit hooks                       | all passed (prettier, codespell, JSON/YAML, UI contract, large-files)  |
| Adversarial review (3 subagents in parallel) | acceptance auditor: GO; 13 patches landed in this PR, 7 deferred |

### New test coverage

- dashboard/electron/__tests__/wslDetect.test.ts (NEW) — 14 cases: parser pinning (WSL2/Hyper-V/native Linux/empty/malformed/CRLF/case-insensitive), dispatcher behaviors (probe ok/fail, Hyper-V short-circuit, docker info throw), single-flight caching, rejection-clearing.
- dashboard/electron/__tests__/dockerManagerVulkanPreflight.test.ts — +9 cases for vulkan-wsl2 × wslSupport permutations and back-compat regressions (legacy v1.3.4 darwin behavior pinned).
- dashboard/electron/__tests__/composeFileArgs.test.ts — +4 cases including defense-in-depth platform guards.
- isRuntimeProfile mocks updated in 3 component tests (ServerView.test.tsx, SessionView.test.tsx, SessionView.canary-language.test.tsx) to recognize 'vulkan-wsl2'.

### Test plan (post-merge)

#### For Linux maintainers:
- On Linux + AMD/Intel + /dev/dri/renderD128: open Settings, pick GPU (Vulkan), Start Server. Confirm sidecar starts identically to v1.3.4 (no regression).
- On Linux without /dev/dri: confirm the existing WSL2/driver-missing error message still surfaces.
- On Linux: confirm no "Vulkan WSL2 (experimental)" button appears anywhere (probe gated to Win32).

#### For volunteer Windows + AMD/Intel testers (recruit via Issue #101):
- Build the WSL2 image once: powershell -ExecutionPolicy Bypass -File .\server\docker\build-vulkan-wsl2.ps1 (or bash server/docker/build-vulkan-wsl2.sh from Git Bash). Verify docker images | findstr whisper-cpp-vulkan-wsl2.
- On Docker Desktop with WSL2 backend: confirm the experimental button appears in both Settings and ServerView.
- Switch Docker Desktop to Hyper-V backend, restart dashboard: confirm the button disappears.
- Pick the experimental profile + Start Server with the image present: sidecar should start; if dzn doesn't enumerate the GPU, transcription will be CPU-bound (visible in speed) — please run docker exec <whisper-server-container> vulkaninfo --summary and report whether you see llvmpipe only or a real GPU device.
- Pick the experimental profile + Start Server with the image missing: dashboard should surface an actionable error pointing at the build script (NOT a Docker daemon error).

### What's intentionally out of scope

The custom sidecar image is not published to GHCR for v1.3.5. Promotion to GHCR is gated on a real-world AMD/Intel WSL2 validator confirming /dev/dxg enumeration via dzn (i.e. vulkaninfo --summary lists a discrete or integrated GPU device, not just llvmpipe). Until then, every WSL2 user builds locally — this is by design to avoid shipping a broken-looking image to GHCR that silently CPU-falls-back without anyone noticing.

Other deferred refinements (Docker Desktop backend toggle invalidation mid-session, JSON-output parser upgrade, corrupted-layer detection on image inspect, --rm container leak on SIGKILL) are tracked in _bmad-output/implementation-artifacts/deferred-work.md with concrete defense shapes for follow-up PRs.
