### PR TITLE
fix(dashboard): Server Configuration card responsive layout + sidebar collapse button hit area

### DIFF
--- a/dashboard/components/Sidebar.tsx
+++ b/dashboard/components/Sidebar.tsx
@@ -231,12 +231,20 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
   return (
     <div
-      className={`blur-panel bg-glass-surface border-glass-border relative flex h-full shrink-0 flex-col border-r backdrop-blur-2xl transition-all duration-300 ease-[cubic-bezier(0.25,0.1,0.25,1)] ${collapsed ? 'w-20' : 'w-48'} `}
+      className={`blur-panel bg-glass-surface border-glass-border relative z-30 flex h-full shrink-0 flex-col border-r backdrop-blur-2xl transition-all duration-300 ease-[cubic-bezier(0.25,0.1,0.25,1)] ${collapsed ? 'w-20' : 'w-48'} `}
       style={{
         width: sidebarWidthPx,
       }}
     >
-      {/* Toggle Button */}
+      {/*
+        Toggle Button. It is offset to straddle the sidebar right edge and so
+        overflows into the main content area. Because the sidebar uses a blur
+        backdrop it forms its own stacking context, which traps the low stacking
+        order of this button inside the sidebar. The parent z index lifts the
+        whole sidebar (and therefore this button) above the main content area,
+        so the overflowing half of the circle is no longer painted over and the
+        entire circle stays clickable.
+      */}
       <button
         onClick={() => setCollapsed(!collapsed)}
         className="hover:bg-accent-cyan absolute top-10 -right-3 z-20 rounded-full border border-white/10 bg-slate-800 p-1 text-white shadow-lg transition-colors outline-none hover:text-black focus:outline-none"

--- a/dashboard/components/ui/ImageTagChips.tsx
+++ b/dashboard/components/ui/ImageTagChips.tsx
@@ -106,7 +106,11 @@ export const ImageTagChips: React.FC<ImageTagChipsProps> = ({
   };
 
   return (
-    <div className="flex items-center gap-1.5">
+    // flex-wrap so the chips reflow onto additional rows instead of
+    // overflowing their container (each chip is min-w-[5rem] and cannot
+    // shrink) — prevents the chip row from spilling over the "Remove Image"
+    // button at medium widths and being clipped at the card edge when narrow.
+    <div className="flex flex-wrap items-center gap-1.5">
       {stableChips.map((rt) => {
         const date = getDate(rt);
         const isLocal = localTags.has(rt.tag);

--- a/dashboard/components/views/ServerView.tsx
+++ b/dashboard/components/views/ServerView.tsx
@@ -1791,7 +1791,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                   <div className="flex items-center gap-3">
                     <Button
                       variant="secondary"
-                      className="h-9 px-4"
+                      className="h-9 px-4 whitespace-nowrap"
                       onClick={handleMLXStart}
                       disabled={
                         mlxStatus === 'running' ||
@@ -1811,7 +1811,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                     </Button>
                     <Button
                       variant="danger"
-                      className="h-9 px-4"
+                      className="h-9 px-4 whitespace-nowrap"
                       onClick={handleMLXStop}
                       disabled={mlxStatus !== 'running' && mlxStatus !== 'starting'}
                     >
@@ -1843,10 +1843,10 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
               >
                 <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
                   <div className="space-y-4">
-                    <div className="flex items-center space-x-3">
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
                       <StatusLight status={hasImages ? 'active' : 'inactive'} />
                       <span
-                        className={`font-mono text-sm transition-colors ${hasImages ? 'text-slate-300' : 'text-slate-500'}`}
+                        className={`font-mono text-sm whitespace-nowrap transition-colors ${hasImages ? 'text-slate-300' : 'text-slate-500'}`}
                       >
                         {hasImages
                           ? `${docker.images.length} image${docker.images.length > 1 ? 's' : ''} available`
@@ -1854,12 +1854,12 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                       </span>
 
                       {hasImages && docker.images[0] && (
-                        <div className="flex gap-2 transition-opacity duration-300">
-                          <span className="rounded bg-white/10 px-2 py-0.5 text-xs text-slate-400">
+                        <div className="flex shrink-0 gap-2 transition-opacity duration-300">
+                          <span className="rounded bg-white/10 px-2 py-0.5 text-xs whitespace-nowrap text-slate-400">
                             {formatDateDMY(docker.images[0].created) ??
                               docker.images[0].created.split(' ')[0]}
                           </span>
-                          <span className="rounded bg-white/10 px-2 py-0.5 text-xs text-slate-400">
+                          <span className="rounded bg-white/10 px-2 py-0.5 text-xs whitespace-nowrap text-slate-400">
                             {docker.images[0].size}
                           </span>
                         </div>
@@ -1896,42 +1896,53 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                       )}
                     </div>
                   </div>
-                  <div className="flex flex-col justify-end space-y-2">
-                    <Button
-                      variant="secondary"
-                      className="h-10 w-full"
-                      onClick={handleFetchFreshImage}
-                      disabled={docker.operating}
-                    >
-                      {docker.pulling ? (
-                        <>
-                          <Loader2 size={14} className="mr-2 animate-spin" /> Pulling...
-                        </>
-                      ) : (
-                        'Fetch Fresh Image'
+                  <div className="flex flex-col justify-end">
+                    {/*
+                      Give "Fetch Fresh Image" and "Remove Image" a shared width
+                      (the wider of the two labels) and right-align the pair so
+                      they no longer smoosh against the version-tag chips at
+                      narrower window widths. w-max sizes the group to its widest
+                      child; w-full makes both buttons fill that shared width.
+                    */}
+                    <div className="ml-auto flex w-max flex-col gap-2">
+                      <Button
+                        variant="secondary"
+                        className="h-10 w-full"
+                        onClick={handleFetchFreshImage}
+                        disabled={docker.operating}
+                      >
+                        {docker.pulling ? (
+                          <>
+                            <Loader2 size={14} className="mr-2 animate-spin" /> Pulling...
+                          </>
+                        ) : (
+                          'Fetch Fresh Image'
+                        )}
+                      </Button>
+                      {docker.pulling && (
+                        <Button
+                          variant="danger"
+                          className="h-10 w-full"
+                          onClick={() => {
+                            docker.cancelPull();
+                            const dlId = `docker-image-${selectedTagForActions}`;
+                            useActivityStore
+                              .getState()
+                              .updateActivity(dlId, { status: 'dismissed' });
+                          }}
+                        >
+                          Cancel Pull
+                        </Button>
                       )}
-                    </Button>
-                    {docker.pulling && (
                       <Button
                         variant="danger"
                         className="h-10 w-full"
-                        onClick={() => {
-                          docker.cancelPull();
-                          const dlId = `docker-image-${selectedTagForActions}`;
-                          useActivityStore.getState().updateActivity(dlId, { status: 'dismissed' });
-                        }}
+                        onClick={() => docker.removeImage(selectedTagForActions)}
+                        disabled={docker.operating || docker.images.length === 0}
                       >
-                        Cancel Pull
+                        Remove Image
                       </Button>
-                    )}
-                    <Button
-                      variant="danger"
-                      className="h-10 w-full"
-                      onClick={() => docker.removeImage(selectedTagForActions)}
-                      disabled={docker.operating || docker.images.length === 0}
-                    >
-                      Remove Image
-                    </Button>
+                    </div>
                   </div>
                 </div>
                 {docker.operationError && (
@@ -1983,10 +1994,10 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                     )}
                   </div>
                   <div className="flex min-w-0 flex-1 flex-wrap items-center justify-between gap-4">
-                    <div className="flex gap-2">
+                    <div className="flex flex-wrap gap-2">
                       <Button
                         variant="secondary"
-                        className="h-9 px-4"
+                        className="h-9 px-4 whitespace-nowrap"
                         onClick={() =>
                           onStartServer('local', runtimeProfile, selectedTagForStart, {
                             mainTranscriberModel: sanitizeModelName(activeTranscriber),
@@ -2015,7 +2026,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                       </Button>
                       <Button
                         variant="secondary"
-                        className="h-9 px-4"
+                        className="h-9 px-4 whitespace-nowrap"
                         onClick={() =>
                           onStartServer('remote', runtimeProfile, selectedTagForStart, {
                             mainTranscriberModel: sanitizeModelName(activeTranscriber),
@@ -2040,7 +2051,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                       </Button>
                       <Button
                         variant="danger"
-                        className="h-9 px-4"
+                        className="h-9 px-4 whitespace-nowrap"
                         onClick={() => docker.stopContainer()}
                         disabled={docker.operating || !isRunning}
                       >
@@ -2049,7 +2060,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                     </div>
                     <Button
                       variant="danger"
-                      className="h-9 px-4"
+                      className="h-9 px-4 whitespace-nowrap"
                       onClick={() => docker.removeContainer()}
                       disabled={docker.operating || isRunning || !containerStatus.exists}
                     >
@@ -2549,7 +2560,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                 <div className="flex gap-2 border-t border-white/5 pt-2">
                   <Button
                     variant={adminStatus?.models_loaded === false ? 'secondary' : 'danger'}
-                    className="h-9 px-4"
+                    className="h-9 px-4 whitespace-nowrap"
                     onClick={
                       adminStatus?.models_loaded === false ? handleLoadModels : handleUnloadModels
                     }

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.0.52",
-  "contract_sha256": "d1ee12fca54fe275dcdf713a68e6fb86ef7d7e8fe7fb2e5439459ceb6a51c54b",
-  "updated_at": "2026-06-01T21:27:22.815Z"
+  "spec_version": "1.0.55",
+  "contract_sha256": "0f5c303b3c6009805335e9e803183a017d1677f7d81474b67c93afee8690f565",
+  "updated_at": "2026-06-04T16:32:24.160Z"
 }

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.0.55",
-  "contract_sha256": "0f5c303b3c6009805335e9e803183a017d1677f7d81474b67c93afee8690f565",
-  "updated_at": "2026-06-04T16:32:24.160Z"
+  "spec_version": "1.0.56",
+  "contract_sha256": "6b58eb185349fec87c1b46830119d3eb7807e1a384efc93edb23a9785066457b",
+  "updated_at": "2026-06-04T17:56:30.279Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.0.52
+  spec_version: 1.0.55
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -97,7 +97,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-06-01T21:27:07.852Z
+    generated_at: 2026-06-04T16:32:09.625Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -674,6 +674,8 @@ utility_allowlist:
     - gap-6
     - gap-8
     - gap-px
+    - gap-x-3
+    - gap-y-1
     - grid
     - grid-cols-1
     - grid-cols-2
@@ -1112,6 +1114,7 @@ utility_allowlist:
     - w-8
     - w-9
     - w-full
+    - w-max
     - w-px
     - w-screen
     - whitespace-nowrap

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.0.55
+  spec_version: 1.0.56
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -97,7 +97,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-06-04T16:32:09.625Z
+    generated_at: 2026-06-04T17:56:12.601Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -341,6 +341,7 @@ foundation:
         - z-10
         - z-10000
         - z-20
+        - z-30
         - z-50
         - z-60
         - z-9999
@@ -1123,6 +1124,7 @@ utility_allowlist:
     - z-10
     - z-10000
     - z-20
+    - z-30
     - z-50
     - z-60
     - z-9999


### PR DESCRIPTION
# fix(dashboard): Server Configuration card responsive layout + sidebar collapse button hit area

## Summary

Two small, self-contained UI fixes for the dashboard. Both are presentational
(`className`-only changes — no logic, state, or API touched) and ship with the
UI-contract baseline refreshed.

1. **Server Configuration → "1. Docker Image" card** no longer overlaps or
   clips its own content when the window is narrowed. Previously the action
   buttons, the image status chips, and the version-tag chips all degraded
   badly below full width (buttons crowding the tag chips, dates breaking
   mid-value, tag chips overflowing into "Remove Image" / clipping at the card
   edge, button labels wrapping across two lines).
2. **Sidebar collapse button** is now fully clickable. Clicks on the right half
   of the circle used to do nothing.

## Background / root causes

### 1. Docker Image card degraded poorly at narrow widths

The card is a two-column grid, so each half only gets ~50% of the card width.
Several elements had no graceful way to reflow as that space shrank:

- **"Fetch Fresh Image" / "Remove Image"** were `w-full`, so they stretched to
  fill the right column and crowded the version-tag chips on the left.
- The **image status row** (`N image(s) available` + date/size chips) was a
  non-wrapping flex row, so `2026-06-04` was squeezed and broke at its hyphens
  into `2026-` / `06-04`.
- The **version-tag chip row** (`ImageTagChips`) was a non-wrapping flex row of
  chips that each carry `min-w-[5rem]` — they could neither shrink nor wrap, so
  they overflowed: into the "Remove Image" button in the 2-column layout, and
  clipped at the card edge in the 1-column layout.
- The **bottom action buttons** (`Start Local` / `Start Remote` / `Stop` /
  `Remove Container`) wrapped their labels across two lines when cramped.

### 2. Sidebar collapse button swallowed half its clicks

The toggle button sits at `-right-3`, deliberately straddling the sidebar's
right edge so half of it overflows into the main content area. The sidebar uses
`backdrop-blur-2xl`, and `backdrop-filter` establishes a **stacking context** —
which traps the button's `z-20` inside the sidebar. Because the sidebar and
`<main>` are equal-priority flex siblings (`z-auto`, painted in DOM order),
`<main>` paints last and covered the button's overflowing half, so clicks there
hit `<main>` instead of the button. The left half (over the sidebar) worked; the
right half (over main) did not — hence the inconsistent hit area.

## Changes

### `components/views/ServerView.tsx`
- Wrapped "Fetch Fresh Image" / "Remove Image" in a `w-max` + `ml-auto`
  container with `w-full` children, giving the pair a **shared content width**
  (the wider of the two labels) and right-aligning them so they line up with
  "Remove Container" below and stop crowding the tag chips.
- Image status row → `flex-wrap` with `whitespace-nowrap` on the label and the
  date/size chips (and `shrink-0` on the chip group) so the row reflows cleanly
  and date/size values never break mid-token.
- Added `whitespace-nowrap` to the `h-9` action buttons and `flex-wrap` to the
  `Start Local` / `Start Remote` / `Stop` group so labels stay on one line and
  the buttons wrap as whole units only when there is genuinely no room.

### `components/ui/ImageTagChips.tsx`
- Chip row `flex` → `flex flex-wrap` so chips reflow onto additional rows
  instead of overflowing their container (each chip is `min-w-[5rem]` and cannot
  shrink). The existing `gap-1.5` provides matching vertical spacing for wrapped
  rows.

### `components/Sidebar.tsx`
- Sidebar container `relative` → `relative z-30`, lifting the whole sidebar
  (and the trapped toggle button) above `<main>` so the entire collapse circle
  is clickable. Verified all overlays (Settings `z-60`, About / Bug Report /
  Star modals `fixed inset-0 z-50`) still render above the sidebar, so there is
  no regression.

### `ui-contract/`
- Refreshed `transcription-suite-ui.contract.yaml` + `contract-baseline.json`
  and bumped `meta.spec_version` to `1.0.56` for the new utility classes
  (`w-max`, `ml-auto`, `gap-x-3`, `gap-y-1`, `whitespace-nowrap`, `flex-wrap`,
  `shrink-0`, `z-30`).

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` on all changed components — clean
- `npm run ui:contract:check` — `Semantic Valid: yes`, 16/16 checks pass
- Pre-commit hooks (prettier, codespell, UI contract validate+test, json/yaml)
  pass on both commits

## Test plan

- [ ] Open **Server → 1. Docker Image** and slowly resize the window from full
      width down to the minimum:
  - [ ] "Fetch Fresh Image" / "Remove Image" stay equal-width, right-aligned,
        and never overlap the version-tag chips.
  - [ ] The `2026-06-04` date chip never breaks across two lines; the status row
        wraps the chips onto their own line instead.
  - [ ] The version-tag chips wrap onto extra rows; the `...` overflow chip is
        never clipped at the card edge and never overlaps "Remove Image".
  - [ ] `Start Local` / `Start Remote` / `Stop` / `Remove Container` labels never
        wrap mid-word.
- [ ] Click every part of the **sidebar collapse circle** (especially the right
      half that overhangs the content area) — all clicks toggle the sidebar.
- [ ] Toggle **Settings → Blur effects off** and re-test the collapse button
      (the fix should hold with `backdrop-filter` disabled too).
- [ ] Open Settings / About / Bug Report and confirm each modal still renders
      above the sidebar.

## Notes

- No functional/behavioral changes — purely layout and stacking.
- General principle applied throughout: give the layout an *escape valve*
  (`flex-wrap`, content-based shared widths, `whitespace-nowrap` to make labels
  atomic) so the card degrades gracefully across the whole width range rather
  than relying on a single hand-tuned breakpoint.
