### PR TITLE
fix(server, stt, tests): route nvidia/canary-1b-v2 to NeMo's EncDecMultiTaskModel and skip RNN-T-only Hydra override

### DIFF
--- a/server/backend/core/stt/backends/canary_backend.py
+++ b/server/backend/core/stt/backends/canary_backend.py
@@ -33,9 +33,45 @@ logger = logging.getLogger(__name__)
 class CanaryBackend(ParakeetBackend):
     """NVIDIA Canary / NeMo multitask ASR + translation backend."""
 
+    # NeMo loads Canary checkpoints via ``EncDecMultiTaskModel`` — the AED
+    # (Attention Encoder-Decoder) class. Loading them with the inherited
+    # Parakeet default (``EncDecRNNTBPEModel``) crashes in
+    # ``rnnt_bpe_models.py`` with ``ConfigAttributeError: Key 'decoder' is
+    # not in struct`` because the saved Canary config has ``encoder`` and
+    # ``decoding`` only — there is no top-level ``decoder`` key for the
+    # RNN-T transducer. Confirmed via NeMo's official Canary tutorial,
+    # which loads ``nvidia/canary-1b-v2`` with ``EncDecMultiTaskModel``.
+    _NEMO_MODEL_CLASS_NAME: str = "EncDecMultiTaskModel"
+    # Canary's AED model rejects Parakeet's minimal ``decoding.greedy``
+    # override at restore time (the AED loader insists the override config
+    # supply a full ``tokenizer`` section). Skip the pre-load Hydra patch
+    # entirely — the RNN-T-specific CUDA-graph workaround it carries does
+    # not apply to AED decoding.
+    _LOAD_OVERRIDE_CONFIG: dict[str, Any] | None = None
+
     # ------------------------------------------------------------------
     # STTBackend interface overrides
     # ------------------------------------------------------------------
+
+    def _apply_post_load_setup(self, model: Any) -> None:
+        """Canary AED post-load configuration.
+
+        The Parakeet superclass applies the RNN-T CUDA-graph workaround and
+        the optional ``parakeet:`` Conformer-encoder tweaks. Both target
+        constructs that do not exist on the Canary AED model:
+
+        * the CUDA-graph patch reads ``cfg.decoding.greedy.use_cuda_graph_decoder``,
+          which Canary's beam-search-over-Transformer-decoder configuration
+          does not define;
+        * ``change_attention_model`` / ``change_subsampling_conv_chunking_factor``
+          target the Conformer encoder helpers and are gated on the
+          ``parakeet:`` config block — applying them implicitly to a
+          Canary load would silently re-shape its encoder.
+
+        Just record ``_max_chunk_duration_s`` so the inherited chunking
+        path in ``_transcribe_long`` has a sane value.
+        """
+        self._max_chunk_duration_s = MAX_CHUNK_DURATION
 
     def _do_warmup(self) -> None:
         """Internal method to perform actual Canary warmup."""

--- a/server/backend/core/stt/backends/parakeet_backend.py
+++ b/server/backend/core/stt/backends/parakeet_backend.py
@@ -76,6 +76,23 @@ def _import_nemo_asr() -> Any:
 class ParakeetBackend(STTBackend):
     """NVIDIA Parakeet / NeMo ASR backend."""
 
+    # ------------------------------------------------------------------
+    # Subclass override hooks
+    # ------------------------------------------------------------------
+    # Concrete NeMo model class used by ``load()``. Subclasses targeting
+    # different NeMo model families (e.g. CanaryBackend's AED multitask
+    # model) override this instead of duplicating the full ``load()`` body.
+    _NEMO_MODEL_CLASS_NAME: str = "EncDecRNNTBPEModel"
+    # Optional Hydra override config written to a temp YAML and passed as
+    # ``override_config_path`` to ``from_pretrained()`` / ``restore_from()``.
+    # Disables NeMo's CUDA graph decoder for CUDA ≥ 12.8 (RNN-T-specific).
+    # Subclasses whose model class rejects this minimal override (e.g. the
+    # Canary AED model, which insists the override include a tokenizer
+    # section) set this to ``None`` to skip pre-load patching entirely.
+    _LOAD_OVERRIDE_CONFIG: dict[str, Any] | None = {
+        "decoding": {"greedy": {"use_cuda_graph_decoder": False}}
+    }
+
     def __init__(self) -> None:
         self._model: Any | None = None
         self._model_name: str | None = None
