### PR TITLE
ci(release): add platform selector for manual release runs (Metal-only on demand)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,24 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      platform:
+        description: "Platform(s) to build on a manual run (tag pushes always build everything)"
+        type: choice
+        default: all
+        options:
+          - all
+          - macos-metal
+          - macos
+          - linux
+          - windows
 
 permissions:
   contents: write
 
 jobs:
   build-linux:
+    if: ${{ github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'linux' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -55,6 +67,7 @@ jobs:
           if-no-files-found: error
 
   build-windows:
+    if: ${{ github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'windows' }}
     runs-on: windows-latest
     defaults:
       run:
@@ -114,6 +127,7 @@ jobs:
           if-no-files-found: error
 
   build-macos:
+    if: ${{ github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'macos' }}
     runs-on: macos-14
     steps:
       - name: Checkout repository
@@ -158,6 +172,7 @@ jobs:
           if-no-files-found: error
 
   build-macos-metal:
+    if: ${{ github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'macos-metal' }}
     runs-on: macos-14
     steps:
       - name: Checkout repository
@@ -336,6 +351,10 @@ jobs:
           if-no-files-found: error
 
   create-release:
+    # Only real tag pushes publish a (draft) GitHub Release. Manual
+    # workflow_dispatch runs just produce downloadable artifacts on the run
+    # page — no draft Release is created.
+    if: ${{ github.event_name == 'push' }}
     needs: [build-linux, build-windows, build-macos, build-macos-metal]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Adds a `platform` selector to the **Release** workflow so a maintainer can run a single
platform's packaging on demand — without tagging a commit. The primary motivation is being
able to (re)build the **Apple Metal** DMG (`build-macos-metal`) by itself, since that bundle
can only be produced on a `macos-14` arm64 runner and is not reproducible locally on Linux.

## What changed

`​.github/workflows/release.yml`:

- **New `workflow_dispatch` input** `platform` (choice): `all` (default) / `macos-metal` /
  `macos` / `linux` / `windows`.
- **Each build job is now conditional.** Example for Metal:
  `if: github.event_name == 'push' || inputs.platform == 'all' || inputs.platform == 'macos-metal'`.
  The `github.event_name == 'push'` clause preserves existing behavior — **tag pushes (`v*`)
  still build all four platforms**. The `inputs.platform` clauses only apply to manual runs.
- **`create-release` is gated to `github.event_name == 'push'`.** Manual runs now produce only
  downloadable artifacts on the run page; no draft GitHub Release is created. Tag pushes are
  unchanged (all builds + draft Release with generated notes).

## Why

Today the only way to produce the Metal DMG is to push a `v*` tag, which rebuilds **all four**
platforms and cuts a release. This input lets us rebuild just one platform (e.g. to iterate on
the Metal bundle / verify the MLX venv injection) cheaply and without release side effects.

## Behavior matrix

| Trigger | Jobs that run | Draft Release? |
|---|---|---|
| Push tag `v*` | all 4 builds + create-release | Yes (draft) |
| Manual, `platform=all` | all 4 builds | No |
| Manual, `platform=macos-metal` | build-macos-metal only | No |
| Manual, `platform=<x>` | build-`<x>` only | No |

## Important: default-branch requirement

`workflow_dispatch` input definitions are read from the **default branch**. The selector only
becomes usable **after this merges to `main`**. Once merged, trigger Metal-only with:

```bash
gh workflow run release.yml --ref main -f platform=macos-metal
gh run watch
gh run download --name release-macos-metal   # -> TranscriptionSuite-<ver>-arm64-mac-metal.dmg
```

## Test plan

- [ ] CI: workflow file parses on GitHub (Actions tab shows the "Run workflow" dropdown with
      the `platform` choices) — verifiable only after merge to `main`.
- [ ] Manual run with `platform=macos-metal` runs **only** `build-macos-metal`; the
      "Verify bundled MLX venv" gate passes and the `release-macos-metal` artifact is produced.
- [ ] Manual run with `platform=all` runs all four builds and creates **no** draft Release.
- [ ] Regression: pushing a `v*` tag still builds all four platforms and creates a draft Release.

## Risk

Low. GitNexus `detect_changes` reports zero affected code symbols / execution flows (CI YAML is
outside the code graph). No application code touched.
