### PR TITLE
fix(server, docker): unblock legacy-cu126 bootstrap for pyannote-pipeline 4.0.0 / tqdm>=4.67.1 (Issue #115)

### DIFF
--- a/server/backend/tests/test_bootstrap_runtime.py
+++ b/server/backend/tests/test_bootstrap_runtime.py
@@ -1275,8 +1275,21 @@ def test_run_dependency_sync_legacy_cu126_drops_frozen_and_overrides_cu129_name(
         "cu126 path must reuse the `pytorch-cu129` name with the cu126 URL — "
         "adding a new index name would not override the `[tool.uv.sources]` pin"
     )
-    # No --index-strategy override — only one named index is in play post-amendment.
-    assert "--index-strategy" not in cmd
+    # Issue #115: the CLI form `--index name=url` redefines the index but does
+    # not preserve the `explicit = true` flag from pyproject, so uv would apply
+    # the default first-index policy to non-torch packages on cu126 and refuse
+    # to fall back to PyPI for newer transitive deps (e.g. tqdm>=4.67.1 needed
+    # by pyannote-pipeline 4.0.0). `unsafe-best-match` lets uv consider every
+    # index for non-explicit packages while keeping torch/torchaudio pinned to
+    # the cu126-swapped index via [tool.uv.sources].
+    assert "--index-strategy" in cmd, (
+        "cu126 path must pass --index-strategy unsafe-best-match (Issue #115)"
+    )
+    strategy_idx = cmd.index("--index-strategy")
+    assert cmd[strategy_idx + 1] == "unsafe-best-match", (
+        "cu126 path must use unsafe-best-match so uv considers PyPI for "
+        "non-torch packages whose pinned versions don't exist on cu126"
+    )
 
 
 def test_run_dependency_sync_legacy_propagates_extras(

--- a/server/docker/bootstrap_runtime.py
+++ b/server/docker/bootstrap_runtime.py
@@ -385,6 +385,21 @@ def run_dependency_sync(
                           untouched and uv would still install cu129 wheels.
                           uv.lock pins wheel hashes to the cu129 URL, so
                           --frozen would reject the cu126 wheels; hence drop it.
+
+    Index strategy on cu126 (Issue #115):
+        The CLI form `--index name=url` redefines the named index but does
+        not preserve the `explicit = true` flag set in pyproject.toml, so uv
+        treats cu126 as a general-purpose index and applies the default
+        first-index-only policy to *every* package it happens to host
+        (numpy, tqdm, etc.). When pyannote-pipeline 4.0.0 (transitive from
+        pyannote.audio>=4.0.4) requires tqdm>=4.67.1 but cu126 hosts only
+        tqdm 4.66.5, that policy refuses to fall back to PyPI and the sync
+        fails with "your project's requirements are unsatisfiable". Passing
+        `--index-strategy unsafe-best-match` tells uv to consider every
+        index for non-explicit packages and pick the highest matching
+        version — torch/torchaudio still resolve from cu126 because they
+        are explicitly source-pinned, while everything else resolves from
+        whichever index has a satisfying version (PyPI, in practice).
     """
     cmd: list[str] = [
         "uv",
@@ -399,6 +414,8 @@ def run_dependency_sync(
             [
                 "--index",
                 "pytorch-cu129=https://download.pytorch.org/whl/cu126",
+                "--index-strategy",
+                "unsafe-best-match",
             ]
         )
     else:


### PR DESCRIPTION
## Summary

- The legacy-GPU image `ghcr.io/homelab-00/transcriptionsuite:legacy-1.3.5` (also `legacy-1.3.4`) fails to start on a clean install with `your project's requirements are unsatisfiable` during the runtime `uv sync`.
- Root cause is in the legacy bootstrap path's `uv` invocation, not in the user's Docker volumes — the bootstrap log already shows `mode=rebuild-sync reason=structural_mismatch`, meaning the venv is rebuilt from scratch on every boot and would hit the same resolution failure regardless of cached state.
- Fix is a one-flag change in `server/docker/bootstrap_runtime.py`: pass `--index-strategy unsafe-best-match` on the cu126 path so uv can resolve transitive deps from PyPI when the cu126 wheel index doesn't host a satisfying version.

## Root cause

Two interacting facts produce the failure:

1. The cu126 (Pascal/Maxwell) image reuses the named index `pytorch-cu129` with a swapped URL via the CLI:

   ```
   uv sync --no-dev --project /app/server \
           --index pytorch-cu129=https://download.pytorch.org/whl/cu126 \
           --extra nemo --extra whisper
   ```

   The CLI form `--index name=url` redefines the named index but does **not** preserve the `explicit = true` flag set on `[[tool.uv.index]]` in `server/backend/pyproject.toml:166-169`. As a result, uv treats the cu126 wheel index as a general-purpose source and applies the default first-index policy to **every** package the cu126 index happens to host (numpy, tqdm, sympy, …).

2. The 1.3.4/1.3.5 dependency graph requires `pyannote.audio>=4.0.4` (`server/backend/pyproject.toml:33`), which transitively pulls in `pyannote-pipeline==4.0.0`, which requires `tqdm>=4.67.1`. The cu126 index hosts only `tqdm 4.66.5`. Under the default first-index policy, uv refuses to look at PyPI for newer versions and fails with:

   ```
   × No solution found …
     ╰─▶ Because only tqdm<=4.66.5 is available and pyannote-pipeline==4.0.0
         depends on tqdm>=4.67.1, we can conclude that pyannote-pipeline==4.0.0
         cannot be used.
   ```

uv's own error hint recommends `--index-strategy unsafe-best-match` for this exact situation. That is what this PR adds.

The standard cu129 image is unaffected — the cu129 wheel index ships a newer `tqdm`, so the resolver succeeds without any strategy override. Only the legacy variant breaks, which is why the regression slipped past 1.3.4 and 1.3.5 release smoke testing.

## Change

`server/docker/bootstrap_runtime.py` (cu126 branch only):

```python
if pytorch_variant == "cu126":
    cmd.extend([
        "--index",
        "pytorch-cu129=https://download.pytorch.org/whl/cu126",
        "--index-strategy",        # NEW
        "unsafe-best-match",       # NEW
    ])
```

The cu129 default path is byte-identical to before. Module docstring updated to document the new behavior under an "Index strategy on cu126 (Issue #115)" subsection.

### Why `unsafe-best-match` is safe here

- `torch` and `torchaudio` are pinned via `[tool.uv.sources]` to the `pytorch-cu129` named index — those continue to resolve from cu126 (post-URL-swap) regardless of the strategy.
- For every other package (the actual problem space), the cu126 mirror is just a stale partial copy of PyPI. Letting uv pick the highest matching version across indexes is the desired behavior — it's what the cu129 path effectively does already (cu129 just happens to have newer wheels so the strategy doesn't matter there).
- The `unsafe` label refers to dependency-confusion risk (a malicious PyPI upload shadowing a private package). Not relevant here: cu126 hosts only public open-source packages already on PyPI.

## Validation

- `server/backend/tests/test_bootstrap_runtime.py::test_run_dependency_sync_legacy_cu126_*` updated to assert `--index-strategy unsafe-best-match` is present on the cu126 path.
- `test_run_dependency_sync_default_cu129_uses_frozen` continues to assert no strategy override on cu129 (unchanged contract).
- Full backend suite: **1873 passed, 3 skipped** (`pytest server/backend/tests/`).
- Manual reasoning trace: the resolver should now find tqdm 4.67.1+ on PyPI, satisfying `pyannote-pipeline==4.0.0`, which satisfies `pyannote.audio>=4.0.4`, which makes the dependency graph solvable. The next legacy-cu126 build will reproduce this in CI/release smoke.

## Test plan

- [ ] Rebuild legacy-cu126 image locally with this branch checked out: `docker build --build-arg PYTORCH_VARIANT=cu126 -t ts-legacy-test -f server/docker/Dockerfile .`
- [ ] Verify the runtime bootstrap completes `uv sync` without the `pyannote-pipeline / tqdm` error
- [ ] Boot a container with at least one volume bind to confirm an end-to-end clean start
- [ ] (Optional) reproduce Nate's failure on legacy-1.3.5 BEFORE the fix to confirm the same path triggers it, then re-run on this branch's image
- [ ] CI: legacy-image GHA workflow goes green
- [ ] Republish `ghcr.io/homelab-00/transcriptionsuite:legacy-1.3.5` from the rebuilt image (in-place tag overwrite, per maintainer decision in issue thread)
- [ ] Post a follow-up note on Issue #115 once the new image is live so Nate can `docker pull --platform linux/amd64 ghcr.io/homelab-00/transcriptionsuite:legacy-1.3.5` and retry
