### PR TITLE
fix(server, dashboard, docs): resolve Windows/CPU local start failures (GH #125)

### DIFF
--- a/_bmad-output/implementation-artifacts/spec-gh-125-windows-cpu-start.md
+++ b/_bmad-output/implementation-artifacts/spec-gh-125-windows-cpu-start.md
@@ -1,0 +1,173 @@
+---
+title: 'Fix Windows/CPU local start (GH #125): CPU torch profile, HF token guard, TLS mitigation'
+type: 'bugfix'
+created: '2026-05-31'
+status: 'done'
+baseline_commit: '3e98bb0c90137572446fe803e01e0fb482074f76'
+context:
+  - '{project-root}/docs/project-context.md'
+  - '{project-root}/docs/deployment-guide.md'
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** On Windows/CPU-only setups (Issue #125), local start fails two ways: (A) first-run `uv sync` aborts with `invalid peer certificate: UnknownIssuer` while pulling multi-GB `cu129` CUDA wheels the machine can't use, because there is no CPU PyTorch variant; (B) model load crashes with `UnicodeEncodeError: 'latin-1' ... 'ş'` because a non-ASCII `HUGGINGFACE_TOKEN` is placed verbatim into the HF `Authorization` header (huggingface_hub's `_clean_token` never validates encodability), which crashes *every* backend, not just NeMo.
+
+**Approach:** Three complementary, independent fixes unified as "Windows/CPU support": (1) add a `cpu` PyTorch variant to the bootstrap (CPU wheels via index-swap, mirroring the existing `cu126` path) and have the dashboard's CPU profile select it + a faster-whisper default + `INSTALL_NEMO=false`; (2) guard `HF_TOKEN`/`HUGGINGFACE_TOKEN` at server startup — unset + warn if non-ASCII; (3) mitigate corporate-network TLS interception via opt-in `UV_NATIVE_TLS` + CA passthrough + an actionable error hint + docs. The TLS error is environmental; we mitigate and document, not "fix" the user's network.
+
+## Boundaries & Constraints
+
+**Always:**
+- Preserve byte-identical `cu129` (default) and `cu126` bootstrap behavior — GPU users must not regress. Keep `--frozen` for `cu129`.
+- CPU variant is a *safe downgrade*: a runtime `PYTORCH_VARIANT=cpu` may override a baked GPU variant (cpu wheels install over any base); other mismatches keep trusting the baked value.
+- Python: absolute imports (`from server.xxx`), return type hints, `logger = logging.getLogger(__name__)`.
+- Token guard must run before any model load and cover NeMo, faster-whisper, WhisperX, and pyannote (all read the token lazily).
+
+**Ask First:**
+- Changing the *global* default model in `config.yaml:56` (currently `nvidia/parakeet-tdt-0.6b-v3`). Default plan: do NOT change it — keep parakeet as the GPU default and let the CPU profile override per-launch via the dashboard.
+- Shipping a dedicated prebuilt CPU image (vs. the runtime-variant approach chosen here).
+
+**Never:**
+- Never disable/weaken TLS certificate verification (no `--allow-insecure-host`, no `verify=False`). `UV_NATIVE_TLS` uses the OS trust store — verification stays on.
+- Never remove the `cu126` legacy path or the baked-variant defense for non-cpu mismatches.
+- Out of scope: making NeMo/parakeet usable on CPU; auto-installing a user's corporate CA without their opt-in.
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| CPU profile on prebuilt cu129 image | runtime `PYTORCH_VARIANT=cpu`, baked `.pytorch_variant=cu129` | bootstrap installs CPU torch wheels into `/runtime/.venv`; whisper default; NeMo skipped | log downgrade, proceed |
+| Non-ASCII HF token | `HUGGINGFACE_TOKEN`=`hf_…ş…` | var unset + WARNING; anonymous HF download proceeds | warn, no crash |
+| Empty/ASCII HF token | unset or valid `hf_*` | no-op; token untouched | N/A |
+| TLS interception at sync | `uv sync` output contains `UnknownIssuer`/`invalid peer certificate` | actionable hint logged + error-event pointing to docs; `UV_NATIVE_TLS` opt-in documented | non-zero exit, hint not truncated |
+| GPU regression guard | `PYTORCH_VARIANT` unset or `cu129` | unchanged: `--frozen`, no index swap, parakeet default | N/A |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `server/docker/bootstrap_runtime.py` -- variant normalization (`:1445`), baked-variant trust (`:1459`), `run_dependency_sync` index-swap (`:411`), `build_uv_sync_env` (`:358`), sync-failure handlers (`:665`,`:710`), extras (`:1490`), `load_config_models` (`:799`)
+- `server/docker/docker-compose.yml` -- runtime `environment:` allow-list (`:72-109`); `PYTORCH_VARIANT` currently only a build-arg (`:58-64`)
+- `server/docker/Dockerfile` -- `ca-certificates` installed (`:70`) but `update-ca-certificates` never run; bakes `.pytorch_variant` (`:94`)
+- `server/backend/api/main.py` -- startup; `import os` at top; lifespan loads model (`~:623`) — token-guard site
+- `dashboard/electron/dockerManager.ts` -- `startContainer()` CPU special-case (`:2149`), model/install env writes (`:2175-2207`), `upsertComposeEnvValues` (`:2259`)
+- `dashboard/src/services/modelSelection.ts` (`:12-13`), `dashboard/src/App.tsx` (`:568`) -- recommended main model per profile
+- `docs/deployment-guide.md` (Bootstrap `:65`, env table `:211`), `docs/README.md` (env table `:217`) -- docs
+- `server/backend/tests/test_bootstrap_runtime.py` -- bootstrap test patterns to mirror (`_capture_run_dependency_sync_cmd`, `test_run_dependency_sync_legacy_cu126_*`)
+
+## Tasks & Acceptance
+
+**Execution — Fix B: HF token guard (smallest, highest-confidence):**
+- [x] `server/backend/api/main.py` -- add a small startup guard (module level after imports, or first thing in lifespan before model load): for `HF_TOKEN` and `HUGGINGFACE_TOKEN`, if value is non-empty and not `value.isascii()`, `os.environ.pop(var)` + `logger.warning(...)`. -- prevents latin-1 crash across all backends; downgrades to anonymous (works for public default models).
+- [x] `server/backend/tests/test_hf_token_guard.py` -- new test: non-ASCII token → unset; valid ASCII `hf_*` → untouched; both var names parametrized; assert resulting value is latin-1 encodable. -- covers I/O matrix rows 2–3.
+
+**Execution — Fix C: TLS mitigation (mostly additive + docs):**
+- [x] `server/docker/bootstrap_runtime.py` -- (a) in `build_uv_sync_env` (`:358`) normalize/honor `UV_NATIVE_TLS` (and pass `SSL_CERT_FILE` through if set); (b) in the sync-failure handlers (`:665`,`:710`) detect `UnknownIssuer`/`invalid peer certificate`/`self-signed` in the *full* error string (before the 240-char truncation) and `log` + `emit_event(status="error")` an actionable hint referencing docs. -- surfaces the real cause instead of a bare traceback.
+- [x] `server/docker/docker-compose.yml` -- add `UV_NATIVE_TLS=${UV_NATIVE_TLS:-false}` (and optional `SSL_CERT_FILE`) to the runtime `environment:` allow-list (`:72-109`); optional commented CA bind-mount example under `volumes:`. -- lets affected users opt in.
+- [x] `server/docker/Dockerfile` -- run `update-ca-certificates` after `ca-certificates` install; document `/usr/local/share/ca-certificates` as the CA drop-in path. -- makes a mounted corporate CA actually trusted.
+- [x] `docs/deployment-guide.md` + `docs/README.md` -- new "TLS interception / corporate network (UnknownIssuer)" troubleshooting subsection + `UV_NATIVE_TLS`/`SSL_CERT_FILE` env-table rows. -- self-serve fix.
+- [x] `server/backend/tests/test_bootstrap_runtime.py` -- test: a simulated `UnknownIssuer` sync failure produces the hint (mirror existing failure-handling tests). -- covers I/O matrix row 4.
+
+**Execution — Fix A: CPU PyTorch variant + CPU-profile defaults (largest):**
+- [x] `server/docker/bootstrap_runtime.py` -- (a) variant normalization (`:1445`): accept `"cpu"`; (b) baked-variant trust (`:1459`): allow runtime `cpu` to override a baked non-cpu variant (safe downgrade) — keep trusting baked for all other mismatches; (c) `run_dependency_sync` (`:411`): extend the index-swap branch to `cpu` → `--index pytorch-cu129=https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match`, with `--frozen` dropped (cpu wheels have different hashes). -- enables CPU wheels on prebuilt images.
+- [x] `server/docker/docker-compose.yml` -- add `PYTORCH_VARIANT=${PYTORCH_VARIANT:-cu129}` to the runtime `environment:` block (it is currently build-arg-only, so the container never sees a runtime value). -- closes the plumbing gap.
+- [x] `dashboard/electron/dockerManager.ts` -- in `startContainer()` when `runtimeProfile === 'cpu'` (near `:2149`): set `composeEnv['PYTORCH_VARIANT']='cpu'`, force `INSTALL_NEMO=false`/`INSTALL_WHISPER=true`, and default `MAIN_TRANSCRIBER_MODEL` to a faster-whisper model (persist via `upsertComposeEnvValues`). -- CPU launches skip CUDA wheels + NeMo entirely.
+- [x] `dashboard/src/services/modelSelection.ts` (+ `App.tsx:568`) -- when CPU profile, the recommended/default main model resolves to faster-whisper (e.g. `Systran/faster-whisper-medium`), not parakeet. -- aligns UI default with the CPU env.
+- [x] `server/backend/tests/test_bootstrap_runtime.py` -- tests mirroring the cu126 set: `cpu` accepted by normalization; cpu index-swap argv (`whl/cpu`, no `--frozen`, `unsafe-best-match`); baked `cu129` + runtime `cpu` → resolves to `cpu`; marker records `"cpu"`. -- locks the bootstrap contract.
+
+**Acceptance Criteria:**
+- Given a prebuilt `cu129` image and CPU profile, when the dashboard starts the container, then `PYTORCH_VARIANT=cpu` reaches bootstrap, the baked-trust permits the downgrade, and the planned `uv sync` argv targets `whl/cpu` without `--frozen` (asserted in tests).
+- Given the dashboard CPU profile, when launching, then `INSTALL_NEMO=false` and the main model is a faster-whisper model (no NeMo install, no parakeet on CPU).
+- Given a non-ASCII `HUGGINGFACE_TOKEN`, when the server starts, then the variable is unset with a warning and no `UnicodeEncodeError` occurs on model load.
+- Given a TLS-interception sync failure, when bootstrap fails, then the logs contain a non-truncated actionable hint naming `UV_NATIVE_TLS` and the docs section — not just a raw traceback.
+- Given GPU profiles (`cu129`/`cu126`), when starting, then bootstrap behavior is unchanged (regression tests stay green).
+
+## Design Notes
+
+- **Why a token guard, not a model swap:** failure B lives in `huggingface_hub.file_download` header building, shared by faster-whisper/WhisperX/pyannote — switching the default model would NOT fix it. Verified against pinned `huggingface_hub==0.36.2`: the User-Agent is pure ASCII; the only env-derived header value is `Authorization: Bearer <token>`. Guarding the token value is the single robust lever. (Root cause is inferred from the traceback + position-32 math; reproduction depends on the reporter's env — see Verification.)
+- **Why relaxing baked-variant trust is safe for cpu only:** CPU wheels are a universal subset (no CUDA runtime needed); installing them over a cu129-baked image is always valid. The reverse (cu126/cu129 over a cpu-baked image) is not, so the existing defense stays for every non-cpu mismatch.
+- **Index-swap trick:** `[tool.uv.sources]` pins torch to the *named* index `pytorch-cu129`; redefining that name's URL on the CLI (`--index pytorch-cu129=…/whl/cpu`) redirects the pin. `--frozen` must be dropped because uv.lock hashes are cu129-specific. Mirror `cu126` exactly.
+
+### Implementation notes (where the code landed vs. the task file-pointers)
+
+- **Fix B guard module:** the guard logic lives in a new small module `server/backend/core/hf_token_guard.py` (`purge_non_ascii_hf_tokens`), called from `main.py`'s lifespan right after `setup_logging`. Putting it in its own module keeps it unit-testable without importing the heavy `main.py`. Also guards `HUGGING_FACE_HUB_TOKEN` (the third var huggingface_hub reads), not just the two named in the task.
+- **Fix A CPU model default:** implemented in `dashboard/components/views/ServerView.tsx::handleRuntimeProfileChange` (not `modelSelection.ts`/`App.tsx` — the recommended-model constant is actually applied there, mirroring the existing Metal→non-MLX reset). Switching to the CPU profile resets a NeMo main/live selection to `WHISPER_MEDIUM`. Install flags are **derived** from the model family (`computeMissingModelFamilies`), so a whisper model yields `INSTALL_NEMO=false` automatically — no hard override needed in `dockerManager.ts` beyond setting `PYTORCH_VARIANT=cpu`.
+- **`SSL_CERT_FILE`:** intentionally NOT added to the compose env with an empty default (an empty `SSL_CERT_FILE` can break OpenSSL). The corporate-CA path is documented via `UV_NATIVE_TLS=true` + the system trust store / a derived image instead.
+- **Review patch (edge-case HIGH):** the UI reset alone misses the first-run auto-detect path (the CPU profile is set before the model selection hydrates, so `isNemoModel(placeholder)` is false and no reset fires). Added an authoritative, race-free funnel guard `applyCpuModelDefaults`/`isNemoModelName` in `dockerManager.ts::startContainer` (unit-tested in `dockerManagerCpuModel.test.ts`) that substitutes `Systran/faster-whisper-medium` + `INSTALL_NEMO=false`/`INSTALL_WHISPER=true` whenever a CPU launch resolves to a NeMo model — every start path funnels through here, so AC2 ("no parakeet on CPU") holds regardless of UI timing.
+
+## Verification
+
+**Commands:**
+- `cd server/backend && ../../build/.venv/bin/pytest tests/test_bootstrap_runtime.py tests/test_hf_token_guard.py -v --tb=short` -- expected: all pass, including new cpu-variant + token-guard + TLS-hint cases.
+- `cd server/backend && ../../build/.venv/bin/pytest tests/ -q` -- expected: no regressions vs. baseline.
+- `cd dashboard && npm run typecheck` -- expected: clean (dockerManager.ts / modelSelection.ts / App.tsx).
+
+**Manual checks (cannot be validated locally — no CPU-only Docker host here):**
+- The real CPU `uv sync` against `whl/cpu` (Agent A flagged `unsafe-best-match` resolution as untested) must be confirmed on a CPU machine — via CI matrix job or by asking reporters @odnodn / @cbarkinozer to test the branch image. Tests assert the *argv*, not a live install.
+- Confirm the server's device selection runs on CPU when `CUDA_VISIBLE_DEVICES=''` (set by the dashboard CPU profile) — model load should report `Using device: cpu`.
+
+## Suggested Review Order
+
+**CPU profile (root cause — start here)**
+
+- Authoritative funnel guard: CPU launches never request a NeMo model, race-free.
+  [`dockerManager.ts:2050`](../../dashboard/electron/dockerManager.ts#L2050)
+
+- CPU profile selects the cpu wheels + forces CUDA invisible.
+  [`dockerManager.ts:2199`](../../dashboard/electron/dockerManager.ts#L2199)
+
+- Bootstrap accepts `PYTORCH_VARIANT=cpu` (else falls back to cu129).
+  [`bootstrap_runtime.py:1507`](../../server/docker/bootstrap_runtime.py#L1507)
+
+- Swaps the named torch index to `whl/cpu`, dropping `--frozen` (mirrors cu126).
+  [`bootstrap_runtime.py:425`](../../server/docker/bootstrap_runtime.py#L425)
+
+- The crux: lets a runtime `cpu` request override a baked GPU image (safe downgrade).
+  [`bootstrap_runtime.py:1527`](../../server/docker/bootstrap_runtime.py#L1527)
+
+- Threads `PYTORCH_VARIANT` into the runtime environment (was build-arg only).
+  [`docker-compose.yml:90`](../../server/docker/docker-compose.yml#L90)
+
+- UI reset: switching to CPU swaps a NeMo selection to faster-whisper.
+  [`ServerView.tsx:579`](../../dashboard/components/views/ServerView.tsx#L579)
+
+**HF token guard (Unicode crash)**
+
+- Purges non-ASCII HF tokens before any model load (covers all backends).
+  [`hf_token_guard.py:29`](../../server/backend/core/hf_token_guard.py#L29)
+
+- Call site, right after logging is configured in the lifespan.
+  [`main.py:404`](../../server/backend/api/main.py#L404)
+
+**TLS interception mitigation**
+
+- Detects `UnknownIssuer`/cert failures in the full error before truncation.
+  [`bootstrap_runtime.py:473`](../../server/docker/bootstrap_runtime.py#L473)
+
+- Emits the actionable hint, then raises (used by both sync handlers).
+  [`bootstrap_runtime.py:479`](../../server/docker/bootstrap_runtime.py#L479)
+
+- Opt-in `UV_NATIVE_TLS` makes uv trust the system CA store (verification stays on).
+  [`bootstrap_runtime.py:370`](../../server/docker/bootstrap_runtime.py#L370)
+
+- Exposes `UV_NATIVE_TLS` to the container; `update-ca-certificates` builds the trust store.
+  [`docker-compose.yml:95`](../../server/docker/docker-compose.yml#L95)
+
+**Docs & tests (peripherals)**
+
+- TLS-interception troubleshooting + env-var table.
+  [`deployment-guide.md:82`](../../docs/deployment-guide.md#L82)
+
+- End-user Windows/CPU troubleshooting entry.
+  [`README.md:880`](../../docs/README.md#L880)
+
+- Token-guard unit tests.
+  [`test_hf_token_guard.py:19`](../../server/backend/tests/test_hf_token_guard.py#L19)
+
+- cpu-variant argv, baked-trust downgrade, and TLS-hint tests.
+  [`test_bootstrap_runtime.py:1769`](../../server/backend/tests/test_bootstrap_runtime.py#L1769)
+
+- Funnel-guard helper tests.
+  [`dockerManagerCpuModel.test.ts:67`](../../dashboard/electron/__tests__/dockerManagerCpuModel.test.ts#L67)

--- a/dashboard/components/views/ServerView.tsx
+++ b/dashboard/components/views/ServerView.tsx
@@ -44,7 +44,7 @@ import { useDockerContext } from '../../src/hooks/DockerContext';
 import { apiClient } from '../../src/api/client';
 import { writeToClipboard } from '../../src/hooks/useClipboard';
 import { formatDateDMY, compareVersionTags } from '../../src/services/versionUtils';
-import { isWhisperModel, isMLXModel } from '../../src/services/modelCapabilities';
+import { isWhisperModel, isMLXModel, isNemoModel } from '../../src/services/modelCapabilities';
 import { MODEL_REGISTRY, getModelsByFamily } from '../../src/services/modelRegistry';
 import {
   MODEL_DEFAULT_LOADING_PLACEHOLDER,
@@ -567,6 +567,20 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
           api?.config?.set('server.mainModelSelection', MAIN_RECOMMENDED_MODEL);
         }
         if (MLX_MODEL_IDS.has(liveModelSelection)) {
+          setLiveModelSelection(LIVE_MODEL_SAME_AS_MAIN_OPTION);
+          api?.config?.set('server.liveModelSelection', LIVE_MODEL_SAME_AS_MAIN_OPTION);
+        }
+      }
+      // Switching to CPU: NeMo models (Parakeet/Canary) need a GPU to be
+      // practical and pull in the heavy `nemo` extra (GH-125). Reset a NeMo
+      // selection to a CPU-friendly faster-whisper default so CPU hosts skip the
+      // CUDA wheels and the NeMo install entirely.
+      if (profile === 'cpu') {
+        if (isNemoModel(mainModelSelection)) {
+          setMainModelSelection(WHISPER_MEDIUM);
+          api?.config?.set('server.mainModelSelection', WHISPER_MEDIUM);
+        }
+        if (isNemoModel(liveModelSelection)) {
           setLiveModelSelection(LIVE_MODEL_SAME_AS_MAIN_OPTION);
           api?.config?.set('server.liveModelSelection', LIVE_MODEL_SAME_AS_MAIN_OPTION);
         }

--- a/dashboard/electron/__tests__/dockerManagerCpuModel.test.ts
+++ b/dashboard/electron/__tests__/dockerManagerCpuModel.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment node
+
+/**
+ * GH-125 — CPU profile must never request a NeMo model.
+ *
+ * `applyCpuModelDefaults` is the authoritative funnel guard in startContainer:
+ * every start path flows through it, so it also covers the first-run auto-detect
+ * path where the UI-side reset in ServerView may not have fired yet. These tests
+ * lock in that a NeMo main model on the CPU profile is substituted with a
+ * faster-whisper model + INSTALL_NEMO=false / INSTALL_WHISPER=true, and that all
+ * other combinations pass through unchanged.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+const userDataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ts-cpu-model-test-'));
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: (_name: string) => userDataRoot,
+    setPath: vi.fn(),
+  },
+}));
+
+vi.mock('electron-store', () => ({
+  default: class MockStore {
+    get() {
+      return undefined;
+    }
+    set() {}
+  },
+}));
+
+vi.mock('../containerRuntime.js', () => ({
+  getRuntimeBin: vi.fn(async () => '/usr/bin/docker'),
+  getContainerRuntime: vi.fn(async () => ({ kind: 'docker', displayName: 'Docker' })),
+  getDetectionResult: vi.fn(() => null),
+  resetDetection: vi.fn(),
+  resolveRootlessSocket: vi.fn(() => null),
+  getSocketPaths: vi.fn(() => ({ docker: '/var/run/docker.sock', podman: null })),
+}));
+
+import { isNemoModelName, applyCpuModelDefaults } from '../dockerManager.js';
+
+describe('isNemoModelName', () => {
+  it('detects NeMo families (case-insensitive)', () => {
+    expect(isNemoModelName('nvidia/parakeet-tdt-0.6b-v3')).toBe(true);
+    expect(isNemoModelName('nvidia/canary-1b-v2')).toBe(true);
+    expect(isNemoModelName('NVIDIA/Parakeet-TDT-1.1b')).toBe(true);
+    expect(isNemoModelName('  nvidia/nemotron-speech-4b  ')).toBe(true);
+  });
+
+  it('returns false for non-NeMo and empty inputs', () => {
+    expect(isNemoModelName('Systran/faster-whisper-medium')).toBe(false);
+    expect(isNemoModelName('ggml-large-v3.bin')).toBe(false);
+    expect(isNemoModelName('mlx-community/whisper-large-v3-asr-fp16')).toBe(false);
+    expect(isNemoModelName('')).toBe(false);
+    expect(isNemoModelName(undefined)).toBe(false);
+    expect(isNemoModelName(null)).toBe(false);
+  });
+});
+
+describe('applyCpuModelDefaults', () => {
+  it('substitutes a NeMo main model with faster-whisper on the CPU profile', () => {
+    const result = applyCpuModelDefaults('cpu', {
+      mainTranscriberModel: 'nvidia/parakeet-tdt-0.6b-v3',
+      installNemo: true,
+      installWhisper: false,
+    });
+    expect(result.mainTranscriberModel).toBe('Systran/faster-whisper-medium');
+    expect(result.installNemo).toBe(false);
+    expect(result.installWhisper).toBe(true);
+  });
+
+  it('leaves a whisper main model unchanged on the CPU profile', () => {
+    const opts = {
+      mainTranscriberModel: 'Systran/faster-whisper-large-v3',
+      installNemo: false,
+      installWhisper: true,
+    };
+    expect(applyCpuModelDefaults('cpu', opts)).toEqual(opts);
+  });
+
+  it('does not touch NeMo models on non-CPU profiles', () => {
+    const opts = {
+      mainTranscriberModel: 'nvidia/parakeet-tdt-0.6b-v3',
+      installNemo: true,
+      installWhisper: false,
+    };
+    expect(applyCpuModelDefaults('gpu', opts)).toEqual(opts);
+    expect(applyCpuModelDefaults('metal', opts)).toEqual(opts);
+  });
+
+  it('is a no-op when no main model is set on the CPU profile', () => {
+    const opts = { installNemo: undefined, installWhisper: undefined };
+    expect(applyCpuModelDefaults('cpu', opts)).toEqual(opts);
+  });
+});

--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -2016,6 +2016,51 @@ async function getContainerStatus(): Promise<ContainerStatus> {
   }
 }
 
+// GH-125: NeMo models (Parakeet/Canary/Nemotron-speech) need a GPU to be
+// practical and pull in the heavy `nemo` extra that broke first-run CPU installs.
+// Detection mirrors server/backend/core/stt/backends/factory.py and
+// src/services/modelCapabilities.ts — the Electron main process cannot import the
+// renderer-side service, so keep these in sync.
+const CPU_FALLBACK_MAIN_MODEL = 'Systran/faster-whisper-medium';
+
+export function isNemoModelName(model: string | undefined | null): boolean {
+  if (!model) return false;
+  const normalized = model.trim().toLowerCase();
+  return (
+    normalized.startsWith('nvidia/parakeet') ||
+    normalized.startsWith('nvidia/canary') ||
+    normalized.startsWith('nvidia/nemotron-speech')
+  );
+}
+
+export interface CpuModelDefaults {
+  mainTranscriberModel?: string;
+  installNemo?: boolean;
+  installWhisper?: boolean;
+}
+
+/**
+ * On the CPU profile, substitute a faster-whisper main model when a NeMo model
+ * was selected so CPU launches never install or run NeMo (GH-125). This is the
+ * authoritative guard: every start path funnels through startContainer, so it
+ * also covers the first-run auto-detect path where the UI-side reset in
+ * ServerView may not have fired yet. A no-op for non-CPU profiles or non-NeMo
+ * models — values pass through unchanged.
+ */
+export function applyCpuModelDefaults(
+  profile: RuntimeProfile,
+  opts: CpuModelDefaults,
+): CpuModelDefaults {
+  if (profile !== 'cpu' || !isNemoModelName(opts.mainTranscriberModel)) {
+    return opts;
+  }
+  return {
+    mainTranscriberModel: CPU_FALLBACK_MAIN_MODEL,
+    installNemo: false,
+    installWhisper: true,
+  };
+}
+
 /**
  * Start the container via docker compose with layered compose files.
  * @param options - Container start options including mode, runtime profile, and optional TLS env.
@@ -2145,10 +2190,27 @@ async function startContainer(options: StartContainerOptions): Promise<string> {
     composeEnv['TLS_ENABLED'] = 'false';
   }
 
-  // For CPU mode, force CUDA invisible so the server deterministically uses CPU
+  // For CPU mode, force CUDA invisible so the server deterministically uses CPU,
+  // and select the cpu PyTorch wheels so the bootstrap skips the multi-GB CUDA
+  // wheels a CPU-only host can't use (GH-125). Set on composeEnv only (not
+  // persisted to .env) so a later GPU launch is unaffected.
   if (runtimeProfile === 'cpu') {
     composeEnv['CUDA_VISIBLE_DEVICES'] = '';
+    composeEnv['PYTORCH_VARIANT'] = 'cpu';
   }
+
+  // GH-125: guarantee CPU launches never request a NeMo model. The UI-side
+  // reset can be bypassed on first-run auto-detect (profile is set before the
+  // model selection hydrates), so enforce the faster-whisper substitution here
+  // at the single funnel all start paths pass through. No-op otherwise.
+  const cpuDefaults = applyCpuModelDefaults(runtimeProfile, {
+    mainTranscriberModel,
+    installNemo,
+    installWhisper,
+  });
+  const effectiveMainTranscriberModel = cpuDefaults.mainTranscriberModel;
+  const effectiveInstallNemo = cpuDefaults.installNemo;
+  const effectiveInstallWhisper = cpuDefaults.installWhisper;
 
   // Pass HuggingFace token to the container for diarization model access
   if (hfToken !== undefined) {
@@ -2172,15 +2234,15 @@ async function startContainer(options: StartContainerOptions): Promise<string> {
     envUpdates['HUGGINGFACE_TOKEN_DECISION'] = normalizedHfDecision;
   }
 
-  if (installWhisper !== undefined) {
-    const whisperValue = installWhisper ? 'true' : 'false';
+  if (effectiveInstallWhisper !== undefined) {
+    const whisperValue = effectiveInstallWhisper ? 'true' : 'false';
     composeEnv['INSTALL_WHISPER'] = whisperValue;
     envUpdates['INSTALL_WHISPER'] = whisperValue;
   }
 
   // Pass NeMo install preference to the container for Parakeet ASR support
-  if (installNemo !== undefined) {
-    const nemoValue = installNemo ? 'true' : 'false';
+  if (effectiveInstallNemo !== undefined) {
+    const nemoValue = effectiveInstallNemo ? 'true' : 'false';
     composeEnv['INSTALL_NEMO'] = nemoValue;
     envUpdates['INSTALL_NEMO'] = nemoValue;
   }
@@ -2193,9 +2255,9 @@ async function startContainer(options: StartContainerOptions): Promise<string> {
   }
 
   // Pass ASR model selections to the container (empty string = use config.yaml default)
-  if (mainTranscriberModel !== undefined) {
-    composeEnv['MAIN_TRANSCRIBER_MODEL'] = mainTranscriberModel;
-    envUpdates['MAIN_TRANSCRIBER_MODEL'] = mainTranscriberModel;
+  if (effectiveMainTranscriberModel !== undefined) {
+    composeEnv['MAIN_TRANSCRIBER_MODEL'] = effectiveMainTranscriberModel;
+    envUpdates['MAIN_TRANSCRIBER_MODEL'] = effectiveMainTranscriberModel;
   }
   if (liveTranscriberModel !== undefined) {
     composeEnv['LIVE_TRANSCRIBER_MODEL'] = liveTranscriberModel;

--- a/docs/README.md
+++ b/docs/README.md
@@ -877,6 +877,16 @@ sudo systemctl enable --now nvidia-persistence.service
 
 **Alternative:** Reboot the host to fully reset the driver state.
 
+### Windows / CPU-only: local start fails
+
+**Symptom:** On a CPU-only machine (no NVIDIA GPU), first start fails during dependency install — either with `invalid peer certificate: UnknownIssuer` while downloading packages, or later with `UnicodeEncodeError: 'latin-1' codec can't encode ...` when loading the model.
+
+**Steps:**
+
+1. **Use the CPU profile.** In **Settings > Server**, select the **CPU** profile before starting. CPU-only hosts no longer download the multi-GB NVIDIA CUDA wheels and default to a lighter faster-whisper model instead of the GPU-only NeMo model.
+2. **`UnknownIssuer` / certificate errors** mean your network (a corporate proxy or antivirus HTTPS scanning) is intercepting HTTPS, so the container can't verify the package index. Set `UV_NATIVE_TLS=true` and add your organization's root CA — see the [deployment guide](deployment-guide.md#tls-interception--corporate-network-unknownissuer).
+3. **`UnicodeEncodeError` on model load** means a HuggingFace token containing a non-ASCII character was provided. Clear the token (most models don't need one); the server now also ignores non-ASCII tokens automatically and downloads anonymously.
+
 ### Advanced Troubleshooting
 
 For more advanced troubleshooting steps, head over to README_DEV's [Troubleshooting section](README_DEV.md#13-troubleshooting).

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -79,6 +79,36 @@ On first container start, the server installs Python dependencies into `/runtime
 
 **Timeout:** 30 minutes default (`BOOTSTRAP_TIMEOUT_SECONDS=1800`)
 
+### TLS interception / corporate network (`UnknownIssuer`)
+
+If first-run `uv sync` fails with `invalid peer certificate: UnknownIssuer` (or
+`certificate verify failed`), your network is intercepting HTTPS — a corporate
+proxy or antivirus "HTTPS scanning" feature presents a re-signed certificate
+whose root CA is trusted on your host but **not** inside the container. uv ships
+its own CA roots and ignores the system store by default, so it rejects the
+re-signed cert. The bootstrap now detects this and prints an actionable hint
+instead of a bare traceback.
+
+Fix (certificate verification stays ON — never disable it):
+
+1. **Trust the system CA store:** set `UV_NATIVE_TLS=true` (already wired into
+   `docker-compose.yml`). uv then reads the container's CA trust store instead
+   of its bundled roots.
+2. **Add your corporate root CA** so that store actually contains it. Easiest is
+   a small derived image:
+   ```dockerfile
+   FROM ghcr.io/homelab-00/transcriptionsuite-server:latest
+   COPY corp-root-ca.crt /usr/local/share/ca-certificates/corp-root-ca.crt
+   RUN update-ca-certificates
+   ```
+   Point `IMAGE_REPO`/`TAG` at your derived image and run with
+   `UV_NATIVE_TLS=true`. Alternatively, mount the CA and set
+   `SSL_CERT_FILE=/path/to/corp-root-ca.pem` in your own compose override.
+
+CPU-only hosts hit this most often because the default install pulls multi-GB
+CUDA wheels. Selecting the **CPU profile** in the dashboard (or
+`PYTORCH_VARIANT=cpu`) skips those wheels and shrinks the download surface.
+
 ## TLS / Remote Access
 
 ### Tailscale Setup
@@ -220,6 +250,8 @@ non-flipping cu129 path is zero-cost.
 | `INSTALL_WHISPER` | false | Install faster-whisper extras |
 | `INSTALL_NEMO` | false | Install NeMo toolkit |
 | `INSTALL_VIBEVOICE_ASR` | false | Install VibeVoice backend |
+| `PYTORCH_VARIANT` | cu129 | PyTorch wheels: `cu129`, `cu126` (legacy GPU), or `cpu` (no CUDA, GH #125) |
+| `UV_NATIVE_TLS` | false | Trust the system CA store for `uv` (corporate TLS interception, GH #125) |
 | `TLS_ENABLED` | false | Enable HTTPS + auth |
 | `LM_STUDIO_URL` | http://127.0.0.1:1234 | LM Studio API endpoint |
 

--- a/server/backend/api/main.py
+++ b/server/backend/api/main.py
@@ -74,6 +74,7 @@ from server.logging import get_logger, setup_logging  # noqa: E402
 
 _log_time("logging imported")
 
+from server.core.hf_token_guard import purge_non_ascii_hf_tokens  # noqa: E402
 from server.core.startup_events import emit_event  # noqa: E402
 
 _log_time("startup_events imported")
@@ -396,6 +397,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     # Initialize logging
     setup_logging(config.logging)
     _log_time("logging setup complete")
+
+    # GH #125: a non-ASCII HF token value crashes every STT backend at model
+    # load (huggingface_hub copies it verbatim into a latin-1 HTTP header).
+    # Purge any invalid token now, before any model is loaded.
+    purge_non_ascii_hf_tokens()
 
     # Initialize database
     init_db()

--- a/server/backend/core/hf_token_guard.py
+++ b/server/backend/core/hf_token_guard.py
@@ -1,0 +1,47 @@
+"""Guard against non-ASCII HuggingFace token env vars (GH #125, failure B).
+
+huggingface_hub builds the HTTP ``Authorization: Bearer <token>`` header from
+``HF_TOKEN`` / ``HUGGING_FACE_HUB_TOKEN`` and only strips surrounding
+whitespace — it never checks that the value is latin-1 encodable. A token
+containing a non-ASCII character (e.g. a stray ``ş`` pasted into the token
+field on a Windows box) therefore crashes EVERY backend (NeMo, faster-whisper,
+WhisperX, pyannote) with ``UnicodeEncodeError: 'latin-1' codec can't encode ...``
+at model load, because HTTP headers must be latin-1 encodable.
+
+Real HuggingFace tokens are always ASCII (``hf_`` + base62), so a non-ASCII
+value cannot be a valid token. We unset it and warn, which downgrades to
+anonymous downloads (fine for the public default models) instead of crashing.
+"""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# Every env var huggingface_hub (and our backends) read for the HF token.
+HF_TOKEN_ENV_VARS: tuple[str, ...] = (
+    "HF_TOKEN",
+    "HUGGINGFACE_TOKEN",
+    "HUGGING_FACE_HUB_TOKEN",
+)
+
+
+def purge_non_ascii_hf_tokens() -> list[str]:
+    """Unset any HF token env var whose value is not ASCII-encodable.
+
+    Returns the list of env var names that were purged (empty when all tokens
+    are valid, empty, or unset). Safe to call multiple times (idempotent).
+    """
+    purged: list[str] = []
+    for var in HF_TOKEN_ENV_VARS:
+        value = os.environ.get(var)
+        if value and not value.isascii():
+            os.environ.pop(var, None)
+            purged.append(var)
+            logger.warning(
+                "%s contained non-ASCII characters and was ignored "
+                "(HuggingFace tokens are ASCII-only). Falling back to anonymous "
+                "downloads. See GH #125.",
+                var,
+            )
+    return purged

--- a/server/backend/tests/test_bootstrap_runtime.py
+++ b/server/backend/tests/test_bootstrap_runtime.py
@@ -1698,3 +1698,186 @@ def test_main_trusts_baked_variant_over_env(
 
     assert rc == 0
     assert resolved_variant["variant"] == "cu126"
+
+
+# ---------------------------------------------------------------------------
+# GH #125 — TLS interception hint (Fix C)
+# ---------------------------------------------------------------------------
+
+
+def test_detect_tls_interception_matches_known_markers() -> None:
+    module = _load_bootstrap_module()
+    samples = [
+        "invalid peer certificate: UnknownIssuer",
+        "error: certificate verify failed: unable to get local issuer certificate",
+        "the remote host presented a self-signed certificate",
+    ]
+    for text in samples:
+        assert module.detect_tls_interception(text) is True
+
+
+def test_detect_tls_interception_ignores_unrelated_errors() -> None:
+    module = _load_bootstrap_module()
+    assert module.detect_tls_interception("No space left on device") is False
+    assert module.detect_tls_interception("your project's requirements are unsatisfiable") is False
+
+
+def test_raise_dependency_sync_failure_emits_tls_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A TLS-interception failure logs the full actionable hint before truncating."""
+    module = _load_bootstrap_module()
+    logs: list[str] = []
+    events: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    monkeypatch.setattr(module, "log", lambda msg: logs.append(msg))
+    monkeypatch.setattr(module, "emit_event", lambda *a, **k: events.append((a, k)))
+
+    # A long error so the snippet would otherwise be truncated past the cert text.
+    long_cert_error = (
+        "Failed to download `nvidia-cuda-runtime-cu12`: client error (Connect): "
+        "invalid peer certificate: UnknownIssuer" + " padding" * 40
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        module._raise_dependency_sync_failure(RuntimeError(long_cert_error), "rebuild-sync")
+
+    assert any("UV_NATIVE_TLS" in line for line in logs), "TLS hint must be logged in full"
+    assert any(kwargs.get("status") == "error" for _, kwargs in events)
+    assert "Dependency sync failed for mode=rebuild-sync" in str(excinfo.value)
+
+
+def test_raise_dependency_sync_failure_no_hint_for_unrelated_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_bootstrap_module()
+    logs: list[str] = []
+    monkeypatch.setattr(module, "log", lambda msg: logs.append(msg))
+    monkeypatch.setattr(module, "emit_event", lambda *a, **k: None)
+    with pytest.raises(RuntimeError):
+        module._raise_dependency_sync_failure(
+            RuntimeError("No space left on device"), "rebuild-sync"
+        )
+    assert not any("UV_NATIVE_TLS" in line for line in logs)
+
+
+# ---------------------------------------------------------------------------
+# GH #125 — CPU PyTorch variant (Fix A)
+# ---------------------------------------------------------------------------
+
+
+def test_run_dependency_sync_cpu_drops_frozen_and_targets_cpu_index(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cpu path mirrors cu126: drop --frozen, swap the pytorch-cu129 URL to whl/cpu."""
+    module = _load_bootstrap_module()
+    cmd = _capture_run_dependency_sync_cmd(monkeypatch, module, pytorch_variant="cpu")
+
+    assert "--frozen" not in cmd, "cpu path must drop --frozen (lock pins cu129 hashes)"
+    assert "--index" in cmd, "cpu path must supply the --index override"
+    idx = cmd.index("--index")
+    assert cmd[idx + 1] == "pytorch-cu129=https://download.pytorch.org/whl/cpu", (
+        "cpu path must reuse the `pytorch-cu129` name with the cpu URL"
+    )
+    assert "--index-strategy" in cmd
+    strategy_idx = cmd.index("--index-strategy")
+    assert cmd[strategy_idx + 1] == "unsafe-best-match"
+
+
+def test_run_dependency_sync_cpu_propagates_extras(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_bootstrap_module()
+    cmd = _capture_run_dependency_sync_cmd(
+        monkeypatch, module, pytorch_variant="cpu", extras=("whisper",)
+    )
+    extras_pairs = [(cmd[i], cmd[i + 1]) for i in range(len(cmd) - 1) if cmd[i] == "--extra"]
+    assert ("--extra", "whisper") in extras_pairs
+    assert cmd.index("--extra") > cmd.index("--index")
+
+
+def _invoke_main_resolving_variant(
+    module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    baked_variant: str,
+    env_variant: str,
+) -> str:
+    """Run main() with the heavy startup mocked out; return the resolved pytorch variant."""
+    runtime_dir = tmp_path / "runtime"
+    cache_dir = tmp_path / "runtime-cache"
+    status_file = runtime_dir / "bootstrap-status.json"
+    runtime_dir.mkdir()
+    cache_dir.mkdir()
+    _touch_runtime_python(runtime_dir)
+
+    baked_file = tmp_path / ".pytorch_variant"
+    baked_file.write_text(f"{baked_variant}\n", encoding="utf-8")
+    monkeypatch.setattr(module, "APP_ROOT", tmp_path)
+
+    resolved: dict[str, str] = {}
+
+    def fake_ensure_runtime_dependencies(**kwargs: object):  # type: ignore[no-untyped-def]
+        resolved["variant"] = str(kwargs.get("pytorch_variant"))
+        diagnostics = {"selection_reason": "hash_match_skip", "escalated_to_rebuild": False}
+        return runtime_dir / ".venv", "skip", {}, diagnostics
+
+    monkeypatch.setattr(module, "ensure_runtime_dependencies", fake_ensure_runtime_dependencies)
+    monkeypatch.setattr(
+        module,
+        "load_config_models",
+        lambda: (
+            "Systran/faster-whisper-large-v3",
+            "Systran/faster-whisper-large-v3",
+            module.DEFAULT_DIARIZATION_MODEL,
+        ),
+    )
+    monkeypatch.setattr(module, "compute_diarization_preload_cache_key", lambda **_: "k")
+    monkeypatch.setattr(
+        module,
+        "check_diarization_access",
+        lambda **_: {"available": False, "reason": "token_missing"},
+    )
+    monkeypatch.setattr(
+        module,
+        "probe_whisper_with_cudnn_fallback",
+        lambda **_: ({"available": True, "reason": "ready"}, ""),
+    )
+    monkeypatch.setattr(
+        module,
+        "check_nemo_asr_import",
+        lambda **_: {"available": False, "reason": "not_requested"},
+    )
+    monkeypatch.setattr(module, "write_status_file", lambda *_args, **_kwargs: None)
+
+    monkeypatch.setenv("BOOTSTRAP_RUNTIME_DIR", str(runtime_dir))
+    monkeypatch.setenv("BOOTSTRAP_CACHE_DIR", str(cache_dir))
+    monkeypatch.setenv("BOOTSTRAP_STATUS_FILE", str(status_file))
+    monkeypatch.setenv("HF_HOME", str(tmp_path / "models"))
+    monkeypatch.setenv("PYTORCH_VARIANT", env_variant)
+
+    assert module.main() == 0
+    return resolved["variant"]
+
+
+def test_main_honors_cpu_request_over_baked_gpu_variant(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """cpu is a safe downgrade, so a runtime cpu request overrides a baked GPU variant (GH #125)."""
+    module = _load_bootstrap_module()
+    resolved = _invoke_main_resolving_variant(
+        module, monkeypatch, tmp_path, baked_variant="cu129", env_variant="cpu"
+    )
+    assert resolved == "cpu"
+
+
+def test_main_still_trusts_baked_for_non_cpu_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-cpu env/baked mismatch must keep trusting the baked variant (Issue #83 defense)."""
+    module = _load_bootstrap_module()
+    resolved = _invoke_main_resolving_variant(
+        module, monkeypatch, tmp_path, baked_variant="cu126", env_variant="cu129"
+    )
+    assert resolved == "cu126"

--- a/server/backend/tests/test_hf_token_guard.py
+++ b/server/backend/tests/test_hf_token_guard.py
@@ -1,0 +1,66 @@
+"""Tests for the HF token env guard (GH #125, failure B).
+
+A non-ASCII ``HUGGINGFACE_TOKEN`` / ``HF_TOKEN`` value crashes every STT backend
+with ``UnicodeEncodeError: 'latin-1' codec can't encode ...`` because
+huggingface_hub places the token verbatim into the ``Authorization`` HTTP
+header (which must be latin-1 encodable) and never validates it. The guard
+unsets any non-ASCII token before model load so downloads fall back to
+anonymous access instead of crashing.
+"""
+
+import os
+
+import pytest
+from server.core.hf_token_guard import HF_TOKEN_ENV_VARS, purge_non_ascii_hf_tokens
+
+
+@pytest.mark.parametrize("var", HF_TOKEN_ENV_VARS)
+def test_purges_non_ascii_token(monkeypatch, var):
+    # 'ş' (U+015F) is the exact character from the issue report.
+    monkeypatch.setenv(var, "hf_abcdefghijklmnopqrstuvwxyzş0123456789")
+    purged = purge_non_ascii_hf_tokens()
+    assert var in purged
+    assert var not in os.environ
+
+
+@pytest.mark.parametrize("var", HF_TOKEN_ENV_VARS)
+def test_keeps_valid_ascii_token(monkeypatch, var):
+    token = "hf_validAsciiToken0123456789ABCDEF"
+    monkeypatch.setenv(var, token)
+    purged = purge_non_ascii_hf_tokens()
+    assert purged == []
+    assert os.environ[var] == token
+
+
+def test_noop_when_unset(monkeypatch):
+    for var in HF_TOKEN_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    assert purge_non_ascii_hf_tokens() == []
+
+
+def test_empty_string_is_untouched(monkeypatch):
+    # docker-compose maps HF_TOKEN=${HUGGINGFACE_TOKEN:-}, so empty is common.
+    monkeypatch.setenv("HF_TOKEN", "")
+    purged = purge_non_ascii_hf_tokens()
+    assert purged == []
+    assert os.environ.get("HF_TOKEN") == ""
+
+
+def test_remaining_tokens_are_latin1_encodable(monkeypatch):
+    # Mixed state: one bad token, one good — after the guard, whatever remains
+    # must be latin-1 encodable (exactly what huggingface_hub does internally).
+    monkeypatch.setenv("HF_TOKEN", "hf_badtokenwithş")
+    monkeypatch.setenv("HUGGINGFACE_TOKEN", "hf_goodasciitoken")
+    purge_non_ascii_hf_tokens()
+    for var in HF_TOKEN_ENV_VARS:
+        value = os.environ.get(var)
+        if value is not None:
+            value.encode("latin-1")  # must not raise
+
+
+def test_idempotent(monkeypatch):
+    monkeypatch.setenv("HF_TOKEN", "hf_badş")
+    first = purge_non_ascii_hf_tokens()
+    second = purge_non_ascii_hf_tokens()
+    assert first == ["HF_TOKEN"]
+    assert second == []

--- a/server/docker/Dockerfile
+++ b/server/docker/Dockerfile
@@ -68,6 +68,7 @@ RUN printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\nAcquire::https:
     git \
     gosu \
     ca-certificates \
+    && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv (fast Python package manager)

--- a/server/docker/bootstrap_runtime.py
+++ b/server/docker/bootstrap_runtime.py
@@ -361,6 +361,14 @@ def build_uv_sync_env(venv_dir: Path, cache_dir: Path) -> dict[str, str]:
     env["UV_PROJECT_ENVIRONMENT"] = str(venv_dir)
     env["UV_CACHE_DIR"] = str(cache_dir)
     env["UV_PYTHON"] = "/usr/bin/python3.13"
+    # GH #125: on TLS-intercepting networks (corporate proxy / antivirus HTTPS
+    # scanning) uv's bundled webpki roots reject the re-signed certificate
+    # ("UnknownIssuer"). Opt-in UV_NATIVE_TLS makes uv trust the system/container
+    # CA store instead, so a mounted corporate root CA is honored. SSL_CERT_FILE,
+    # if set, already flows through via os.environ.copy() above. Certificate
+    # verification stays ON — this never disables TLS checking.
+    if parse_bool_env("UV_NATIVE_TLS", False):
+        env["UV_NATIVE_TLS"] = "true"
     return env
 
 
@@ -373,7 +381,7 @@ def run_dependency_sync(
 ) -> None:
     """Run dependency sync into the runtime virtual environment.
 
-    Variant handling (Issue #83):
+    Variant handling (Issue #83; cpu variant added in GH #125, same URL-swap):
         cu129 (default) — frozen sync against the lock-pinned PyTorch index.
         cu126 (legacy)  — drops --frozen and overrides the URL of the named
                           index `pytorch-cu129` with the cu126 wheel URL via
@@ -408,12 +416,22 @@ def run_dependency_sync(
         "--project",
         str(PROJECT_DIR),
     ]
-    if pytorch_variant == "cu126":
-        # Legacy-GPU path — Pascal/Maxwell support requires cu126 wheels (sm_50..sm_90).
+    # Non-default variants swap the URL of the *named* index `pytorch-cu129`
+    # (which [tool.uv.sources] pins torch/torchaudio to): cu126 for legacy GPUs
+    # (Pascal/Maxwell, sm_50..sm_90) and cpu for CPU-only hosts (GH #125 — no
+    # multi-GB CUDA wheels). --frozen is dropped because uv.lock pins cu129 wheel
+    # hashes; --index-strategy unsafe-best-match lets non-torch packages fall
+    # back to PyPI (Issue #115).
+    variant_index_urls = {
+        "cu126": "https://download.pytorch.org/whl/cu126",
+        "cpu": "https://download.pytorch.org/whl/cpu",
+    }
+    index_url = variant_index_urls.get(pytorch_variant)
+    if index_url is not None:
         cmd.extend(
             [
                 "--index",
-                "pytorch-cu129=https://download.pytorch.org/whl/cu126",
+                f"pytorch-cu129={index_url}",
                 "--index-strategy",
                 "unsafe-best-match",
             ]
@@ -428,6 +446,57 @@ def run_dependency_sync(
         timeout_seconds=max(timeout_seconds, 10800),
         env=build_uv_sync_env(venv_dir=venv_dir, cache_dir=cache_dir),
     )
+
+
+# GH #125: substrings that indicate the package-index TLS certificate could not
+# be verified — almost always a corporate proxy or antivirus intercepting HTTPS
+# whose root CA is not trusted inside the container.
+_TLS_INTERCEPTION_MARKERS: tuple[str, ...] = (
+    "invalid peer certificate",
+    "unknownissuer",
+    "self-signed certificate",
+    "self signed certificate",
+    "certificate verify failed",
+    "unable to get local issuer",
+)
+
+_TLS_INTERCEPTION_HINT = (
+    "TLS certificate verification failed while downloading dependencies. Your "
+    "network appears to intercept HTTPS (corporate proxy or antivirus HTTPS "
+    "scanning), so the package-index certificate is not trusted inside the "
+    "container. Fix: set UV_NATIVE_TLS=true to trust the system CA store, and/or "
+    "mount your organization's root CA into the container. See "
+    "docs/deployment-guide.md (TLS interception / corporate network)."
+)
+
+
+def detect_tls_interception(error_text: str) -> bool:
+    """Return True when *error_text* looks like an untrusted-CA / TLS-intercept failure."""
+    lowered = error_text.lower()
+    return any(marker in lowered for marker in _TLS_INTERCEPTION_MARKERS)
+
+
+def _raise_dependency_sync_failure(exc: Exception, final_sync_mode: str) -> None:
+    """Log an actionable hint for recognized causes, then raise a RuntimeError.
+
+    Always raises. The full error text is inspected for TLS-interception markers
+    *before* it is truncated for the RuntimeError message, so the actionable hint
+    is never lost to truncation (GH #125).
+    """
+    error_text = str(exc).strip()
+    if detect_tls_interception(error_text):
+        log(_TLS_INTERCEPTION_HINT)
+        emit_event(
+            "bootstrap-tls",
+            "server",
+            _TLS_INTERCEPTION_HINT,
+            status="error",
+            phase="bootstrap",
+        )
+    failure_snippet = error_text if len(error_text) <= 240 else f"{error_text[:237]}..."
+    raise RuntimeError(
+        f"Dependency sync failed for mode={final_sync_mode}: {failure_snippet}"
+    ) from exc
 
 
 def summarize_package_delta(
@@ -667,12 +736,7 @@ def ensure_runtime_dependencies(
                         f"dependency sync failed (mode={final_sync_mode})",
                         sync_start,
                     )
-                    failure_snippet = str(exc).strip()
-                    if len(failure_snippet) > 240:
-                        failure_snippet = f"{failure_snippet[:237]}..."
-                    raise RuntimeError(
-                        f"Dependency sync failed for mode={final_sync_mode}: {failure_snippet}"
-                    ) from exc
+                    _raise_dependency_sync_failure(exc, final_sync_mode)
         else:
             # Rebuild-sync: venv missing, structural mismatch, or force rebuild
             if force_rebuild:
@@ -712,12 +776,7 @@ def ensure_runtime_dependencies(
                     f"dependency sync failed (mode={final_sync_mode})",
                     sync_start,
                 )
-                failure_snippet = str(exc).strip()
-                if len(failure_snippet) > 240:
-                    failure_snippet = f"{failure_snippet[:237]}..."
-                raise RuntimeError(
-                    f"Dependency sync failed for mode={final_sync_mode}: {failure_snippet}"
-                ) from exc
+                _raise_dependency_sync_failure(exc, final_sync_mode)
 
         venv_python = venv_dir / "bin/python"
         if not venv_python.exists():
@@ -1445,8 +1504,8 @@ def main() -> int:
     raw_variant = (os.environ.get("PYTORCH_VARIANT") or "").strip().lower()
     if raw_variant in {"", "cu129"}:
         pytorch_variant = "cu129"
-    elif raw_variant == "cu126":
-        pytorch_variant = "cu126"
+    elif raw_variant in {"cu126", "cpu"}:
+        pytorch_variant = raw_variant
     else:
         log(f"Unknown PYTORCH_VARIANT={raw_variant!r}; falling back to cu129")
         pytorch_variant = "cu129"
@@ -1465,15 +1524,24 @@ def main() -> int:
         except OSError:
             baked_variant = ""
         if baked_variant and baked_variant != pytorch_variant:
-            log(
-                f"WARNING: image was built with PYTORCH_VARIANT={baked_variant!r} "
-                f"but runtime env reports {pytorch_variant!r} — trusting the "
-                "baked build-arg (installed wheels are the ground truth). This "
-                "usually indicates a manual `compose build` that paired "
-                "IMAGE_REPO and PYTORCH_VARIANT incorrectly; see "
-                "docs/deployment-guide.md."
-            )
-            pytorch_variant = baked_variant
+            if pytorch_variant == "cpu":
+                # GH #125: cpu is a safe downgrade — CPU wheels install over any
+                # baked GPU image — so an explicit runtime cpu request wins. This
+                # is what lets a prebuilt cu129 image run on a CPU-only host.
+                log(
+                    f"Runtime requested PYTORCH_VARIANT=cpu over baked "
+                    f"{baked_variant!r}; honoring the CPU downgrade (GH #125)."
+                )
+            else:
+                log(
+                    f"WARNING: image was built with PYTORCH_VARIANT={baked_variant!r} "
+                    f"but runtime env reports {pytorch_variant!r} — trusting the "
+                    "baked build-arg (installed wheels are the ground truth). This "
+                    "usually indicates a manual `compose build` that paired "
+                    "IMAGE_REPO and PYTORCH_VARIANT incorrectly; see "
+                    "docs/deployment-guide.md."
+                )
+                pytorch_variant = baked_variant
     log(f"PyTorch variant: {pytorch_variant}")
 
     if require_hf_token and not hf_token:

--- a/server/docker/docker-compose.yml
+++ b/server/docker/docker-compose.yml
@@ -84,6 +84,15 @@ services:
       - BOOTSTRAP_TIMEOUT_SECONDS=${BOOTSTRAP_TIMEOUT_SECONDS:-1800}
       - BOOTSTRAP_REQUIRE_HF_TOKEN=false
       - BOOTSTRAP_LOG_CHANGES=${BOOTSTRAP_LOG_CHANGES:-true}
+      # PyTorch wheel variant for the runtime venv: cu129 (default), cu126
+      # (legacy GPU, Issue #83), or cpu (no CUDA). The dashboard's CPU profile
+      # sets cpu so CPU-only hosts skip the multi-GB CUDA wheels (GH #125).
+      - PYTORCH_VARIANT=${PYTORCH_VARIANT:-cu129}
+      # GH #125: opt-in for TLS-intercepting networks (corporate proxy / antivirus
+      # HTTPS scanning). true makes uv trust the system/container CA store instead
+      # of its bundled roots — mount your corporate root CA so it is honored.
+      # Certificate verification stays ON. See docs/deployment-guide.md.
+      - UV_NATIVE_TLS=${UV_NATIVE_TLS:-false}
       # ASR model overrides (set by dashboard, empty = use config.yaml defaults)
       - MAIN_TRANSCRIBER_MODEL=${MAIN_TRANSCRIBER_MODEL:-}
       - LIVE_TRANSCRIBER_MODEL=${LIVE_TRANSCRIBER_MODEL:-}


### PR DESCRIPTION
## Summary

Fixes **#125** — "1.3.5 Windows / CPU: local start not possible". On CPU-only Windows hosts the server fails two independent ways, both rooted in **GPU-targeted defaults running on CPU-only hardware**:

1. **Bootstrap dependency sync aborts** with `invalid peer certificate: UnknownIssuer` while downloading multi-GB CUDA wheels (`nvidia-cuda-runtime-cu12`, `grpcio`, …) — the machine has no GPU but there was no CPU PyTorch variant, so it pulled `cu129` wheels it can't use.
2. **Model load crashes** with `UnicodeEncodeError: 'latin-1' codec can't encode character 'ş' (ş)` — a non-ASCII `HUGGINGFACE_TOKEN` is placed verbatim into the huggingface_hub `Authorization` header, which crashes **every** STT backend (NeMo, faster-whisper, WhisperX, pyannote), not just NeMo.

This PR ships three complementary fixes as one cohesive "Windows/CPU support" change.

## Changes

### A — CPU PyTorch variant (root cause)
- `bootstrap_runtime.py`: new `PYTORCH_VARIANT=cpu` — swaps the named `pytorch-cu129` index to `https://download.pytorch.org/whl/cpu` (drops `--frozen`, mirrors the existing `cu126` legacy path), and lets a runtime `cpu` request **safely override a baked GPU variant** (CPU wheels install over any base — the crux that makes this work on prebuilt GHCR images). The Issue #83 baked-trust defense is preserved for all non-`cpu` mismatches.
- `docker-compose.yml`: threads `PYTORCH_VARIANT` into the runtime `environment:` (was build-arg only).
- `dashboard`: the CPU profile selects the `cpu` variant and substitutes a faster-whisper model (no NeMo) via a race-free funnel guard in `dockerManager.ts::startContainer` plus a UI-side reset in `ServerView.tsx`.

### B — HF token guard (Unicode crash)
- New `server/backend/core/hf_token_guard.py` purges non-ASCII `HF_TOKEN`/`HUGGINGFACE_TOKEN`/`HUGGING_FACE_HUB_TOKEN` at startup (before any model load), so an invalid token downgrades to anonymous downloads instead of crashing. Verified against pinned `huggingface_hub==0.36.2`: the crash is in the `Authorization` header, so switching the model would NOT fix it — guarding the token value is the single robust lever.

### C — TLS interception mitigation (environmental)
- Opt-in `UV_NATIVE_TLS=true` makes `uv` trust the system/container CA store (its bundled roots reject re-signed certs from corporate proxies / antivirus HTTPS scanning).
- The bootstrap now detects `UnknownIssuer`/cert failures and logs an **actionable hint** (pointing at the docs) instead of a bare traceback, reading the full error before truncation.
- `Dockerfile` runs `update-ca-certificates`; docs cover the corporate-CA workaround.
- **Certificate verification is never disabled** — no `--allow-insecure-host`, no `verify=False`.

## Test plan

- [x] Backend: `cd server/backend && ../../build/.venv/bin/pytest tests/ -v` — **1914 passed, 3 skipped** (18 new tests: token guard, cpu-variant argv, baked-trust downgrade, TLS hint).
- [x] Dashboard: `cd dashboard && npm run typecheck` — clean; **158 Vitest tests pass** (new `dockerManagerCpuModel.test.ts` covers the CPU funnel guard).
- [x] Adversarial review (3 agents): acceptance auditor full PASS; one first-run-auto-detect edge case patched with the funnel guard.
- [ ] **Needs validation on real CPU-only hardware** (not possible in the dev environment): the live `uv sync` against `whl/cpu` — tests assert the bootstrap *argv*, not a live install. Ideally confirmed via a CI matrix job or by @odnodn / @cbarkinozer testing a branch image before release.
- [ ] GPU regression: confirm `cu129`/`cu126` images still bootstrap unchanged (regression tests cover the argv; a quick GPU smoke test is worthwhile).

## Notes

- The global default model in `config.yaml` is intentionally **unchanged** (stays `nvidia/parakeet-tdt-0.6b-v3` for GPU); the CPU profile overrides per-launch.
- No dedicated prebuilt CPU image — the runtime-variant approach reuses the existing image.

Closes #125
