### PR TITLE
fix(dockerManager): repoint whisper-server.exe download URL to main branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **TranscriptionSuite** (18474 symbols, 31014 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **TranscriptionSuite** (18819 symbols, 31400 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ feat/fix/chore/etc(impacted area e.g. tests, stt, dashboard, ui, server, etc): s
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **TranscriptionSuite** (18474 symbols, 31014 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **TranscriptionSuite** (18819 symbols, 31400 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -3496,7 +3496,7 @@ async function downloadWhisperServerExe(): Promise<void> {
   const tmp = `${exePath}.tmp`;
   // TODO: change ref to `v${app.getVersion()}` once whisper-server.exe is
   // committed at each release tag (currently lives on fix-vulcan-on-windows).
-  const url = `https://media.githubusercontent.com/media/homelab-00/TranscriptionSuite/feat/vulkan-on-windows/whisper-server/whisper-server.exe`;
+  const url = `https://github.com/homelab-00/TranscriptionSuite/raw/refs/heads/main/whisper-server/whisper-server.exe`;
   fs.mkdirSync(path.dirname(exePath), { recursive: true });
 
   const { net } = await import('electron');


### PR DESCRIPTION
# fix(dockerManager): repoint whisper-server.exe download URL to main branch

## Summary

The Windows Electron app downloads `whisper-server.exe` (the whisper.cpp
Vulkan sidecar) from GitHub LFS at runtime via `downloadWhisperServerExe()`
in `dashboard/electron/dockerManager.ts`. The download URL was hardcoded to a
stale feature branch (`feat/vulkan-on-windows`) using GitHub's direct LFS
media endpoint. Now that the binary lives on `main`, that URL points at a
location that will eventually disappear when the branch is deleted, breaking
the Vulkan-on-Windows download path for end users.

This PR repoints the download to the canonical location on `main`.

## Changes

- **fix(dockerManager): update whisper-server.exe download URL**
  - Old: `https://media.githubusercontent.com/media/homelab-00/TranscriptionSuite/feat/vulkan-on-windows/whisper-server/whisper-server.exe`
  - New: `https://github.com/homelab-00/TranscriptionSuite/raw/refs/heads/main/whisper-server/whisper-server.exe`
  - Switches from the direct LFS media endpoint pinned to a feature branch to
    the `github.com/.../raw/refs/heads/main/...` form, which auto-redirects to
    the LFS object for public repos (the request already uses
    `redirect: 'follow'`, so no other logic changes are needed).
  - The pre-existing `TODO` to pin the ref to `v${app.getVersion()}` once the
    binary is committed at each release tag remains in place.

- **chore(docs): regenerate GitNexus index counts** in `AGENTS.md` and
  `CLAUDE.md` (auto-generated symbol/relationship totals; no behavioral
  effect).

## Why this matters

`whisper-server.exe` is fetched lazily on first use, not bundled. If the URL
points at a branch that gets deleted, every Windows user relying on the
whisper.cpp Vulkan backend would hit an HTTP 404 with no local fallback. The
`.tmp` sidecar + rename-on-success flow already guards against corrupt partial
downloads, but it cannot recover from a dead URL — hence this fix.

## Test plan

- [ ] On Windows 11, trigger a whisper-server download (fresh AppData, no
      cached `whisper-server.exe`) and confirm the binary downloads from the
      `main` URL and launches.
- [ ] Confirm the LFS redirect resolves (HTTP 200, correct file size — not the
      ~130-byte LFS pointer text).
- [ ] Verify the `.tmp` sidecar is cleaned up on a simulated failure and the
      final rename only occurs on success.
- [ ] Smoke-test a whisper.cpp Vulkan transcription end-to-end on Windows.

## Notes

- Linux/macOS are unaffected — this code path is Windows-only.
- Follow-up (tracked by the existing `TODO`): once `whisper-server.exe` is
  committed at each release tag, pin the ref to `v${app.getVersion()}` so the
  app downloads the binary matching its own version instead of tracking `main`.
