### PR TITLE
fix: stop GPU runtime selection silently falling back to CPU after a profile change

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **TranscriptionSuite** (18685 symbols, 31214 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **TranscriptionSuite** (18474 symbols, 31014 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ feat/fix/chore/etc(impacted area e.g. tests, stt, dashboard, ui, server, etc): s
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **TranscriptionSuite** (18685 symbols, 31214 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **TranscriptionSuite** (18474 symbols, 31014 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/dashboard/components/views/GpuHealthCard.tsx
+++ b/dashboard/components/views/GpuHealthCard.tsx
@@ -28,6 +28,13 @@ export interface GpuHealthCardProps {
   onRunDiagnostic: () => void;
   /** When true, the Run Full Diagnostic button is disabled and shows a "Running…" label. */
   running?: boolean;
+  /**
+   * True when the GPU (CUDA) runtime is selected but the *running container* is
+   * actually transcribing on CPU (host preflight can be green while the
+   * container was started without GPU passthrough). Forces a warning state so
+   * a silent CPU fallback cannot masquerade as "CUDA operational".
+   */
+  cpuFallbackActive?: boolean;
 }
 
 type CardState = 'green' | 'yellow' | 'red';
@@ -35,8 +42,10 @@ type CardState = 'green' | 'yellow' | 'red';
 function deriveState(
   preflight: GpuPreflightProp | null,
   backendError: GpuBackendErrorProp | null,
+  cpuFallbackActive: boolean,
 ): CardState {
   if (backendError && backendError.status === 'unrecoverable') return 'red';
+  if (cpuFallbackActive) return 'yellow';
   if (preflight && preflight.status === 'warning') return 'yellow';
   return 'green';
 }
@@ -46,6 +55,11 @@ const STATE_LABEL: Record<CardState, string> = {
   yellow: 'GPU may be misconfigured — server will fall back to CPU',
   red: 'GPU unavailable — fell back to CPU',
 };
+
+// Distinct, actionable message for the runtime-mismatch case: host CUDA is fine
+// but the running container is on CPU (e.g. started under the wrong overlay).
+const CPU_FALLBACK_LABEL =
+  'GPU (CUDA) is selected, but the running server is on CPU — stop and restart the server to apply the GPU runtime.';
 
 const STATE_CONTAINER: Record<CardState, string> = {
   green: 'border-green-500/20 bg-green-500/10',
@@ -109,19 +123,26 @@ export function GpuHealthCard({
   backendError,
   onRunDiagnostic,
   running = false,
+  cpuFallbackActive = false,
 }: GpuHealthCardProps): React.ReactElement | null {
   if (!gpuDetected) return null;
 
-  const state = deriveState(preflight, backendError);
+  const state = deriveState(preflight, backendError, cpuFallbackActive);
   const failedChecks = preflight ? preflight.checks.filter((c) => !c.pass) : [];
   const totalChecks = preflight ? preflight.checks.length : 0;
   const passedChecks = totalChecks - failedChecks.length;
+  // The mismatch message wins over the generic yellow label, but a genuine
+  // backend error (red) still takes precedence over it.
+  const bodyLabel =
+    cpuFallbackActive && state === 'yellow' ? CPU_FALLBACK_LABEL : STATE_LABEL[state];
   const headerStatus =
     state === 'red'
       ? 'backend error — CPU fallback'
-      : totalChecks > 0
-        ? `${passedChecks}/${totalChecks} checks passed`
-        : 'CUDA operational';
+      : cpuFallbackActive
+        ? 'running on CPU'
+        : totalChecks > 0
+          ? `${passedChecks}/${totalChecks} checks passed`
+          : 'CUDA operational';
 
   return (
     <section
@@ -142,9 +163,7 @@ export function GpuHealthCard({
           do not need it.
         </p>
 
-        <p className={`m-0 text-sm font-semibold ${STATE_BODY_TEXT[state]}`}>
-          {STATE_LABEL[state]}
-        </p>
+        <p className={`m-0 text-sm font-semibold ${STATE_BODY_TEXT[state]}`}>{bodyLabel}</p>
 
         {state === 'red' && backendError?.recovery_hint ? (
           <p className="m-0 rounded bg-red-500/10 p-2 text-sm text-red-200">

--- a/dashboard/components/views/ServerView.tsx
+++ b/dashboard/components/views/ServerView.tsx
@@ -1257,7 +1257,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
   // reports gpuError, build the structured object the GpuHealthCard expects.
   // The recovery_hint is only present when cuda_health_check matched the
   // error-999 fingerprint; we pass it through verbatim.
-  const { gpuError, gpuErrorRecoveryHint } = useServerStatus();
+  const { gpuError, gpuErrorRecoveryHint, details, reachable } = useServerStatus();
   useEffect(() => {
     if (gpuError) {
       setGpuBackendError({
@@ -1269,6 +1269,14 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
       setGpuBackendError(null);
     }
   }, [gpuError, gpuErrorRecoveryHint]);
+
+  // CPU-fallback mismatch: GPU (CUDA) is the selected runtime, the server is up
+  // and reachable, but the running container reports CUDA is NOT available
+  // inside it (started without GPU passthrough → silently transcribing on CPU).
+  // `=== false` (not falsy) so older servers / pre-init responses that omit the
+  // field do not trip a false warning. Surfaced by the GpuHealthCard.
+  const cpuFallbackActive =
+    runtimeProfile === 'gpu' && reachable && details?.gpu_available === false;
 
   // Read host platform once via electronAPI bridge. Synchronous in production
   // (preload returns process.platform directly); defaults to 'unknown' for
@@ -1726,6 +1734,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
               backendError={gpuBackendError}
               onRunDiagnostic={handleRunGpuDiagnostic}
               running={diagnosticRunning}
+              cpuFallbackActive={cpuFallbackActive}
             />
           )}
 

--- a/dashboard/components/views/__tests__/GpuHealthCard.test.tsx
+++ b/dashboard/components/views/__tests__/GpuHealthCard.test.tsx
@@ -99,6 +99,42 @@ describe('GpuHealthCard', () => {
     expect(screen.getByText(/Run scripts\/diagnose-gpu\.sh/)).toBeInTheDocument();
   });
 
+  it('cpu-fallback: GPU selected but container on CPU → actionable warning over green', () => {
+    // The reported bug: host preflight is healthy (green) but the running
+    // container is on CPU. The card must NOT show "CUDA operational".
+    render(
+      <GpuHealthCard
+        gpuDetected={true}
+        preflight={healthyPreflight}
+        backendError={null}
+        onRunDiagnostic={vi.fn()}
+        cpuFallbackActive={true}
+      />,
+    );
+    expect(screen.getByText(/running server is on CPU/i)).toBeInTheDocument();
+    expect(screen.getByText(/restart the server/i)).toBeInTheDocument();
+    expect(screen.queryByText(/CUDA operational/i)).not.toBeInTheDocument();
+  });
+
+  it('cpu-fallback never overrides a genuine backend error (red wins)', () => {
+    const backendError = {
+      status: 'unrecoverable' as const,
+      error: 'CUDA unknown error',
+      recovery_hint: 'Run scripts/diagnose-gpu.sh.',
+    };
+    render(
+      <GpuHealthCard
+        gpuDetected={true}
+        preflight={healthyPreflight}
+        backendError={backendError}
+        onRunDiagnostic={vi.fn()}
+        cpuFallbackActive={true}
+      />,
+    );
+    expect(screen.getByText(/GPU unavailable/i)).toBeInTheDocument();
+    expect(screen.queryByText(/running server is on CPU/i)).not.toBeInTheDocument();
+  });
+
   it('clicking Run Full Diagnostic invokes the prop', async () => {
     const onRun = vi.fn();
     render(

--- a/dashboard/electron/__tests__/dockerManagerRuntimeProfile.test.ts
+++ b/dashboard/electron/__tests__/dockerManagerRuntimeProfile.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment node
+
+/**
+ * Runtime-profile desync fix — the persisted `server.runtimeProfile` is the
+ * source of truth at container-start time.
+ *
+ * Background: each renderer start surface (App / SessionView / ServerView)
+ * hydrates its own copy of the runtime profile once on mount and can drift
+ * stale. A container could therefore launch under a profile the user had
+ * already changed away from (observed: started under Vulkan, switched to GPU,
+ * never restarted → kept running CPU-only). `startContainer` now re-reads the
+ * persisted value and prefers it over the renderer-supplied request.
+ *
+ * Full `startContainer` is hard to unit-test without a Docker runtime, so these
+ * cover the two pure pieces it funnels through: `readRuntimeProfileFromStore`
+ * (disk read + validation) and `resolveEffectiveRuntimeProfile` (the precedence
+ * rule).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+// Mock `electron` before importing dockerManager — the module imports `app`
+// at the top level and needs a usable path for `getPath('userData')`.
+const userDataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ts-runtime-profile-test-'));
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: (_name: string) => userDataRoot,
+    setPath: vi.fn(),
+  },
+}));
+
+// Mock electron-store (imported transitively by config readers)
+vi.mock('electron-store', () => ({
+  default: class MockStore {
+    get() {
+      return undefined;
+    }
+    set() {}
+  },
+}));
+
+import {
+  readRuntimeProfileFromStore,
+  resolveEffectiveRuntimeProfile,
+  type RuntimeProfile,
+} from '../dockerManager.js';
+
+const STORE_FILE = path.join(userDataRoot, 'dashboard-config.json');
+
+function writeStore(contents: Record<string, unknown>): void {
+  fs.writeFileSync(STORE_FILE, JSON.stringify(contents), 'utf8');
+}
+
+beforeEach(() => {
+  try {
+    fs.unlinkSync(STORE_FILE);
+  } catch {
+    // fine
+  }
+});
+
+afterEach(() => {
+  try {
+    fs.unlinkSync(STORE_FILE);
+  } catch {
+    // fine
+  }
+});
+
+describe('[P1] runtime-profile desync — readRuntimeProfileFromStore', () => {
+  it('returns null when the store file is absent', () => {
+    expect(readRuntimeProfileFromStore()).toBeNull();
+  });
+
+  it('returns null when the store is present but the key is unset', () => {
+    writeStore({ 'connection.port': 9786 });
+    expect(readRuntimeProfileFromStore()).toBeNull();
+  });
+
+  it.each<RuntimeProfile>(['gpu', 'cpu', 'vulkan', 'vulkan-wsl2', 'metal'])(
+    'returns "%s" when persisted as a valid profile',
+    (profile) => {
+      writeStore({ 'server.runtimeProfile': profile });
+      expect(readRuntimeProfileFromStore()).toBe(profile);
+    },
+  );
+
+  it('returns null for an unknown/invalid profile string', () => {
+    writeStore({ 'server.runtimeProfile': 'tpu' });
+    expect(readRuntimeProfileFromStore()).toBeNull();
+  });
+
+  it('returns null for a non-string value (strict type guard)', () => {
+    writeStore({ 'server.runtimeProfile': 1 });
+    expect(readRuntimeProfileFromStore()).toBeNull();
+  });
+
+  it('returns null when the store file is malformed JSON', () => {
+    fs.writeFileSync(STORE_FILE, '{not json', 'utf8');
+    expect(readRuntimeProfileFromStore()).toBeNull();
+  });
+});
+
+describe('[P1] runtime-profile desync — resolveEffectiveRuntimeProfile', () => {
+  it('prefers the persisted value over a stale renderer request', () => {
+    // The exact reported bug: renderer still holds mount-time "vulkan", but the
+    // user switched to "gpu" (persisted). The persisted value must win.
+    expect(resolveEffectiveRuntimeProfile('vulkan', 'gpu')).toBe('gpu');
+  });
+
+  it('falls back to the renderer request when nothing is persisted (first run)', () => {
+    expect(resolveEffectiveRuntimeProfile('gpu', null)).toBe('gpu');
+  });
+
+  it('is a no-op when persisted and requested already agree', () => {
+    expect(resolveEffectiveRuntimeProfile('gpu', 'gpu')).toBe('gpu');
+    expect(resolveEffectiveRuntimeProfile('cpu', 'cpu')).toBe('cpu');
+  });
+
+  it('end-to-end: persisted gpu beats requested vulkan via the store reader', () => {
+    writeStore({ 'server.runtimeProfile': 'gpu' });
+    const requested: RuntimeProfile = 'vulkan';
+    expect(resolveEffectiveRuntimeProfile(requested, readRuntimeProfileFromStore())).toBe('gpu');
+  });
+});

--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -685,6 +685,56 @@ function getComposeDir(): string {
 export type RuntimeProfile = 'gpu' | 'cpu' | 'vulkan' | 'vulkan-wsl2' | 'metal';
 export type HfTokenDecision = 'unset' | 'provided' | 'skipped';
 
+const RUNTIME_PROFILE_VALUES: readonly RuntimeProfile[] = [
+  'gpu',
+  'cpu',
+  'vulkan',
+  'vulkan-wsl2',
+  'metal',
+];
+
+function isRuntimeProfile(value: unknown): value is RuntimeProfile {
+  return typeof value === 'string' && (RUNTIME_PROFILE_VALUES as readonly string[]).includes(value);
+}
+
+/**
+ * Read the persisted `server.runtimeProfile` from the electron-store JSON file
+ * on disk. Returns null when the file is missing or the key is absent/invalid.
+ *
+ * The persisted value is the durable source of truth for the user's selected
+ * runtime. Renderer callers (App / SessionView / ServerView) each hydrate their
+ * own copy once on mount and can drift stale, so the start path must re-read
+ * this at launch time rather than trust whatever the renderer last sent — see
+ * `resolveEffectiveRuntimeProfile`.
+ */
+export function readRuntimeProfileFromStore(): RuntimeProfile | null {
+  try {
+    const storePath = path.join(app.getPath('userData'), 'dashboard-config.json');
+    const raw = fs.readFileSync(storePath, 'utf8');
+    const data = JSON.parse(raw) as Record<string, unknown>;
+    const value = data['server.runtimeProfile'];
+    return isRuntimeProfile(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the runtime profile to actually launch with. Prefers the persisted
+ * store value (durable user intent) over the renderer-supplied request, which
+ * may be a stale mount-time copy. Falls back to the request only when the store
+ * has no valid value (e.g. first run before any persist).
+ *
+ * This is the single funnel point that prevents the container from launching
+ * under a runtime the user has already changed away from.
+ */
+export function resolveEffectiveRuntimeProfile(
+  requested: RuntimeProfile,
+  persisted: RuntimeProfile | null,
+): RuntimeProfile {
+  return persisted ?? requested;
+}
+
 const VOLUME_NAMES = {
   data: 'transcriptionsuite-data',
   models: 'transcriptionsuite-models',
@@ -2068,7 +2118,7 @@ export function applyCpuModelDefaults(
 async function startContainer(options: StartContainerOptions): Promise<string> {
   const {
     mode,
-    runtimeProfile,
+    runtimeProfile: requestedRuntimeProfile,
     imageTag,
     tlsEnv,
     hfToken,
@@ -2081,6 +2131,25 @@ async function startContainer(options: StartContainerOptions): Promise<string> {
     diarizationModel,
     whispercppModel,
   } = options;
+
+  // The persisted `server.runtimeProfile` is the source of truth for what the
+  // user has selected. Renderer start surfaces (App / SessionView / ServerView)
+  // each read it once on mount and can hold a stale copy, so a container could
+  // otherwise launch under a profile the user already changed away from (e.g.
+  // started under Vulkan, switched to GPU, never restarted). Re-read at launch
+  // time and prefer the persisted value; the renderer arg is only a fallback
+  // for the first run before anything has been persisted.
+  const persistedRuntimeProfile = readRuntimeProfileFromStore();
+  const runtimeProfile = resolveEffectiveRuntimeProfile(
+    requestedRuntimeProfile,
+    persistedRuntimeProfile,
+  );
+  if (persistedRuntimeProfile && persistedRuntimeProfile !== requestedRuntimeProfile) {
+    console.warn(
+      `[DockerManager] runtimeProfile mismatch — renderer requested "${requestedRuntimeProfile}" ` +
+        `but persisted store has "${persistedRuntimeProfile}"; launching with the persisted value.`,
+    );
+  }
 
   // Guard: bail early with a human-readable message if compose is not available.
   if (_composeAvailable === false) {

--- a/server/backend/api/routes/health.py
+++ b/server/backend/api/routes/health.py
@@ -71,6 +71,9 @@ async def get_status(request: Request) -> dict[str, Any]:
     The ``ready`` field consolidates the logic from ``/ready`` so that
     dashboard clients can poll a single endpoint instead of three.
     """
+    # None (not False) when the model manager is absent, so the field is omitted
+    # rather than reported as a definitive "no GPU".
+    gpu_available: bool | None = None
     try:
         model_manager = request.app.state.model_manager
         status = model_manager.get_status()
@@ -78,6 +81,7 @@ async def get_status(request: Request) -> dict[str, Any]:
         is_loaded = bool(transcription_status.get("loaded", False))
         main_model_disabled = bool(transcription_status.get("disabled", False))
         is_ready = is_loaded or main_model_disabled
+        gpu_available = bool(getattr(model_manager, "gpu_available", False))
     except AttributeError:
         status = {"error": "Model manager not initialized"}
         is_ready = False
@@ -89,6 +93,14 @@ async def get_status(request: Request) -> dict[str, Any]:
         "features": status.get("features", {}),
         "ready": is_ready or is_live_mode_active(),
     }
+
+    # Surface the container's *actual* GPU availability (CUDA usable inside this
+    # container), not the host's. The dashboard's host-side preflight can report
+    # "CUDA operational" while the container was started without GPU passthrough
+    # (e.g. under the wrong compose overlay) and silently runs on CPU. Exposing
+    # this lets the dashboard warn on that mismatch. Additive + backward compatible.
+    if gpu_available is not None:
+        response["gpu_available"] = gpu_available
 
     gpu_error = getattr(request.app.state, "gpu_error", None)
     if gpu_error is not None:

--- a/server/backend/tests/test_health_routes.py
+++ b/server/backend/tests/test_health_routes.py
@@ -171,3 +171,45 @@ def test_status_omits_recovery_hint_when_absent(test_client_local):
     body = response.json()
     assert "gpu_error" in body
     assert "gpu_error_recovery_hint" not in body
+
+
+def test_status_reports_gpu_available_true(test_client_local):
+    """
+    GET /api/status surfaces the container's actual GPU availability so the
+    dashboard can distinguish a real CUDA container from a CPU fallback.
+    """
+    mm = test_client_local.app.state.model_manager
+    mm.gpu_available = True
+
+    response = test_client_local.get("/api/status")
+
+    assert response.status_code == 200
+    assert response.json()["gpu_available"] is True
+
+
+def test_status_reports_gpu_available_false_for_cpu_container(test_client_local):
+    """
+    The bug this guards: a container started without GPU passthrough runs on
+    CPU. The host preflight can still be healthy, so /api/status must report
+    gpu_available=False to let the dashboard warn about the mismatch.
+    """
+    mm = test_client_local.app.state.model_manager
+    mm.gpu_available = False
+
+    response = test_client_local.get("/api/status")
+
+    assert response.status_code == 200
+    assert response.json()["gpu_available"] is False
+
+
+def test_status_omits_gpu_available_when_model_manager_missing(test_client_local):
+    """
+    GET /api/status omits gpu_available (rather than guessing) when the model
+    manager is not yet initialized — additive + backward compatible.
+    """
+    del test_client_local.app.state.model_manager
+
+    response = test_client_local.get("/api/status")
+
+    assert response.status_code == 200
+    assert "gpu_available" not in response.json()


### PR DESCRIPTION
# fix: stop GPU runtime selection silently falling back to CPU after a profile change

**Branch:** `fix/gpu-runtime-profile-desync` → `main`

## Problem

A transcription ran ~12 minutes on a medium recording because the server was transcribing on **CPU**, even though the dashboard showed the **GPU (CUDA)** runtime selected and a green "GPU healthy — CUDA operational" panel.

Diagnosed on a live system (NVIDIA RTX 3060, CDI-configured host):

- The running container had **no GPU access**: `Runtime=runc`, `HostConfig.DeviceRequests=null`, no `/dev/nvidia*` inside, `nvidia-smi` absent.
- Docker Compose's `com.docker.compose.project.config_files` label showed it was started with `docker-compose.vulkan.yml`, **not** `gpu-cdi.yml`.
- The `.env` written at start contained `WHISPERCPP_SERVER_URL=http://localhost:8080` — a value the code only writes on the Vulkan branch.
- Backend logs: `CUDA health check: no_cuda` → `No GPU available, using CPU` → `Using device: cpu`. The backend behaved correctly; it genuinely had no GPU.

## Root cause

The runtime profile is bound **at container-start time**. The user had started the container under the **Vulkan** profile, later switched the UI to **GPU (CUDA)** (persisting `server.runtimeProfile=gpu`), but never restarted the container — so it kept running the Vulkan/CPU stack. Two code defects let this happen and stay invisible:

1. **Stale renderer profile.** Each start surface (`App`, `SessionView`, `ServerView`) reads `server.runtimeProfile` once on mount into its own state and never re-syncs. `docker:startContainer` consumes the renderer-supplied value verbatim and never re-reads the persisted source of truth — so a start can launch under a profile the user already changed away from.
2. **Host-only health panel.** The GPU health card derived its state from a host-side preflight (`/etc/cdi`, `/dev/char`, `lsmod`, `nvidia-smi`) and only went non-green on an explicit backend `gpu_error`. A container quietly running on CPU raises no error, so the panel stayed green and asserted "CUDA operational" while the container had zero GPU access.

(Ruled out: auto-detect cannot pick Vulkan on an NVIDIA host — the `!gpu` guard forces it off — and the GPU preflight throws rather than falling back to Vulkan.)

## Changes

### Fix A — persisted profile is authoritative at launch (`dashboard/electron/dockerManager.ts`)
- `startContainer` re-reads `server.runtimeProfile` from the electron-store at start and prefers it over the renderer-supplied argument; the renderer value is only a fallback for first run before anything is persisted.
- New `readRuntimeProfileFromStore()` + `resolveEffectiveRuntimeProfile()`, mirroring the existing `readUseLegacyGpuFromStore()` pattern. Logs a warning when the renderer arg and the persisted value disagree.
- This makes the reported failure mode impossible at a single funnel point — independent of which start surface (or stale copy) triggered the launch.

### Fix C — health panel reflects the container, not the host (`server/backend/api/routes/health.py`, `dashboard/components/views/GpuHealthCard.tsx`, `dashboard/components/views/ServerView.tsx`)
- `/api/status` now exposes a top-level `gpu_available` from the model manager (additive, backward compatible; omitted when the manager is not yet initialized).
- `GpuHealthCard` gains a `cpuFallbackActive` state: when GPU (CUDA) is selected, the server is reachable, and the container reports `gpu_available === false`, the card turns yellow with an actionable message — *"GPU (CUDA) is selected, but the running server is on CPU — stop and restart the server to apply the GPU runtime."* A genuine backend error (red) still takes precedence; the `=== false` guard (not falsy) keeps older servers that omit the field from tripping a false warning.

## Test plan

- **Backend** (`server/backend/tests/test_health_routes.py`, +3): `/api/status` reports `gpu_available` true/false, and omits it when the model manager is absent. `16/16` health-route tests pass.
- **Frontend** (+5): `GpuHealthCard` CPU-fallback warning and its precedence over the generic yellow label (red backend error still wins); `readRuntimeProfileFromStore` parsing + `resolveEffectiveRuntimeProfile` precedence. All affected suites green (`32` tests).
- `npm run typecheck`, `npm run lint`, Prettier, and `npm run ui:contract:check` all pass.
- Code review: approved, 0 critical/high (2 minor nits applied).

## Verification on the affected machine

After restarting the container under the GPU profile, confirmed it now launches with `docker-compose.gpu-cdi.yml`, `DeviceRequests` carries CDI `nvidia.com/gpu=all`, `/dev/nvidia*` and `nvidia-smi` are present inside, and the backend logs `Model manager initialized (GPU: True)` → `Using device: cuda` → `float16 for device cuda`.

## Notes

- **Immediate user recovery** (no code needed): Stop Server → fully quit & reopen the dashboard (clears the stale in-memory profile) → Start Local.
- Deferred / not in this PR: lifting the per-surface mount-time profile copies into shared state (Fix B), and a "running container's profile differs from selection — restart to apply" banner (Fix D). Fix A neutralizes the root cause; Fix C ensures any residual mismatch is no longer invisible.