@@ -218,7 +235,7 @@ class ParakeetBackend(STTBackend):
 
     def load(self, model_name: str, device: str, **kwargs: Any) -> None:
         nemo_asr = _import_nemo_asr()
-        logger.info(f"Loading Parakeet model: {model_name}")
+        logger.info(f"Loading {self.backend_name.capitalize()} model: {model_name}")
 
         # Fix 5: Check if model is cached locally and use restore_from()
         import tempfile
@@ -231,18 +248,26 @@ class ParakeetBackend(STTBackend):
         config_override_path = None
 
         try:
-            # Create a minimal config override to disable CUDA graphs (Fix 2)
-            override_dict = {"decoding": {"greedy": {"use_cuda_graph_decoder": False}}}
+            # Optional Hydra override (RNN-T-specific CUDA-graph disable, Fix 2).
+            # Subclasses set ``_LOAD_OVERRIDE_CONFIG = None`` to skip this when
+            # their NeMo model class rejects the minimal override at restore
+            # time (e.g. Canary's AED model demands a full tokenizer section).
+            override_dict = self._LOAD_OVERRIDE_CONFIG
 
-            # Write to a temporary YAML file
-            with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tmp:
-                yaml.dump(override_dict, tmp)
-                config_override_path = tmp.name
+            if override_dict is not None:
+                with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tmp:
+                    yaml.dump(override_dict, tmp)
+                    config_override_path = tmp.name
 
