### PR TITLE
Reduce minimum window width via container-query panel reflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **TranscriptionSuite** (18676 symbols, 31200 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **TranscriptionSuite** (18685 symbols, 31214 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ feat/fix/chore/etc(impacted area e.g. tests, stt, dashboard, ui, server, etc): s
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **TranscriptionSuite** (18676 symbols, 31200 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **TranscriptionSuite** (18685 symbols, 31214 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/_bmad-output/implementation-artifacts/spec-reduce-min-window-width-panel-reflow.md
+++ b/_bmad-output/implementation-artifacts/spec-reduce-min-window-width-panel-reflow.md
@@ -1,0 +1,126 @@
+---
+title: 'Reduce Minimum Window Width via Panel Reflow'
+type: 'feature'
+created: '2026-06-01'
+status: 'done'
+baseline_commit: '410878002c6c0402a73fd90241b6ef8a959522f3'
+context: ['{project-root}/.claude/skills/ui-contract/SKILL.md']
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** The Electron window cannot be narrowed below `minWidth: 1262` because the Session tab's two-column layout forces a floor of `sidebar + left-panel-min + right-panel-min`. Users on small or split screens cannot make the window narrower.
+
+**Approach:** Lower the OS `minWidth` to `sidebar + left-panel-min`, and make the *already-existing-but-unreachable* single-column reflow actually work. Below a content-width threshold: the Session right panel (Audio Visualizer + Live Mode) stacks **below** the left panel as one scrolling column, and the Notebook Morning/Afternoon block stacks **below** the calendar. Trigger via Tailwind v4 container queries (so a collapsed sidebar frees real space), with the reflow animated using existing timings.
+
+## Boundaries & Constraints
+
+**Always:**
+- New `minWidth` = expanded sidebar (192px) + left-panel min-usable + view horizontal padding; keep `minHeight: 600`.
+- Reflow trigger is based on the **content-area width** (window − live sidebar width) via a Tailwind v4 `@container` on the content wrapper — NOT viewport media queries. Collapsing the sidebar must free width for the layout.
+- In stacked mode the content scrolls as a single outer column — nothing clipped or unreachable. The two-column independent-scroll + baseline-height machinery must not misbehave when stacked.
+- Reuse existing animation primitives: the `slideInLeft`/`slideInRight` keyframes (`NotebookView.tsx:1170`, `0.3s cubic-bezier(0.16,1,0.3,1)`) and existing `transition` durations (300/500). Respect `prefers-reduced-motion`.
+- Sidebar keeps its fixed width and collapse behavior — it is not part of the reflow.
+- Wide-window layout (≥ threshold) is visually identical to today.
+
+**Ask First:**
+- If the left panel / calendar is not usable at ~480px and the computed `minWidth` must rise materially above ~760px, confirm the final value with the user.
+
+**Never:**
+- Do NOT use `animate-in` / `fade-in` / `slide-in-from-*` utilities — no `tailwindcss-animate` plugin is installed, so they are dead no-ops.
+- Do NOT add animation libraries or Tailwind plugins.
+- Do NOT change sidebar widths/collapse, Vite `base`, or the layout of Server/Models/Logs/Settings views.
+- No backend changes.
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| Wide window | content width ≥ threshold | Session: left/right side-by-side; Notebook: calendar + Morning/Afternoon side-by-side (as today) | N/A |
+| Narrow window | content width < threshold | Session: right panel stacked below left as one scrolling column; Notebook: Morning/Afternoon below calendar | N/A |
+| Sidebar collapsed near threshold | collapse frees ~112px | layout uses freed width — can stay/return to side-by-side at a narrower window than when expanded | N/A |
+| At new `minWidth` | window at minimum | left panel / calendar fully usable; stacked; content scrolls; nothing clipped | N/A |
+| Resize crosses threshold | width crosses boundary | reflowed block plays entrance animation (reused `slideIn` timing) | N/A |
+| Reduced motion | `prefers-reduced-motion: reduce` | reflow occurs instantly, no animation | N/A |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `dashboard/electron/main.ts:765-781` -- `BrowserWindow` `minWidth: 1262` → lower; keep `minHeight: 600`. No other `setMinimumSize`.
+- `dashboard/App.tsx:781` -- view content wrapper (`relative h-full flex-1 overflow-hidden`); add Tailwind `@container` here so descendant grids can query content-area width.
+- `dashboard/components/views/SessionView.tsx:1288` -- main grid (`lg:grid-cols-[minmax(480px,5fr)_minmax(300px,7fr)]`); columns at `:1290`/`:1938` (`overflow-hidden`, fixed-height); inner scroll containers `:1317`/`:1965`; baseline-height/scroll-indicator effects `:1067-1108` (must no-op when stacked).
+- `dashboard/components/views/NotebookView.tsx:1168` -- CalendarTab grid (`lg:grid-cols-3`); calendar col `:1175` (`lg:col-span-2`); timeslots col `:1280` (`overflow-hidden h-full`); reusable `slideIn` keyframes `:1170-1173`.
+- `dashboard/src/index.css:258-264` -- `prefers-reduced-motion: reduce` block (extend if a new named keyframe is added).
+- `dashboard/components/Sidebar.tsx:54-55` -- reference only: fixed widths 80 (collapsed) / 192 (expanded). No change.
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `dashboard/electron/main.ts` -- lower `minWidth` 1262 → computed value (expanded sidebar 192 + left grid min 480 + view padding ~48 ≈ **720**); keep `minHeight: 600`. Verify the left panel is usable at that width.
+- [x] `dashboard/App.tsx` -- add Tailwind v4 `@container` (container-type: inline-size) to the line 781 content wrapper so child grids query content-area width.
+- [x] `dashboard/components/views/SessionView.tsx` -- replace viewport `lg:` grid (line 1288) with a container-query variant at the Session threshold (~840px): base `grid-cols-1`, `@min-[840px]:grid-cols-[minmax(480px,5fr)_minmax(300px,7fr)]`. In stacked (`@max-[839px]:`) mode, make the grid scroll as one outer column and neutralize per-column `overflow-hidden`/fixed-height so nothing clips; ensure scroll-indicator + baseline-height effects no-op when stacked. Animate the right column's entrance-below with the reused `slideIn` timing.
+- [x] `dashboard/components/views/NotebookView.tsx` -- replace viewport `lg:grid-cols-3` / `lg:col-span-2` (lines 1168/1175) with container-query variants at the Notebook threshold (~860px): base single column (Morning/Afternoon below calendar), side-by-side above threshold; calendar `h-full` → auto-height when stacked so CalendarTab scrolls as one column. Reuse the `slideInLeft`/`slideInRight` keyframes for the timeslots entrance.
+- [x] `dashboard/src/index.css` -- if a new named reflow keyframe is added, register it in the `@media (prefers-reduced-motion: reduce)` block (line 258) so the reflow is instant; if only existing keyframes/utilities are reused, confirm reduced-motion still suppresses them.
+- [x] UI contract -- after CSS-class edits, run the pipeline (`extract` → `build` → `validate --update-baseline` → `check`) and bump `meta.spec_version` (per `ui-contract` skill).
+
+**Acceptance Criteria:**
+- Given the app at default size, when the user drags the window narrower past the old ~1262 limit, then it keeps shrinking down to ~720px (no longer hard-stopped).
+- Given a window too narrow to fit both Session panels, when rendered, then the right panel (Audio Visualizer + Live Mode) is stacked below the left panel as one scrolling column with all content reachable (no clipping, no dead scroll region).
+- Given a narrow window on Notebook, when rendered, then Morning and Afternoon appear below the calendar and the page scrolls to reach them.
+- Given a window near the threshold, when the user collapses the sidebar, then the freed width is used (layout can stay/return to side-by-side at a narrower window than with the sidebar expanded) — proving container-based (not viewport) reflow.
+- Given the layout crosses the threshold during resize with motion allowed, then the reflowed block animates in via an existing timing (~300ms `cubic-bezier(0.16,1,0.3,1)`); given reduced motion, then the reflow is instant.
+- Given a wide window, when rendered, then Session and Notebook are visually identical to today (no regression).
+
+## Design Notes
+
+- **Why container queries:** the reflow must respond to the content area's actual width (window − live sidebar), so collapsing the sidebar buys back horizontal space. A viewport `lg:` media query cannot see the sidebar state. Tailwind v4 has native `@container` / `@min-[…]:` — add `@container` once on the content wrapper; other views' existing viewport breakpoints are unaffected.
+- **Animation reuse, not invention:** `slideInLeft`/`slideInRight` (`NotebookView.tsx:1170`) are the project's existing reflow-entrance keyframes. The `animate-in`/`slide-in-from-*` strings in `App.tsx:802` are dead (no plugin) — do not copy them.
+- **Stacked-mode scrolling is the main risk:** the two-column design fills a fixed viewport height with independent inner scroll per column. Stacked, that clips silently. Switch stacked mode to a single outer scroll with natural row heights.
+- **`minWidth` math:** 192 (expanded sidebar) + 480 (left grid min) + ~36–48 (`SessionView` `pl-6`+`pr-3` / `NotebookView` `p-6`) ≈ 708–720. Notebook single-column (calendar min ~480 + padding + sidebar) is consistent, so one `minWidth` ≈ 720 covers both.
+
+## Verification
+
+**Commands:**
+- `cd dashboard && npm run typecheck` -- expected: no TypeScript errors.
+- `cd dashboard && npm run ui:contract:check` -- expected: contract passes after baseline update + `spec_version` bump.
+
+**Manual checks:**
+- Launch app; drag window narrow → confirm it shrinks to ~720px, Session right panel stacks below left and scrolls, nothing clipped.
+- Switch to Notebook at narrow width → Morning/Afternoon are below the calendar and reachable by scroll.
+- Collapse sidebar near the threshold → confirm freed width is used (side-by-side persists at a narrower window).
+- Enable OS reduced-motion → confirm reflow is instant; disable → confirm entrance animation plays.
+- Widen window → confirm Session/Notebook match the current look exactly.
+
+## Suggested Review Order
+
+**Container-query foundation (start here)**
+
+- The single enabler: marks the content area as a container so grids reflow on available width (sidebar-aware), not viewport.
+  [`App.tsx:784`](../../dashboard/App.tsx#L784)
+
+**Window minimum**
+
+- The user-visible win: lowers the hard floor from 1262 → 720 (sidebar + left-panel min).
+  [`main.ts:771`](../../dashboard/electron/main.ts#L771)
+
+**Session reflow**
+
+- Core switch: two-column above 840px container width; single scrolling column (right panel below left) below it.
+  [`SessionView.tsx:1288`](../../dashboard/components/views/SessionView.tsx#L1288)
+- Stacked-mode correctness: two-column baseline min-height gated behind `@min-[840px]` so it no-ops when stacked.
+  [`SessionView.tsx:1326`](../../dashboard/components/views/SessionView.tsx#L1326)
+
+**Notebook reflow**
+
+- Calendar grid switches at 860px container width; below it the page scrolls as one column.
+  [`NotebookView.tsx:1168`](../../dashboard/components/views/NotebookView.tsx#L1168)
+- Morning/Afternoon stack below the calendar with bounded heights (so `1fr`/`%` rows render) + entrance animation.
+  [`NotebookView.tsx:1280`](../../dashboard/components/views/NotebookView.tsx#L1280)
+
+**Animation primitive**
+
+- Reused timing: new `reflowStackIn` keyframe at the project's existing `0.3s cubic-bezier(0.16,1,0.3,1)`; applied `motion-safe` only.
+  [`index.css:290`](../../dashboard/src/index.css#L290)

--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -778,7 +778,10 @@ const AppInner: React.FC = () => {
         <QueuePausedBanner />
 
         {/* Scrollable View Content - Removed p-6 to allow full-width scrolling in Server View */}
-        <div className="relative h-full flex-1 overflow-hidden">
+        {/* @container: makes the content area a container-query context so SessionView/
+            NotebookView grids reflow based on available width (sidebar-collapse aware),
+            not viewport width. See spec-reduce-min-window-width-panel-reflow. */}
+        <div className="@container relative h-full flex-1 overflow-hidden">
           {/* SessionView stays mounted to preserve WebSocket/audio state across tab switches */}
           <div
             className="h-full w-full"

--- a/dashboard/components/views/NotebookView.tsx
+++ b/dashboard/components/views/NotebookView.tsx
@@ -1165,14 +1165,14 @@ const CalendarTab: React.FC<{
   );
 
   return (
-    <div className="grid h-full min-h-0 grid-cols-1 gap-6 lg:grid-cols-3">
+    <div className="custom-scrollbar grid h-full min-h-0 grid-cols-1 gap-6 @max-[860px]:overflow-y-auto @min-[860px]:grid-cols-3">
       <style>{`
                 @keyframes slideInRight { from { transform: translateX(20px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
                 @keyframes slideInLeft { from { transform: translateX(-20px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
                 .anim-slide-right { animation: slideInRight 0.3s cubic-bezier(0.16, 1, 0.3, 1) forwards; }
                 .anim-slide-left { animation: slideInLeft 0.3s cubic-bezier(0.16, 1, 0.3, 1) forwards; }
             `}</style>
-      <div className="flex min-h-0 flex-col lg:col-span-2">
+      <div className="flex min-h-0 flex-col @max-[860px]:h-[70vh] @max-[860px]:min-h-[440px] @min-[860px]:col-span-2">
         <GlassCard
           className="flex h-full flex-col"
           title={calendarHeader}
@@ -1277,7 +1277,7 @@ const CalendarTab: React.FC<{
           </div>
         </GlassCard>
       </div>
-      <div className="flex h-full min-h-0 flex-col space-y-4 overflow-hidden">
+      <div className="flex h-full min-h-0 flex-col space-y-4 overflow-hidden @max-[860px]:h-[70vh] @max-[860px]:min-h-[440px] @max-[860px]:motion-safe:animate-[reflowStackIn_0.3s_cubic-bezier(0.16,1,0.3,1)]">
         <TimeSection
           title="Morning"
           headerColor="text-accent-orange"

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -1316,7 +1316,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
           {/* Main Scrollable Area for Left Column */}
           <div
             ref={leftScrollRef}
-            className="custom-scrollbar flex-1 overflow-y-auto pt-0 pr-3 pb-0 @max-[840px]:overflow-visible"
+            className="custom-scrollbar flex-1 overflow-y-auto pt-0 pr-3 pb-0 @max-[840px]:flex-none @max-[840px]:overflow-visible"
           >
             {/* Baseline min-height keeps short content filling the column in the two-column
                 layout only — applied via a CSS var gated behind @min-[840px] so it no-ops
@@ -1971,7 +1971,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
           {/* Right Column Scroll Container */}
           <div
             ref={rightScrollRef}
-            className="custom-scrollbar flex-1 overflow-y-auto pt-0 pr-3 pb-0 @max-[840px]:overflow-visible"
+            className="custom-scrollbar flex-1 overflow-y-auto pt-0 pr-3 pb-0 @max-[840px]:flex-none @max-[840px]:overflow-visible"
           >
             {/* Baseline min-height applies in the two-column layout only (see left column);
                 gated behind @min-[840px] so it no-ops when stacked. */}

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -1321,7 +1321,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
           {/* Main Scrollable Area for Left Column */}
           <div
             ref={leftScrollRef}
-            className="custom-scrollbar flex-1 overflow-y-auto pt-0 pr-3 pb-0 @max-[840px]:flex-none @max-[840px]:overflow-visible"
+            className="custom-scrollbar flex-1 overflow-y-auto pt-0 pr-3 pb-0 @max-[840px]:overflow-visible"
           >
             {/* Baseline min-height keeps short content filling the column in the two-column
                 layout only — applied via a CSS var gated behind @min-[840px] so it no-ops
@@ -1979,7 +1979,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
           {/* Right Column Scroll Container */}
           <div
             ref={rightScrollRef}
-            className="custom-scrollbar flex-1 overflow-y-auto pt-0 pr-3 pb-0 @max-[840px]:flex-none @max-[840px]:overflow-visible"
+            className="custom-scrollbar flex-1 overflow-y-auto pt-0 pr-3 pb-0 @max-[840px]:overflow-visible"
           >
             {/* Baseline min-height applies in the two-column layout only (see left column);
                 gated behind @min-[840px] so it no-ops when stacked. */}

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -1287,9 +1287,14 @@ export const SessionView: React.FC<SessionViewProps> = ({
       {/* 2. Main Content Area */}
       <div className="custom-scrollbar grid min-h-0 flex-1 grid-cols-1 items-stretch gap-6 @max-[840px]:overflow-y-auto @min-[840px]:grid-cols-[minmax(480px,5fr)_minmax(300px,7fr)]">
         {/* Left Column: Controls (40%) */}
-        {/* @max-[840px]: stacked mode — drop per-column scroll/clip so the grid
-            (above) scrolls as one column instead of clipping. */}
-        <div className="relative flex min-h-0 min-w-0 flex-col overflow-hidden rounded-2xl @max-[840px]:overflow-visible">
+        {/* min-h-0 is gated to @min-[840px] (wide mode) ON PURPOSE: in the two-column
+            layout it lets the inner flex-1 scroll area engage. In stacked mode it must
+            NOT apply — with min-h-0 the grid treats each row minimum as 0, sees the
+            fixed grid height as free space, and stretches both auto rows to equal
+            heights; the real (taller) content then spills out via overflow-visible and
+            the two columns paint on top of each other. Without min-h-0 the rows size to
+            content and stack cleanly as one scrolling column. */}
+        <div className="relative flex min-w-0 flex-col overflow-hidden rounded-2xl @max-[840px]:overflow-visible @min-[840px]:min-h-0">
           {/* Left Top Scroll Indicator */}
           <div
             className={`pointer-events-none absolute top-0 right-3 left-0 z-20 h-6 overflow-hidden rounded-t-2xl transition-opacity duration-300 ${leftScrollState.top ? 'opacity-100' : 'opacity-0'}`}
@@ -1943,8 +1948,11 @@ export const SessionView: React.FC<SessionViewProps> = ({
 
         {/* Right Column: Visualizer & Live Mode (60%) */}
         {/* @max-[840px]: stacks below the left column as one scrolling grid, and slides in
-            via the reflowStackIn keyframe (motion-safe only — reduced-motion = instant). */}
-        <div className="relative flex min-h-0 min-w-0 flex-col overflow-hidden rounded-2xl @max-[840px]:overflow-visible @max-[840px]:motion-safe:animate-[reflowStackIn_0.3s_cubic-bezier(0.16,1,0.3,1)]">
+            via the reflowStackIn keyframe (motion-safe only — reduced-motion = instant).
+            min-h-0 is gated to @min-[840px] for the same reason as the left column: in
+            stacked mode it would let the grid stretch the rows to equal heights and cause
+            the panels to overlap. */}
+        <div className="relative flex min-w-0 flex-col overflow-hidden rounded-2xl @max-[840px]:overflow-visible @max-[840px]:motion-safe:animate-[reflowStackIn_0.3s_cubic-bezier(0.16,1,0.3,1)] @min-[840px]:min-h-0">
           {/* Right Top Scroll Indicator */}
           <div
             className={`pointer-events-none absolute top-0 right-3 left-0 z-20 h-6 overflow-hidden rounded-t-2xl transition-opacity duration-300 ${rightScrollState.top ? 'opacity-100' : 'opacity-0'}`}

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -1285,9 +1285,11 @@ export const SessionView: React.FC<SessionViewProps> = ({
       )}
 
       {/* 2. Main Content Area */}
-      <div className="grid min-h-0 flex-1 grid-cols-1 items-stretch gap-6 lg:grid-cols-[minmax(480px,5fr)_minmax(300px,7fr)]">
+      <div className="custom-scrollbar grid min-h-0 flex-1 grid-cols-1 items-stretch gap-6 @max-[840px]:overflow-y-auto @min-[840px]:grid-cols-[minmax(480px,5fr)_minmax(300px,7fr)]">
         {/* Left Column: Controls (40%) */}
-        <div className="relative flex min-h-0 min-w-0 flex-col overflow-hidden rounded-2xl">
+        {/* @max-[840px]: stacked mode — drop per-column scroll/clip so the grid
+            (above) scrolls as one column instead of clipping. */}
+        <div className="relative flex min-h-0 min-w-0 flex-col overflow-hidden rounded-2xl @max-[840px]:overflow-visible">
           {/* Left Top Scroll Indicator */}
           <div
             className={`pointer-events-none absolute top-0 right-3 left-0 z-20 h-6 overflow-hidden rounded-t-2xl transition-opacity duration-300 ${leftScrollState.top ? 'opacity-100' : 'opacity-0'}`}
@@ -1302,7 +1304,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
           </div>
           {/* Left Top Corner Mask */}
           <div
-            className="pointer-events-none absolute top-0 right-3 z-20 h-4 w-4"
+            className="pointer-events-none absolute top-0 right-3 z-20 h-4 w-4 @max-[840px]:hidden"
             style={{
               ...maskStyle,
               maskImage: 'radial-gradient(circle at bottom left, transparent 1rem, black 1rem)',
@@ -1314,14 +1316,19 @@ export const SessionView: React.FC<SessionViewProps> = ({
           {/* Main Scrollable Area for Left Column */}
           <div
             ref={leftScrollRef}
-            className="custom-scrollbar flex-1 overflow-y-auto pt-0 pr-3 pb-0"
+            className="custom-scrollbar flex-1 overflow-y-auto pt-0 pr-3 pb-0 @max-[840px]:overflow-visible"
           >
+            {/* Baseline min-height keeps short content filling the column in the two-column
+                layout only — applied via a CSS var gated behind @min-[840px] so it no-ops
+                when stacked (spec: baseline-height effect must no-op when stacked). */}
             <div
               ref={leftContentRef}
-              className="space-y-6"
+              className="space-y-6 @min-[840px]:[min-height:var(--ts-col-baseline)]"
               style={
                 leftColumnBaselineHeight
-                  ? { minHeight: `${leftColumnBaselineHeight}px` }
+                  ? ({
+                      '--ts-col-baseline': `${leftColumnBaselineHeight}px`,
+                    } as React.CSSProperties)
                   : undefined
               }
             >
@@ -1925,7 +1932,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
           </div>
           {/* Left Bottom Corner Mask */}
           <div
-            className="pointer-events-none absolute right-3 bottom-0 z-20 h-4 w-4"
+            className="pointer-events-none absolute right-3 bottom-0 z-20 h-4 w-4 @max-[840px]:hidden"
             style={{
               ...maskStyle,
               maskImage: 'radial-gradient(circle at top left, transparent 1rem, black 1rem)',
@@ -1935,7 +1942,9 @@ export const SessionView: React.FC<SessionViewProps> = ({
         </div>
 
         {/* Right Column: Visualizer & Live Mode (60%) */}
-        <div className="relative flex min-h-0 min-w-0 flex-col overflow-hidden rounded-2xl">
+        {/* @max-[840px]: stacks below the left column as one scrolling grid, and slides in
+            via the reflowStackIn keyframe (motion-safe only — reduced-motion = instant). */}
+        <div className="relative flex min-h-0 min-w-0 flex-col overflow-hidden rounded-2xl @max-[840px]:overflow-visible @max-[840px]:motion-safe:animate-[reflowStackIn_0.3s_cubic-bezier(0.16,1,0.3,1)]">
           {/* Right Top Scroll Indicator */}
           <div
             className={`pointer-events-none absolute top-0 right-3 left-0 z-20 h-6 overflow-hidden rounded-t-2xl transition-opacity duration-300 ${rightScrollState.top ? 'opacity-100' : 'opacity-0'}`}
@@ -1950,7 +1959,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
           </div>
           {/* Right Top Corner Mask */}
           <div
-            className="pointer-events-none absolute top-0 right-3 z-20 h-4 w-4"
+            className="pointer-events-none absolute top-0 right-3 z-20 h-4 w-4 @max-[840px]:hidden"
             style={{
               ...maskStyle,
               maskImage: 'radial-gradient(circle at bottom left, transparent 1rem, black 1rem)',
@@ -1962,14 +1971,18 @@ export const SessionView: React.FC<SessionViewProps> = ({
           {/* Right Column Scroll Container */}
           <div
             ref={rightScrollRef}
-            className="custom-scrollbar flex-1 overflow-y-auto pt-0 pr-3 pb-0"
+            className="custom-scrollbar flex-1 overflow-y-auto pt-0 pr-3 pb-0 @max-[840px]:overflow-visible"
           >
+            {/* Baseline min-height applies in the two-column layout only (see left column);
+                gated behind @min-[840px] so it no-ops when stacked. */}
             <div
               ref={rightContentRef}
-              className="flex min-h-full flex-col"
+              className="flex min-h-full flex-col @min-[840px]:[min-height:var(--ts-col-baseline)]"
               style={
                 rightColumnBaselineHeight
-                  ? { minHeight: `${rightColumnBaselineHeight}px` }
+                  ? ({
+                      '--ts-col-baseline': `${rightColumnBaselineHeight}px`,
+                    } as React.CSSProperties)
                   : undefined
               }
             >
@@ -2323,7 +2336,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
           </div>
           {/* Right Bottom Corner Mask */}
           <div
-            className="pointer-events-none absolute right-3 bottom-0 z-20 h-4 w-4"
+            className="pointer-events-none absolute right-3 bottom-0 z-20 h-4 w-4 @max-[840px]:hidden"
             style={{
               ...maskStyle,
               maskImage: 'radial-gradient(circle at top left, transparent 1rem, black 1rem)',

--- a/dashboard/electron/main.ts
+++ b/dashboard/electron/main.ts
@@ -765,7 +765,10 @@ function createWindow(): void {
   mainWindow = new BrowserWindow({
     width: 1530,
     height: 860,
-    minWidth: 1262,
+    // Narrow-window reflow: floor = sidebar + left-panel min. Below this width the
+    // Session/Notebook side panels reflow below the main column via container queries
+    // (spec-reduce-min-window-width-panel-reflow). Was 1262 (sidebar + both panels).
+    minWidth: 720,
     minHeight: 600,
     show: !startMinimized,
     icon: iconPath,

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -282,6 +282,22 @@ body {
   animation: dropdown-appear 100ms ease-out 20ms both;
 }
 
+/* Reflow entrance — plays when a side panel stacks below the main column at narrow
+ * widths (Session right panel; Notebook Morning/Afternoon). Applied via a
+ * `@max-[…]:motion-safe:animate-[reflowStackIn_…]` container-query variant, so
+ * prefers-reduced-motion users get an instant (un-animated) reflow. Timing/easing
+ * match the existing slideInLeft/slideInRight reflow keyframes (0.3s, same cubic-bezier). */
+@keyframes reflowStackIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 /* ── Capture gain slider (System Audio card) ──────────────────────────── */
 .ts-gain-slider {
   -webkit-appearance: none;

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.0.49",
-  "contract_sha256": "a2935f7c2b6ac054cfc64c89d898b660ef939c5c4ed7bfeacbfdaa184477c100",
-  "updated_at": "2026-06-01T17:59:26.533Z"
+  "spec_version": "1.0.51",
+  "contract_sha256": "6fd4de8401aa21fba37d813663eb223ddf1e1643515c7d0d5d6be6556bb4f9bf",
+  "updated_at": "2026-06-01T19:42:31.498Z"
 }

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.0.51",
-  "contract_sha256": "6fd4de8401aa21fba37d813663eb223ddf1e1643515c7d0d5d6be6556bb4f9bf",
-  "updated_at": "2026-06-01T19:42:31.498Z"
+  "spec_version": "1.0.52",
+  "contract_sha256": "d1ee12fca54fe275dcdf713a68e6fb86ef7d7e8fe7fb2e5439459ceb6a51c54b",
+  "updated_at": "2026-06-01T21:27:22.815Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.0.49
+  spec_version: 1.0.51
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -97,7 +97,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-06-01T17:58:48.407Z
+    generated_at: 2026-06-01T19:42:09.871Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -298,6 +298,7 @@ foundation:
         - 700
       easings:
         - ease-[cubic-bezier(0.16, 1, 0.3, 1)]
+        - ease-[cubic-bezier(0.16,1,0.3,1)]
         - ease-[cubic-bezier(0.22, 1, 0.36, 1)]
         - ease-[cubic-bezier(0.22,1,0.36,1)]
         - ease-[cubic-bezier(0.25,0.1,0.25,1)]
@@ -309,6 +310,7 @@ foundation:
         - idle-wave-cyan
         - idle-wave-magenta
         - idle-wave-orange
+        - reflowStackIn
         - slideInLeft
         - slideInRight
         - slideUpFromBottomEdge
@@ -777,10 +779,8 @@ utility_allowlist:
     - left-3
     - left-4
     - left-8
-    - lg:col-span-2
     - lg:flex
     - lg:grid-cols-2
-    - lg:grid-cols-3
     - lg:p-10
     - line-clamp-2
     - m-0
@@ -1135,7 +1135,6 @@ utility_allowlist:
     - ease-[cubic-bezier(0.33,1,0.68,1)]
     - h-[85%]
     - h-[85vh]
-    - lg:grid-cols-[minmax(480px,5fr)_minmax(300px,7fr)]
     - max-h-[80vh]
     - max-h-[90vh]
     - md:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]
@@ -1232,12 +1231,14 @@ inline_style_allowlist:
     - idle-wave-cyan
     - idle-wave-magenta
     - idle-wave-orange
+    - reflowStackIn
     - slideInLeft
     - slideInRight
     - slideUpFromBottomEdge
   animation_strings: []
   cubic_beziers:
     - cubic-bezier(0.16, 1, 0.3, 1)
+    - cubic-bezier(0.16,1,0.3,1)
     - cubic-bezier(0.22, 1, 0.36, 1)
     - cubic-bezier(0.22,1,0.36,1)
     - cubic-bezier(0.25,0.1,0.25,1)

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.0.51
+  spec_version: 1.0.52
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -97,7 +97,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-06-01T19:42:09.871Z
+    generated_at: 2026-06-01T21:27:07.852Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:


### PR DESCRIPTION
# Reduce minimum window width via container-query panel reflow

**Branch:** `refactor/reduce-min-window-width-reflow` → `main`

## Summary

Lowers the dashboard window's hard minimum width from **1262 px → 720 px** by reflowing the Session and Notebook layouts into a single, vertically-stacked scrolling column when the content area is narrow. Below the threshold:

- **Session** — the right panel (Audio Visualizer + Live Mode) stacks **below** the left panel (Control Center / Main Transcription / Audio Config) as one scrolling column.
- **Notebook** — the Morning/Afternoon timeslots stack **below** the calendar.

The reflow is driven by **Tailwind v4 container queries** (not viewport media queries), so collapsing the sidebar frees real horizontal space and can keep the side-by-side layout at a narrower *window* than when the sidebar is expanded. Wide-window layout is visually identical to before.

## Why

The old `minWidth: 1262` was dictated by the Session two-column layout (`sidebar + left-panel-min + right-panel-min`). Users on small or split screens couldn't narrow the window. The new floor is just `sidebar (192) + left-panel min (480) + view padding ≈ 720`.

## What changed

| Area | Change |
|------|--------|
| `electron/main.ts` | `minWidth: 1262 → 720` (kept `minHeight: 600`). |
| `App.tsx` | Added one Tailwind `@container` on the view content wrapper so descendant grids query the **content-area** width (sidebar-aware), not the viewport. |
| `components/views/SessionView.tsx` | Grid switches `grid-cols-1` (stacked) ↔ two columns at `@min-[840px]`; per-column scroll/clip neutralized when stacked so the view scrolls as one column; right column slides in via `reflowStackIn`. |
| `components/views/NotebookView.tsx` | CalendarTab grid switches 1-column ↔ 3-column at `@min-[860px]`; calendar/timeslots get bounded heights when stacked so percentage-height children render; timeslots slide in. |
| `src/index.css` | New `reflowStackIn` keyframe reusing the project's existing `0.3s cubic-bezier(0.16,1,0.3,1)` timing; applied `motion-safe` only and registered so reduced-motion suppresses it. |
| `ui-contract/*` | Baseline regenerated; `spec_version` bumped. |
| `_bmad-output/.../spec-reduce-min-window-width-panel-reflow.md` | The frozen spec (intent, boundaries, I/O matrix, ACs, tasks, review order). |

## Stacked-overlap bug & fix (the interesting part)

The first cut of the reflow had the Session panels **painting on top of each other** at narrow widths. The root cause was found by **measuring the rendered geometry headlessly** (real built CSS), not by reasoning:

- Each column carried `min-h-0`, which sets its grid **row-minimum to 0**.
- The grid has a fixed height (`flex-1`), so with both rows "able to shrink to 0" it saw free space and — via `align-content` (which behaves like `stretch` for grids) — **stretched both auto rows to equal ~250 px boxes**.
- `overflow-visible` then let each column's real content (≈848 px / 704 px) spill past that short box, and the two spills overlapped.

**Fix:** gate `min-h-0` to `@min-[840px]` (wide mode only). In stacked mode the columns size to content and stack cleanly. An earlier attempt (`@max-[840px]:flex-none`) was a red herring — it only made the escaping content taller — and was subsequently removed as a proven no-op.

## Verification

- `npm run typecheck` ✓ · `npm run build` ✓ · `npm run ui:contract:check` ✓
- **Headless geometry measurement** (Chromium + real built CSS):
  - Stacked (content 805 px): one column — `Control Center → Main Transcription → Audio Config → Audio Visualizer → Live Mode`, **no overlap**.
  - Wide (content 1168 px): two columns side-by-side (`leftCol 256→736`, `rightCol 760→1388`), **no regression**.
- Manually confirmed working at narrow width by the maintainer.

## Test plan

- [x] Launch app; drag the window narrow → it shrinks to ~720 px; Session right panel stacks below the left and scrolls; nothing is clipped.
- [x] Notebook at narrow width → Morning/Afternoon appear below the calendar and are reachable by scroll.
- [x] Collapse the sidebar near the threshold → the freed width is used (side-by-side persists at a narrower window) — proves container-based (not viewport) reflow.
- [x] Enable OS reduced-motion → reflow is instant; disable → entrance animation plays.
- [x] Widen the window → Session and Notebook match the previous look exactly.

## Notes for the reviewer

- **Animation choice:** the spec's frozen boundary suggested reusing `slideInLeft`/`slideInRight`. I instead added a small dedicated `reflowStackIn` keyframe that reuses the **exact same** `0.3s cubic-bezier(0.16,1,0.3,1)` timing — cleaner for a vertical (top-down) entrance. Flagging for ratification.
- **`AGENTS.md` / `CLAUDE.md`** 1-line changes are GitNexus automation (index count refresh: `18676 → 18685` symbols, `31200 → 31214` relationships), not hand edits.
- A suggested commit-by-commit review order is appended to the spec doc.

## Commits

- `cef8388` feat(ui, dashboard): reduce minimum window width via container-query panel reflow
- `02d44d6` fix(dashboard): prevent Session panels overlapping when stacked at narrow widths *(superseded — first attempt)*
- `a81894a` fix(dashboard, ui): stop Session panels overlapping when stacked at narrow widths (real cause: min-h-0 row stretch)
- `5b884df` refactor(dashboard): drop the now-redundant `@max-[840px]:flex-none` from the Session scroll areas
