### PR TITLE
# fix(dashboard, mlx): Metal/MLX model downloads, Model Manager messaging, and persistent-volume path actions (GH #135/#136/#137)

### DIFF
--- a/_bmad-output/implementation-artifacts/spec-gh-135-137-metal-mlx-model-manager-ux.md
+++ b/_bmad-output/implementation-artifacts/spec-gh-135-137-metal-mlx-model-manager-ux.md
@@ -1,0 +1,164 @@
+---
+title: 'Metal/MLX Model Manager downloads + messaging fix, and persistent-volume path actions (GH #135/#136/#137)'
+type: 'bugfix'
+created: '2026-06-01'
+baseline_commit: '86572773d31af1f5b480991feb0e6019110be4ea'
+status: 'done'
+context: ['{project-root}/docs/project-context.md']
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** On the Apple-Silicon **Metal/MLX** profile (no Docker container) the Model Manager is broken and confusing: (#135) it shows a self-contradictory banner — "Start the server to manage model downloads. Model selection is available while the server is stopped"; (#136) models cannot be downloaded at all, because `isRunning` is derived purely from `docker.container.running` (permanently `false` on Metal) so every button is disabled, and even the underlying download/cache IPC is hard-wired to `docker exec` into a non-existent container. Separately, (#137) the Server → "5. Persistent Volumes" section shows truncated host paths with no way to view, open, or copy them.
+
+**Approach:** Add a native (Docker-free) model-cache path for Metal that mirrors the Docker logic but runs `snapshot_download` directly via the MLX venv's Python — so it works whether or not the server is running. Make the Model Manager profile-aware: drive its "running" signal from MLX status, ungate downloads on Metal (a host-local operation), and replace the banner with non-contradictory, profile-specific copy. For #137, reuse the existing `app.openPath` IPC and `writeToClipboard` helper to add per-row "open in file manager" + "copy path" buttons and reveal the full path in the Metal branch.
+
+## Boundaries & Constraints
+
+**Always:**
+- Reuse existing IPC/helpers where present: `window.electronAPI.app.openPath` (already wired) and `writeToClipboard` from `src/hooks/useClipboard.ts` (Wayland-safe) for #137 — add **no** new IPC for #137.
+- New Metal cache IPC must mirror Docker semantics & error messages (gated-repo 403, still-starting ModuleNotFound) from `dockerManager.ts:3512-3554`, but with **no** Docker dependency.
+- Validate `modelId` before any filesystem op: reject path separators/`..`; assert the resolved cache directory stays under `<HF_HOME>/hub` (security: prevent path traversal in remove).
+- Selection-while-stopped semantics stay intact on both profiles (select disabled while the server runs).
+
+**Ask First:**
+- If implementation reveals Metal model downloads genuinely require the server process running (i.e. a host-side `snapshot_download` via the venv Python is not viable), HALT — the chosen "downloads work while stopped" UX for #135/#136 depends on this assumption.
+
+**Never:**
+- Do not change Docker-profile behavior (its download/select gating on `isRunning` stays as-is).
+- Do not add open/copy buttons to the Docker branch of Persistent Volumes (it lists Docker volume *names*, not host paths).
+- Do not invert the Docker banner or call `navigator.clipboard.writeText` directly.
+- Do not stream download progress / add activity-system integration — match Docker's blocking-spinner UX.
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| Metal download (server stopped) | Metal profile, MLX server stopped, click Download on an uncached model | Native `snapshot_download` runs via venv Python into `<HF_HOME>/hub`; on success button flips to Remove, cache size shown | Toast with error message; button reverts to Download |
+| Metal download (server running) | Metal profile, MLX server running, click Download | Same as above — host subprocess, independent of server | Same |
+| Metal gated/auth model | Metal, download a gated repo without token | Actionable toast: "gated model — accept license + add HF token" (mirror Docker) | Caught from stderr `403`/`GatedRepoError` |
+| Metal remove with traversal id | `modelId` contains `/`, `..`, or backslash | Rejected before any fs op; nothing deleted outside hub | Throws/no-ops with clear message |
+| Metal cache check (stopped) | Metal, view Model Manager, server stopped | Cache status reflects on-disk `<HF_HOME>/hub/models--…` correctly | Missing/empty hub → all `{exists:false}` |
+| Docker profile (regression) | Docker profile, server stopped | Banner + disabled download/select unchanged from today | N/A |
+| #137 open | Metal, click "open" on Data directory | OS file manager opens that directory | `openPath` error → best-effort fallback to parent dir |
+| #137 copy | Metal, click "copy" on Models cache | Full path on clipboard; icon shows Check ~2s | copy failure swallowed (no crash) |
+| #137 full path | Metal, view Persistent Volumes | Full path visible (not ellipsis-truncated) | N/A |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `dashboard/electron/mlxServerManager.ts` -- MLX native server manager; has `_resolveHfHome()` (`<userData>/models`) and venv discovery (`_uvicornCandidates()` → bin dir → `python3`). **Add** native `downloadModelToCache`/`checkModelsCached`/`removeModelCache` + venv-python resolver here.
+- `dashboard/electron/dockerManager.ts:3336-3554` -- Docker `checkModelsCached`/`removeModelCache`/`downloadModelToCache` to mirror (cache-name = `models--{id.replace('/','--')}`; HF cache under `hub/`; error messages).
+- `dashboard/electron/main.ts:2407-2420` -- existing `mlx:*` IPC handlers; **add** 3 new handlers here.
+- `dashboard/electron/preload.ts:441` (interface) + `:778` (impl) -- `ElectronAPI.mlx` block; **add** the 3 methods in both places.
+- `dashboard/components/views/ModelManagerView.tsx:16,126-140,166-168` -- `isRunning = docker.container.running` (wrong on Metal); `refreshCacheStatus`; props to Tab. **Make MLX-aware.**
+- `dashboard/components/views/ModelManagerTab.tsx:240-275,439-461,577-614,700-731` -- gating (`disabled={!isRunning}`/`disabled={isRunning}`) for ModelRow + CustomModelRow, `handleDownload`/`handleRemove`, cache-poll effect, the contradictory banner. **Make profile-aware.**
+- `dashboard/components/views/ServerView.tsx:2627-2650` -- Metal branch of "5. Persistent Volumes"; `nativeDataDir`/`nativeModelsDir`; already imports `writeToClipboard` (line 45) and lucide `Copy`/`Check` (#137 target).
+- `dashboard/electron/__tests__/mlxServerManager.test.ts` -- existing Vitest suite to extend.
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `dashboard/electron/mlxServerManager.ts` -- Add a private venv-Python resolver (reuse `_uvicornCandidates()` → bin dir → `python3`/`python`) and three public methods: `downloadModelToCache(modelId)` spawns `<venv>/python3 -c "snapshot_download(sys.argv[1], cache_dir=<HF_HOME>/hub)"` with `HF_HOME` env, passing the id as argv (not interpolated), 10-min timeout, mapping 403/ModuleNotFound to the same messages as Docker; `checkModelsCached(ids)` returns `Record<id,{exists,size?}>` via Node fs check of `<HF_HOME>/hub/models--{id.replace('/','--')}` + best-effort size; `removeModelCache(id)` validates the id (reject `/`,`\`,`..`; assert resolved path under hub) then `fs.rmSync(dir,{recursive,force})`. -- supplies the Docker-free cache path that #136 needs and that resolves #135's premise.
+- [x] `dashboard/electron/main.ts` -- Register `mlx:downloadModelToCache`, `mlx:checkModelsCached`, `mlx:removeModelCache` IPC handlers delegating to `mlxServerManager`. -- exposes the new ops to the renderer.
+- [x] `dashboard/electron/preload.ts` -- Add the three methods to the `ElectronAPI.mlx` interface (~:441) and its implementation (~:778). -- typed bridge consistency.
+- [x] `dashboard/components/views/ModelManagerView.tsx` -- Subscribe to MLX status (`electronAPI.mlx.getStatus()` + `onStatusChanged`/`mlx:statusChanged`, like ServerView); compute `isMetal = runtimeProfile === 'metal'` and `serverRunning = isMetal ? mlxStatus === 'running' : docker.container.running`; pass `serverRunning` as `isRunning`; route `refreshCacheStatus` to `mlx.checkModelsCached` on Metal and allow it while stopped (`isMetal || isRunning`). -- fixes the permanently-false running signal on Metal.
+- [x] `dashboard/components/views/ModelManagerTab.tsx` -- Replace the banner (`:726-731`) with profile-aware copy (Metal: downloads/cache manageable anytime, selection applies on next start — no contradiction; Docker: clarified, non-contradictory); on Metal ungate Download/Remove from `isRunning` (host-local op) for both ModelRow (`:251,261`) and CustomModelRow (`:439,449`); route `handleDownload`/`handleRemove` (`:577-614`) to `mlx.*` when Metal else `docker.*`; poll cache when `isMetal || isRunning` (`:700-715`). Keep Select gated on `isRunning`. -- resolves #135 (text) and the UI half of #136 (gating + routing).
+- [x] `dashboard/components/views/ServerView.tsx` -- In the Metal branch of "5. Persistent Volumes" (`:2630-2650`), reveal the full path (drop/relax `truncate` or add expand) and add two inline icon-buttons per row: open (`electronAPI.app.openPath(dir)` with parent-dir fallback) and copy (`writeToClipboard(dir)` + 2s `Check` feedback via local `useState`); import `FolderOpen` from lucide. -- #137.
+- [x] `dashboard/electron/__tests__/mlxServerManager.test.ts` -- Add unit tests for the I/O matrix's Metal cache rows: `checkModelsCached` name-mapping + exists/missing, `removeModelCache` path-traversal rejection + stays-under-hub, venv-Python resolution (mock `fs`). -- locks the security guard and cache-name logic.
+
+**Acceptance Criteria:**
+- Given the Metal profile with the MLX server stopped, when I open the Model Manager, then no contradictory banner appears and Download buttons are enabled.
+- Given the Metal profile, when I click Download on an uncached model (server stopped or running), then the model downloads to the local HF cache and the row flips to "Downloaded {size}" / Remove.
+- Given the Docker profile, when I view the Model Manager with the server stopped, then behavior is identical to before this change (no regression).
+- Given the Metal profile, when I view Persistent Volumes, then full paths are visible and each row has working "open in file manager" and "copy path" actions.
+- Given any profile, when `npm run typecheck` and the Vitest suite run, then both pass; `npm run ui:contract:check` passes after the contract pipeline is run.
+
+## Spec Change Log
+
+- **2026-06-01 (review patch):** Adversarial review (edge-case hunter) found `downloadModelToCache` lacked the path-traversal guard that `removeModelCache`/`checkModelsCached` had. Extracted a shared `_assertSafeModelId` (rejects `..`/backslash/null) applied to all three native cache ops; added a test. No known-bad state shipped (the diff was caught in-review); the guard now uniformly satisfies the "validate `modelId` before any filesystem op" boundary.
+- **2026-06-01 (intent-preserving divergence):** The frozen Boundaries say "mirror Docker error messages … still-starting ModuleNotFound." For the `ModuleNotFoundError` branch the implementation emits a Metal-appropriate message ("the Metal Python environment is incomplete — reinstall the -metal build") instead of Docker's "server is still starting (installing dependencies)". On Metal the venv is baked into the app bundle, not bootstrapped at runtime, so Docker's wording would be misleading. The *intent* — actionable messages covering the gated-repo (403) and missing-module categories — is preserved; only the ModuleNotFound wording is adapted. Frozen block left unmodified; flagged to user.
+- **2026-06-01 (implementation clarification):** The frozen Boundaries / I/O-matrix phrasing "reject path separators incl. `/`" is too literal — forward-slash is legitimate in HuggingFace IDs (`org/name`), and rejecting it would break every real model. **Amendment (in `removeModelCache`/`checkModelsCached`):** reject only `..`, backslash, and null bytes; transform `/`→`--` (HuggingFace's own cache-dir convention); then assert the resolved directory is a *direct child* of `<HF_HOME>/hub` (`path.dirname(resolved) === resolve(hub)`). This preserves the frozen *intent* — "nothing deleted/read outside the hub directory" — while keeping valid `org/name` IDs working. The frozen block was left unmodified (human-owned intent) and the change is flagged to the user.
+
+## Design Notes
+
+The native download is the host-side mirror of Docker's `docker exec … python3 -c snapshot_download`: same one-liner, same argv-passing (no shell interpolation), but the binary is the MLX venv's `python3` and `cache_dir` is `<HF_HOME>/hub` (`HF_HOME` = `<userData>/models`, per `mlxServerManager._resolveHfHome()`). Because it is an independent subprocess, it needs no running server — which is exactly why #135's "start the server to download" premise is wrong for Metal and downloads can work while stopped.
+
+`checkModelsCached`/`removeModelCache` are pure host-fs ops (no venv needed): map `org/name` → `models--org--name` under `hub/`. Security guard for remove (golden):
+
+```ts
+const trimmed = modelId.trim();
+if (/[\\/]|\.\./.test(trimmed)) throw new Error('Invalid model id');
+const cacheName = `models--${trimmed.replace(/\//g, '--')}`; // (slashes already rejected)
+const dir = path.join(hubDir, cacheName);
+if (!path.resolve(dir).startsWith(path.resolve(hubDir) + path.sep)) throw new Error('Refusing to delete outside cache');
+```
+
+`isMetal` is already available in both Model Manager components (`runtimeProfile === 'metal'`); only the *running* signal and the docker-only IPC routing are new. GGML/whispercpp models never appear on Metal (`DOCKER_ONLY_FAMILIES` hides them), so the native path only handles HF-hub models.
+
+## Verification
+
+**Commands:**
+- `npm run typecheck` (from `dashboard/`) -- expected: no type errors.
+- `npx vitest run electron/__tests__/mlxServerManager.test.ts` (from `dashboard/`, Node 22) -- expected: new cache/security tests pass.
+- UI-contract pipeline (from `dashboard/`): `npm run ui:contract:extract` → `ui:contract:build` → `node scripts/ui-contract/validate-contract.mjs --update-baseline` → `npm run ui:contract:check` -- expected: contract check passes (ServerView + ModelManagerTab touch CSS classes).
+
+**Manual checks (if no CLI):**
+- On an Apple-Silicon Mac: Metal profile, server stopped → Model Manager has no contradictory banner, Download works and persists to `~/Library/Application Support/TranscriptionSuite/models/hub`; Persistent Volumes shows full paths with working open/copy. (No Mac available in CI — flag for the human to verify on-device.)
+
+## Suggested Review Order
+
+**Native cache layer — the core of #136 (Docker-free, host-local)**
+
+- Entry point: host-side mirror of `docker exec … snapshot_download`, server-independent.
+  [`mlxServerManager.ts:329`](../../dashboard/electron/mlxServerManager.ts#L329)
+
+- Pure-fs cache inspection + path-containment backstop (`dirname === hub`).
+  [`mlxServerManager.ts:377`](../../dashboard/electron/mlxServerManager.ts#L377)
+
+- Destructive op — read the traversal guard before the `fs.rmSync`.
+  [`mlxServerManager.ts:414`](../../dashboard/electron/mlxServerManager.ts#L414)
+
+- Shared validation helper (review patch — guard parity across all three ops).
+  [`mlxServerManager.ts:450`](../../dashboard/electron/mlxServerManager.ts#L450)
+
+**IPC wiring (main ↔ preload)**
+
+- Three new `mlx:*` handlers delegating to the manager.
+  [`main.ts:2424`](../../dashboard/electron/main.ts#L2424)
+
+- Bridge methods on `window.electronAPI.mlx` (interface + impl).
+  [`preload.ts:797`](../../dashboard/electron/preload.ts#L797)
+
+**Model Manager — MLX-aware running signal & routing (#135 + #136 UI)**
+
+- The fix's keystone: `isRunning` now derives from MLX status on Metal, not Docker.
+  [`ModelManagerView.tsx:38`](../../dashboard/components/views/ModelManagerView.tsx#L38)
+
+- `refreshCacheStatus` routes to the native check on Metal, works while stopped.
+  [`ModelManagerView.tsx:164`](../../dashboard/components/views/ModelManagerView.tsx#L164)
+
+- `canManage = isMetal || isRunning` — ungates download/remove on Metal.
+  [`ModelManagerTab.tsx:529`](../../dashboard/components/views/ModelManagerTab.tsx#L529)
+
+- Profile-routed download/remove handlers (mlx vs docker).
+  [`ModelManagerTab.tsx:591`](../../dashboard/components/views/ModelManagerTab.tsx#L591)
+
+- #135 fix: profile-aware, non-contradictory banner.
+  [`ModelManagerTab.tsx:741`](../../dashboard/components/views/ModelManagerTab.tsx#L741)
+
+**Persistent-volume path actions (#137)**
+
+- Open-in-file-manager handler with parent-dir fallback (reuses existing IPC).
+  [`ServerView.tsx:296`](../../dashboard/components/views/ServerView.tsx#L296)
+
+- Full-path reveal + open/copy buttons in the Metal branch only.
+  [`ServerView.tsx:2679`](../../dashboard/components/views/ServerView.tsx#L2679)
+
+**Tests (peripheral)**
+
+- Cache-name mapping, traversal guard, venv gate, gated-repo message.
+  [`mlxServerManager.test.ts:447`](../../dashboard/electron/__tests__/mlxServerManager.test.ts#L447)

--- a/dashboard/components/views/ModelManagerTab.tsx
+++ b/dashboard/components/views/ModelManagerTab.tsx
@@ -150,6 +150,9 @@ interface ModelRowProps {
   cacheSize?: string;
   downloading: boolean;
   isRunning: boolean;
+  /** Whether download/remove are allowed. On Metal this is true regardless of
+   *  server state (host-local cache ops); on Docker it tracks isRunning. */
+  canManage: boolean;
   isActiveMain: boolean;
   isActiveLive: boolean;
   isActiveDiarization: boolean;
@@ -164,6 +167,7 @@ const ModelRow = React.memo(function ModelRow({
   cacheSize,
   downloading,
   isRunning,
+  canManage,
   isActiveMain,
   isActiveLive,
   isActiveDiarization,
@@ -248,7 +252,7 @@ const ModelRow = React.memo(function ModelRow({
               variant="danger"
               size="sm"
               onClick={() => onRemove(model.id)}
-              disabled={!isRunning}
+              disabled={!canManage}
             >
               <Trash2 size={13} className="mr-1.5" />
               Remove
@@ -258,7 +262,7 @@ const ModelRow = React.memo(function ModelRow({
               variant="secondary"
               size="sm"
               onClick={() => onDownload(model.id)}
-              disabled={!isRunning}
+              disabled={!canManage}
             >
               <Download size={13} className="mr-1.5" />
               Download
@@ -348,6 +352,8 @@ interface CustomModelRowProps {
   cacheSize?: string;
   downloading: boolean;
   isRunning: boolean;
+  /** See ModelRowProps.canManage. */
+  canManage: boolean;
   isActiveMain: boolean;
   isActiveLive: boolean;
   isActiveDiarization: boolean;
@@ -363,6 +369,7 @@ const CustomModelRow = React.memo(function CustomModelRow({
   cacheSize,
   downloading,
   isRunning,
+  canManage,
   isActiveMain,
   isActiveLive,
   isActiveDiarization,
@@ -436,7 +443,7 @@ const CustomModelRow = React.memo(function CustomModelRow({
               variant="danger"
               size="sm"
               onClick={() => onRemove(modelId)}
-              disabled={!isRunning}
+              disabled={!canManage}
             >
               <Trash2 size={13} className="mr-1.5" />
               Remove
@@ -446,7 +453,7 @@ const CustomModelRow = React.memo(function CustomModelRow({
               variant="secondary"
               size="sm"
               onClick={() => onDownload(modelId)}
-              disabled={!isRunning}
+              disabled={!canManage}
             >
               <Download size={13} className="mr-1.5" />
               Download
@@ -517,6 +524,9 @@ export const ModelManagerTab: React.FC<ModelManagerTabProps> = ({
   refreshCacheStatus,
   isMetal = false,
 }) => {
+  // On Metal there is no Docker container — model download/remove are host-local
+  // operations that work whether or not the server is running (GH-136).
+  const canManage = isMetal || isRunning;
   const [downloadingModels, setDownloadingModels] = useState<Set<string>>(new Set());
   const [customModels, setCustomModels] = useState<string[]>([]);
   const [customModelInput, setCustomModelInput] = useState('');
@@ -577,11 +587,13 @@ export const ModelManagerTab: React.FC<ModelManagerTabProps> = ({
   const handleDownload = useCallback(
     async (modelId: string) => {
       const api = (window as any).electronAPI;
-      if (!api?.docker?.downloadModelToCache) return;
+      // Metal has no container — use the native (host-local) cache path.
+      const download = isMetal ? api?.mlx?.downloadModelToCache : api?.docker?.downloadModelToCache;
+      if (!download) return;
 
       setDownloadingModels((prev) => new Set(prev).add(modelId));
       try {
-        await api.docker.downloadModelToCache(modelId);
+        await download(modelId);
         showToast(`Downloaded ${modelId}`);
         refreshCacheStatus([modelId]);
       } catch (err: any) {
@@ -594,23 +606,24 @@ export const ModelManagerTab: React.FC<ModelManagerTabProps> = ({
         });
       }
     },
-    [refreshCacheStatus, showToast],
+    [refreshCacheStatus, showToast, isMetal],
   );
 
   const handleRemove = useCallback(
     async (modelId: string) => {
       const api = (window as any).electronAPI;
-      if (!api?.docker?.removeModelCache) return;
+      const remove = isMetal ? api?.mlx?.removeModelCache : api?.docker?.removeModelCache;
+      if (!remove) return;
 
       try {
-        await api.docker.removeModelCache(modelId);
+        await remove(modelId);
         showToast(`Removed cache for ${modelId}`);
         refreshCacheStatus([modelId]);
       } catch (err: any) {
         showToast(`Remove failed: ${err?.message || 'Unknown error'}`);
       }
     },
-    [refreshCacheStatus, showToast],
+    [refreshCacheStatus, showToast, isMetal],
   );
 
   const handleSelectAs = useCallback(
@@ -692,13 +705,14 @@ export const ModelManagerTab: React.FC<ModelManagerTabProps> = ({
     [customModels, persistCustomModels],
   );
 
-  // Check cache for all models (registry + custom) when container is running
+  // Check cache for all models (registry + custom). On Docker this needs the
+  // container running; on Metal it is a host-local check that works anytime.
   const allModelIds = [...MODEL_REGISTRY.map((m) => m.id), ...customModels];
 
   const cacheCheckRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    if (!isRunning) return;
+    if (!isMetal && !isRunning) return;
 
     const ids = allModelIds.filter(Boolean);
     if (ids.length === 0) return;
@@ -712,7 +726,7 @@ export const ModelManagerTab: React.FC<ModelManagerTabProps> = ({
       if (cacheCheckRef.current) clearTimeout(cacheCheckRef.current);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isRunning, customModels.length, refreshCacheStatus]);
+  }, [isRunning, isMetal, customModels.length, refreshCacheStatus]);
 
   return (
     <div className="space-y-6">
@@ -723,12 +737,18 @@ export const ModelManagerTab: React.FC<ModelManagerTabProps> = ({
         </div>
       )}
 
-      {!isRunning && (
-        <div className="rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-sm text-slate-400">
-          Start the server to manage model downloads. Model selection is available while the server
-          is stopped.
-        </div>
-      )}
+      {!isRunning &&
+        (isMetal ? (
+          <div className="rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-sm text-slate-400">
+            The server is stopped. You can download and manage models now — your model selection
+            takes effect the next time you start the server.
+          </div>
+        ) : (
+          <div className="rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-sm text-slate-400">
+            Start the server to download or remove models. Your model selection is saved now and
+            applied when the server starts.
+          </div>
+        ))}
 
       {/* Family sections */}
       {FAMILY_SECTIONS.map((section) => {
@@ -763,6 +783,7 @@ export const ModelManagerTab: React.FC<ModelManagerTabProps> = ({
                   cacheSize={modelCacheStatus[model.id]?.size}
                   downloading={downloadingModels.has(model.id)}
                   isRunning={isRunning}
+                  canManage={canManage}
                   isActiveMain={activeMain.toLowerCase() === model.id.toLowerCase()}
                   isActiveLive={activeLive.toLowerCase() === model.id.toLowerCase()}
                   isActiveDiarization={activeDiarization.toLowerCase() === model.id.toLowerCase()}
@@ -828,6 +849,7 @@ export const ModelManagerTab: React.FC<ModelManagerTabProps> = ({
                     cacheSize={modelCacheStatus[id]?.size}
                     downloading={downloadingModels.has(id)}
                     isRunning={isRunning}
+                    canManage={canManage}
                     isActiveMain={activeMain.toLowerCase() === id.toLowerCase()}
                     isActiveLive={activeLive.toLowerCase() === id.toLowerCase()}
                     isActiveDiarization={activeDiarization.toLowerCase() === id.toLowerCase()}

--- a/dashboard/components/views/ModelManagerView.tsx
+++ b/dashboard/components/views/ModelManagerView.tsx
@@ -13,7 +13,6 @@ const MLX_DEFAULT_MODEL = 'mlx-community/parakeet-tdt-0.6b-v3';
 
 export const ModelManagerView: React.FC = () => {
   const docker = useDockerContext();
-  const isRunning = docker.container.running;
 
   // Model selection state — reads/writes the same electron-store keys as ServerView
   const [mainModelSelection, setMainModelSelection] = useState(MODEL_DEFAULT_LOADING_PLACEHOLDER);
@@ -29,6 +28,32 @@ export const ModelManagerView: React.FC = () => {
   const [modelCacheStatus, setModelCacheStatus] = useState<
     Record<string, { exists: boolean; size?: string }>
   >({});
+
+  const [mlxStatus, setMlxStatus] = useState<string>('stopped');
+
+  // On the Metal (bare-metal) profile there is no Docker container, so the
+  // Model Manager's "running" signal comes from the MLX server status instead
+  // of docker.container.running (which is permanently false on Metal — GH-136).
+  const isMetal = runtimeProfile === 'metal';
+  const isRunning = isMetal ? mlxStatus === 'running' : docker.container.running;
+
+  // Track MLX server status for the running signal above (Metal profile).
+  useEffect(() => {
+    const api = (window as any).electronAPI;
+    if (!api?.mlx?.getStatus) return;
+    let active = true;
+    api.mlx
+      .getStatus()
+      .then((s: string) => {
+        if (active) setMlxStatus(s);
+      })
+      .catch(() => {});
+    const unsub = api.mlx.onStatusChanged?.((s: string) => setMlxStatus(s));
+    return () => {
+      active = false;
+      if (typeof unsub === 'function') unsub();
+    };
+  }, []);
 
   // Load persisted selections from electron store on mount
   useEffect(() => {
@@ -126,17 +151,30 @@ export const ModelManagerView: React.FC = () => {
   const refreshCacheStatus = useCallback(
     (extraIds?: string[]) => {
       const api = (window as any).electronAPI;
-      if (!api?.docker?.checkModelsCached || !isRunning) return;
       const modelIds = [...new Set(extraIds ?? [])].filter(Boolean);
       if (modelIds.length === 0) return;
+
+      const apply = (result: Record<string, { exists: boolean; size?: string }>) => {
+        setModelCacheStatus((prev) => ({ ...prev, ...result }));
+      };
+
+      if (isMetal) {
+        // Metal: pure host-filesystem check — works whether or not the server runs.
+        if (!api?.mlx?.checkModelsCached) return;
+        api.mlx
+          .checkModelsCached(modelIds)
+          .then(apply)
+          .catch(() => {});
+        return;
+      }
+      // Docker: cache lives inside the container, so it must be running.
+      if (!api?.docker?.checkModelsCached || !isRunning) return;
       api.docker
         .checkModelsCached(modelIds)
-        .then((result: Record<string, { exists: boolean; size?: string }>) => {
-          setModelCacheStatus((prev) => ({ ...prev, ...result }));
-        })
+        .then(apply)
         .catch(() => {});
     },
-    [isRunning],
+    [isRunning, isMetal],
   );
 
   return (
@@ -165,7 +203,7 @@ export const ModelManagerView: React.FC = () => {
           modelCacheStatus={modelCacheStatus}
           isRunning={isRunning}
           refreshCacheStatus={refreshCacheStatus}
-          isMetal={runtimeProfile === 'metal'}
+          isMetal={isMetal}
         />
       </div>
     </div>

--- a/dashboard/components/views/ServerView.tsx
+++ b/dashboard/components/views/ServerView.tsx
@@ -16,6 +16,7 @@ import {
   RotateCcw,
   Copy,
   Check,
+  FolderOpen,
   Eye,
   EyeOff,
   Users,
@@ -285,6 +286,33 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
         setNativeModelsDir(dir + '/models');
       })
       .catch(() => {});
+  }, []);
+
+  // Per-row "copied" feedback for the persistent-volume path actions (GH-137).
+  const [copiedPath, setCopiedPath] = useState<string | null>(null);
+
+  // Open a native directory in the OS file manager; on failure (e.g. the dir
+  // does not exist yet) fall back to its parent.
+  const handleOpenNativePath = useCallback(async (dir: string | null) => {
+    if (!dir) return;
+    const api = (window as any).electronAPI;
+    if (!api?.app?.openPath) return;
+    try {
+      const err: string = await api.app.openPath(dir);
+      if (err) {
+        const parent = dir.replace(/[\\/]+[^\\/]*[\\/]*$/, '');
+        if (parent && parent !== dir) await api.app.openPath(parent).catch(() => {});
+      }
+    } catch {
+      /* best-effort — opening a folder must never crash the view */
+    }
+  }, []);
+
+  const handleCopyNativePath = useCallback((dir: string | null, label: string) => {
+    if (!dir) return;
+    writeToClipboard(dir).catch(() => {});
+    setCopiedPath(label);
+    setTimeout(() => setCopiedPath((c) => (c === label ? null : c)), 2000);
   }, []);
 
   // Derive model option lists filtered by the active runtime profile.
@@ -2635,17 +2663,38 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                         color: 'bg-purple-500',
                       },
                     ].map(({ label, path: dir, color }) => (
-                      <div key={label} className="flex items-center justify-between py-1 text-sm">
-                        <div className="flex items-center gap-3">
-                          <div className={`h-2 w-2 rounded-full ${color}`} />
-                          <span className="text-slate-300">{label}</span>
+                      <div key={label} className="py-1 text-sm">
+                        <div className="flex items-center justify-between gap-2">
+                          <div className="flex items-center gap-3">
+                            <div className={`h-2 w-2 rounded-full ${color}`} />
+                            <span className="text-slate-300">{label}</span>
+                          </div>
+                          <div className="flex shrink-0 items-center gap-1">
+                            <button
+                              onClick={() => handleOpenNativePath(dir)}
+                              disabled={!dir}
+                              className="rounded p-1 text-slate-500 transition-colors hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
+                              title="Open in file manager"
+                            >
+                              <FolderOpen size={14} />
+                            </button>
+                            <button
+                              onClick={() => handleCopyNativePath(dir, label)}
+                              disabled={!dir}
+                              className="rounded p-1 text-slate-500 transition-colors hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
+                              title="Copy path"
+                            >
+                              {copiedPath === label ? (
+                                <Check size={14} className="text-green-400" />
+                              ) : (
+                                <Copy size={14} />
+                              )}
+                            </button>
+                          </div>
                         </div>
-                        <span
-                          className="max-w-[55%] truncate text-right font-mono text-xs text-slate-400"
-                          title={dir ?? ''}
-                        >
+                        <div className="mt-1 pl-5 font-mono text-xs break-all text-slate-400">
                           {dir ?? '…'}
-                        </span>
+                        </div>
                       </div>
                     ))}
                     <p className="text-xs text-slate-500 italic">

--- a/dashboard/electron/__tests__/mlxServerManager.test.ts
+++ b/dashboard/electron/__tests__/mlxServerManager.test.ts
@@ -14,25 +14,45 @@ import { EventEmitter } from 'events';
 
 const {
   mockSpawn,
+  mockExecFile,
   mockExistsSync,
   mockMkdirSync,
   mockSymlinkSync,
   mockCopyFileSync,
   mockWriteFileSync,
+  mockRmSync,
   mockApp,
 } = vi.hoisted(() => ({
   mockSpawn: vi.fn(),
+  // promisify(execFile) wraps this at module load; the default invokes the
+  // node-style callback with a success result so unrelated tests are unaffected.
+  mockExecFile: vi.fn(
+    (
+      _file: string,
+      _args: string[],
+      options: unknown,
+      callback?: (err: unknown, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      const cb = (typeof options === 'function' ? options : callback) as (
+        err: unknown,
+        result: { stdout: string; stderr: string },
+      ) => void;
+      cb(null, { stdout: '', stderr: '' });
+    },
+  ),
   mockExistsSync: vi.fn().mockReturnValue(false),
   mockMkdirSync: vi.fn(),
   mockSymlinkSync: vi.fn(),
   mockCopyFileSync: vi.fn(),
   mockWriteFileSync: vi.fn(),
+  mockRmSync: vi.fn(),
   // Mutable so individual tests can flip packaged-vs-dev and override getVersion().
   mockApp: { isPackaged: false, getVersion: (): string => '1.3.5' },
 }));
 
 vi.mock('child_process', () => ({
   spawn: mockSpawn,
+  execFile: mockExecFile,
 }));
 
 vi.mock('fs', async (importOriginal) => {
@@ -46,12 +66,14 @@ vi.mock('fs', async (importOriginal) => {
       symlinkSync: mockSymlinkSync,
       copyFileSync: mockCopyFileSync,
       writeFileSync: mockWriteFileSync,
+      rmSync: mockRmSync,
     },
     existsSync: mockExistsSync,
     mkdirSync: mockMkdirSync,
     symlinkSync: mockSymlinkSync,
     copyFileSync: mockCopyFileSync,
     writeFileSync: mockWriteFileSync,
+    rmSync: mockRmSync,
   };
 });
 
@@ -413,5 +435,133 @@ describe('[GH #124] MLXServerManager uvicorn-missing diagnostics', () => {
 
     const appended: string[] = sinkAppend.mock.calls.map((c) => c[0] as string);
     expect(appended.some((l) => l.includes('dashboard-only build'))).toBe(true);
+  });
+});
+
+// ── GH #135/#136 — native (Docker-free) model-cache operations on Metal ─────
+//
+// Locks the host-filesystem cache logic the Metal profile depends on: the HF
+// cache-name mapping, the path-traversal guard in removeModelCache, the
+// venv-Python gate, and the gated-repo error message.
+
+describe('[GH #136] MLXServerManager native model cache', () => {
+  // _resolveHfHome() = app.getPath('userData') + '/models' = /mock/userData/models
+  const HUB = '/mock/userData/models/hub';
+  const successExecFile = (
+    _f: string,
+    _a: string[],
+    options: unknown,
+    callback?: (err: unknown, result: { stdout: string; stderr: string }) => void,
+  ): void => {
+    const cb = (typeof options === 'function' ? options : callback) as (
+      err: unknown,
+      result: { stdout: string; stderr: string },
+    ) => void;
+    cb(null, { stdout: '', stderr: '' });
+  };
+
+  let manager: MLXServerManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = new MLXServerManager(() => makeMockWindow() as never);
+    mockExecFile.mockImplementation(successExecFile);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('checkModelsCached', () => {
+    it('maps "org/name" → "models--org--name" under hub/ and reports exists + size', async () => {
+      const id = 'mlx-community/parakeet-tdt-0.6b-v3';
+      const expectedDir = `${HUB}/models--mlx-community--parakeet-tdt-0.6b-v3`;
+      mockExistsSync.mockImplementation((p: string) => p === expectedDir);
+      mockExecFile.mockImplementation((_f, _a, options, callback) => {
+        const cb = (typeof options === 'function' ? options : callback) as (
+          e: unknown,
+          r: { stdout: string; stderr: string },
+        ) => void;
+        cb(null, { stdout: `1.2G\t${expectedDir}\n`, stderr: '' });
+      });
+
+      const result = await manager.checkModelsCached([id]);
+      expect(result[id]).toEqual({ exists: true, size: '1.2G' });
+      expect(mockExistsSync).toHaveBeenCalledWith(expectedDir);
+    });
+
+    it('reports exists:false for an uncached model', async () => {
+      mockExistsSync.mockReturnValue(false);
+      const id = 'mlx-community/whisper-large-v3-asr-fp16';
+      const result = await manager.checkModelsCached([id]);
+      expect(result[id]).toEqual({ exists: false });
+    });
+
+    it('never escapes the hub dir: a "../" id is reported missing even if fs would say yes', async () => {
+      mockExistsSync.mockReturnValue(true); // guard must reject before consulting fs
+      const result = await manager.checkModelsCached(['../../../etc/passwd']);
+      expect(result['../../../etc/passwd']).toEqual({ exists: false });
+    });
+  });
+
+  describe('removeModelCache', () => {
+    it('removes the mapped cache directory under hub/', async () => {
+      await manager.removeModelCache('mlx-community/parakeet-tdt-0.6b-v3');
+      expect(mockRmSync).toHaveBeenCalledWith(
+        `${HUB}/models--mlx-community--parakeet-tdt-0.6b-v3`,
+        { recursive: true, force: true },
+      );
+    });
+
+    it('rejects a "../" id and performs no filesystem delete (path-traversal guard)', async () => {
+      await expect(manager.removeModelCache('../../etc')).rejects.toThrow(/Invalid model id/);
+      expect(mockRmSync).not.toHaveBeenCalled();
+    });
+
+    it('rejects a backslash id and performs no delete', async () => {
+      await expect(manager.removeModelCache('foo\\bar')).rejects.toThrow(/Invalid model id/);
+      expect(mockRmSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('downloadModelToCache', () => {
+    it('throws an actionable error when no venv Python is found (thin build)', async () => {
+      mockExistsSync.mockReturnValue(false); // no uvicorn → no venv python
+      await expect(
+        manager.downloadModelToCache('mlx-community/parakeet-tdt-0.6b-v3'),
+      ).rejects.toThrow(/Metal Python environment was not found/);
+    });
+
+    it('rejects a traversal model id before spawning Python (guard parity with remove)', async () => {
+      mockExistsSync.mockReturnValue(true); // a venv exists, but the guard runs first
+      await expect(manager.downloadModelToCache('../../evil')).rejects.toThrow(/Invalid model id/);
+      expect(mockExecFile).not.toHaveBeenCalled();
+    });
+
+    it('runs snapshot_download via the venv Python with the id and hub dir as argv', async () => {
+      mockExistsSync.mockImplementation(
+        (p: string) => p.includes('uvicorn') || p.includes('python3'),
+      );
+      await manager.downloadModelToCache('mlx-community/parakeet-tdt-0.6b-v3');
+      const call = mockExecFile.mock.calls[0]; // [file, args, options, callback]
+      expect(String(call[0])).toContain('python3');
+      expect(call[1]).toContain('mlx-community/parakeet-tdt-0.6b-v3');
+      expect(call[1]).toContain(`${HUB}`);
+    });
+
+    it('maps a gated-repo 403 to an actionable license/token message', async () => {
+      mockExistsSync.mockImplementation(
+        (p: string) => p.includes('uvicorn') || p.includes('python3'),
+      );
+      mockExecFile.mockImplementation((_f, _a, options, callback) => {
+        const cb = (typeof options === 'function' ? options : callback) as (e: unknown) => void;
+        const err = new Error('exited') as Error & { stderr: string };
+        err.stderr = 'huggingface_hub.utils._errors.GatedRepoError: 403 Client Error';
+        cb(err);
+      });
+      await expect(
+        manager.downloadModelToCache('mlx-community/parakeet-tdt-0.6b-v3'),
+      ).rejects.toThrow(/gated model/);
+    });
   });
 });

--- a/dashboard/electron/main.ts
+++ b/dashboard/electron/main.ts
@@ -2420,6 +2420,19 @@ ipcMain.handle('mlx:getLogs', (_event, tail?: number) => {
   return mlxServerManager.getLogs(tail);
 });
 
+// Native model-cache ops for the Metal/MLX profile (no Docker container).
+ipcMain.handle('mlx:downloadModelToCache', async (_event, modelId: string) => {
+  await mlxServerManager.downloadModelToCache(modelId);
+});
+
+ipcMain.handle('mlx:checkModelsCached', async (_event, modelIds: string[]) => {
+  return mlxServerManager.checkModelsCached(modelIds);
+});
+
+ipcMain.handle('mlx:removeModelCache', async (_event, modelId: string) => {
+  await mlxServerManager.removeModelCache(modelId);
+});
+
 // ─── Watcher IPC Handlers ────────────────────────────────────────────────────
 
 ipcMain.handle('watcher:startSession', async (_event, folderPath: string) => {

--- a/dashboard/electron/mlxServerManager.ts
+++ b/dashboard/electron/mlxServerManager.ts
@@ -11,11 +11,14 @@
  *   2. `<resourcesPath>/backend/.venv/bin/uvicorn`       (packaged)
  */
 
-import { ChildProcess, spawn } from 'child_process';
+import { ChildProcess, spawn, execFile } from 'child_process';
+import { promisify } from 'util';
 import { app, BrowserWindow } from 'electron';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { MlxLogSink } from './mlxLogSink.js';
+
+const execFileAsync = promisify(execFile);
 
 export type MLXServerStatus = 'stopped' | 'starting' | 'running' | 'stopping' | 'error';
 
@@ -25,6 +28,11 @@ export interface MLXStartOptions {
   mainTranscriberModel?: string;
   liveTranscriberModel?: string;
   diarizationModel?: string;
+}
+
+export interface MLXModelCacheEntry {
+  exists: boolean;
+  size?: string;
 }
 
 const MAX_LOG_LINES = 500;
@@ -303,8 +311,149 @@ export class MLXServerManager {
   }
 
   // ──────────────────────────────────────────────────────────────────────────
+  // Native model-cache operations (Docker-free, for the Metal/MLX profile)
+  //
+  // These mirror dockerManager's downloadModelToCache/checkModelsCached/
+  // removeModelCache but run directly on the host: the HuggingFace cache lives
+  // at <HF_HOME>/hub on the local filesystem, and the download is a
+  // `snapshot_download` via the MLX venv's Python. None of these require the
+  // Metal server process to be running.
+  // ──────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Download a model's weights into the local HuggingFace cache
+   * (<HF_HOME>/hub) without GPU-loading it. Runs `snapshot_download` via the
+   * MLX venv's Python as an independent subprocess, so it works whether or not
+   * the Metal server is running.
+   */
+  async downloadModelToCache(modelId: string): Promise<void> {
+    const trimmed = this._assertSafeModelId(modelId);
+
+    const python = this._resolveVenvPython();
+    if (!python) {
+      throw new Error(
+        'The Metal Python environment was not found, so models cannot be ' +
+          `downloaded. Reinstall from "${this._metalDmgName()}".`,
+      );
+    }
+
+    const hfHome = this._resolveHfHome();
+    const hubDir = path.join(hfHome, 'hub');
+    // Pass the model ID and cache dir as argv values — never interpolated into
+    // the Python source — to avoid any code-injection surface.
+    const pyCmd =
+      'import sys; from huggingface_hub import snapshot_download; ' +
+      'snapshot_download(sys.argv[1], cache_dir=sys.argv[2])';
+    try {
+      await execFileAsync(python, ['-c', pyCmd, trimmed, hubDir], {
+        maxBuffer: 10 * 1024 * 1024,
+        timeout: 600_000, // 10 minutes for large models
+        env: { ...process.env, HF_HOME: hfHome },
+      });
+    } catch (err: unknown) {
+      const stderr: string = (err as { stderr?: string })?.stderr ?? '';
+      if (stderr.includes('ModuleNotFoundError') || stderr.includes('No module named')) {
+        throw new Error(
+          'The Metal Python environment is incomplete (huggingface_hub was not ' +
+            `found). The app bundle may be damaged — reinstall from "${this._metalDmgName()}".`,
+        );
+      }
+      if (stderr.includes('GatedRepoError') || stderr.includes('403 Client Error')) {
+        throw new Error(
+          `Access denied for "${trimmed}". This is a gated model — ` +
+            `visit https://huggingface.co/${trimmed} to accept the license, ` +
+            `then add your HuggingFace token in Settings.`,
+        );
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Check which HuggingFace repos already exist in the local cache.
+   * Returns a record mapping each model ID to `{ exists, size? }`.
+   * Pure host-filesystem inspection — does not require the server running.
+   */
+  async checkModelsCached(modelIds: string[]): Promise<Record<string, MLXModelCacheEntry>> {
+    const result: Record<string, MLXModelCacheEntry> = {};
+    const hubDir = path.join(this._resolveHfHome(), 'hub');
+    const resolvedHub = path.resolve(hubDir);
+
+    for (const id of modelIds) {
+      result[id] = { exists: false };
+      const trimmed = id.trim();
+      // Skip unsafe IDs (mutating ops throw via _assertSafeModelId; this batch
+      // check just reports them as not-cached). Keep the char set in sync.
+      if (!trimmed || trimmed.includes('..') || trimmed.includes('\\') || trimmed.includes('\0'))
+        continue;
+
+      // HuggingFace convention: "org/name" → "models--org--name" under hub/.
+      const cacheName = `models--${trimmed.replace(/\//g, '--')}`;
+      const dir = path.resolve(path.join(hubDir, cacheName));
+      if (path.dirname(dir) !== resolvedHub) continue; // not a direct child of hub
+      if (!fs.existsSync(dir)) continue;
+
+      let size: string | undefined;
+      try {
+        const { stdout } = await execFileAsync('du', ['-sh', dir], { timeout: 15_000 });
+        const parsed = stdout.split(/\s+/)[0]?.trim();
+        if (parsed) size = parsed;
+      } catch {
+        // Keep exists=true even when the size lookup fails.
+      }
+      result[id] = size ? { exists: true, size } : { exists: true };
+    }
+    return result;
+  }
+
+  /**
+   * Remove a model's cache directory from the local HuggingFace cache.
+   * Validates the ID and refuses to touch anything outside <HF_HOME>/hub
+   * (path-traversal guard for the host filesystem).
+   */
+  async removeModelCache(modelId: string): Promise<void> {
+    const trimmed = this._assertSafeModelId(modelId);
+    const hubDir = path.join(this._resolveHfHome(), 'hub');
+    const cacheName = `models--${trimmed.replace(/\//g, '--')}`;
+    const dir = path.resolve(path.join(hubDir, cacheName));
+    if (path.dirname(dir) !== path.resolve(hubDir)) {
+      throw new Error('Refusing to remove a cache directory outside the hub directory');
+    }
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
   // Private helpers
   // ──────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Locate the MLX venv's Python interpreter (python3 preferred). Derived from
+   * the same venv that hosts uvicorn, so huggingface_hub is guaranteed present.
+   * Returns null when no venv is found (e.g. the dashboard-only "thin" build).
+   */
+  private _resolveVenvPython(): string | null {
+    const uvicornPath = this._uvicornCandidates().find((c) => fs.existsSync(c));
+    if (!uvicornPath) return null;
+    const binDir = path.dirname(uvicornPath);
+    return (
+      (['python3', 'python'] as const).map((n) => path.join(binDir, n)).find(fs.existsSync) ?? null
+    );
+  }
+
+  /**
+   * Validate a model ID before it influences a host filesystem path or a
+   * subprocess. Rejects traversal sequences and control characters. Forward
+   * slashes are allowed (legitimate in HuggingFace "org/name" IDs) — callers
+   * map them to the "models--org--name" cache convention, and the resolved-path
+   * containment check (`path.dirname(dir) === <hub>`) is the real backstop.
+   */
+  private _assertSafeModelId(modelId: string): string {
+    const trimmed = modelId.trim();
+    if (!trimmed || trimmed.includes('..') || trimmed.includes('\\') || trimmed.includes('\0')) {
+      throw new Error(`Invalid model id: ${modelId}`);
+    }
+    return trimmed;
+  }
 
   private _uvicornCandidates(): string[] {
     const candidates: string[] = [];

--- a/dashboard/electron/preload.ts
+++ b/dashboard/electron/preload.ts
@@ -449,6 +449,11 @@ export interface ElectronAPI {
     stop: () => Promise<void>;
     getStatus: () => Promise<'stopped' | 'starting' | 'running' | 'stopping' | 'error'>;
     getLogs: (tail?: number) => Promise<string[]>;
+    downloadModelToCache: (modelId: string) => Promise<void>;
+    checkModelsCached: (
+      modelIds: string[],
+    ) => Promise<Record<string, { exists: boolean; size?: string }>>;
+    removeModelCache: (modelId: string) => Promise<void>;
     onStatusChanged: (
       callback: (status: 'stopped' | 'starting' | 'running' | 'stopping' | 'error') => void,
     ) => () => void;
@@ -789,6 +794,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
         'stopped' | 'starting' | 'running' | 'stopping' | 'error'
       >,
     getLogs: (tail?: number) => ipcRenderer.invoke('mlx:getLogs', tail) as Promise<string[]>,
+    downloadModelToCache: (modelId: string) =>
+      ipcRenderer.invoke('mlx:downloadModelToCache', modelId) as Promise<void>,
+    checkModelsCached: (modelIds: string[]) =>
+      ipcRenderer.invoke('mlx:checkModelsCached', modelIds) as Promise<
+        Record<string, { exists: boolean; size?: string }>
+      >,
+    removeModelCache: (modelId: string) =>
+      ipcRenderer.invoke('mlx:removeModelCache', modelId) as Promise<void>,
     onStatusChanged: (
       callback: (status: 'stopped' | 'starting' | 'running' | 'stopping' | 'error') => void,
     ) => {


### PR DESCRIPTION
## Summary

Fixes three Apple-Silicon **Metal/MLX**-profile issues in the dashboard, all rooted in the fact that the Metal profile runs the server as a **bare-metal local process with no Docker container** — yet the Model Manager and its model-cache layer were written entirely around the Docker mental model.

- **#136 — models can't be downloaded on Metal (root cause).** The Model Manager's whole download/cache layer (`downloadModelToCache` / `checkModelsCached` / `removeModelCache`) was hard-wired to `docker exec` into a container that doesn't exist on Metal, and `ModelManagerView` derived its "running" signal from `docker.container.running` (permanently `false` on Metal), so every button was disabled *and* the underlying IPC would have failed anyway.
- **#135 — contradictory Model Manager banner.** "Start the server to manage model downloads. Model selection is available while the server is stopped." — Docker-centric copy shown on every profile.
- **#137 — persistent-volume paths.** Server → "5. Persistent Volumes" truncated the host paths with no way to view, open, or copy them.

## What changed

### #136 — native, Docker-free model cache (the core fix)
- Added native cache operations to `MLXServerManager` (`dashboard/electron/mlxServerManager.ts`):
  - `downloadModelToCache` runs `huggingface_hub.snapshot_download` via the **MLX venv's Python** (model id + cache dir passed as argv, never interpolated) into `<HF_HOME>/hub`. Because it's an independent subprocess, it works **whether or not the server is running** — which is exactly why #135's "start the server to download" premise was wrong for Metal.
  - `checkModelsCached` / `removeModelCache` are pure host-filesystem ops over `<HF_HOME>/hub/models--org--name`.
  - A shared `_assertSafeModelId` guard rejects `..` / backslash / null bytes, and a resolved-path containment check (`path.dirname(dir) === <hub>`) confines all deletes/reads to the hub directory.
- Wired three new IPC channels — `mlx:downloadModelToCache`, `mlx:checkModelsCached`, `mlx:removeModelCache` — through `main.ts` and `preload.ts`.
- Made the Model Manager **profile-aware** (`ModelManagerView.tsx` / `ModelManagerTab.tsx`):
  - "running" signal now comes from MLX status on Metal (`isMetal ? mlxStatus === 'running' : docker.container.running`).
  - `canManage = isMetal || isRunning` ungates Download/Remove on Metal (host-local op); the Select dropdown stays gated on `isRunning` (unchanged semantics).
  - Download/remove/cache-check now route to `mlx.*` on Metal and `docker.*` otherwise; cache status is checked on Metal even while the server is stopped.

### #135 — non-contradictory banner
- Profile-aware copy: on Metal, explains models are manageable now and selection applies at next start; on Docker, the constraint is clarified (downloads need the server; selection is saved while stopped) — clarified, not inverted.

### #137 — persistent-volume path actions
- The Metal branch of "5. Persistent Volumes" now shows the **full path** (no truncation) plus per-row **open-in-file-manager** and **copy-to-clipboard** buttons, reusing the existing `app.openPath` IPC and the Wayland-safe `writeToClipboard` helper. **No new IPC.** Docker branch (which lists Docker volume *names*, not host paths) is unchanged.

### Tests
- Extended `dashboard/electron/__tests__/mlxServerManager.test.ts` with 10 cases covering the HF cache-name mapping, the path-traversal guard (download/remove parity + `../`/backslash rejection), the venv-Python gate, and the gated-repo (403) error message.

## Files changed
- `dashboard/electron/mlxServerManager.ts` — native cache ops + shared `_assertSafeModelId` + venv-Python resolver
- `dashboard/electron/main.ts` — 3 new `mlx:*` IPC handlers
- `dashboard/electron/preload.ts` — `mlx.*` bridge methods (interface + impl)
- `dashboard/components/views/ModelManagerView.tsx` — MLX-aware running signal + profile-routed cache refresh
- `dashboard/components/views/ModelManagerTab.tsx` — `canManage` gating, profile-routed handlers, profile-aware banner
- `dashboard/components/views/ServerView.tsx` — full-path display + open/copy actions (Metal branch)
- `dashboard/electron/__tests__/mlxServerManager.test.ts` — native cache test coverage

## Test plan
- [x] `npm run typecheck` (dashboard) — clean
- [x] `npx vitest run` (dashboard) — full suite **1351 passed** (mlxServerManager: 26, incl. 10 new)
- [x] `npm run ui:contract:check` — passes (no new className tokens introduced)
- [x] Pre-commit hooks (prettier, codespell, UI contract) — pass
- [ ] **On-device (Apple-Silicon Mac), Metal profile — not coverable in CI:**
  - [ ] Model Manager with the server **stopped**: no contradictory banner; Download is enabled.
  - [ ] Click Download (server stopped *and* running): model downloads into `~/Library/Application Support/TranscriptionSuite/models/hub`; row flips to "Downloaded {size}" / Remove.
  - [ ] Remove a cached model: cache directory is deleted; nothing outside the hub dir is touched.
  - [ ] Download a gated model without a token: actionable "accept license + add HF token" toast.
  - [ ] Persistent Volumes: full paths visible; "open in file manager" opens the dir (or its parent if it doesn't exist yet); "copy path" copies the full path with a Check confirmation.
- [ ] Docker profile regression check: Model Manager banner/gating and volume list behave exactly as before.

## Risk & notes
- **Blast radius:** changes touch `ModelManagerTab/View` and `ServerView`, which participate in many UI flows, but the behavioral changes are confined to the Metal/MLX paths; Docker behavior is unchanged and the full Vitest suite passes.
- **Two deliberate, documented deviations** (recorded in the spec's Spec Change Log; human-owned intent left untouched):
  1. The path guard allows `/` (legitimate in HuggingFace `org/name` IDs), transforming it to the `--` cache convention and confining deletes to the hub dir — rather than rejecting `/` outright (which would break every model).
  2. The `ModuleNotFoundError` download error emits a Metal-appropriate message ("environment incomplete — reinstall the -metal build") instead of Docker's "server still installing dependencies", which would be misleading on Metal (the venv is baked into the bundle, not bootstrapped at runtime).
- **No new IPC for #137** — reuses `app.openPath` + `writeToClipboard`.

Closes #135, #136, #137.