-            # Use concrete EncDecRNNTBPEModel instead of abstract ASRModel
-            # to avoid "Can't instantiate abstract class ASRModel" errors
-            # when NeMo fails to resolve the target class from config.
-            model_cls = nemo_asr.models.EncDecRNNTBPEModel
+            # Resolve the concrete NeMo model class from the subclass-overridable
+            # ``_NEMO_MODEL_CLASS_NAME`` attribute. Using a concrete class
+            # (rather than abstract ``ASRModel``) avoids "Can't instantiate
+            # abstract class" errors when NeMo's saved-config target lookup
+            # fails. CanaryBackend overrides this to ``"EncDecMultiTaskModel"``
+            # so its AED checkpoint is loaded by the right class — using the
+            # default RNN-T BPE class on a Canary model crashes inside
+            # ``rnnt_bpe_models.py`` with ``cfg.decoder`` not in struct.
+            model_cls = getattr(nemo_asr.models, self._NEMO_MODEL_CLASS_NAME)
 
             def _load_with_optional_override(
                 load_fn: Any, load_name: str, **load_kwargs: Any
@@ -311,9 +336,31 @@ class ParakeetBackend(STTBackend):
 
         model = model.to(device)
         model.eval()
+        self._apply_post_load_setup(model)
+
+        self._model = model
+        self._model_name = model_name
+        logger.info(
+            "%s model loaded (max_chunk_duration_s=%d)",
+            self.backend_name.capitalize(),
+            self._max_chunk_duration_s,
+        )
+
+    def _apply_post_load_setup(self, model: Any) -> None:
+        """Apply RNN-T / Parakeet-specific post-load configuration.
+
+        Disables NeMo's CUDA graph decoder (incompatible with CUDA ≥ 12.8),
+        applies optional Conformer encoder optimisations from the
+        ``parakeet:`` config block, and resolves ``_max_chunk_duration_s``.
+
+        Subclasses targeting non-RNN-T NeMo models (e.g. Canary's AED
+        multitask backend) override this — both the CUDA-graph patch and
+        the encoder helpers are tied to the RNN-T decoding stack and the
+        Conformer encoder respectively, neither of which apply to AED
+        attention-encoder-decoder models.
+        """
         self._disable_cuda_graphs(model)
 
-        # Apply NeMo memory optimizations from config
         cfg = get_config()
         parakeet_cfg = cfg.get("parakeet", default={}) or {}
 
@@ -326,7 +373,6 @@ class ParakeetBackend(STTBackend):
             model.change_subsampling_conv_chunking_factor(1)
             logger.info("Enabled subsampling conv chunking (factor=1)")
 
-        # Configurable chunk duration (default 300s = 5 min)
         try:
             self._max_chunk_duration_s = max(
                 60,
@@ -334,10 +380,6 @@ class ParakeetBackend(STTBackend):
             )
         except (TypeError, ValueError):
             self._max_chunk_duration_s = 300
-
-        self._model = model
-        self._model_name = model_name
-        logger.info("Parakeet model loaded (max_chunk_duration_s=%d)", self._max_chunk_duration_s)
 
     def unload(self) -> None:
         self._model = None

--- a/server/backend/tests/test_canary_backend_load.py
+++ b/server/backend/tests/test_canary_backend_load.py
@@ -1,0 +1,294 @@
+"""Unit tests for the NeMo Canary v2 loader fix.
+
+Confirms that loading ``nvidia/canary-1b-v2`` routes through CanaryBackend
+and instantiates the AED ``EncDecMultiTaskModel`` class — never the
+RNN-T-only ``EncDecRNNTBPEModel`` class that crashes on Canary's saved
+config (``omegaconf.errors.ConfigAttributeError: Key 'decoder' is not in
+struct``).
+
+Mocks NeMo at the ``_import_nemo_asr`` boundary so the tests run on any
+host without the heavy ``nemo_toolkit`` dependency installed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_fake_nemo_asr() -> tuple[MagicMock, MagicMock, MagicMock, MagicMock]:
+    """Build a fake ``nemo.collections.asr`` namespace with both classes.
+
+    Returns ``(nemo_asr, rnnt_cls, multitask_cls, loaded_model)`` so each
+    test can assert on which class was actually invoked and inspect the
+    keyword arguments passed to ``from_pretrained`` / ``restore_from``.
+    """
+    loaded_model = MagicMock(name="loaded_model")
+    # ``model = model.to(device)`` reassigns ``model`` to the ``.to`` return
+    # value, so the same mock object must come back to keep ``.eval()`` and
+    # downstream attribute access pointing at the correct instance.
+    loaded_model.to.return_value = loaded_model
+
+    rnnt_cls = MagicMock(name="EncDecRNNTBPEModel")
+    rnnt_cls.from_pretrained.return_value = loaded_model
+    rnnt_cls.restore_from.return_value = loaded_model
+
+    multitask_cls = MagicMock(name="EncDecMultiTaskModel")
+    multitask_cls.from_pretrained.return_value = loaded_model
+    multitask_cls.restore_from.return_value = loaded_model
+
+    nemo_asr = MagicMock(name="nemo_asr")
+    nemo_asr.models = MagicMock(name="nemo_asr.models")
+    nemo_asr.models.EncDecRNNTBPEModel = rnnt_cls
+    nemo_asr.models.EncDecMultiTaskModel = multitask_cls
+
+    return nemo_asr, rnnt_cls, multitask_cls, loaded_model
+
+
+# ---------------------------------------------------------------------------
+# Subclass override hooks: class-level routing
+# ---------------------------------------------------------------------------
+
+
+class TestNemoModelClassRouting:
+    """The two backends must announce the right NeMo model class via the
+    ``_NEMO_MODEL_CLASS_NAME`` hook. Routing the wrong class through
+    ``EncDecRNNTBPEModel.from_pretrained()`` is what crashes Canary v2 with
+    ``ConfigAttributeError: Key 'decoder' is not in struct``.
+    """
+
+    def test_parakeet_default_class_is_rnnt_bpe(self) -> None:
+        from server.core.stt.backends.parakeet_backend import ParakeetBackend
+
+        assert ParakeetBackend._NEMO_MODEL_CLASS_NAME == "EncDecRNNTBPEModel"
+
+    def test_canary_overrides_class_to_aed_multitask(self) -> None:
+        from server.core.stt.backends.canary_backend import CanaryBackend
+
+        assert CanaryBackend._NEMO_MODEL_CLASS_NAME == "EncDecMultiTaskModel"
+
+    def test_parakeet_default_override_disables_cuda_graph_decoder(self) -> None:
+        from server.core.stt.backends.parakeet_backend import ParakeetBackend
+
+        assert ParakeetBackend._LOAD_OVERRIDE_CONFIG == {
+            "decoding": {"greedy": {"use_cuda_graph_decoder": False}}
+        }
+
+    def test_canary_skips_load_override_config(self) -> None:
+        """Canary's AED loader rejects Parakeet's minimal ``decoding.greedy``
+        Hydra override at restore time (the AED class demands a full
+        ``tokenizer`` section). Skipping the override entirely is the only
+        way the v2 model loads cleanly under default cu129 builds.
+        """
+        from server.core.stt.backends.canary_backend import CanaryBackend
+
+        assert CanaryBackend._LOAD_OVERRIDE_CONFIG is None
+
+
+# ---------------------------------------------------------------------------
+# Factory routing: defensive check for the canary-1b-v2 model id
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryRoutingForCanaryV2:
+    """``test_stt_backend_factory.py`` already covers basic routing; this
+    duplicate exists to guard against an accidental regex tightening that
+    excludes the ``-v2`` suffix or instantiates the wrong backend class.
+    """
+
+    def test_detect_backend_type_returns_canary(self) -> None:
+        from server.core.stt.backends.factory import detect_backend_type
+
+        assert detect_backend_type("nvidia/canary-1b-v2") == "canary"
+
+    def test_create_backend_returns_canary_backend_instance(self) -> None:
+        from server.core.stt.backends.canary_backend import CanaryBackend
+        from server.core.stt.backends.factory import create_backend
+
+        backend = create_backend("nvidia/canary-1b-v2")
+        assert isinstance(backend, CanaryBackend)
+
+
+# ---------------------------------------------------------------------------
+# load() integration: confirm the right NeMo class is invoked
+# ---------------------------------------------------------------------------
+
+
+class TestCanaryLoadUsesAedClass:
+    """End-to-end coverage of ``CanaryBackend.load()`` with NeMo mocked."""
+
+    def test_canary_load_calls_encdec_multitask_from_pretrained(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Loading ``nvidia/canary-1b-v2`` MUST invoke
+        ``EncDecMultiTaskModel.from_pretrained`` and NOT the RNN-T BPE
+        class. Regression test for the omegaconf ``cfg.decoder`` crash.
+        """
+        from server.core.stt.backends import canary_backend, parakeet_backend
+
+        nemo_asr, rnnt_cls, multitask_cls, _model = _build_fake_nemo_asr()
+
+        monkeypatch.setattr(parakeet_backend, "_import_nemo_asr", lambda: nemo_asr)
+        # No cached ``.nemo`` file → take the from_pretrained branch
+        monkeypatch.setattr(
+            parakeet_backend.ParakeetBackend,
+            "_find_cached_nemo_file",
+            staticmethod(lambda model_name: None),
+        )
+
+        backend = canary_backend.CanaryBackend()
+        backend.load("nvidia/canary-1b-v2", "cpu")
+
+        multitask_cls.from_pretrained.assert_called_once()
+        rnnt_cls.from_pretrained.assert_not_called()
+        rnnt_cls.restore_from.assert_not_called()
+
+        kwargs = multitask_cls.from_pretrained.call_args.kwargs
+        assert kwargs.get("model_name") == "nvidia/canary-1b-v2"
+
+    def test_canary_load_skips_override_config_path_kwarg(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Canary load must NOT pass ``override_config_path`` — Parakeet's
+        RNN-T-specific override would be rejected by the AED loader and
+        force a noisy retry with no useful effect for AED decoding.
+        """
+        from server.core.stt.backends import canary_backend, parakeet_backend
+
+        nemo_asr, _rnnt_cls, multitask_cls, _model = _build_fake_nemo_asr()
+
+        monkeypatch.setattr(parakeet_backend, "_import_nemo_asr", lambda: nemo_asr)
+        monkeypatch.setattr(
+            parakeet_backend.ParakeetBackend,
+            "_find_cached_nemo_file",
+            staticmethod(lambda model_name: None),
+        )
+
+        backend = canary_backend.CanaryBackend()
+        backend.load("nvidia/canary-1b-v2", "cpu")
+
+        kwargs = multitask_cls.from_pretrained.call_args.kwargs
+        assert "override_config_path" not in kwargs
+
+    def test_canary_load_sets_max_chunk_duration_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The Canary post-load hook must initialise ``_max_chunk_duration_s``
+        so the inherited ``_transcribe_long`` chunking path has a usable
+        value (Parakeet's hook reads the ``parakeet:`` config block — that
+        path does not apply to Canary).
+        """
+        from server.core.stt.backends import canary_backend, parakeet_backend
+
+        nemo_asr, *_ = _build_fake_nemo_asr()
+
+        monkeypatch.setattr(parakeet_backend, "_import_nemo_asr", lambda: nemo_asr)
+        monkeypatch.setattr(
+            parakeet_backend.ParakeetBackend,
+            "_find_cached_nemo_file",
+            staticmethod(lambda model_name: None),
+        )
+
+        backend = canary_backend.CanaryBackend()
+        backend.load("nvidia/canary-1b-v2", "cpu")
+
+        assert backend._max_chunk_duration_s == parakeet_backend.MAX_CHUNK_DURATION
+
+    def test_canary_load_does_not_invoke_parakeet_post_load_setup(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The RNN-T CUDA-graph workaround and Conformer encoder helpers
+        belong to the Parakeet post-load hook — they target constructs
+        that do not exist on the Canary AED model. Canary's override must
+        not call them; if it did, ``_disable_cuda_graphs`` would import
+        omegaconf and ``change_attention_model`` would silently re-shape
+        the encoder.
+        """
+        from server.core.stt.backends import canary_backend, parakeet_backend
+
+        nemo_asr, *_ = _build_fake_nemo_asr()
+
+        monkeypatch.setattr(parakeet_backend, "_import_nemo_asr", lambda: nemo_asr)
+        monkeypatch.setattr(
+            parakeet_backend.ParakeetBackend,
+            "_find_cached_nemo_file",
+            staticmethod(lambda model_name: None),
+        )
+
+        sentinel = MagicMock()
+        monkeypatch.setattr(
+            parakeet_backend.ParakeetBackend,
+            "_disable_cuda_graphs",
+            staticmethod(sentinel),
+        )
+
+        backend = canary_backend.CanaryBackend()
+        backend.load("nvidia/canary-1b-v2", "cpu")
+
+        sentinel.assert_not_called()
+
+
+class TestParakeetLoadStillUsesRnntClass:
+    """Regression check: refactoring the override hooks must not change
+    the Parakeet-default behaviour. Parakeet keeps loading via the RNN-T
+    BPE class with the CUDA-graph override pre-applied.
+    """
+
+    def test_parakeet_load_calls_encdec_rnnt_bpe_from_pretrained(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from server.core.stt.backends import parakeet_backend
+
+        nemo_asr, rnnt_cls, multitask_cls, _model = _build_fake_nemo_asr()
+
+        monkeypatch.setattr(parakeet_backend, "_import_nemo_asr", lambda: nemo_asr)
+        monkeypatch.setattr(
+            parakeet_backend.ParakeetBackend,
+            "_find_cached_nemo_file",
+            staticmethod(lambda model_name: None),
+        )
+        # Avoid pulling in omegaconf / config-driven Conformer tweaks.
+        monkeypatch.setattr(
+            parakeet_backend.ParakeetBackend,
+            "_apply_post_load_setup",
+            lambda self, model: None,
+        )
+
+        backend = parakeet_backend.ParakeetBackend()
+        backend.load("nvidia/parakeet-tdt-0.6b-v3", "cpu")
+
+        rnnt_cls.from_pretrained.assert_called_once()
+        multitask_cls.from_pretrained.assert_not_called()
+
+    def test_parakeet_load_passes_override_config_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The CUDA-graph override is still produced and forwarded for the
+        RNN-T-default path."""
+        from server.core.stt.backends import parakeet_backend
+
+        nemo_asr, rnnt_cls, _multitask_cls, _model = _build_fake_nemo_asr()
+
+        monkeypatch.setattr(parakeet_backend, "_import_nemo_asr", lambda: nemo_asr)
+        monkeypatch.setattr(
+            parakeet_backend.ParakeetBackend,
+            "_find_cached_nemo_file",
+            staticmethod(lambda model_name: None),
+        )
+        monkeypatch.setattr(
+            parakeet_backend.ParakeetBackend,
+            "_apply_post_load_setup",
+            lambda self, model: None,
+        )
+
+        backend = parakeet_backend.ParakeetBackend()
+        backend.load("nvidia/parakeet-tdt-0.6b-v3", "cpu")
+
+        kwargs = rnnt_cls.from_pretrained.call_args.kwargs
+        assert "override_config_path" in kwargs
+        assert kwargs["override_config_path"] is not None


### PR DESCRIPTION
## Summary

- The default cu129 image (and, by extension, the legacy cu126 image) crashes
  during server startup when `main_model: nvidia/canary-1b-v2` is configured.
  Bootstrap and `uv sync` complete cleanly; the failure is in the FastAPI
  lifespan model preload, mid-NeMo `from_pretrained()`.
- Root cause is **not** routing — `factory.detect_backend_type` correctly
  returns `"canary"` and `create_backend()` instantiates `CanaryBackend`.
  The bug is that `CanaryBackend(ParakeetBackend)` did not override
  `load()`, so it inherited a body that hardcoded
  `model_cls = nemo_asr.models.EncDecRNNTBPEModel`. Canary checkpoints are
  AED (Attention-Encoder-Decoder) models and must load via
  `EncDecMultiTaskModel`. NeMo's saved Canary config has `encoder` and
  `decoding` only (no top-level `decoder`), so RNN-T-class init dies with
  `omegaconf.errors.ConfigAttributeError: Key 'decoder' is not in struct`.
- Fix is a small surgical change in two files: factor three subclass
  override hooks on `ParakeetBackend` (`_NEMO_MODEL_CLASS_NAME`,
  `_LOAD_OVERRIDE_CONFIG`, `_apply_post_load_setup`) and override them in
  `CanaryBackend`. ParakeetBackend's default behaviour is byte-identical
  to before.

## Root cause

The user's log shows three signals that, together, point at a wrong-class
load rather than a NeMo packaging issue:

1. The first preload line is `Loading Parakeet model: nvidia/canary-1b-v2`,
   logged from `server.core.stt.backends.parakeet_backend`. That logger
   only fires from `ParakeetBackend.load()` — `CanaryBackend` did not
   override `load()` and so was using the inherited body verbatim.

2. After ~3.5 min of download + first-attempt warmup, NeMo emits

   ```
   from_pretrained() rejected minimal override config
   (`cfg` must have `tokenizer` config to create a tokenizer !);
   retrying without pre-patch
   ```

   Parakeet's pre-load Hydra override (`{decoding: {greedy:
   {use_cuda_graph_decoder: false}}}`) is RNN-T-decoding-specific.
   The AED loader treats override YAMLs as a full config and rejects ours
   because it lacks a `tokenizer` section. This is the path that produces
   the `restore_from()` retry without override.

3. The retry then enters `EncDecRNNTBPEModel.__init__` and dies on:

   ```
   File ".../nemo/collections/asr/models/rnnt_bpe_models.py", line 306, in __init__
       with open_dict(cfg.decoder):
                      ^^^^^^^^^^^
   omegaconf.errors.ConfigAttributeError: Key 'decoder' is not in struct
       full_key: decoder
       object_type=dict. Did you mean: 'encoder'?
   ```

   This is the structural mismatch: Canary's saved config carries
   `encoder` (FastConformer) and `decoding` (multitask beam search) but
   has no `decoder` key. The `Did you mean: 'encoder'?` hint is the
   omegaconf struct-mode similar-key suggestion.

NeMo's official Canary tutorial loads the same checkpoint via the
correct class:

```python
from nemo.collections.asr.models import EncDecMultiTaskModel
canary_model = EncDecMultiTaskModel.from_pretrained('nvidia/canary-1b-v2', map_location=map_location)
```

(`tutorials/asr/Canary_Multitask_Speech_Model.ipynb` in NVIDIA/NeMo.)
This is the single source of truth for what class Canary needs.

## Change

Three subclass override hooks are added to `ParakeetBackend`:

```python
class ParakeetBackend(STTBackend):
    _NEMO_MODEL_CLASS_NAME: str = "EncDecRNNTBPEModel"
    _LOAD_OVERRIDE_CONFIG: dict[str, Any] | None = {
        "decoding": {"greedy": {"use_cuda_graph_decoder": False}}
    }
    # ...
    def _apply_post_load_setup(self, model: Any) -> None:
        # CUDA-graph workaround + parakeet: config block + chunking
        ...
```

`load()` reads them via `getattr` / direct attribute access, so the
default Parakeet path is byte-identical to before. The hardcoded
`"Parakeet"` log strings are replaced by `self.backend_name.capitalize()`
so Canary loads no longer log under the Parakeet logger.

`CanaryBackend` overrides all three:

```python
class CanaryBackend(ParakeetBackend):
    _NEMO_MODEL_CLASS_NAME: str = "EncDecMultiTaskModel"
    _LOAD_OVERRIDE_CONFIG: dict[str, Any] | None = None  # AED model rejects RNN-T override

    def _apply_post_load_setup(self, model: Any) -> None:
        # Skip RNN-T CUDA-graph patching and Parakeet's Conformer encoder
        # helpers; both target constructs that don't exist on the AED model.
        self._max_chunk_duration_s = MAX_CHUNK_DURATION
```

### Why three hooks (not just one)

| Hook | What it controls | Why Canary differs |
|------|------------------|--------------------|
| `_NEMO_MODEL_CLASS_NAME` | Which `nemo_asr.models.<Class>` is instantiated | RNN-T BPE vs AED MultiTask are different model families with different `cfg` schemas |
| `_LOAD_OVERRIDE_CONFIG` | The optional Hydra YAML written before `from_pretrained()` | AED loader rejects `decoding.greedy.use_cuda_graph_decoder` (the section is RNN-T-specific) and the "must have tokenizer" gate makes the override a no-op anyway |
| `_apply_post_load_setup()` | Calls `_disable_cuda_graphs`, `change_attention_model`, `change_subsampling_conv_chunking_factor`, and reads the `parakeet:` config block | The CUDA-graph patch is RNN-T-decoding-specific; `change_attention_model` would silently re-shape Canary's encoder; the `parakeet:` config block is the wrong source of truth for Canary chunking |

### What I considered and rejected

- **Override `load()` entirely in `CanaryBackend`.** Cleaner per-subclass
  but duplicates ~80 lines of cache lookup + temp-file scaffolding +
  device transfer + logging. Also makes future Canary-flash / 180m-flash
  variants regress against future Parakeet refactors. Rejected.
- **`isinstance(self, CanaryBackend)` branches inside `ParakeetBackend.load()`.**
  Inverts ownership — base class would have to import its subclass.
  Rejected.
- **Single `_NEMO_LOAD_PROFILE` enum hook covering all three knobs.** Too
  coarse. The three differences above don't always co-vary (e.g. a future
  encoder-only model might need a different override config but Parakeet's
  post-load setup). Three independent hooks let each axis vary alone.

## Validation

- New test file `server/backend/tests/test_canary_backend_load.py`:
  12 tests, all green. Coverage:
  - `_NEMO_MODEL_CLASS_NAME` and `_LOAD_OVERRIDE_CONFIG` defaults vs
    Canary overrides.
  - Factory routing for `nvidia/canary-1b-v2` returns `"canary"` and
    `create_backend()` returns a `CanaryBackend` instance.
  - End-to-end `CanaryBackend.load("nvidia/canary-1b-v2", "cpu")` calls
    `EncDecMultiTaskModel.from_pretrained` with `model_name=` and **no**
    `override_config_path` kwarg, sets `_max_chunk_duration_s`, and does
    not invoke `_disable_cuda_graphs`.
  - Regression: `ParakeetBackend.load("nvidia/parakeet-tdt-0.6b-v3", "cpu")`
    still calls `EncDecRNNTBPEModel.from_pretrained` with
    `override_config_path` set.
  - NeMo is mocked at the `_import_nemo_asr` boundary so the file runs
    on any host without `nemo_toolkit` installed.

- Full backend suite: **1885 passed, 3 skipped, 0 failed** (`pytest server/backend/tests/`,
  ~27 s). The 3 skips are pre-existing (MLX backend tests on Linux, one
  Sprint-5 future-feature placeholder).

- Cu126 vs cu129: this is a NeMo schema-mismatch crash, not a CUDA
  dispatch issue. The fix lands in CPU-load-path code that runs
  identically on both image variants.

## Test plan

- [ ] Pull the branch and run `pytest server/backend/tests/test_canary_backend_load.py -v`
  — confirm 12/12 green.
- [ ] Pull the branch and run the full backend suite — confirm 1885+ green.
- [ ] In a default cu129 container with `main_model: nvidia/canary-1b-v2`,
  start the server and confirm:
  - Log line is `Loading Canary model: nvidia/canary-1b-v2` (not Parakeet).
  - No `from_pretrained() rejected minimal override config` warning.
  - No `ConfigAttributeError: Key 'decoder' is not in struct`.
  - Server reaches `Application startup complete`.
- [ ] Smoke: transcribe a short English clip via the Canary model — confirm
  output text + segment timestamps come back.
- [ ] Regression smoke: with `main_model: nvidia/parakeet-tdt-0.6b-v3`,
  confirm load still succeeds and the log line reads `Loading Parakeet
  model:` (capitalisation may differ from before — old log was
  `Loading Parakeet model:` literal, new log is
  `Loading {backend_name.capitalize()} model:` which evaluates to the
  same string for Parakeet).
- [ ] (Optional) Run the same scenario on the legacy cu126 image to confirm
  the fix is not GPU-dispatch-dependent.
