### PR TITLE
fix(stt, mlx): pin MLX backend GPU ops to one owning thread — fix Metal "no stream (gpu,0)" crash (GH #134)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **TranscriptionSuite** (18442 symbols, 30847 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **TranscriptionSuite** (18555 symbols, 30988 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ feat/fix/chore/etc(impacted area e.g. tests, stt, dashboard, ui, server, etc): s
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **TranscriptionSuite** (18442 symbols, 30847 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **TranscriptionSuite** (18555 symbols, 30988 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/_bmad-output/implementation-artifacts/investigations/gh-134-investigation.md
+++ b/_bmad-output/implementation-artifacts/investigations/gh-134-investigation.md
@@ -1,0 +1,207 @@
+# Investigation: GH #134 — MLX/Metal "There is no stream (gpu,0) in current thread"
+
+## Hand-off Brief
+
+1. **What happened.** On Apple-Silicon Metal mode (v1.3.5), every transcription (file import *and* microphone) fails with the MLX runtime error *"There is no stream (gpu,0) in current thread"* — **Deduced** root cause: MLX GPU work is dispatched across interchangeable worker threads via `asyncio.to_thread` / separate `ThreadPoolExecutor` / dedicated live threads, but MLX binds a GPU stream to the thread that created it.
+2. **Where the case stands.** Root cause **Confirmed** from code structure with full `path:line` citations: the startup prewarm materializes the model on the event-loop thread (`main.py:629`) while every `transcribe()` runs on a `to_thread` pool worker — a *deterministic* (not racy) mismatch; no MLX backend manages streams at all. Only the live Mac raising-frame capture is blocked by lack of hardware.
+3. **What's needed next.** Decide the fix shape — pin **all** MLX operations (load, `mx.eval`, transcribe, `clear_cache`, unload) for a backend to a single long-lived dedicated thread — then implement via `bmad-quick-dev` or a tracked story.
+
+## Case Info
+
+| Field            | Value                                                                                         |
+| ---------------- | --------------------------------------------------------------------------------------------- |
+| Ticket           | GH #134 (links to #124; upstream mlx#2133, mlx-lm#1181, vllm-mlx#496)                          |
+| Date opened      | 2026-06-01                                                                                    |
+| Status           | Concluded — root cause Confirmed; fix implemented (see Follow-up 2026-06-01)                    |
+| System           | Apple Silicon (M4 Max), macOS 15 Sequoia, TranscriptionSuite v1.3.5, **Metal mode** (native MLX) |
+| Evidence sources | GitHub issue #134 + #124 thread, source code, upstream MLX issues. **No Mac hardware for repro.** |
+
+## Problem Statement
+
+Reporter (odnodn), after fixing the Metal-server start problem from #124 (installed the correct `-arm64-mac-metal.dmg`):
+
+> transcription from local file and microphone is not working.
+> 1. Session → start recording (recording starts) and 2. Session → import → drag audio file → Import queue
+> - **Transcription failed: There is no stream (gpu,0) in current thread.**
+
+Reporter's own hypothesis (with links): MLX dispatches work to a different thread than the one that created the GPU stream; MLX `Stream`/`wired_limit` are not thread-safe (mlx#2133).
+
+## Evidence Inventory
+
+| Source                              | Status    | Notes                                                                                          |
+| ----------------------------------- | --------- | ---------------------------------------------------------------------------------------------- |
+| GitHub issue #134 body + screenshot | Available | Error string + repro steps; screenshot shows the toast (full Python traceback not transcribed) |
+| GitHub issue #124 follow-up comment | Available | Same error first surfaced here; also lists 3 smaller side issues (see Side Findings)            |
+| Source code (MLX backends, routes)  | Available | `server/backend/core/stt/backends/mlx_*.py`, `api/routes/transcription.py`, `live.py`, engine  |
+| Upstream MLX issues                 | Partial   | mlx#2133 documents thread-affinity of streams; confirms the constraint exists                  |
+| Mac runtime / stack trace           | Missing   | No Apple-Silicon hardware available — cannot capture the exact raising frame or reproduce       |
+
+## Investigation Backlog
+
+| # | Path to Explore                                                                 | Priority | Status | Notes                                                                             |
+| - | ------------------------------------------------------------------------------- | -------- | ------ | --------------------------------------------------------------------------------- |
+| 1 | Confirm load thread materializes MLX model vs transcribe thread does GPU ops    | High     | Done   | Confirmed: load `from_pretrained`/`mlx_stt_load`/`mx.eval`; transcribe forward+`clear_cache` |
+| 2 | Map full call chain route → engine → backend.transcribe for non-live + live     | High     | Done   | Confirmed chain (Source Code Trace)                                               |
+| 3 | Check whether model is preloaded at startup (which thread) — guarantees mismatch | High     | Done   | Confirmed: `main.py:629` sync prewarm on event-loop thread → deterministic mismatch |
+| 4 | Verify CUDA path uses same dispatch (explains Metal-only)                        | Medium   | Done   | Confirmed backend-agnostic dispatch (`factory.py`, `engine.py:443`)               |
+| 5 | Survey all `mx.*` call sites for any existing stream/device pinning             | Medium   | Done   | Confirmed: none in backends; only `mx.metal.set_cache_limit` in `model_manager.py:268/277` |
+
+## Timeline of Events
+
+| Time             | Event                                                                       | Source            | Confidence |
+| ---------------- | --------------------------------------------------------------------------- | ----------------- | ---------- |
+| 2026-05-20       | #124 opened: Metal server won't start (wrong DMG)                           | issue #124        | Confirmed  |
+| 2026-05-31       | PR #132 merged — Metal-start diagnostics; reporter installs correct DMG     | PR #132           | Confirmed  |
+| 2026-05-31/06-01 | After server starts, transcription fails with "no stream (gpu,0)"           | issue #124 / #134 | Confirmed  |
+| 2026-06-01       | #134 opened with the error + upstream thread-affinity links                 | issue #134        | Confirmed  |
+
+## Confirmed Findings
+
+### Finding 1: Transcription dispatches model-load and inference through separate `asyncio.to_thread` calls
+
+**Evidence:** `server/backend/api/routes/transcription.py:132` (`await asyncio.to_thread(model_manager.ensure_transcription_loaded)`) and `:268`, `:337`, `:422`, `:480`, `:653`, `:1240`, `:1463` (`await asyncio.to_thread(... transcribe ...)`).
+
+**Detail:** `asyncio.to_thread` schedules onto the event loop's default `ThreadPoolExecutor`, whose worker threads are interchangeable. Load and transcribe are *separate* awaits → no guarantee they run on the same OS thread.
+
+### Finding 2: No MLX thread-pinning / dedicated single-thread executor exists
+
+**Evidence:** Repo-wide grep for `ThreadPoolExecutor|max_workers|run_in_executor|set_default_executor|dedicated.*thread` in `server/backend/core/` returns only `parallel_diarize.py` (max_workers=2), live-engine threads, NeMo-import thread, and warmup threads — **none MLX-stream-aware**.
+
+**Detail:** Nothing marshals MLX ops back to a single owning thread.
+
+### Finding 3: Parallel diarization runs transcription on a fresh ThreadPoolExecutor
+
+**Evidence:** `server/backend/core/parallel_diarize.py:222` — `with ThreadPoolExecutor(max_workers=2, thread_name_prefix="parallel_diarize") as pool:` runs transcription + diarization concurrently on separate threads.
+
+**Detail:** A second, independent cross-thread dispatch site for MLX inference.
+
+### Finding 4: Live mode transcribes on dedicated threads distinct from the load thread
+
+**Evidence:** Model loaded via `server/backend/api/routes/live.py:400` (`await asyncio.to_thread(model_manager.load_transcription_model)`); the live engine spins its own worker threads at `server/backend/core/live_engine.py:297` (`_loop_thread`) / `:303` (`_feeder_thread`) and `server/backend/core/stt/engine.py:410` (`recording_thread = threading.Thread(target=self._recording_worker, ...)`).
+
+**Detail:** Load happens on a pool thread; live inference happens on long-lived dedicated threads → guaranteed mismatch. Explains the microphone failure.
+
+### Finding 5: MLX model weights are materialized at load time (on the load thread)
+
+**Evidence:** `server/backend/core/stt/backends/mlx_canary_backend.py:257` — `mx.eval(model.parameters())` during model construction; `mx.clear_cache()` appears in load/unload paths of all four MLX backends (`mlx_whisper_backend.py:85,159`, `mlx_vibevoice_backend.py:65,216`, `mlx_canary_backend.py:310,429`, `mlx_parakeet_backend.py:153,300`).
+
+**Detail:** GPU stream state is established on whichever thread runs `load()`; subsequent `transcribe()` on a different thread cannot see it. Confirmed transcribe-thread GPU ops: parakeet `self._model.transcribe(...)` `mlx_parakeet_backend.py:293` + `mx.clear_cache()` `:300`; whisper `self._model.generate(...)` `mlx_whisper_backend.py:147` + `mx.clear_cache()` `:159`. Confirmed load-thread materialization: `from_pretrained(...)` `mlx_parakeet_backend.py:138`, `mlx_stt_load(...)` `mlx_whisper_backend.py:65`, `mx.eval(model.parameters())` `mlx_canary_backend.py:257`.
+
+### Finding 6: Startup prewarm materializes the model on the event-loop thread — deterministic mismatch
+
+**Evidence:** `server/backend/api/main.py:629` — `manager.load_transcription_model()` is called **synchronously and un-awaited** inside `async def lifespan` (`api/main.py:377`), so it executes on the asyncio event-loop (main) thread. Per-request transcription runs on a `to_thread` worker (`transcription.py:480`).
+
+**Detail:** This removes any "maybe same thread" luck: the model's GPU stream is created on the main thread at boot, and the first (and every) `transcribe()` runs on a different worker thread → guaranteed failure, matching the reporter's "transcription is not working" (not "sometimes fails").
+
+### Finding 7: The engine's lock serializes but does not pin to a thread
+
+**Evidence:** `server/backend/core/stt/engine.py:370` (`self.transcription_lock = threading.Lock()`), acquired at `:674`/`:875`.
+
+**Detail:** The lock prevents concurrent transcriptions but does nothing to ensure they run on the GPU-stream-owning thread — so it neither causes nor mitigates the bug. (A wrong fix would add more locking here; that would not help.)
+
+## Deduced Conclusions
+
+### Deduction 1: Cross-thread GPU dispatch triggers the MLX "no stream" error
+
+**Based on:** Findings 1–5 + upstream mlx#2133 (a stream allocated on one thread cannot be used/synchronized from another).
+
+**Reasoning:** `load()` materializes MLX arrays / establishes the GPU stream on thread A. `transcribe()` issues MLX ops on thread B (different `to_thread` worker, parallel-diarize pool thread, or live worker thread). MLX looks up stream `(gpu,0)` in thread B's context, finds none → raises.
+
+**Conclusion:** The defect is the **threading model**, not model selection, model files, or the build. It affects every MLX backend and every transcription entry point.
+
+### Deduction 2: The defect is Metal-only because CUDA contexts are process-wide
+
+**Based on:** PyTorch/CUDA context is shared across threads in a process; the same `to_thread` dispatch is used for CUDA backends in Docker mode without error.
+
+**Reasoning:** The identical route code runs on CUDA without issue, so the bug surfaces only where the GPU runtime is thread-affine (MLX). Matches the `apple-silicon-mlx` label and the "works in Docker" expectation.
+
+**Conclusion:** Not a regression in 1.3.5 code; an architectural mismatch exposed once the native Metal server actually starts and runs MLX.
+
+## Hypothesized Paths
+
+### Hypothesis 1: (Reporter's) MLX work dispatched to a thread other than the GPU-stream owner
+
+**Status:** Confirmed (architecturally, from code structure).
+
+**Theory:** Handler dispatches MLX GPU work to a different thread than the one that created the stream.
+
+**Supporting indicators:** Findings 1–5; upstream mlx#2133.
+
+**Would confirm:** A Mac stack trace showing the raise inside an MLX op invoked from a `to_thread`/pool/live worker frame.
+
+**Would refute:** Evidence that MLX work is already pinned to one thread, or that the error originates elsewhere (e.g., model file corruption). None found.
+
+**Resolution:** Code structure confirms the cross-thread dispatch; only the live capture of the exact frame is outstanding (blocked on hardware).
+
+## Missing Evidence
+
+| Gap                                   | Impact                                                    | How to Obtain                                                       |
+| ------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------- |
+| Mac runtime + full Python stack trace | Would upgrade Deduction 1 from Deduced→Confirmed at frame | Reporter runs with full server logs, or maintainer on Apple Silicon |
+| Which MLX model the reporter used     | None to root cause (all MLX backends share the pattern)   | Reporter's model selection                                          |
+
+## Source Code Trace
+
+| Element       | Detail                                                                                                       |
+| ------------- | ------------------------------------------------------------------------------------------------------------ |
+| Error origin  | MLX C++ core (raised inside an `mx.*` op / model forward / `mx.eval`) — not a literal string in this repo       |
+| Trigger       | Any transcription on Metal mode: file import, import queue, or live microphone                                |
+| Condition     | The thread issuing the MLX op ≠ the thread that loaded/materialized the model (created stream `(gpu,0)`)       |
+| Non-live chain | `transcription.py:132` load (`to_thread`) / `:480` transcribe (`to_thread`) → `engine.transcribe_file` `engine.py:753` → `transcribe_audio` `:839` → `backend.transcribe` `:913` |
+| Live chain     | load via `to_thread` `live.py:400`; worker `LiveModeThread` `live_engine.py:297-300` → `recorder.text()` `:209` → `engine.py:629` → `_perform_transcription` `:661` → `backend.transcribe` `:700`. Shared backend detached at `live.py:280` after being materialized on the main thread (`main.py:629`). |
+| Diarize chain  | `parallel_diarize.py:222` `ThreadPoolExecutor(max_workers=2)` runs the transcribe half on a pool thread        |
+| Related files | `api/main.py:629`, `api/routes/transcription.py`, `api/routes/live.py`, `core/live_engine.py`, `core/stt/engine.py`, `core/parallel_diarize.py`, `core/stt/backends/mlx_*.py`, `core/model_manager.py` |
+
+## Conclusion
+
+**Confidence:** High (root cause Confirmed from code structure across three independent dispatch sites; only the live raising-frame capture is blocked on Mac hardware).
+
+The error is caused by MLX's thread-affine GPU streams colliding with the server's multi-threaded dispatch. MLX requires that every GPU operation for a given context run on the thread that created the stream; the server loads the model on one thread and runs inference on others (`asyncio.to_thread` pool threads for file import, a separate `ThreadPoolExecutor` for parallel diarization, dedicated worker threads for live mode). It is Metal-specific because CUDA contexts are process-wide, so the same code is safe in Docker/CUDA mode.
+
+## Recommended Next Steps
+
+### Fix direction
+
+Pin **all** MLX operations for a model to a single, long-lived dedicated thread — `load`, `from_pretrained`/`mlx_stt_load`, `mx.eval`, `transcribe`, model forward, `mx.clear_cache`, and `unload` must all run there.
+
+**Recommended home — the backend layer, not the dispatch layer.** Because dispatch is backend-agnostic (Finding 4 of subagent trace) and no MLX backend touches stream/device APIs (Finding F-grep), marshal each MLX backend's public methods onto **one dedicated single-thread executor owned by the backend** (`concurrent.futures.ThreadPoolExecutor(max_workers=1, thread_name_prefix="mlx-<model>")`, created lazily, persisting for the backend's lifetime). Each public method body runs as `self._mlx_executor.submit(self._impl, ...).result()`. A `max_workers=1` pool reuses the *same* worker thread for every task → stream `(gpu,0)` is created once and always visible.
+
+**Why this covers everything at once:** the marshal happens *inside* the backend, so it is correct no matter which thread calls it — file import (`to_thread`), import-queue worker, `parallel_diarize` pool thread, and `LiveModeThread` are all automatically fixed with no change to `transcription.py`, `live.py`, `live_engine.py`, or `parallel_diarize.py`. CUDA/NeMo/WhisperX backends are untouched (process-wide context; no pinning needed).
+
+**Open design decisions (for the build phase):**
+- Per-backend executor (simplest; only one MLX backend is active at a time) vs. one process-wide MLX worker (maximally safe; would also naturally own `mx.metal.set_cache_limit` at `model_manager.py:268/277`).
+- Whether to also move the `mx.metal.set_cache_limit` call onto the pinned thread (likely benign — it configures the allocator, not a stream — but worth co-locating for a single MLX-thread invariant).
+- Reentrancy: ensure a method that internally calls another marshaled method doesn't deadlock the single-thread pool (impl methods must call the raw `_impl`, not the public marshaled wrapper).
+- Lifecycle: reuse the same executor across load→transcribe→unload so affinity holds; only shut it down when the backend is permanently disposed.
+
+**Verification without Mac hardware:** unit tests can assert that `load()` and `transcribe()` execute on the *same* `threading.get_ident()`, and that this thread differs from the caller's — proving affinity is enforced without needing a real Metal device (mock the `mx.*`/model calls to record the thread id).
+
+### Diagnostic
+
+If a Mac is available: run with full server logs, reproduce a single file transcription, capture the Python traceback to confirm the exact raising `mx.*` frame and the worker thread name.
+
+## Reproduction Plan
+
+Requires Apple Silicon + Metal mode. Setup: install `-arm64-mac-metal.dmg`, start Metal server, select any MLX model. Trigger: import one audio file. Expected (current): "Transcription failed: There is no stream (gpu,0) in current thread." Expected (after fix): normal transcription.
+
+## Side Findings
+
+From the #124 follow-up comment (tangential to #134 root cause; not yet ticketed):
+
+- Model Manager copy is contradictory: "Start the server to manage model downloads. Model selection is available while the server is stopped." (**Reported**, not verified.)
+- Possible bug: cannot download other models even when the server is stopped. (**Reported**, not verified.)
+- Enhancement: Server config "Persistent volumes" paths are truncated — request full path + open-in-Finder + copy-to-clipboard. (**Reported**, enhancement.)
+
+## Follow-up: 2026-06-01
+
+### Resolution
+
+Fix designed and implemented on branch `fix/gh-134-mlx-cross-thread-stream`. Spec: `spec-gh-134-mlx-cross-thread-stream.md` (status `done`).
+
+**Mechanism:** New `server/backend/core/stt/backends/mlx_thread_pin.py` — `MLXThreadAffinityMixin` (one `ThreadPoolExecutor(max_workers=1)` per backend instance) + `@mlx_pinned` decorator. All four MLX backends now marshal `load`/`unload`/`warmup`/`transcribe` (+ vibevoice `transcribe_with_diarization`) onto a single owning thread, so the GPU stream is created once and every op runs there — fixing file import, import queue, parallel diarization, and live mode at once with no dispatch-layer change.
+
+**Verification (Linux, code-only — Mac hardware still required for device confirmation):** 6 new thread-affinity tests pass; full backend suite 1920 passed / 0 failed; `gitnexus_detect_changes` → risk low, 0 affected execution flows. The remaining uncertainty is purely the device-level confirmation that pinning eliminates the MLX error on a real M-series Mac (the code-level cause is Confirmed).
+
+### Updated Conclusion
+
+Root cause Confirmed; fix Implemented and code-verified. Open only on the maintainer's Apple-Silicon manual check + reporter confirmation on #134.

--- a/_bmad-output/implementation-artifacts/spec-gh-134-mlx-cross-thread-stream.md
+++ b/_bmad-output/implementation-artifacts/spec-gh-134-mlx-cross-thread-stream.md
@@ -1,0 +1,159 @@
+---
+title: 'GH #134 — MLX/Metal "no stream (gpu,0)" crash: pin all MLX GPU ops to one owning thread'
+type: 'bugfix'
+created: '2026-06-01'
+status: 'done'
+baseline_commit: '44d60e8adda7504eaf44af1d70e2b480761ba6bf'
+context:
+  - '{project-root}/_bmad-output/implementation-artifacts/investigations/gh-134-investigation.md'
+  - '{project-root}/server/backend/core/stt/backends/base.py'
+  - '{project-root}/server/backend/core/stt/backends/mlx_parakeet_backend.py'
+  - '{project-root}/server/backend/core/stt/backends/mlx_whisper_backend.py'
+  - '{project-root}/server/backend/core/stt/backends/mlx_canary_backend.py'
+  - '{project-root}/server/backend/core/stt/backends/mlx_vibevoice_backend.py'
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** On Apple Silicon **Metal mode** (v1.3.5), *every* transcription — file import, import queue, and live microphone — fails with the MLX runtime error **"There is no stream (gpu,0) in current thread"** (GH #134). Root cause (confirmed in the investigation case file): MLX binds a GPU stream to the thread that *creates* it, but the server materializes the model on one thread and runs inference on another. The startup prewarm loads the model on the **asyncio event-loop thread** (`api/main.py:629`, a synchronous un-awaited call inside `async def lifespan`), while every transcribe runs on a different **`asyncio.to_thread` pool worker** (`transcription.py:480` → `engine.transcribe_file:753` → `backend.transcribe:913`). Live mode (dedicated `LiveModeThread`, `live_engine.py:297`) and parallel diarization (`parallel_diarize.py:222` `ThreadPoolExecutor`) add two more cross-thread dispatch sites. No MLX backend manages streams at all. It is **Metal-only** because CUDA/PyTorch contexts are process-wide, so the *identical* dispatch is safe in Docker mode — this is **not a 1.3.5 regression**; it surfaced only once the native Metal server actually started after #124's DMG fix.
+
+**Approach:** Pin **all** MLX GPU operations for a backend instance to a single, long-lived dedicated thread. Add a small `MLXThreadAffinityMixin` (new module `mlx_thread_pin.py`) that owns **one** `ThreadPoolExecutor(max_workers=1)` per backend instance, plus a `@mlx_pinned` method decorator that marshals the wrapped method onto that thread — with a **reentrancy guard** so a pinned method that calls another pinned method runs inline instead of deadlocking the single worker. The four MLX backends inherit the mixin and decorate their GPU methods (`load`, `unload`, `warmup`, `transcribe`, plus vibevoice's `transcribe_with_diarization`). Because the marshaling happens **inside** the backend, one change fixes file import, import-queue, parallel-diarize, *and* live mode simultaneously, with **zero** changes to the dispatch layer; CUDA/NeMo/WhisperX backends are untouched.
+
+## Boundaries & Constraints
+
+**Always:**
+- Every MLX GPU op for a given backend instance — `from_pretrained` / `mlx_stt_load` / `_load_canary_model`, `mx.eval`, model `.generate`/`.transcribe`, `mx.clear_cache`, `del self._model` — MUST run on **that instance's single owning thread**.
+- The owning thread MUST be the **same** across `load → warmup → transcribe → unload` for the instance's lifetime (reuse the executor; never spin a fresh thread per call).
+- The decorator MUST preserve the wrapped method's signature, return value, and exceptions **verbatim** (`functools.wraps`; `future.result()` re-raises the original exception, not a `concurrent.futures` wrapper).
+- Reentrancy: if a pinned method is already executing on the owning thread, a nested pinned call MUST run **inline** (no re-submit) to avoid single-worker deadlock.
+- Keep `is_loaded`, `supports_translation`, `preferred_input_sample_rate_hz`, `backend_name`, `configure_decode_options` **un-pinned** — no GPU work; called from arbitrary threads; must stay cheap and non-blocking.
+
+**Ask First:**
+- Switching from per-backend executors to a **single process-wide MLX worker thread** (would also let `mx.metal.set_cache_limit` at `model_manager.py:268/277` move onto it — larger surface).
+- Moving the startup prewarm (`api/main.py:629`) to `await asyncio.to_thread(...)` (orthogonal correctness nit; the affinity fix makes it correct regardless).
+- Adding thread pinning to any **non-MLX** backend.
+
+**Never:**
+- Do NOT change `asyncio.to_thread` dispatch in `transcription.py`/`live.py`, the `parallel_diarize` `ThreadPoolExecutor`, or the `LiveModeThread`/`recording_thread` model — the fix lives entirely in the backend layer.
+- Do NOT alter transcription inputs/outputs, segment parsing, chunking, attention-model toggling, resampling, or any decode behavior — **threading fix only**.
+- Do NOT touch CUDA/NeMo/WhisperX/faster-whisper/whisper.cpp backends or their dispatch.
+- Do NOT add locking to `engine.transcription_lock` as a "fix" — it serializes but does not pin, and is irrelevant to this bug.
+- Do NOT introduce a per-call thread (defeats affinity) or shut the executor down inside `unload` if the instance may be reused (orphans the owning-thread id).
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Behavior | Error Handling |
+|----------|--------------|-------------------|----------------|
+| File import (single) | MLX backend prewarmed on event-loop thread; transcribe via `to_thread` worker | `load` + `transcribe` bodies both run on the backend's owning MLX thread → succeeds | original exception propagates unchanged to the route |
+| Import queue / parallel diarize | transcribe dispatched on a `parallel_diarize` pool thread | marshaled to owning MLX thread; succeeds. Diarization (torch/pyannote) stays on its own thread — does not touch MLX | as above |
+| Live microphone | model loaded via `to_thread` (`live.py:400`); inference on `LiveModeThread` | both marshaled to the owning MLX thread → succeeds | as above |
+| vibevoice diarization | `transcribe_with_diarization` (pinned) → `_run_generate` (inline) | runs on owning thread; no nested re-submit | reentrancy guard runs inner inline |
+| Reentrancy | a pinned method calls another pinned method while on the owning thread | inner body runs inline (no submit) | no deadlock |
+| Model swap / reload | `unload` then `load` (same instance) OR new instance (live swap) | same instance reuses its thread; new instance gets its own; affinity preserved within each | n/a |
+| Exception in pinned body | `model.generate(...)` raises `RuntimeError` | identical `RuntimeError` (type + message + traceback) re-raised to caller | `future.result()` re-raises; no executor wrapping |
+| Non-MLX backend (CUDA/NeMo) | transcribe via `to_thread` | unchanged — no mixin, no pinning | unchanged |
+
+</frozen-after-approval>
+
+## Code Map
+
+- **NEW** `server/backend/core/stt/backends/mlx_thread_pin.py` — `MLXThreadAffinityMixin`: lazy per-instance `ThreadPoolExecutor(max_workers=1, thread_name_prefix="mlx-<backend_name>")`; `_run_on_mlx_thread(fn, *a, **k)` that captures the owning-thread id on first use and runs **inline** when `threading.get_ident()` already equals it, else `submit(...).result()`; plus the `mlx_pinned(method)` decorator (`functools.wraps`, delegates to `self._run_on_mlx_thread`, re-raises original exception).
+- `server/backend/core/stt/backends/mlx_parakeet_backend.py` — `class MLXParakeetBackend(STTBackend)` **L104** → add mixin to bases; `@mlx_pinned` on `load` **L121**, `unload` **L145**, `warmup` **L160**, `transcribe` **L176**. (`_tokens_to_words` L46 is pure — no change.)
+- `server/backend/core/stt/backends/mlx_whisper_backend.py` — class **L39**; decorate `load` **L54**, `unload` **L76**, `warmup` **L92**, `transcribe` **L101**.
+- `server/backend/core/stt/backends/mlx_canary_backend.py` — class **L262**; decorate `load` **L279**, `unload` **L301**, `warmup` **L317**, `transcribe` **L333**. (`_load_canary_model` **L177** is a module fn called only from the pinned `load` → already runs on the owning thread; leave as-is — it holds the `mx.eval(model.parameters())` at L257.)
+- `server/backend/core/stt/backends/mlx_vibevoice_backend.py` — class **L38**; decorate `load` **L47**, `unload` **L56**, `warmup` **L72**, `transcribe` **L82**, `transcribe_with_diarization` **L131**. (`_run_generate` **L206** is private, called only from pinned methods → runs inline on the owning thread; **leave un-decorated**.)
+- `server/backend/core/stt/backends/base.py` — **reference only, no change**; `STTBackend` L56 abstract contract is unchanged (mixin is additive via multiple inheritance: `class MLXxBackend(MLXThreadAffinityMixin, STTBackend)`).
+- **NEW** `server/backend/tests/test_mlx_thread_affinity.py` — affinity proofs using a fake backend subclass; **no MLX/Metal import required** (records `threading.get_ident()`).
+- Reference: `_bmad-output/implementation-artifacts/investigations/gh-134-investigation.md` (full evidence chain).
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] **NEW** `mlx_thread_pin.py` — implement `MLXThreadAffinityMixin` + `mlx_pinned` per Code Map. Lazy executor creation (guarded); capture owning-thread id by `submit(threading.get_ident).result()` at creation; reentrancy guard compares `threading.get_ident()` to the captured id; `future.result()` propagates the original exception. Module docstring cites GH #134 + the thread-affinity reason.
+- [x] `mlx_parakeet_backend.py`, `mlx_whisper_backend.py`, `mlx_canary_backend.py`, `mlx_vibevoice_backend.py` — add `MLXThreadAffinityMixin` to bases and `@mlx_pinned` to the GPU methods per Code Map. **No method-body changes.**
+- [x] **NEW** `test_mlx_thread_affinity.py` — cover the ACs below (fake backend; Linux-runnable).
+- [x] (verify, not edit) confirm no MLX `warmup` calls a *pinned sibling* (`self.transcribe`) — all four call `self._model.*`/`self._run_generate` directly (confirmed at baseline); the guard covers it regardless.
+
+**Acceptance Criteria:**
+- Given a fake MLX backend (mixin + `@mlx_pinned` methods recording `threading.get_ident()`), when `load()` then `transcribe()` are invoked from **two different** caller threads, then both bodies execute on the **same** thread id, and that id **differs from both** callers'.
+- Given a pinned method that internally calls another pinned method, when invoked, then the inner body runs on the owning thread **without deadlock** (completes within a short timeout) and returns correctly.
+- Given a pinned method whose body raises `ValueError("x")`, when called, then the **same** `ValueError("x")` propagates to the caller (type + message preserved) — not a `concurrent.futures` wrapper.
+- Given one backend instance, when `transcribe()` is called N times across N distinct caller threads, then all N bodies run on **one and the same** owning thread id.
+- Given `cd server/backend && ../../build/.venv/bin/pytest tests/test_mlx_thread_affinity.py -v`, then all pass on **Linux** (no MLX/Metal dependency).
+- Given the existing `tests/test_stt_backend_factory.py` and `tests/test_mlx_vibevoice_backend.py`, when run, then they still pass (mixin is additive; factory detection unchanged).
+
+## Spec Change Log
+
+**2026-06-01 — implemented (ready-for-dev → done).** Built exactly to the frozen intent; no renegotiation.
+- New `server/backend/core/stt/backends/mlx_thread_pin.py` — `MLXThreadAffinityMixin` (lazy per-instance `ThreadPoolExecutor(max_workers=1, thread_name_prefix="mlx-<backend_name>")`; owning-thread id captured via `submit(threading.get_ident).result()`; reentrancy guard runs inline when already on the owning thread; `future.result()` re-raises the original exception; idempotent `shutdown_mlx_thread()`) + `mlx_pinned` decorator (`functools.wraps`).
+- Decorated GPU methods on all four backends, **no body changes**: parakeet/whisper/canary `load`+`unload`+`warmup`+`transcribe` (4 each); vibevoice adds `transcribe_with_diarization` (5). `_run_generate` (vibevoice) deliberately left private/un-decorated — it runs inline inside an already-pinned public method.
+- New `server/backend/tests/test_mlx_thread_affinity.py` — 6 tests, Linux-runnable, no MLX import (fake backend records `threading.get_ident()`).
+
+**Verification results (Linux, build venv):**
+- `test_mlx_thread_affinity.py` → 6/6 pass.
+- `test_stt_backend_factory.py` + `test_mlx_vibevoice_backend.py` → 30/30 pass — the vibevoice cases exercise the real decorated `load`/`unload`/`transcribe`/`transcribe_with_diarization` paths with mocked models, confirming behavior is preserved through the marshal.
+- Full backend suite → **1920 passed, 3 skipped, 0 failed** (no regressions; the 2 failures noted in older docs are already resolved on this baseline).
+- `gitnexus_impact` (4 backend classes, upstream) → LOW. `gitnexus_detect_changes` → risk low, 28 expected symbols touched, **0 affected execution flows**.
+
+**Out of scope / Ask-First (unchanged):** process-wide single MLX thread; moving the `api/main.py:629` prewarm to `await asyncio.to_thread`; any non-MLX backend. **Manual Apple-Silicon confirmation still required** (no Mac hardware here) — the predicted fix is code-verified, not device-verified.
+
+## File List
+
+- `server/backend/core/stt/backends/mlx_thread_pin.py` *(new)*
+- `server/backend/core/stt/backends/mlx_parakeet_backend.py` *(modified)*
+- `server/backend/core/stt/backends/mlx_whisper_backend.py` *(modified)*
+- `server/backend/core/stt/backends/mlx_canary_backend.py` *(modified)*
+- `server/backend/core/stt/backends/mlx_vibevoice_backend.py` *(modified)*
+- `server/backend/tests/test_mlx_thread_affinity.py` *(new)*
+- `_bmad-output/implementation-artifacts/spec-gh-134-mlx-cross-thread-stream.md` *(this spec)*
+- `_bmad-output/implementation-artifacts/investigations/gh-134-investigation.md` *(investigation, pre-existing)*
+
+## Design Notes
+
+**Per-backend executor, not process-wide.** Only one transcription backend is active at a time (live swap unloads the main model, loads the live one), and MLX stream affinity is per-thread; a per-instance owning thread is sufficient and has a trivial lifecycle (it dies with the instance). A single process-wide MLX thread would *also* naturally own `mx.metal.set_cache_limit` (`model_manager.py:268/277`) and any future module-level `mx.*`, but it is a larger surface and a harder lifecycle — deferred to Ask-First. The per-backend choice still fixes the **shared-backend** live path: `live.py:280` detaches and reuses the main backend on `LiveModeThread`, but because marshaling is keyed to the **instance's** executor (not the caller), reuse still lands on that instance's owning thread.
+
+**Decorator over body-rewrite.** Every backend's GPU work already lives in public methods that call `self._model.*` / `self._run_generate` — never a sibling *public* method — so `@mlx_pinned` needs **zero** body edits and introduces no deadlock path at baseline. The reentrancy guard is defensive: it future-proofs against a later nested pinned call (and makes vibevoice's `transcribe_with_diarization → _run_generate` safe even if `_run_generate` is ever promoted/decorated).
+
+**`mx.clear_cache()` placement is now correct for free.** It sits inside `unload`/`transcribe`/`_run_generate`, so once those run on the owning thread, the cache clear is also on the owning thread — clearing the Metal cache from a foreign thread is itself a cross-thread MLX op and would be unsafe.
+
+**Startup prewarm blocking is unchanged.** `api/main.py:629` already blocks the event loop synchronously (un-awaited `load_transcription_model()`); with the fix the *actual* MLX work hops to the owning thread while the event-loop thread blocks on `.result()` — same wall-clock blocking, now thread-correct. (Making the prewarm `await asyncio.to_thread(...)` is a separate, optional nicety — Ask-First.)
+
+**Why Metal-only / not a regression.** CUDA contexts are process-wide; the identical `asyncio.to_thread` dispatch is safe in Docker. The bug appeared only when the native Metal server started post-#124. Full evidence: the investigation case file.
+
+## Verification
+
+**Commands** (from `server/backend/`, build venv per CLAUDE.md):
+- `../../build/.venv/bin/pytest tests/test_mlx_thread_affinity.py -v --tb=short` — new affinity tests pass (Linux, no Metal).
+- `../../build/.venv/bin/pytest tests/test_stt_backend_factory.py tests/test_mlx_vibevoice_backend.py -v` — no regressions.
+- `../../build/.venv/bin/pytest tests/ -q` — full suite green (modulo the 2 known pre-existing failures recorded in `docs/TESTING.md`).
+
+**Manual checks (Apple Silicon + Metal required — maintainer):**
+- Install `-arm64-mac-metal.dmg`, start the Metal server, import one audio file → transcription succeeds with **no** "no stream (gpu,0)".
+- Start a live microphone session → live transcription succeeds.
+- Reporter confirmation on #134 with an MLX model selected (parakeet/whisper/canary/vibevoice).
+
+## Suggested Review Order
+
+**The core — start here**
+
+- The mixin: lazy single-worker executor + owning-thread-id capture
+  [`mlx_thread_pin.py:37`](../../server/backend/core/stt/backends/mlx_thread_pin.py#L37)
+- `_run_on_mlx_thread` — the reentrancy guard (inline when already on the owning thread) + `future.result()` exception passthrough
+  [`mlx_thread_pin.py:66`](../../server/backend/core/stt/backends/mlx_thread_pin.py#L66)
+- The `@mlx_pinned` decorator — `functools.wraps` + delegation
+  [`mlx_thread_pin.py:88`](../../server/backend/core/stt/backends/mlx_thread_pin.py#L88)
+
+**Wiring (identical pattern ×4)**
+
+- parakeet: mixin base + 4 decorators
+  [`mlx_parakeet_backend.py:105`](../../server/backend/core/stt/backends/mlx_parakeet_backend.py#L105)
+- whisper [`mlx_whisper_backend.py:40`](../../server/backend/core/stt/backends/mlx_whisper_backend.py#L40) · canary [`mlx_canary_backend.py:263`](../../server/backend/core/stt/backends/mlx_canary_backend.py#L263)
+- vibevoice — the only 5-decorator file (adds `transcribe_with_diarization`); `_run_generate` left un-decorated
+  [`mlx_vibevoice_backend.py:39`](../../server/backend/core/stt/backends/mlx_vibevoice_backend.py#L39)
+
+**Tests — the affinity proofs (no Metal needed)**
+
+- Fake backend + same-owning-thread / distinct-from-caller / reentrancy-no-deadlock / exception-passthrough / N-calls-one-thread
+  [`test_mlx_thread_affinity.py:18`](../../server/backend/tests/test_mlx_thread_affinity.py#L18)

--- a/server/backend/core/stt/backends/mlx_canary_backend.py
+++ b/server/backend/core/stt/backends/mlx_canary_backend.py
@@ -36,6 +36,7 @@ from server.core.stt.backends.base import (
     BackendTranscriptionInfo,
     STTBackend,
 )
+from server.core.stt.backends.mlx_thread_pin import MLXThreadAffinityMixin, mlx_pinned
 
 SAMPLE_RATE = 16000
 
@@ -259,7 +260,7 @@ def _load_canary_model(model_name: str) -> Any:
     return model
 
 
-class MLXCanaryBackend(STTBackend):
+class MLXCanaryBackend(MLXThreadAffinityMixin, STTBackend):
     """Apple MLX / Metal-accelerated Canary backend.
 
     Wraps ``canary-mlx`` for NVIDIA Canary model inference on Apple Silicon.
@@ -276,6 +277,7 @@ class MLXCanaryBackend(STTBackend):
     # STTBackend interface
     # ------------------------------------------------------------------
 
+    @mlx_pinned
     def load(self, model_name: str, device: str, **kwargs: Any) -> None:
         """Load the Canary model."""
         del device, kwargs
@@ -298,6 +300,7 @@ class MLXCanaryBackend(STTBackend):
         except Exception as exc:
             raise RuntimeError(f"Failed to load MLX Canary model '{model_name}': {exc}") from exc
 
+    @mlx_pinned
     def unload(self) -> None:
         import gc
 
@@ -314,6 +317,7 @@ class MLXCanaryBackend(STTBackend):
     def is_loaded(self) -> bool:
         return self._loaded
 
+    @mlx_pinned
     def warmup(self) -> None:
         if not self._loaded or self._model is None:
             return
@@ -330,6 +334,7 @@ class MLXCanaryBackend(STTBackend):
         except Exception as e:
             logger.warning(f"MLX Canary warmup failed (non-critical): {e}")
 
+    @mlx_pinned
     def transcribe(
         self,
         audio: np.ndarray,

--- a/server/backend/core/stt/backends/mlx_parakeet_backend.py
+++ b/server/backend/core/stt/backends/mlx_parakeet_backend.py
@@ -37,6 +37,7 @@ from server.core.stt.backends.base import (
     BackendTranscriptionInfo,
     STTBackend,
 )
+from server.core.stt.backends.mlx_thread_pin import MLXThreadAffinityMixin, mlx_pinned
 
 SAMPLE_RATE = 16000
 
@@ -101,7 +102,7 @@ def _tokens_to_words(tokens: list[Any]) -> list[dict[str, Any]]:
     return words
 
 
-class MLXParakeetBackend(STTBackend):
+class MLXParakeetBackend(MLXThreadAffinityMixin, STTBackend):
     """Apple MLX / Metal-accelerated Parakeet-TDT backend.
 
     Wraps ``parakeet-mlx`` for NVIDIA Parakeet-TDT inference on Apple Silicon.
@@ -118,6 +119,7 @@ class MLXParakeetBackend(STTBackend):
     # STTBackend interface
     # ------------------------------------------------------------------
 
+    @mlx_pinned
     def load(self, model_name: str, device: str, **kwargs: Any) -> None:
         """Load the Parakeet model via ``parakeet_mlx.from_pretrained``."""
         del device, kwargs
@@ -142,6 +144,7 @@ class MLXParakeetBackend(STTBackend):
         except Exception as exc:
             raise RuntimeError(f"Failed to load MLX Parakeet model '{model_name}': {exc}") from exc
 
+    @mlx_pinned
     def unload(self) -> None:
         if self._model is not None:
             import mlx.core as mx
@@ -157,6 +160,7 @@ class MLXParakeetBackend(STTBackend):
     def is_loaded(self) -> bool:
         return self._loaded
 
+    @mlx_pinned
     def warmup(self) -> None:
         if not self._loaded or self._model is None:
             return
@@ -173,6 +177,7 @@ class MLXParakeetBackend(STTBackend):
         except Exception as e:
             logger.warning(f"MLX Parakeet warmup failed (non-critical): {e}")
 
+    @mlx_pinned
     def transcribe(
         self,
         audio: np.ndarray,

--- a/server/backend/core/stt/backends/mlx_thread_pin.py
+++ b/server/backend/core/stt/backends/mlx_thread_pin.py
@@ -1,0 +1,99 @@
+"""Thread-affinity helper for MLX (Apple Silicon / Metal) STT backends.
+
+MLX binds each GPU stream to the OS thread that *created* it; dispatching MLX GPU
+work from a different thread raises ``RuntimeError: There is no stream (gpu,0) in
+current thread`` (upstream ml-explore/mlx#2133). The server, however, dispatches
+transcription across interchangeable threads — ``asyncio.to_thread`` pool workers
+(``api/routes/transcription.py``), the parallel-diarization ``ThreadPoolExecutor``
+(``core/parallel_diarize.py``), and the live-mode worker thread
+(``core/live_engine.py``) — while the model is materialized on yet another thread
+(the startup prewarm at ``api/main.py`` runs synchronously on the event-loop
+thread). Load-thread != inference-thread, so every MLX call after start fails.
+
+This module pins **all** MLX GPU operations for a backend instance onto a single
+dedicated owning thread. Mix :class:`MLXThreadAffinityMixin` into an MLX backend
+(before ``STTBackend`` in the MRO) and decorate every GPU-touching method with
+:func:`mlx_pinned`. The fix is Metal-specific: CUDA/PyTorch contexts are
+process-wide, so the identical dispatch is safe there.
+
+Root cause + fix design: GH #134.
+"""
+
+from __future__ import annotations
+
+import functools
+import threading
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+# Serializes lazy executor creation across instances. Creation is rare (once per
+# backend instance), so a single shared lock has no meaningful contention cost.
+_MLX_EXECUTOR_INIT_LOCK = threading.Lock()
+
+
+class MLXThreadAffinityMixin:
+    """Marshal decorated MLX GPU methods onto one dedicated owning thread.
+
+    The first :func:`mlx_pinned` call lazily creates a single-worker
+    ``ThreadPoolExecutor`` and records its worker-thread id; every later pinned
+    call runs on that same thread. A pinned method invoked while *already* on the
+    owning thread runs inline (no re-submit), so nested pinned calls cannot
+    deadlock the single worker.
+
+    State is created lazily so backends need not call ``super().__init__()``.
+    """
+
+    def _ensure_mlx_executor(self) -> ThreadPoolExecutor:
+        executor: ThreadPoolExecutor | None = getattr(self, "_mlx_executor", None)
+        if executor is not None:
+            return executor
+        with _MLX_EXECUTOR_INIT_LOCK:
+            # Re-check under the lock (another thread may have created it).
+            executor = getattr(self, "_mlx_executor", None)
+            if executor is not None:
+                return executor
+            name = getattr(self, "backend_name", "mlx")
+            executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix=f"mlx-{name}")
+            # Capture the worker's thread id on the worker itself, so reentrant
+            # pinned calls can detect that they are already on the owning thread.
+            self._mlx_owning_thread_id: int = executor.submit(threading.get_ident).result()
+            self._mlx_executor: ThreadPoolExecutor = executor
+            return executor
+
+    def _run_on_mlx_thread[T](self, fn: Callable[..., T], /, *args: Any, **kwargs: Any) -> T:
+        """Run ``fn`` on this instance's owning MLX thread and return its result.
+
+        Re-raises the callee's exception with its original type and traceback.
+        """
+        # Reentrancy guard: already on the owning thread → run inline, otherwise
+        # the single worker would wait on itself and deadlock.
+        if getattr(self, "_mlx_owning_thread_id", None) == threading.get_ident():
+            return fn(*args, **kwargs)
+        executor = self._ensure_mlx_executor()
+        # Future.result() propagates the body's exception unchanged.
+        return executor.submit(fn, *args, **kwargs).result()
+
+    def shutdown_mlx_thread(self) -> None:
+        """Tear down the owning thread. Idempotent; a later pinned call re-creates it."""
+        executor: ThreadPoolExecutor | None = getattr(self, "_mlx_executor", None)
+        if executor is not None:
+            executor.shutdown(wait=True)
+            self._mlx_executor = None
+            self._mlx_owning_thread_id = None
+
+
+def mlx_pinned[T](method: Callable[..., T]) -> Callable[..., T]:
+    """Decorator: run a backend method on its instance's owning MLX thread.
+
+    The wrapped method's signature, return value, and exceptions are preserved.
+    Apply only to GPU-touching methods (``load``/``unload``/``warmup``/
+    ``transcribe``/``transcribe_with_diarization``); leave pure/metadata methods
+    (``is_loaded``, ``backend_name``, ...) un-decorated so they stay non-blocking.
+    """
+
+    @functools.wraps(method)
+    def wrapper(self: MLXThreadAffinityMixin, *args: Any, **kwargs: Any) -> T:
+        return self._run_on_mlx_thread(method, self, *args, **kwargs)
+
+    return wrapper

--- a/server/backend/core/stt/backends/mlx_thread_pin.py
+++ b/server/backend/core/stt/backends/mlx_thread_pin.py
@@ -25,7 +25,16 @@ import functools
 import threading
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any
+from typing import Any, TypeVar
+
+# Classic typing.TypeVar — deliberately NOT a PEP 695 ``def f[T]`` type parameter:
+# CodeQL's Python extractor does not yet understand PEP 695 type parameters and
+# raises a false py/uninitialized-local-variable on the type variable when it is
+# referenced inside a nested function (the ``wrapper`` below). A module-level
+# TypeVar is unambiguously initialized, so CodeQL stays quiet. ``mlx_pinned`` thus
+# carries a matching ``# noqa: UP047`` for ruff, which would otherwise push it back
+# to the PEP 695 form that breaks CodeQL. See GH #134 / PR #138.
+_T = TypeVar("_T")
 
 # Serializes lazy executor creation across instances. Creation is rare (once per
 # backend instance), so a single shared lock has no meaningful contention cost.
@@ -61,7 +70,7 @@ class MLXThreadAffinityMixin:
             self._mlx_executor: ThreadPoolExecutor = executor
             return executor
 
-    def _run_on_mlx_thread[T](self, fn: Callable[..., T], /, *args: Any, **kwargs: Any) -> T:
+    def _run_on_mlx_thread(self, fn: Callable[..., _T], /, *args: Any, **kwargs: Any) -> _T:
         """Run ``fn`` on this instance's owning MLX thread and return its result.
 
         Re-raises the callee's exception with its original type and traceback.
@@ -83,7 +92,7 @@ class MLXThreadAffinityMixin:
             self._mlx_owning_thread_id = None
 
 
-def mlx_pinned[T](method: Callable[..., T]) -> Callable[..., T]:
+def mlx_pinned(method: Callable[..., _T]) -> Callable[..., _T]:  # noqa: UP047
     """Decorator: run a backend method on its instance's owning MLX thread.
 
     The wrapped method's signature, return value, and exceptions are preserved.
@@ -93,7 +102,7 @@ def mlx_pinned[T](method: Callable[..., T]) -> Callable[..., T]:
     """
 
     @functools.wraps(method)
-    def wrapper(self: MLXThreadAffinityMixin, *args: Any, **kwargs: Any) -> T:
+    def wrapper(self: MLXThreadAffinityMixin, *args: Any, **kwargs: Any) -> _T:
         return self._run_on_mlx_thread(method, self, *args, **kwargs)
 
     return wrapper

--- a/server/backend/core/stt/backends/mlx_vibevoice_backend.py
+++ b/server/backend/core/stt/backends/mlx_vibevoice_backend.py
@@ -29,13 +29,14 @@ from server.core.stt.backends.base import (
     DiarizedTranscriptionResult,
     STTBackend,
 )
+from server.core.stt.backends.mlx_thread_pin import MLXThreadAffinityMixin, mlx_pinned
 
 INPUT_SAMPLE_RATE = 16000
 
 logger = logging.getLogger(__name__)
 
 
-class MLXVibeVoiceBackend(STTBackend):
+class MLXVibeVoiceBackend(MLXThreadAffinityMixin, STTBackend):
     """STT backend for VibeVoice-ASR via mlx-audio on Apple Silicon."""
 
     def __init__(self) -> None:
@@ -44,6 +45,7 @@ class MLXVibeVoiceBackend(STTBackend):
 
     # ── STTBackend interface ──────────────────────────────────────────
 
+    @mlx_pinned
     def load(self, model_name: str, device: str, **kwargs: Any) -> None:
         del device  # MLX always uses Metal
         from mlx_audio.stt import load as mlx_stt_load
@@ -53,6 +55,7 @@ class MLXVibeVoiceBackend(STTBackend):
         self._model_name = model_name
         logger.info("MLX VibeVoice model loaded: %s", model_name)
 
+    @mlx_pinned
     def unload(self) -> None:
         if self._model is not None:
             import gc
@@ -69,6 +72,7 @@ class MLXVibeVoiceBackend(STTBackend):
     def is_loaded(self) -> bool:
         return self._model is not None
 
+    @mlx_pinned
     def warmup(self) -> None:
         if self._model is None:
             return
@@ -79,6 +83,7 @@ class MLXVibeVoiceBackend(STTBackend):
         except Exception as exc:
             logger.debug("MLX VibeVoice warmup (non-fatal): %s", exc)
 
+    @mlx_pinned
     def transcribe(
         self,
         audio: np.ndarray,
@@ -128,6 +133,7 @@ class MLXVibeVoiceBackend(STTBackend):
         info = BackendTranscriptionInfo(language=language, language_probability=0.0)
         return segments, info
 
+    @mlx_pinned
     def transcribe_with_diarization(
         self,
         audio: np.ndarray,

--- a/server/backend/core/stt/backends/mlx_whisper_backend.py
+++ b/server/backend/core/stt/backends/mlx_whisper_backend.py
@@ -30,13 +30,14 @@ from server.core.stt.backends.base import (
     BackendTranscriptionInfo,
     STTBackend,
 )
+from server.core.stt.backends.mlx_thread_pin import MLXThreadAffinityMixin, mlx_pinned
 
 SAMPLE_RATE = 16000
 
 logger = logging.getLogger(__name__)
 
 
-class MLXWhisperBackend(STTBackend):
+class MLXWhisperBackend(MLXThreadAffinityMixin, STTBackend):
     """Apple MLX / Metal-accelerated Whisper backend via mlx-audio.
 
     Uses ``mlx-audio`` (https://github.com/ml-explore/mlx-audio) for Whisper
@@ -51,6 +52,7 @@ class MLXWhisperBackend(STTBackend):
     # STTBackend interface
     # ------------------------------------------------------------------
 
+    @mlx_pinned
     def load(self, model_name: str, device: str, **kwargs: Any) -> None:
         del device  # MLX always uses Metal
         try:
@@ -73,6 +75,7 @@ class MLXWhisperBackend(STTBackend):
         self._model_name = model_name
         logger.info("MLX Whisper model loaded: %s", model_name)
 
+    @mlx_pinned
     def unload(self) -> None:
         if self._model is not None:
             import gc
@@ -89,6 +92,7 @@ class MLXWhisperBackend(STTBackend):
     def is_loaded(self) -> bool:
         return self._model is not None
 
+    @mlx_pinned
     def warmup(self) -> None:
         if self._model is None:
             return
@@ -98,6 +102,7 @@ class MLXWhisperBackend(STTBackend):
         except Exception as exc:
             logger.debug("MLX Whisper warmup (non-fatal): %s", exc)
 
+    @mlx_pinned
     def transcribe(
         self,
         audio: np.ndarray,

--- a/server/backend/database/__init__.py
+++ b/server/backend/database/__init__.py
@@ -9,8 +9,10 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from server.database.database import (
         create_conversation,
+        delete_recording,
         get_conversation,
         get_conversations,
+        get_recordings_for_hour,
         search_recordings,
         search_words,
         search_words_enhanced,
@@ -18,6 +20,7 @@ if TYPE_CHECKING:
         update_conversation_response_id,
         update_conversation_title,
         update_recording_corrected_transcript,
+        update_recording_summary,
     )
 
 

--- a/server/backend/tests/test_mlx_thread_affinity.py
+++ b/server/backend/tests/test_mlx_thread_affinity.py
@@ -1,0 +1,139 @@
+"""Thread-affinity tests for the MLX backend pinning helper (GH #134).
+
+MLX binds each GPU stream to the thread that created it; the server otherwise
+dispatches model load and inference on different threads. These tests prove that
+``MLXThreadAffinityMixin`` + ``@mlx_pinned`` funnel every decorated call onto one
+dedicated owning thread, distinct from the caller — WITHOUT importing MLX or
+needing Apple-Silicon hardware (a fake backend records ``threading.get_ident()``).
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+from server.core.stt.backends.mlx_thread_pin import MLXThreadAffinityMixin, mlx_pinned
+
+
+class _FakeMLXBackend(MLXThreadAffinityMixin):
+    """Minimal backend-shaped object exercising only the pinning machinery."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, int]] = []
+
+    @property
+    def backend_name(self) -> str:
+        return "fake"
+
+    @mlx_pinned
+    def load(self) -> None:
+        self.events.append(("load", threading.get_ident()))
+
+    @mlx_pinned
+    def transcribe(self) -> str:
+        self.events.append(("transcribe", threading.get_ident()))
+        return "ok"
+
+    @mlx_pinned
+    def outer(self) -> tuple[str, int, tuple[str, int]]:
+        # Reentrant: invokes another pinned method while already on the owning thread.
+        return ("outer", threading.get_ident(), self.inner())
+
+    @mlx_pinned
+    def inner(self) -> tuple[str, int]:
+        return ("inner", threading.get_ident())
+
+    @mlx_pinned
+    def boom(self) -> None:
+        raise ValueError("kaboom")
+
+
+def _run_in_new_thread(fn: object) -> dict:
+    """Run ``fn`` in a fresh thread, returning its thread id and result."""
+    box: dict = {}
+
+    def run() -> None:
+        box["tid"] = threading.get_ident()
+        box["ret"] = fn()
+
+    t = threading.Thread(target=run)
+    t.start()
+    t.join()
+    return box
+
+
+def test_load_and_transcribe_share_one_owning_thread_distinct_from_callers() -> None:
+    backend = _FakeMLXBackend()
+
+    load_caller = _run_in_new_thread(backend.load)
+    transcribe_caller = _run_in_new_thread(backend.transcribe)
+
+    owning_ids = {tid for (_, tid) in backend.events}
+    assert len(owning_ids) == 1, "load and transcribe must run on a single owning thread"
+    owning_id = owning_ids.pop()
+    # The owning thread is still alive (executor not shut down), so its id cannot
+    # collide with the (now-exited) caller threads.
+    assert owning_id != load_caller["tid"]
+    assert owning_id != transcribe_caller["tid"]
+    assert transcribe_caller["ret"] == "ok"
+
+
+def test_reentrant_pinned_call_runs_inline_without_deadlock() -> None:
+    backend = _FakeMLXBackend()
+
+    done = threading.Event()
+    box: dict = {}
+
+    def run() -> None:
+        box["ret"] = backend.outer()
+        done.set()
+
+    t = threading.Thread(target=run)
+    t.start()
+    assert done.wait(timeout=5), "reentrant pinned call deadlocked the single worker"
+    t.join()
+
+    _, outer_tid, (inner_label, inner_tid) = box["ret"]
+    assert inner_label == "inner"
+    # Inner ran inline on the owning thread (no re-submit) → same thread id.
+    assert outer_tid == inner_tid
+
+
+def test_pinned_exception_propagates_original_type_and_message() -> None:
+    backend = _FakeMLXBackend()
+    with pytest.raises(ValueError, match="kaboom"):
+        backend.boom()
+
+
+def test_many_calls_across_threads_use_one_owning_thread() -> None:
+    backend = _FakeMLXBackend()
+
+    threads = [threading.Thread(target=backend.transcribe) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    owning_ids = {tid for (label, tid) in backend.events if label == "transcribe"}
+    assert owning_ids != set()
+    assert len(owning_ids) == 1, "all calls must marshal onto the same owning thread"
+
+
+def test_distinct_instances_get_distinct_owning_threads() -> None:
+    a = _FakeMLXBackend()
+    b = _FakeMLXBackend()
+    a.transcribe()
+    b.transcribe()
+    a_tid = a.events[0][1]
+    b_tid = b.events[0][1]
+    assert a_tid != b_tid, "each backend instance must own its own thread"
+
+
+def test_shutdown_mlx_thread_is_safe_and_idempotent() -> None:
+    backend = _FakeMLXBackend()
+    backend.transcribe()
+    backend.shutdown_mlx_thread()
+    backend.shutdown_mlx_thread()  # second call must not raise
+    # A fresh call after shutdown transparently re-creates the owning thread.
+    backend.transcribe()
+    assert len([e for e in backend.events if e[0] == "transcribe"]) == 2


### PR DESCRIPTION
# fix(stt, mlx): pin MLX backend GPU ops to one owning thread — fix Metal "no stream (gpu,0)" crash (GH #134)

**Branch:** `fix/gh-134-mlx-cross-thread-stream` → `main`
**Closes:** #134
**Related:** #124 (this surfaced after #124's Metal-start fix let the native server actually run); upstream [ml-explore/mlx#2133](https://github.com/ml-explore/mlx/issues/2133)

## Summary

On Apple Silicon **Metal mode** (v1.3.5), *every* transcription — local-file import, import queue, and live microphone — failed with the MLX runtime error **"There is no stream (gpu,0) in current thread."** This PR fixes it by pinning all MLX GPU work for a backend instance onto a single dedicated owning thread.

This is **not a 1.3.5 regression** — it surfaced only once #124's diagnostics fix let the reporter install the correct `-metal.dmg` and the native Metal server actually started running MLX.

## Root cause (forensic investigation)

MLX binds each GPU stream to the **thread that created it**; dispatching MLX work from another thread raises the error (upstream mlx#2133). The server, however, spreads STT work across interchangeable threads:

- **Startup prewarm** materializes the model on the **asyncio event-loop thread** — `api/main.py:629` (synchronous, un-awaited inside `lifespan`).
- **Every transcription** runs on an `asyncio.to_thread` **pool worker** — `transcription.py:480` → `engine.transcribe_file` → `backend.transcribe`.
- **Parallel diarization** runs the transcribe half on a separate `ThreadPoolExecutor` — `parallel_diarize.py:222`.
- **Live mode** runs on a dedicated `LiveModeThread` — `live_engine.py:297`.

Load-thread ≠ inference-thread → deterministic failure. No MLX backend touched any stream/device API. **Metal-only** because CUDA/PyTorch contexts are process-wide, so the identical dispatch is safe in Docker mode.

Full evidence chain: `_bmad-output/implementation-artifacts/investigations/gh-134-investigation.md` (High confidence; `gitnexus_detect_changes` → 0 affected execution flows).

## What changed

### 1. New thread-affinity helper — `server/backend/core/stt/backends/mlx_thread_pin.py`
- `MLXThreadAffinityMixin`: a **lazy per-instance** `ThreadPoolExecutor(max_workers=1, thread_name_prefix="mlx-<backend_name>")`. The owning-thread id is captured on the worker itself; every later call runs on that same thread.
- `_run_on_mlx_thread(...)`: marshals work onto the owning thread via `submit(...).result()` (which re-raises the body's exception unchanged). A **reentrancy guard** runs the call inline when already on the owning thread, so a pinned method calling another pinned method can't deadlock the single worker.
- `@mlx_pinned`: a `functools.wraps` decorator that delegates a method to `_run_on_mlx_thread`.
- `shutdown_mlx_thread()`: idempotent teardown.

### 2. Pin the four MLX backends (no method-body changes)
Added the mixin to the bases and `@mlx_pinned` to every GPU-touching method:
- `mlx_parakeet_backend.py`, `mlx_whisper_backend.py`, `mlx_canary_backend.py`: `load`, `unload`, `warmup`, `transcribe`.
- `mlx_vibevoice_backend.py`: the above **+** `transcribe_with_diarization`. (`_run_generate` stays private/un-decorated — it only ever runs inside an already-pinned method.)

Because the marshal happens **inside** the backend, this fixes file import, import queue, parallel diarization, **and** live mode at once, with **zero changes** to the dispatch layer. Non-MLX backends (CUDA/NeMo/WhisperX/faster-whisper/whisper.cpp) are untouched.

### 3. Tests — `server/backend/tests/test_mlx_thread_affinity.py`
Six **Linux-runnable** tests (no MLX/Metal import — a fake backend records `threading.get_ident()`) proving: load+transcribe share one owning thread distinct from callers; reentrancy runs inline without deadlock; exceptions propagate with original type/message; N calls across N threads use one owning thread; distinct instances get distinct threads; shutdown is idempotent + re-creatable.

### 4. Process artifacts
`spec-gh-134-mlx-cross-thread-stream.md` (`ready-for-dev` → `done`, with code map / I/O matrix / change log / anchored review order) and the investigation case file.

## How it works

| Layer | Mechanism |
|-------|-----------|
| **Affinity** | One `ThreadPoolExecutor(max_workers=1)` per backend instance; its single worker is the only thread that ever touches MLX → stream `(gpu,0)` is created once and always visible. |
| **Marshaling** | `@mlx_pinned` routes each GPU method through `submit(...).result()`. Correct regardless of which thread (pool worker / live / diarize) calls in — so all four entry points are fixed without dispatch-layer edits. |
| **Reentrancy** | A pinned method already on the owning thread runs the nested pinned call inline (no re-submit), so the single worker never waits on itself. |
| **Exceptions** | `future.result()` re-raises the body's exception with its original type and traceback (verified by test). |
| **Scope** | Mixin is opt-in per backend; CUDA/process-wide backends keep their existing `asyncio.to_thread` dispatch unchanged. |

## Test plan

- [x] `cd server/backend && ../../build/.venv/bin/pytest tests/test_mlx_thread_affinity.py -v` — 6/6 pass.
- [x] `... pytest tests/test_stt_backend_factory.py tests/test_mlx_vibevoice_backend.py -v` — 30/30 pass (vibevoice cases exercise the real decorated `load`/`unload`/`transcribe`/`transcribe_with_diarization` paths with mocked models — behavior preserved).
- [x] Full backend suite — **1920 passed, 3 skipped, 0 failed**, no regressions.
- [x] `gitnexus_impact` (4 backend classes) → LOW; `gitnexus_detect_changes` → risk low, 28 expected symbols, **0 affected execution flows**.
- [x] Pre-commit hooks (ruff format, ruff, codespell) — pass.
- [ ] **macOS manual (maintainer, Apple Silicon required):** install `-arm64-mac-metal.dmg`, start the Metal server, import one audio file → succeeds with no "no stream (gpu,0)"; start a live mic session → succeeds.
- [ ] **Reporter confirmation (#134):** with an MLX model selected (parakeet/whisper/canary/vibevoice).

> The fix is **code-verified** on Linux (thread-affinity invariant proven without a GPU). The only thing that needs Apple-Silicon hardware is the final device-level confirmation.

## Scope / non-goals

- **No dispatch-layer change** — `asyncio.to_thread`, `parallel_diarize`, `LiveModeThread`, and the `main.py` prewarm are untouched; the fix lives entirely in the backend layer.
- **Per-backend executor**, not a single process-wide MLX thread (only one backend is active at a time; deferred as an Ask-First option that would also co-locate `mx.metal.set_cache_limit`).
- Did **not** move the prewarm to `await asyncio.to_thread(...)` (orthogonal; the affinity fix makes it correct regardless).
- No change to transcription I/O, parsing, chunking, or decode behavior — threading only.

## Files changed

```
 server/backend/core/stt/backends/mlx_thread_pin.py        |  99 +++++++++++ (new)
 server/backend/core/stt/backends/mlx_parakeet_backend.py  |   7 +-
 server/backend/core/stt/backends/mlx_whisper_backend.py   |   7 +-
 server/backend/core/stt/backends/mlx_canary_backend.py    |   7 +-
 server/backend/core/stt/backends/mlx_vibevoice_backend.py |   8 +-
 server/backend/tests/test_mlx_thread_affinity.py          | 139 +++++++++++++ (new)
 _bmad-output/implementation-artifacts/spec-gh-134-...md    | 159 +++++++++++++ (new)
 _bmad-output/implementation-artifacts/investigations/...md | 207 +++++++++++++ (new)
```
