### PR TITLE
fix(stt, diarization): restore single-pass WhisperX diarization and harden against transient CUDA errors (GH #122)

### DIFF
--- a/_bmad-output/implementation-artifacts/spec-gh-122-whisperx-diarization-reliability.md
+++ b/_bmad-output/implementation-artifacts/spec-gh-122-whisperx-diarization-reliability.md
@@ -1,0 +1,109 @@
+---
+title: 'GH #122 — WhisperX file-import diarization reliability'
+type: 'bugfix'
+created: '2026-06-01'
+status: 'done'
+baseline_commit: '1c2f65c'
+context:
+  - '{project-root}/CLAUDE.md'
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** File-import transcription with diarization on the default WhisperX backend produces inconsistent output (GH #122): out of ~40 files only ~5 got proper `[Speaker N]` SRTs, the rest came back with no speaker attribution. Logs reveal **two stacked causes** firing on every reported run: (1) `WhisperXBackend.transcribe_with_diarization()` raises `TypeError: unexpected keyword argument 'progress_callback'` because its override signature drifted from the base — this kills the fast single-pass path 100% of the time and forces a fallback; (2) the fallback (`transcribe_then_diarize`) unloads STT and loads a fresh pyannote pipeline, which intermittently raises `CUDA driver error: device not ready` on the WSL2 GPU, returning a transcript with no speakers. The intermittency (and the rare successes) is pure luck on the CUDA cold-start race.
+
+**Approach:** (1) Restore `progress_callback` to the WhisperX override so the single-pass path works and reports coarse phase progress; this also keeps the GPU warm (no STT-unload→pyannote-load swap), removing the main trigger for cause #2. (2) Add a bounded retry on **transient** CUDA errors around the pyannote inference call in `diarize_audio`, mirroring the existing `cuda_health_check` backoff pattern, so an occasional "device not ready" self-heals instead of silently dropping speakers.
+
+## Boundaries & Constraints
+
+**Always:**
+- Keep `WhisperXBackend.transcribe_with_diarization` signature a superset of `STTBackend.transcribe_with_diarization` (base contract is the source of truth).
+- Diarization retry must only fire on transient CUDA errors (e.g. "device not ready", "unknown error"/999, generic "cuda driver error"); all other exceptions re-raise immediately.
+- Preserve graceful degradation: if diarization ultimately fails, the transcript MUST still be returned (no data loss — see CLAUDE.md durability invariant).
+- Between retries, sync + empty the CUDA cache before re-attempting.
+
+**Ask First:**
+- Changing retry count/backoff beyond 3 attempts at 1s/2s/4s (matching the established `cuda_health_check` pattern).
+- Any change to the live-mode integrated call site or to `parallel_diarize` orchestration order.
+
+**Never:**
+- Do not modify the route's branch logic (`use_integrated_diarization` gating) or `parallel_diarize` model swap order.
+- Do not touch the NVIDIA driver, Docker entrypoint, or WSL2 host config.
+- Do not change the VibeVoice/MLX overrides (they already match the base contract).
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| Single-pass diarization, file import | `enable_diarization=True`, backend=WhisperX, `progress_callback` passed | Runs transcribe→align→diarize in one pass; emits coarse progress; returns `DiarizedTranscriptionResult` with speakers | N/A |
+| Transient CUDA error, recovers | pyannote pipeline raises `RuntimeError("CUDA driver error: device not ready")` on attempt 1, succeeds after | sync+empty_cache, backoff, retry; diarization succeeds | retry ≤3× (1s/2s/4s); warn per attempt |
+| Persistent transient CUDA error | pipeline raises transient error on every attempt | retries exhausted → exception re-raised; caller returns transcript **without** speakers | caller logs warning, no crash, transcript preserved |
+| Non-transient diarization error | pipeline raises `ValueError`/unrelated error | re-raised immediately, **no** retry | propagate to caller |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `server/backend/core/stt/backends/whisperx_backend.py` — `transcribe_with_diarization` (L272) is missing `progress_callback`; `transcribe` (L199) and base (base.py:142) already have it. Fix site for cause #1.
+- `server/backend/core/stt/backends/base.py` — `STTBackend.transcribe_with_diarization` (L142) defines the canonical signature including `progress_callback`.
+- `server/backend/api/routes/transcription.py` — file-import path calls `transcribe_with_diarization(..., progress_callback=on_progress)` (L904-915); `on_progress` → `update_progress(current,total)` (L816). The `except Exception` at L948 swallows the TypeError as "integrated backend diarization failed". No change here.
+- `server/backend/core/diarization_engine.py` — `diarize_audio` (L244) calls `self._pipeline(...)` (L293) with no retry; raises on CUDA error. Fix site for cause #2.
+- `server/backend/core/parallel_diarize.py` — `transcribe_then_diarize` (L32) is the fallback that catches the diarization failure and returns `(result, None)` (L93-98). Unchanged; degradation already correct.
+- `server/backend/core/audio_utils.py` — `cuda_health_check` (L256) is the backoff/retry precedent to mirror; `clear_gpu_cache` (L205) syncs+empties cache.
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `server/backend/core/stt/backends/whisperx_backend.py` -- Add `progress_callback: Callable[[int, int], None] | None = None` to `transcribe_with_diarization` (keyword-only, after `hf_token`). Emit coarse phase progress when non-None: after transcribe `(60,100)`, after align `(80,100)`, after diarize+assign `(100,100)`. Guard each call with `if progress_callback is not None`.
+- [x] `server/backend/core/diarization_engine.py` -- Add module-level `_is_transient_cuda_error(exc)` helper and `_CUDA_RETRY_DELAYS = (1, 2, 4)`. Wrap the `self._pipeline(...)` call in `diarize_audio` in a bounded retry loop: on transient CUDA error, log warning, `clear_gpu_cache()` (synchronize + empty_cache), sleep(delay), retry; non-transient → re-raise immediately; exhausted → re-raise last.
+- [x] `server/backend/tests/test_stt_backend_diarization_signature.py` -- New regression test: for every concrete `STTBackend` subclass, assert its `transcribe_with_diarization` accepts every keyword-only param the base declares (would have caught cause #1).
+- [x] `server/backend/tests/test_diarization_retry.py` -- New test: stub a pipeline that raises "device not ready" once then succeeds → asserts retry + success; raises a `ValueError` → asserts no retry and immediate propagation; raises transient error every time → asserts ≤3 retries then re-raise; OOM → no retry.
+
+**Acceptance Criteria:**
+- Given the WhisperX backend and a diarization file-import request, when the route calls `transcribe_with_diarization(progress_callback=...)`, then it no longer raises `TypeError` and the single-pass path completes with speaker labels.
+- Given a transient CUDA "device not ready" on the first diarization attempt, when `diarize_audio` runs, then it retries with backoff and returns a populated `DiarizationResult`.
+- Given diarization fails permanently, when the job completes, then the transcript is still returned (degraded, no speakers) and no exception escapes to the client.
+- Given the full backend test suite, when run from the build venv, then all new and existing tests pass.
+
+## Verification
+
+**Commands:**
+- `cd server/backend && ../../build/.venv/bin/pytest tests/test_stt_backend_diarization_signature.py tests/test_diarization_retry.py -v --tb=short` -- expected: all pass.
+- `cd server/backend && ../../build/.venv/bin/pytest tests/ -q` -- expected: no new failures vs. baseline (2 known pre-existing failures only).
+- `cd server/backend && ../../build/.venv/bin/ruff check core/stt/backends/whisperx_backend.py core/diarization_engine.py` -- expected: clean.
+
+## Suggested Review Order
+
+**Cause #1 — the actual GH #122 crash (signature drift)**
+
+- Entry point: the dropped param restored, matching the base contract the route relies on.
+  [`whisperx_backend.py:285`](../../server/backend/core/stt/backends/whisperx_backend.py#L285)
+
+- Coarse phase progress emitted at transcribe / align / diarize boundaries.
+  [`whisperx_backend.py:333`](../../server/backend/core/stt/backends/whisperx_backend.py#L333)
+
+**Data-loss safety (review patch)**
+
+- Progress emission isolated so a throwing callback can never discard a completed transcription.
+  [`whisperx_backend.py:311`](../../server/backend/core/stt/backends/whisperx_backend.py#L311)
+
+**Cause #2 — intermittent CUDA "device not ready"**
+
+- Transient-vs-fatal classifier; OOM deliberately excluded.
+  [`diarization_engine.py:53`](../../server/backend/core/diarization_engine.py#L53)
+
+- Bounded retry (3× @ 1s/2s/4s) wrapping the pyannote call; non-transient re-raises immediately.
+  [`diarization_engine.py:318`](../../server/backend/core/diarization_engine.py#L318)
+
+**Tests**
+
+- Signature-conformance guard that would have caught the original drift at CI time.
+  [`test_stt_backend_diarization_signature.py:80`](../../server/backend/tests/test_stt_backend_diarization_signature.py#L80)
+
+- Retry behavior: recover / no-retry-on-non-transient / exhaust / OOM-excluded.
+  [`test_diarization_retry.py:84`](../../server/backend/tests/test_diarization_retry.py#L84)
+
+- Data-loss guard: a throwing progress_callback must not lose the result.
+  [`test_whisperx_backend.py:508`](../../server/backend/tests/test_whisperx_backend.py#L508)

--- a/server/backend/core/diarization_engine.py
+++ b/server/backend/core/diarization_engine.py
@@ -7,6 +7,7 @@ with the unified transcription engine.
 
 import logging
 import os
+import time
 import warnings
 from pathlib import Path
 from typing import Any
@@ -42,6 +43,25 @@ try:
 except ImportError:
     torch = None  # type: ignore
     HAS_TORCH = False
+
+
+# Backoff delays (seconds) for transient CUDA errors during diarization inference.
+# Mirrors the exponential-backoff pattern in audio_utils.cuda_health_check.
+_CUDA_RETRY_DELAYS = (1, 2, 4)
+
+
+def _is_transient_cuda_error(exc: BaseException) -> bool:
+    """True for CUDA errors that are typically transient and worth retrying.
+
+    Targets the WSL2 cold-start race that surfaces as ``CUDA driver error:
+    device not ready`` (cudaErrorNotReady) right after a model load/unload swap,
+    plus the driver-settling ``error 999`` / ``unknown error``.  Deliberately
+    excludes out-of-memory, which retrying cannot fix.
+    """
+    msg = str(exc).lower()
+    if "out of memory" in msg:
+        return False
+    return "device not ready" in msg or "error 999" in msg or "unknown error" in msg
 
 
 def _resolve_device(requested: str) -> str:
@@ -290,12 +310,37 @@ class DiarizationEngine:
                     category=UserWarning,
                 )
 
-                diarization = self._pipeline(
-                    audio_input,
-                    num_speakers=n_speakers,
-                    min_speakers=self.min_speakers,
-                    max_speakers=self.max_speakers,
-                )
+                # Bounded retry on transient CUDA errors (e.g. WSL2 "device not
+                # ready" after a model swap). Non-transient errors propagate
+                # immediately; once retries are exhausted the last error is
+                # re-raised so the caller can degrade to transcript-without-speakers.
+                diarization = None
+                for attempt in range(len(_CUDA_RETRY_DELAYS) + 1):
+                    try:
+                        diarization = self._pipeline(
+                            audio_input,
+                            num_speakers=n_speakers,
+                            min_speakers=self.min_speakers,
+                            max_speakers=self.max_speakers,
+                        )
+                        break
+                    except Exception as exc:
+                        if not _is_transient_cuda_error(exc) or attempt >= len(_CUDA_RETRY_DELAYS):
+                            raise
+                        delay = _CUDA_RETRY_DELAYS[attempt]
+                        logger.warning(
+                            "Diarization: transient CUDA error (attempt %d/%d), "
+                            "clearing GPU cache and retrying in %ds: %s",
+                            attempt + 1,
+                            len(_CUDA_RETRY_DELAYS) + 1,
+                            delay,
+                            exc,
+                        )
+                        clear_gpu_cache()
+                        time.sleep(delay)
+
+            if diarization is None:  # pragma: no cover - loop always breaks or raises
+                raise RuntimeError("Diarization pipeline returned no result")
 
             # Convert to segments
             segments: list[DiarizationSegment] = []

--- a/server/backend/core/stt/backends/whisperx_backend.py
+++ b/server/backend/core/stt/backends/whisperx_backend.py
@@ -282,8 +282,15 @@ class WhisperXBackend(STTBackend):
         vad_filter: bool = True,
         num_speakers: int | None = None,
         hf_token: str | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
     ) -> DiarizedTranscriptionResult | None:
-        """Full single-pass pipeline: transcribe → align → diarize → assign speakers."""
+        """Full single-pass pipeline: transcribe → align → diarize → assign speakers.
+
+        ``progress_callback`` is required to honour the :class:`STTBackend` base
+        contract — the file-import route always passes it. We report coarse
+        phase-level progress (transcribe → align → diarize) rather than per-chunk,
+        since WhisperX processes the whole file in one pass.
+        """
         del audio_sample_rate
         whisperx, diarize_module = _import_whisperx_modules(include_diarize=True)
         if diarize_module is None:
@@ -301,6 +308,16 @@ class WhisperXBackend(STTBackend):
                 "Set HUGGINGFACE_TOKEN or HF_TOKEN environment variable."
             )
 
+        def _report(pct: int) -> None:
+            # Progress reporting must never be able to discard a completed,
+            # irreplaceable transcription result — isolate callback failures.
+            if progress_callback is None:
+                return
+            try:
+                progress_callback(pct, 100)
+            except Exception:
+                logger.debug("WhisperX progress_callback raised; ignoring", exc_info=True)
+
         # 1. Transcribe
         logger.info("WhisperX: transcribing audio")
         wx_result = self._whisperx_transcribe(
@@ -313,6 +330,7 @@ class WhisperXBackend(STTBackend):
             vad_filter=vad_filter,
         )
         detected_language = wx_result.get("language", language)
+        _report(60)  # transcription done
 
         # 2. Align (wav2vec2 forced alignment for precise word timestamps)
         if wx_result.get("segments"):
@@ -321,6 +339,7 @@ class WhisperXBackend(STTBackend):
                 wx_result = self._align(wx_result, audio, detected_language)
             except Exception as e:
                 logger.warning(f"WhisperX alignment failed, continuing with raw timestamps: {e}")
+        _report(80)  # alignment done
 
         # 3. Diarize
         logger.info("WhisperX: running diarization")
@@ -377,6 +396,8 @@ class WhisperXBackend(STTBackend):
             num_speakers_found,
             len(all_segments),
         )
+
+        _report(100)  # diarization + speaker assignment done
 
         return DiarizedTranscriptionResult(
             segments=all_segments,

--- a/server/backend/tests/test_diarization_retry.py
+++ b/server/backend/tests/test_diarization_retry.py
@@ -1,0 +1,124 @@
+"""GH #122: bounded retry on transient CUDA errors during diarization.
+
+On WSL2 the pyannote pipeline intermittently raises
+``RuntimeError: CUDA driver error: device not ready`` right after a model swap.
+Previously this aborted diarization and silently dropped speaker labels. The
+retry loop in ``DiarizationEngine.diarize_audio`` now self-heals transient CUDA
+errors while still failing fast on unrelated errors.
+"""
+
+from __future__ import annotations
+
+import importlib
+import types
+
+import numpy as np
+import pytest
+
+
+def _import_engine_module():
+    return importlib.import_module("server.core.diarization_engine")
+
+
+class _FakeTensor:
+    def float(self) -> _FakeTensor:
+        return self
+
+    def unsqueeze(self, _dim: int) -> _FakeTensor:
+        return self
+
+
+class _FakeTorch:
+    """Minimal torch shim so diarize_audio's waveform prep is env-independent."""
+
+    @staticmethod
+    def from_numpy(_arr):  # noqa: ANN001
+        return _FakeTensor()
+
+
+class _FakeAnnotation:
+    def __init__(self, tracks: list[tuple[float, float, str]]) -> None:
+        self._tracks = tracks
+
+    def itertracks(self, yield_label: bool = True):  # noqa: ARG002
+        for start, end, speaker in self._tracks:
+            yield types.SimpleNamespace(start=start, end=end), None, speaker
+
+
+class _FlakyPipeline:
+    """Raises the queued exceptions on successive calls, then succeeds."""
+
+    def __init__(self, errors: list[Exception]) -> None:
+        self._errors = list(errors)
+        self.calls = 0
+
+    def __call__(self, _audio_input, **_kwargs):  # noqa: ANN001
+        self.calls += 1
+        if self._errors:
+            raise self._errors.pop(0)
+        return _FakeAnnotation([(0.0, 1.0, "SPEAKER_00")])
+
+
+def _make_engine(module, pipeline) -> object:
+    """Build a DiarizationEngine without running its heavy __init__."""
+    engine = object.__new__(module.DiarizationEngine)
+    engine._loaded = True
+    engine._pipeline = pipeline
+    engine.num_speakers = None
+    engine.min_speakers = None
+    engine.max_speakers = None
+    return engine
+
+
+@pytest.fixture
+def patched_module(monkeypatch):
+    module = _import_engine_module()
+    # Make GPU-dependent calls inert and instant.
+    monkeypatch.setattr(module, "torch", _FakeTorch())
+    monkeypatch.setattr(module, "HAS_TORCH", True)
+    monkeypatch.setattr(module, "clear_gpu_cache", lambda: None)
+    monkeypatch.setattr("server.core.diarization_engine.time.sleep", lambda *a, **k: None)
+    return module
+
+
+def test_retries_then_succeeds_on_transient_cuda_error(patched_module) -> None:
+    pipeline = _FlakyPipeline([RuntimeError("CUDA driver error: device not ready")])
+    engine = _make_engine(patched_module, pipeline)
+
+    result = engine.diarize_audio(np.zeros(16000, dtype=np.float32), 16000)
+
+    assert pipeline.calls == 2  # 1 failure + 1 successful retry
+    assert result.num_speakers == 1
+
+
+def test_non_transient_error_is_not_retried(patched_module) -> None:
+    pipeline = _FlakyPipeline([ValueError("malformed audio input")])
+    engine = _make_engine(patched_module, pipeline)
+
+    with pytest.raises(ValueError, match="malformed audio input"):
+        engine.diarize_audio(np.zeros(16000, dtype=np.float32), 16000)
+
+    assert pipeline.calls == 1  # failed fast, no retry
+
+
+def test_transient_error_reraised_after_retries_exhausted(patched_module) -> None:
+    # 4 transient failures = more than the 3 configured retries.
+    errors = [RuntimeError("CUDA driver error: device not ready") for _ in range(4)]
+    pipeline = _FlakyPipeline(errors)
+    engine = _make_engine(patched_module, pipeline)
+
+    with pytest.raises(RuntimeError, match="device not ready"):
+        engine.diarize_audio(np.zeros(16000, dtype=np.float32), 16000)
+
+    # 1 initial attempt + len(_CUDA_RETRY_DELAYS) retries.
+    assert pipeline.calls == len(patched_module._CUDA_RETRY_DELAYS) + 1
+
+
+def test_out_of_memory_is_not_treated_as_transient(patched_module) -> None:
+    pipeline = _FlakyPipeline([RuntimeError("CUDA out of memory")])
+    engine = _make_engine(patched_module, pipeline)
+
+    with pytest.raises(RuntimeError, match="out of memory"):
+        engine.diarize_audio(np.zeros(16000, dtype=np.float32), 16000)
+
+    assert pipeline.calls == 1  # OOM is not retried — retrying cannot help

--- a/server/backend/tests/test_stt_backend_diarization_signature.py
+++ b/server/backend/tests/test_stt_backend_diarization_signature.py
@@ -50,10 +50,11 @@ def _base_param_names() -> set[str]:
 @pytest.mark.parametrize(("module_path", "class_name"), _BACKENDS)
 def test_override_signature_is_superset_of_base(module_path: str, class_name: str) -> None:
     _install_soundfile_stub()
-    try:
-        module = importlib.import_module(module_path)
-    except Exception as exc:  # e.g. mlx unavailable off Apple Silicon
-        pytest.skip(f"{module_path} not importable in this env: {exc}")
+    # importorskip returns the module, or skips cleanly if its deps are absent
+    # (e.g. the `mlx` runtime off Apple Silicon). Using it instead of a
+    # try/except + pytest.skip keeps `module` unconditionally bound, avoiding a
+    # CodeQL py/uninitialized-local-variable false positive.
+    module = pytest.importorskip(module_path, reason=f"{module_path} not importable in this env")
 
     from server.core.stt.backends.base import STTBackend
 

--- a/server/backend/tests/test_stt_backend_diarization_signature.py
+++ b/server/backend/tests/test_stt_backend_diarization_signature.py
@@ -1,0 +1,88 @@
+"""Regression test for GH #122: STT backend ``transcribe_with_diarization``
+overrides must remain a superset of the base contract.
+
+The bug: ``WhisperXBackend.transcribe_with_diarization()`` had dropped the
+``progress_callback`` parameter that ``STTBackend`` declares and that the
+file-import route always passes. Python only catches this at call time, so it
+shipped — every WhisperX diarization run raised ``TypeError`` and silently fell
+back to the slower, more failure-prone two-model path. This test would have
+caught it at CI time instead.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import sys
+import types
+
+import numpy as np
+import pytest
+
+# WhisperX import touches torch + soundfile; reuse the conftest torch stub.
+pytestmark = pytest.mark.usefixtures("torch_stub")
+
+
+def _install_soundfile_stub() -> None:
+    if "soundfile" not in sys.modules:
+        sf = types.ModuleType("soundfile")
+        sf.read = lambda *a, **k: (np.zeros(16000, dtype=np.float32), 16000)
+        sys.modules["soundfile"] = sf
+
+
+# Every concrete backend that overrides transcribe_with_diarization. mlx_*
+# backends require the `mlx` runtime (Apple Silicon only) and are imported
+# best-effort — skipped where unavailable rather than failing the suite.
+_BACKENDS = [
+    ("server.core.stt.backends.whisperx_backend", "WhisperXBackend"),
+    ("server.core.stt.backends.vibevoice_asr_backend", "VibeVoiceASRBackend"),
+    ("server.core.stt.backends.mlx_vibevoice_backend", "MLXVibeVoiceBackend"),
+]
+
+
+def _base_param_names() -> set[str]:
+    from server.core.stt.backends.base import STTBackend
+
+    sig = inspect.signature(STTBackend.transcribe_with_diarization)
+    return {name for name in sig.parameters if name != "self"}
+
+
+@pytest.mark.parametrize(("module_path", "class_name"), _BACKENDS)
+def test_override_signature_is_superset_of_base(module_path: str, class_name: str) -> None:
+    _install_soundfile_stub()
+    try:
+        module = importlib.import_module(module_path)
+    except Exception as exc:  # e.g. mlx unavailable off Apple Silicon
+        pytest.skip(f"{module_path} not importable in this env: {exc}")
+
+    from server.core.stt.backends.base import STTBackend
+
+    backend_cls = getattr(module, class_name)
+    if backend_cls.transcribe_with_diarization is STTBackend.transcribe_with_diarization:
+        pytest.skip(f"{class_name} does not override transcribe_with_diarization")
+
+    override_params = set(inspect.signature(backend_cls.transcribe_with_diarization).parameters)
+    # An override accepting **kwargs implicitly satisfies the contract.
+    accepts_var_kwargs = any(
+        p.kind is inspect.Parameter.VAR_KEYWORD
+        for p in inspect.signature(backend_cls.transcribe_with_diarization).parameters.values()
+    )
+    if accepts_var_kwargs:
+        return
+
+    missing = _base_param_names() - override_params
+    assert not missing, (
+        f"{class_name}.transcribe_with_diarization is missing base params {sorted(missing)} — "
+        "callers passing them will raise TypeError at runtime (see GH #122)."
+    )
+
+
+def test_whisperx_accepts_progress_callback_explicitly() -> None:
+    """Direct guard for the exact GH #122 regression."""
+    _install_soundfile_stub()
+    module = importlib.import_module("server.core.stt.backends.whisperx_backend")
+    params = inspect.signature(module.WhisperXBackend.transcribe_with_diarization).parameters
+    assert "progress_callback" in params, (
+        "WhisperXBackend.transcribe_with_diarization must accept progress_callback "
+        "(the file-import route passes it)."
+    )

--- a/server/backend/tests/test_whisperx_backend.py
+++ b/server/backend/tests/test_whisperx_backend.py
@@ -505,6 +505,62 @@ def test_whisperx_diarization_forwards_initial_prompt_and_suppress_tokens(monkey
 # ------------------------------------------------------------------
 
 
+def test_whisperx_diarization_progress_callback_failure_does_not_discard_result(
+    monkeypatch,
+) -> None:
+    """GH #122: a throwing progress_callback must never abort a completed diarization.
+
+    Progress reporting is subordinate to result preservation (data-loss invariant).
+    """
+    module = _import_whisperx_backend()
+    backend = module.WhisperXBackend()
+    fake_model = _ModernFakeModel()
+    backend._model = fake_model
+    backend._device = "cpu"
+    backend._align = lambda wx_result, audio, language: wx_result
+
+    whisperx_mod = types.ModuleType("whisperx")
+
+    def assign_word_speakers(diarize_segments, wx_result):
+        wx_result["segments"][0]["speaker"] = "SPEAKER_00"
+        wx_result["segments"][0]["words"] = [
+            {"word": "hi", "start": 0.0, "end": 0.1, "score": 0.9, "speaker": "SPEAKER_00"}
+        ]
+        return wx_result
+
+    whisperx_mod.assign_word_speakers = assign_word_speakers
+
+    diarize_mod = types.ModuleType("whisperx.diarize")
+
+    class FakeDiarizationPipeline:
+        def __init__(self, use_auth_token, device) -> None:
+            pass
+
+        def __call__(self, audio, **kwargs):
+            return [{"speaker": "SPEAKER_00"}]
+
+    diarize_mod.DiarizationPipeline = FakeDiarizationPipeline
+    monkeypatch.setitem(sys.modules, "whisperx", whisperx_mod)
+    monkeypatch.setitem(sys.modules, "whisperx.diarize", diarize_mod)
+
+    calls: list[tuple[int, int]] = []
+
+    def exploding_callback(current: int, total: int) -> None:
+        calls.append((current, total))
+        raise RuntimeError("client socket closed")
+
+    audio = np.zeros(16000, dtype=np.float32)
+    result = backend.transcribe_with_diarization(
+        audio, hf_token="hf_test", progress_callback=exploding_callback
+    )
+
+    # The result survives despite every progress emit raising.
+    assert result is not None
+    assert result.num_speakers == 1
+    # All three phase emits were attempted (each raised and was swallowed).
+    assert calls == [(60, 100), (80, 100), (100, 100)]
+
+
 def test_configure_decode_options_creates_instance_copy() -> None:
     """configure_decode_options() must store an instance copy, not mutate class default."""
     module = _import_whisperx_backend()


### PR DESCRIPTION
# fix(stt, diarization): restore single-pass WhisperX diarization and harden against transient CUDA errors (GH #122)

Fixes #122

## Summary

Issue #122 ("Inconsistent work of the app") reported that file-import transcription **with diarization** produced wildly inconsistent results — out of ~40 files only ~5 came back with proper `[Speaker N]` SRTs; the rest had no speaker attribution at all, even with the same file and the same models. The reporter's attached server logs revealed **two distinct bugs stacked on the same code path**, both firing on every run.

### Root cause

**1. Deterministic — override signature drift (the primary culprit).**
`WhisperXBackend.transcribe_with_diarization()` was missing the `progress_callback` parameter that the `STTBackend` base contract declares and that the file-import route always passes. Every WhisperX diarization run therefore raised:

```
File import: integrated backend diarization failed (continuing without):
WhisperXBackend.transcribe_with_diarization() got an unexpected keyword argument 'progress_callback'
```

WhisperX is the **default** STT backend, so this killed the fast single-pass diarization path for the majority of users and forced a fallback on every run. (Only WhisperX had drifted — the VibeVoice/MLX overrides already carried the parameter.)

**2. Intermittent — unretried transient CUDA error in the fallback.**
The forced fallback (`transcribe_then_diarize`) unloads the STT model and loads a **fresh pyannote pipeline**, then runs it. On WSL2 this cold-load + immediate inference intermittently throws:

```
Diarization failed: CUDA driver error: device not ready
Diarization failed during sequential run — returning transcript without speakers
```

There was no retry on this transient error, so speaker labels were silently dropped. The ~5/40 successes were luck on the GPU cold-start race.

**Why they compound:** bug #1 *forces* the model-swap path that triggers bug #2. Fixing #1 keeps the GPU warm (no swap) and removes the main trigger; fixing #2 makes the residual race self-heal.

## Changes

### `server/backend/core/stt/backends/whisperx_backend.py`
- Added `progress_callback: Callable[[int, int], None] | None = None` to `transcribe_with_diarization`, restoring conformance with the base contract.
- Emit coarse phase-level progress (`60` → `80` → `100`) at the transcribe / align / diarize boundaries (WhisperX processes the whole file in one pass, so per-chunk progress isn't available).
- **Isolated progress emission** behind a local helper so a throwing `progress_callback` can never propagate and discard a completed, irreplaceable transcription (upholds the project's data-loss invariant).

### `server/backend/core/diarization_engine.py`
- Added `_is_transient_cuda_error()` and `_CUDA_RETRY_DELAYS = (1, 2, 4)`.
- Wrapped the pyannote `self._pipeline(...)` call in `diarize_audio` in a bounded retry: on a transient CUDA error (`device not ready` / `error 999` / `unknown error`) it logs, calls `clear_gpu_cache()`, backs off, and retries (3×). Non-transient errors — **including OOM** — re-raise immediately; exhausted retries re-raise so the caller still degrades gracefully to transcript-without-speakers.
- Mirrors the existing exponential-backoff pattern in `audio_utils.cuda_health_check`.

### Tests (+9)
- `tests/test_stt_backend_diarization_signature.py` — signature-conformance guard asserting every `transcribe_with_diarization` override is a superset of the base. **This would have caught the original drift at CI time** (Python can't catch override/base signature mismatches statically).
- `tests/test_diarization_retry.py` — retry behavior: recover-on-transient, no-retry-on-non-transient, exhaust-then-raise, OOM-excluded.
- `tests/test_whisperx_backend.py` — data-loss guard: a throwing `progress_callback` must not lose the result.

## Scope / safety

- **No behavior changes** to the route branch logic, `parallel_diarize` orchestration order, the VibeVoice/MLX overrides, or any Docker/WSL2/driver config.
- Adding an optional keyword-only parameter with a default is a **non-breaking API change** — all existing callers that omit it still bind (confirmed: 63 existing diarization/whisperx tests pass untouched).
- Graceful degradation preserved end-to-end: a permanent diarization failure still returns the transcript.

## Test plan

- [x] `cd server/backend && ../../build/.venv/bin/pytest tests/test_stt_backend_diarization_signature.py tests/test_diarization_retry.py tests/test_whisperx_backend.py -v` — **25 passed**
- [x] Full backend suite: `../../build/.venv/bin/pytest tests/ -q` — **1929 passed, 3 skipped, 0 failures**
- [x] `ruff check` clean on both changed source files
- [x] Adversarial review (blind hunter + edge-case hunter + acceptance auditor) — acceptance auditor confirmed full spec compliance; one data-safety finding patched
- [ ] **Manual / live verification on a WSL2 + CUDA host** — the transient-CUDA retry (#2) is verified by unit tests and reasoning, not a live GPU run. The deterministic fix (#1) restores reliable diarization for the majority of cases and is the primary fix.

## Notes for the reporter (#122)

The "no speaker labels" output was the deterministic bug (#1) forcing a fallback, combined with the WSL2 CUDA race (#2). After this change, WhisperX diarization runs single-pass on a warm GPU; if the residual `device not ready` race still occurs it now self-heals via retry instead of silently dropping speakers.
