### PR TITLE
docs(bmad): refresh project documentation and all PlantUML diagrams to v1.3.6

### DIFF
--- a/docs/api-contracts-server.md
+++ b/docs/api-contracts-server.md
@@ -1,189 +1,202 @@
 # TranscriptionSuite — API Contracts (Server)
 
-> Generated: 2026-04-05 | Base URL: `http(s)://host:9786`
+> Generated: 2026-06-11 | v1.3.6 | Base URL: `http(s)://host:9786`
+
+## Auth Legend
+
+- **none** — public route (always reachable; see `PUBLIC_ROUTES`/`PUBLIC_PREFIXES` in `main.py`)
+- **user** — requires a valid token in TLS mode (enforced globally by `AuthenticationMiddleware`); open in local mode
+- **admin** — handler calls `require_admin()`; 403 if not admin. In local mode, loopback/Docker-gateway hosts are treated as admin.
+
+> **Local-mode nuance:** when `TLS_ENABLED=false` (default), `AuthenticationMiddleware` is not installed, so
+> "user" routes are effectively open; "admin" routes still run `require_admin`, which loopback callers pass.
+> In **TLS mode**, every non-public route needs a Bearer token (header) or `auth_token` cookie; the notebook
+> `…/audio` and `…/export` routes additionally accept a `?token=` query param.
 
 ## Endpoint Summary
 
-### Health & Status (no auth)
-| Method | Path | Purpose |
-|--------|------|---------|
-| GET | `/health` | Lightweight liveness probe |
-| GET | `/ready` | Readiness (200 when models loaded, 503 when loading) |
-| GET | `/api/status` | Detailed server status (GPU, model, features) |
-
-### Authentication
+### Health & Status
 | Method | Path | Auth | Purpose |
 |--------|------|------|---------|
-| POST | `/api/auth/login` | No | Authenticate with token |
-| GET | `/api/auth/tokens` | Admin | List active tokens |
-| POST | `/api/auth/tokens` | Admin | Create new token (plaintext returned once) |
-| DELETE | `/api/auth/tokens/{token_id}` | Admin | Revoke token |
+| GET | `/health` | none | Liveness probe (`{status, service}`) |
+| GET | `/ready` | user | Readiness — 200 when model loaded/disabled or Live Mode active, else 503 |
+| GET | `/api/status` | none | Detailed status: version, models, features, `ready`, `gpu_available`, `gpu_error` |
 
-### Transcription
+### Authentication (`/api/auth`)
 | Method | Path | Auth | Purpose |
 |--------|------|------|---------|
-| POST | `/api/transcribe/audio` | Yes | Transcribe uploaded audio/video file |
-| POST | `/api/transcribe/quick` | Yes | Quick transcription (simplified params) |
-| POST | `/api/transcribe/cancel` | Yes | Cancel in-progress transcription |
-| POST | `/api/transcribe/import` | Yes | Import file to notebook with transcription |
-| GET | `/api/transcribe/languages` | Yes | List supported languages |
-| GET | `/api/transcribe/result/{job_id}` | Yes | Poll for transcription result (durability) |
+| POST | `/api/auth/login` | none | Validate a token; returns `{name, is_admin, token_id}` |
+| GET | `/api/auth/tokens` | admin | List tokens (partial hash only) |
+| POST | `/api/auth/tokens` | admin | Create token (plaintext shown once) |
+| DELETE | `/api/auth/tokens/{token_id}` | admin | Revoke token |
 
-### Audio Notebook
+### Transcription (`/api/transcribe`)
 | Method | Path | Auth | Purpose |
 |--------|------|------|---------|
-| GET | `/api/notebook/recordings` | Yes | List all recordings |
-| GET | `/api/notebook/recordings/{id}` | Yes | Get recording with segments/words |
-| POST | `/api/notebook/recordings` | Yes | Upload and transcribe for notebook |
-| DELETE | `/api/notebook/recordings/{id}` | Yes | Delete recording + audio |
-| GET | `/api/notebook/recordings/{id}/audio` | Yes* | Download original audio |
-| GET | `/api/notebook/recordings/{id}/export` | Yes* | Export as SRT/VTT/ASS |
-| PATCH | `/api/notebook/recordings/{id}/title` | Yes | Update title |
-| PATCH | `/api/notebook/recordings/{id}/recorded_at` | Yes | Update recording date |
-| PATCH | `/api/notebook/recordings/{id}/summary` | Yes | Update summary |
-| PUT | `/api/notebook/recordings/{id}/summary` | Yes | Set summary + model name |
-| POST | `/api/notebook/transcribe/upload` | Yes | Upload to notebook |
-| GET | `/api/notebook/calendar` | Yes | Recordings grouped by date |
-| GET | `/api/notebook/timeslot` | Yes | Check time slot conflicts |
-| GET | `/api/notebook/backups` | Yes | List database backups |
-| POST | `/api/notebook/backup` | Yes | Create backup |
-| POST | `/api/notebook/restore` | Yes | Restore from backup |
+| POST | `/api/transcribe/audio` | user | Full transcription (text + segments + words + optional diarization); supports `multitrack`, `profile_id`; persists before delivery |
+| POST | `/api/transcribe/quick` | user | Fast text-only transcription (Record view) |
+| POST | `/api/transcribe/cancel` | user | Cancel the active job |
+| POST | `/api/transcribe/import` | user | Background transcribe (no DB/notebook); 202 + `job_id` + inline `dedup_matches`; supports `multitrack` |
+| POST | `/api/transcribe/import/dedup-check` | user | **NEW** — look up prior jobs/recordings sharing an audio hash (no side effects) |
+| GET | `/api/transcribe/result/{job_id}` | user | **NEW** — fetch saved result (200 done / 202 processing / 404 / 410 failed); marks delivered; ownership check |
+| POST | `/api/transcribe/retry/{job_id}` | user | **NEW** — re-transcribe a failed job from preserved audio |
+| GET | `/api/transcribe/recent` | user | **NEW** — up to 5 recently completed-but-undelivered jobs (post-restart recovery banner) |
+| POST | `/api/transcribe/result/{job_id}/dismiss` | user | **NEW** — mark a result delivered without transferring payload |
+| GET | `/api/transcribe/languages` | user | Supported languages for active backend, `auto_detect`, `supports_translation` |
 
-*Audio/export endpoints also accept `?token=...` query parameter.
-
-### Search
+### Audio Notebook (`/api/notebook`)
 | Method | Path | Auth | Purpose |
 |--------|------|------|---------|
-| GET | `/api/search` | Yes | Full-text search (FTS5) |
-| GET | `/api/search/words` | Yes | Word-level search with timestamps |
-| GET | `/api/search/recordings` | Yes | Search recording metadata |
+| GET | `/api/notebook/recordings` | user | List recordings (optional `start_date`/`end_date`) |
+| GET | `/api/notebook/recordings/{id}` | user | Recording detail incl. segments, words, `webhook_status`/`webhook_error` |
+| DELETE | `/api/notebook/recordings/{id}` | user | Delete recording (+ optional on-disk artifacts) |
+| PUT/PATCH | `/api/notebook/recordings/{id}/summary` | user | Update summary (query / JSON body) |
+| PATCH | `/api/notebook/recordings/{id}/transcript` | user | **NEW** — set/clear non-destructive `transcript_corrected` (find-replace persistence) |
+| PATCH | `/api/notebook/recordings/{id}/title` | user | Update title |
+| PATCH | `/api/notebook/recordings/{id}/date` | user | Update `recorded_at` |
+| GET | `/api/notebook/recordings/{id}/diarization-review` | user | **NEW** — diarization-review lifecycle state |
+| POST | `/api/notebook/recordings/{id}/diarization-review` | user | **NEW** — lifecycle trigger `open`/`complete` (409 on illegal transition) |
+| GET | `/api/notebook/recordings/{id}/diarization-confidence` | user | **NEW** — per-turn confidence + `alternative_speakers` |
+| GET | `/api/notebook/recordings/{id}/aliases` | user | **NEW** — list speaker aliases |
+| PUT | `/api/notebook/recordings/{id}/aliases` | user | **NEW** — full-replace upsert of speaker aliases |
+| GET | `/api/notebook/recordings/{id}/audio` | user (+`?token=`) | Stream audio with HTTP Range (206) |
+| GET | `/api/notebook/recordings/{id}/transcription` | user | Transcription as segments-with-embedded-words |
+| POST | `/api/notebook/transcribe/upload` | user | Upload + background transcribe + save to notebook; 202 + `job_id`; supports diarization, `profile_id` |
+| GET | `/api/notebook/calendar` | user | Recordings grouped by day for a `year`/`month` |
+| GET | `/api/notebook/timeslot` | user | Time-slot occupancy for `date`+`hour` |
+| GET | `/api/notebook/recordings/{id}/export` | user (+`?token=`) | Export transcript: `txt`/`plaintext`/`srt`/`ass` (alias-substituted) |
+| POST | `/api/notebook/recordings/{id}/reexport` | user | **NEW** — re-render plaintext export with a `profile_id` to its destination folder |
+| POST | `/api/notebook/recordings/{id}/auto-actions/retry` | user | **NEW** — idempotent retry of `auto_summary`/`auto_export`/`webhook` |
+| GET | `/api/notebook/backups` | user | List database backups |
+| POST | `/api/notebook/backup` | user | Create a manual DB backup |
+| POST | `/api/notebook/restore` | user | Restore DB from a named backup (safety-backup first) |
 
-### LLM Integration
+### Profiles (`/api/profiles`) — entire family NEW
 | Method | Path | Auth | Purpose |
 |--------|------|------|---------|
-| GET | `/api/llm/status` | Yes | LM Studio connection status |
-| POST | `/api/llm/process` | Yes | Process text with LLM |
-| POST | `/api/llm/process/stream` | Yes | Streaming LLM processing |
-| POST | `/api/llm/summarize/{id}` | Yes | Summarize recording |
-| POST | `/api/llm/summarize/{id}/stream` | Yes | Streaming summarization |
-| GET | `/api/llm/models/available` | Yes | List available LLM models |
-| POST | `/api/llm/model/load` | Yes | Load LLM model |
-| POST | `/api/llm/model/unload` | Yes | Unload LLM model |
-| POST | `/api/llm/server/start` | Yes | Start LM Studio server |
-| POST | `/api/llm/server/stop` | Yes | Stop LM Studio server |
+| GET | `/api/profiles` | user | List profiles (sensitive keys scrubbed) |
+| GET | `/api/profiles/{profile_id}` | user | Get one profile (404 if absent) |
+| POST | `/api/profiles` | user | Create profile (201); validates schema_version, filename template, webhook URL (SSRF) |
+| PUT | `/api/profiles/{profile_id}` | user | Update profile (exclude-unset; null clears) |
+| DELETE | `/api/profiles/{profile_id}` | user | Delete profile (204 / 404) |
 
-### Admin
+### Search (`/api/search`)
 | Method | Path | Auth | Purpose |
 |--------|------|------|---------|
-| GET | `/api/admin/status` | Admin | Detailed model/config status |
-| GET | `/api/admin/config/full` | Admin | Full server configuration |
-| PATCH | `/api/admin/config` | Admin | Update config key-value pairs |
-| PATCH | `/api/admin/diarization` | Admin | Update diarization settings |
-| POST | `/api/admin/models/load` | Admin | Load specific model |
-| WS | `/api/admin/models/load/stream` | Admin | Stream model loading progress |
-| POST | `/api/admin/models/unload` | Admin | Unload current model |
-| POST | `/api/admin/webhook/test` | Admin | Test webhook endpoint |
-| GET | `/api/admin/logs` | Admin | Stream server logs (WebSocket) |
+| GET | `/api/search/words` | user | FTS5 word search with timing + recording context |
+| GET | `/api/search/recordings` | user | Search recordings containing a query |
+| GET | `/api/search/` | user | Unified search (words + filename/title/summary), optional date range |
 
-### OpenAI-Compatible
+### LLM Integration (`/api/llm`)
 | Method | Path | Auth | Purpose |
 |--------|------|------|---------|
-| POST | `/v1/audio/transcriptions` | Yes | OpenAI-compatible transcription |
-| POST | `/v1/audio/translations` | Yes | OpenAI-compatible translation |
+| GET | `/api/llm/status` | user | Provider reachability + active model + `auto_title_enabled` |
+| POST | `/api/llm/config/reload` | user | **NEW** — reload server config from disk (new LLM base URL) |
+| GET | `/api/llm/models` | user | **NEW** — list provider models (`/v1/models`) |
+| POST | `/api/llm/process` | user | Non-streaming LLM processing of transcription text |
+| POST | `/api/llm/process/stream` | user | Streaming (SSE) LLM processing |
+| POST | `/api/llm/summarize/{recording_id}` | user | Summarize recording (alias-aware; persists; 409 if in-flight) |
+| POST | `/api/llm/summarize/{recording_id}/stream` | user | Streaming summarize (persist-on-complete) |
+| GET | `/api/llm/models/available` | user | LM Studio v0 models (load state, quant, ctx len) |
+| POST | `/api/llm/model/load` | user | Load a model into LM Studio (v1 REST) |
+| POST | `/api/llm/model/unload` | user | Unload a model from LM Studio |
+| GET | `/api/llm/models/loaded` | user | **NEW** — loaded models via `lms ps` |
+| POST | `/api/llm/server/start` | user | Check LM Studio + load configured model |
+| POST | `/api/llm/server/stop` | user | (No-op in Docker) stop LM Studio |
+| GET | `/api/llm/conversations/{recording_id}` | user | **NEW** — list AI-chat conversations for a recording |
+| POST | `/api/llm/conversations` | user | **NEW** — create a conversation |
+| GET | `/api/llm/conversation/{conversation_id}` | user | **NEW** — get conversation + messages |
+| PATCH | `/api/llm/conversation/{conversation_id}` | user | **NEW** — update title and/or model override |
+| DELETE | `/api/llm/conversation/{conversation_id}` | user | **NEW** — delete a conversation |
+| POST | `/api/llm/conversation/{conversation_id}/message` | user | **NEW** — add a manual message |
+| DELETE | `/api/llm/conversation/{conversation_id}/messages-from/{message_id}` | user | **NEW** — truncate history from a message |
+| POST | `/api/llm/conversation/{conversation_id}/generate-title` | user | **NEW** — LLM-generate a short title |
+| POST | `/api/llm/chat` | user | **NEW** — multi-turn streaming chat over transcription (alias-aware) |
 
-### WebSocket Protocols
+### Admin (`/api/admin`)
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| GET | `/api/admin/status` | admin | Detailed model/transcriber/diarization status |
+| PATCH | `/api/admin/diarization` | admin | Update diarization `parallel` setting |
+| GET | `/api/admin/config/full` | admin | Full `config.yaml` as a tree (comments/types) |
+| PATCH | `/api/admin/config` | admin | In-place config updates `{updates:{section.key:value}}` |
+| POST | `/api/admin/webhook/test` | admin | Send a test webhook (legacy config or supplied url/secret) |
+| POST | `/api/admin/models/load` | admin | Load a model (503 on missing backend dep) |
+| WS | `/api/admin/models/load/stream` | admin | Stream model-load progress |
+| POST | `/api/admin/models/unload` | admin | Unload models (409 if busy) |
+| GET | `/api/admin/logs` | none* | Tail recent JSON logs (filter `service`/`level`/`limit`) |
+
+> *`GET /api/admin/logs` is the one admin handler that does **not** call `require_admin`. In TLS mode it still
+> needs a valid token via middleware; in local mode it is fully open. Flagged as a known discrepancy.
+
+### OpenAI-Compatible (`/v1/audio`)
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| POST | `/v1/audio/transcriptions` | user | OpenAI-spec transcription (+ diarization extensions) |
+| POST | `/v1/audio/translations` | user | OpenAI-spec translation (always → English) |
+
+### WebSocket
 | Endpoint | Auth | Purpose |
 |----------|------|---------|
-| `/ws` | Token (first message) | Longform recording transcription |
-| `/ws/live` | Token (first message) | Real-time live transcription |
+| `/ws` | first message | Longform recording transcription |
+| `/ws/live` | first message | Live Mode (sentence-by-sentence) |
+| `/api/admin/models/load/stream` | header token, admin | Model-load progress stream |
+
+## Middleware Stack
+
+Effective request-processing order (Starlette applies middleware in reverse registration order):
+
+1. **AuthenticationMiddleware** (TLS mode only) — Bearer/cookie/query-token auth for non-public routes; API → 401 JSON, browser pages → 302 redirect to `/auth`.
+2. **OriginValidationMiddleware** — CSRF guard. Allows same-origin / `Origin: null` / `file://` (Electron) / localhost; TLS adds same-host; local mode blocks non-localhost (403).
+3. **CORSMiddleware** — permissive headers (`allow_origins=["*"]`); strict enforcement delegated to OriginValidation.
+
+A global `@app.exception_handler(Exception)` returns a generic 500 `{detail:"Internal server error"}`.
 
 ## OpenAI-Compatible Audio Endpoints
 
-Both endpoints accept `multipart/form-data` and follow the OpenAI Audio API spec so drop-in clients (Open-WebUI, LM Studio-compat scripts, curl) work unchanged. Authentication is the usual bearer-token flow.
+Both endpoints accept `multipart/form-data` and follow the OpenAI Audio API so drop-in clients work unchanged.
 
 **Standard fields:** `file`, `model`, `language` (transcriptions only), `prompt`, `response_format`, `temperature`, `timestamp_granularities[]`.
 
-**Diarization fields (extension, GH-88):**
+**Diarization extension (GH-88):** `diarization` (bool), `expected_speakers` (1–10; out-of-range → 400), `parallel_diarization` (bool, defaults to config).
 
-| Field | Type | Default | Purpose |
-|-------|------|---------|---------|
-| `diarization` | bool | `false` | When true, run speaker diarization and attach speaker labels to segments. |
-| `expected_speakers` | int (1–10) | none | Exact speaker count hint. Out-of-range values return 400. |
-| `parallel_diarization` | bool | `config.diarization.parallel` | Override parallel vs sequential diarize + transcribe. |
+**Response formats:** `json` (default, `{"text"}`), `text`, `verbose_json`, `srt`, `vtt`, `diarized_json` (extension).
 
-**Response formats:** `json` (default, OpenAI-minimal `{"text"}`), `text`, `verbose_json`, `srt`, `vtt`, `diarized_json` (extension).
+**Speaker-label behavior:** JSON bodies retain raw `SPEAKER_00` labels; subtitle formats normalize to `Speaker 1`. `response_format=json` stays `{"text"}` even with diarization. Word-level speaker assignments appear only when `timestamp_granularities[]=word`.
 
-**Speaker-label behavior:**
-- JSON bodies (`verbose_json`, `diarized_json`) retain raw `SPEAKER_00`/`SPEAKER_01` labels so programmatic clients get stable identifiers.
-- Subtitle formats (`srt`, `vtt`) normalize to `Speaker 1`/`Speaker 2` (same convention the dashboard's longform export uses) and prefix cue text accordingly.
-- `response_format=json` remains `{"text": ...}` even when diarization ran — speakers are computed internally but not leaked into the minimal body.
-- Word-level speaker assignments appear in `verbose_json.words[*].speaker` and `diarized_json.segments[*].words[*].speaker` only when the client requested word granularity via `timestamp_granularities[]=word`.
-
-**`diarized_json` shape:**
-
-```json
-{
-  "task": "transcribe",
-  "language": "el",
-  "duration": 12.4,
-  "text": "Γεια σας. Καλώς ήρθατε.",
-  "num_speakers": 2,
-  "segments": [
-    {"speaker": "SPEAKER_00", "start": 0.0, "end": 4.1, "text": "Γεια σας."},
-    {"speaker": "SPEAKER_01", "start": 4.5, "end": 12.4, "text": "Καλώς ήρθατε."}
-  ]
-}
-```
-
-**Failure tolerance:** When diarization is requested but any stage fails (no HF token, engine OOM, speaker-merge error), the endpoint returns a 200 with a plain transcript — `num_speakers=0` and no `speaker` keys — and logs a WARNING server-side. The call never 5xxs just because the diarization engine hiccuped.
-
-**Example:**
+**Failure tolerance:** if diarization is requested but any stage fails, the endpoint returns 200 with a plain transcript (`num_speakers=0`, no `speaker` keys) and logs a WARNING — never 5xxs on a diarization hiccup.
 
 ```bash
-curl -F file=@sample.wav \
-     -F diarization=true \
-     -F expected_speakers=2 \
-     -F response_format=diarized_json \
-     -H "Authorization: Bearer $TOKEN" \
+curl -F file=@sample.wav -F diarization=true -F expected_speakers=2 \
+     -F response_format=diarized_json -H "Authorization: Bearer $TOKEN" \
      http://localhost:9786/v1/audio/transcriptions
 ```
 
-## WebSocket Protocol — Longform (`/ws`)
+## WebSocket Protocols
 
-**Auth:** First message must be `{authenticate: "<token>"}`
+All WS endpoints frame messages as JSON `{type, data, timestamp}`. Binary audio frames use:
+**`[4-byte LE metadata length][metadata JSON][PCM Int16 LE]`**.
 
-**Start:** `{start: {language: "en", device: "cuda", translate: false, diarization: true}}`
+### `/ws` — Longform / File Transcription
+- **Auth:** client → `{type:"auth", data:{token}}`; server → `{type:"auth_ok", data:{client_name, capabilities}}`.
+- **Start:** client → `{type:"start", data:{language?, use_vad?, translation_enabled?, translation_target_language?, profile_id?}}`. Slot busy → `{type:"session_busy"}`; else → `{type:"session_started", data:{vad_enabled, job_id, ...}}`.
+- **Audio:** binary frames (metadata `{sample_rate}` + PCM); progress via `{type:"processing_progress"}` every 5 s.
+- **Stop:** client → `{type:"stop"}`. Result inline `{type:"final", ...}` when ≤1 MB, else `{type:"result_ready", data:{job_id}}` → client fetches `GET /api/transcribe/result/{job_id}`. **Persist-before-deliver:** result saved to DB before send; `mark_delivered` only after inline send.
 
-**Audio:** Binary PCM Int16 frames
+### `/ws/live` — Live Mode
+- **Single session only** — a second connection gets an error + close.
+- **Start:** client → `{type:"start", data:{config:{model?, language?, translation_enabled?, silero_sensitivity?, post_speech_silence_duration?}}}`. Server emits `status` during model swap. **Only Whisper (faster-whisper) and whisper.cpp** backends are supported for Live Mode; translation target must be `en` in v1.
+- **Streaming output:** `{type:"partial", data:{text}}` (interim), `{type:"sentence", data:{text}}` (final; also fires the `live_sentence` webhook), `{type:"state", data:{state}}`.
+- **Stop:** restores main model (status messages) → `{type:"state", data:{state:"STOPPED"}}`. Also: `get_history`/`clear_history`/`ping`.
 
-**Stop:** `{stop: true}`
-
-**Result:** `{result: {segments: [...], words: [...], language: "en", duration: 45.2}}`
-
-## WebSocket Protocol — Live Mode (`/ws/live`)
-
-**Auth:** Same as longform (first message)
-
-**Start:** `{start: {language: "en", translate: false}}`
-
-**Audio:** Continuous PCM Int16 binary chunks
-
-**Partial results:** `{type: "partial", text: "I'm currently..."}`
-
-**Final segments:** `{type: "sentence", text: "I'm currently speaking."}`
-
-**Stop:** `{stop: true}` → `{result: final_transcript}`
+### `/api/admin/models/load/stream` — Admin Model Load
+- **Auth:** header-based (`require_admin`, localhost bypass), no first-message handshake.
+- Streams `{type:"progress", message}` then terminal `{type:"complete", status:"loaded"}` or `{type:"error", message}` (BackendDependencyError includes a remedy).
 
 ## Authentication
 
-**Token sources** (checked in priority order):
-1. `Authorization: Bearer <token>` header
-2. `auth_token` cookie
-3. `?token=<token>` query param (notebook audio/export only)
+**Token sources** (priority order): `Authorization: Bearer <token>` → `auth_token` cookie → `?token=` query param (notebook audio/export only).
 
-**Token lifecycle:**
-- Created via `POST /api/auth/tokens` (admin only)
-- Plaintext shown once at creation, SHA-256 hash stored
-- Admin tokens: never expire
-- User tokens: 30-day expiry
-- Revocable by token ID via `DELETE /api/auth/tokens/{token_id}`
+**Token lifecycle:** created via `POST /api/auth/tokens` (admin); plaintext shown once, SHA-256 hash stored; admin tokens never expire, user tokens 30 days; revocable by ID.
+
+**WebSocket auth — two strategies:** auth-by-first-message (`/ws`, `/ws/live`, 10 s timeout, localhost bypass in local mode) and auth-by-headers (admin model-load stream).

--- a/docs/architecture-dashboard.md
+++ b/docs/architecture-dashboard.md
@@ -1,10 +1,14 @@
 # TranscriptionSuite — Dashboard Architecture
 
-> Generated: 2026-04-05 | Part: dashboard | Type: desktop | TypeScript 5.9 / React 19 / Electron 40
+> Generated: 2026-06-11 | v1.3.6 | Part: dashboard | Type: desktop | TypeScript 5.9 / React 19 / Electron 40
 
 ## Executive Summary
 
-The dashboard is an Electron 40 desktop application with a React 19 renderer that manages the TranscriptionSuite Docker server, provides a transcription UI (recording, file upload, live mode), an audio notebook with calendar and full-text search, model management, and server configuration. It communicates with the server over REST and WebSocket.
+The dashboard is an Electron 40 desktop application with a React 19 renderer that manages the
+TranscriptionSuite Docker server, provides a transcription UI (recording, file upload, live mode), an
+audio notebook with calendar/full-text search/LLM chat, transcription/recording **profiles**, speaker
+**aliases** and **diarization review**, in-place transcript **editing with find/replace**, and a hardened
+**auto-update installer pipeline**. It communicates with the server over REST and WebSocket.
 
 ## Technology Stack
 
@@ -13,211 +17,177 @@ The dashboard is an Electron 40 desktop application with a React 19 renderer tha
 | Shell | Electron | ^40.8.5 | Desktop container (BrowserWindow, IPC, tray, shortcuts) |
 | UI Framework | React | 19.2.4 | Component rendering |
 | Language | TypeScript | 5.9.3 | Type safety (ES2022, bundler moduleResolution) |
-| Bundler | Vite | 7.3.1 | Dev server (port 3000), production build (base: `'./'` for Electron file://) |
-| Styling | Tailwind CSS | 4.2.1 | Utility-first CSS (via @tailwindcss/vite plugin) |
-| Server State | @tanstack/react-query | 5.90.21 | Caching, polling, invalidation for server data |
-| Client State | Zustand | ^5.0.12 | Ephemeral client-only state (import queue, activity) |
-| UI Primitives | @headlessui/react | 2.2.9 | Accessible UI components |
+| Bundler | Vite | 7.3.1 | Dev server (port 3000), production build (base `'./'` for Electron file://) |
+| Styling | Tailwind CSS | 4.2.1 | Utility-first CSS (+ custom oklab-strip PostCSS plugin) |
+| Server State | @tanstack/react-query | 5.90.21 | Caching, polling, invalidation |
+| Client State | Zustand | ^5.0.12 | Ephemeral client-only state (5 stores) |
+| UI Primitives | @headlessui/react | 2.2.9 | Accessible components |
 | Icons | lucide-react | 0.564.0 | Icon library |
-| Testing | Vitest + @testing-library/react | 4.0.18 / 16.3.2 | Unit + component tests (jsdom) |
-| Formatting | Prettier | 3.8.1 | Code formatting (+ tailwindcss plugin) |
+| Updates | electron-updater | (electron-builder) | Auto-update download/install |
+| Testing | Vitest + @testing-library/react | 4.1.x / 16.3.2 | Unit + component tests (jsdom) |
 | Packaging | electron-builder | 26.8.1 | AppImage (Linux), NSIS (Windows), DMG (macOS) |
 
 ## Architecture Pattern
 
 **Component-driven architecture** with clear separation:
 
-1. **Electron Main Process** (`electron/`) — System integration, Docker, IPC
+1. **Electron Main Process** (`electron/`, 24 modules) — system integration, Docker, updates, IPC
 2. **React Renderer** (`components/`, `App.tsx`) — UI views and interactions
-3. **Logic Layer** (`src/hooks/`, `src/services/`, `src/stores/`) — Business logic, state, API
+3. **Logic Layer** (`src/hooks/`, `src/services/`, `src/stores/`, `src/utils/`) — business logic, state, API
 
-## Electron Main Process
-
-12 modules in `dashboard/electron/`:
+## Electron Main Process (24 modules)
 
 | Module | Purpose |
 |--------|---------|
-| `main.ts` | App entry: BrowserWindow, IPC handlers, lifecycle, dev tools |
+| `main.ts` | App entry: BrowserWindow, IPC handlers, lifecycle |
 | `preload.ts` | Context bridge: exposes safe IPC API to renderer |
-| `dockerManager.ts` | Docker Compose lifecycle (start/stop/update/logs/status) |
+| `appState.ts` | **NEW** — store accessors: resolve server URL (local/LAN/Tailscale), auth token, idle check |
+| `dockerManager.ts` | Docker Compose lifecycle (start/stop/update/logs); runtime-profile + GHCR repo resolution |
 | `containerRuntime.ts` | Detect Docker vs Podman, platform-specific compose files |
 | `mlxServerManager.ts` | macOS bare-metal server management (no Docker) |
-| `trayManager.ts` | System tray icon, context menu, live mode indicator |
-| `shortcutManager.ts` | Global keyboard shortcuts (record, live mode, paste) |
+| `mlxLogSink.ts` | **NEW** — persist-and-deliver pipeline for MLX log lines |
+| `trayManager.ts` | System tray icon, context menu, live-mode indicator |
+| `shortcutManager.ts` | Global keyboard shortcuts |
 | `waylandShortcuts.ts` | Wayland-specific shortcut implementation (Linux KDE) |
-| `pasteAtCursor.ts` | System-wide paste (xdotool on Linux, AppleScript on macOS) |
-| `startupEventWatcher.ts` | Watch server bootstrap events via fs.watch on JSONL file |
-| `updateManager.ts` | Auto-updater checking GitHub releases |
+| `clipboardWayland.ts` | **NEW** — reliable Wayland clipboard write (verify-retry + `wl-copy` fallback) |
+| `pasteAtCursor.ts` | System-wide paste (xdotool / AppleScript) |
+| `startupEventWatcher.ts` | Watch server bootstrap events via fs.watch on JSONL |
 | `watcherManager.ts` | Folder watcher for auto-import of audio files |
+| `wslDetect.ts` | **NEW** — detect WSL2 Docker backend + `/dev/dxg` GPU-PV (gates vulkan-wsl2) |
+| `platformGate.ts` | **NEW** — resolve per-OS install strategy (`electron-updater` vs `manual-download`) |
+| `compatGuard.ts` | **NEW** — update server-compat pre-flight (manifest + `/api/admin/status` version) |
+| `launchWatchdog.ts` | **NEW** — failed-launch counter → rollback prompt after 3 failures |
+| `installerCache.ts` | **NEW** — cache the prior Dashboard binary (Linux) for rollback |
+| `updateManager.ts` | Auto-updater: poll GitHub releases, notify |
+| `updateInstaller.ts` | **NEW** — electron-updater download/install state machine (autoDownload=false) |
+| `checksumVerifier.ts` | **NEW** — streaming SHA-256 verify of downloads vs manifest |
+| `sha256Lookup.ts` | **NEW** — resolve expected digest from manifest (fail-closed on ambiguity) |
+| `releaseUrl.ts` | **NEW** — build/validate GitHub release URLs (origin allow-list) |
 
-### IPC Bridge
+### Auto-Update / Installer Pipeline (NEW)
 
-The preload script (`preload.ts`) exposes a `contextBridge` API that the renderer uses to:
-- Manage Docker container (start, stop, restart, update, logs)
-- Access system clipboard and file dialogs
-- Register/unregister global shortcuts
-- Read/write Electron-store settings
-- Detect platform capabilities (Wayland, Docker, D-Bus)
+`updateManager` (GitHub poll/notify) now feeds a hardened pipeline: `compatGuard` (server-compat) →
+`updateInstaller` (download) → `checksumVerifier` + `sha256Lookup` (integrity) → `installerCache` +
+`launchWatchdog` (rollback safety) → `releaseUrl` (manual-download fallback). `platformGate` + `wslDetect`
+gate which strategy/profile is offered per OS/runtime. `appState` underpins compat and idle checks.
 
 ## React Component Structure
 
 ### App Entry (`App.tsx`)
 
-Root component (~1400 lines) that:
-- Wraps with `QueryClientProvider` (React Query) and `DockerProvider`
-- Manages top-level state: `currentView`, live mode, uploading, client running
-- Renders `Sidebar` + active view
-- Hosts modals (Settings, About, AudioNote, BugReport, StarPopup)
+Provider tree: `QueryClientProvider` → `DockerProvider` → `AppInner` (siblings: `ErrorBoundary` →
+`ActivityNotifications`, sonner `Toaster`, `ReactQueryDevtools`). SessionView stays permanently mounted
+(`display:none` when inactive) so WebSocket/audio survive tab switches. **Live mode is lifted to App level**
+(`useLiveMode()`) and passed into SessionView. Singleton bridges mounted once at root: `useServerEventReactor`,
+`useAuthTokenSync`, `useBootstrapDownloads`, `useWatcherFilesBridge`, `useStarPopup`, `useAdminStatus`.
 
-### Views (5 main views + modals)
+### Views (main views + modals)
 
 | View | File | Purpose |
 |------|------|---------|
-| **SessionView** | `components/views/SessionView.tsx` | Primary view: record audio, upload files, display transcription, live mode toggle |
-| **NotebookView** | `components/views/NotebookView.tsx` | Audio notebook: calendar, recording list, search, playback, export |
-| **ServerView** | `components/views/ServerView.tsx` | Docker management, server status, connection config |
-| **ModelManagerView** | `components/views/ModelManagerView.tsx` | Browse/download/select STT models |
-| **LogsView** | `components/views/LogsView.tsx` | Real-time server log viewer (LogTerminal component) |
+| **SessionView** | `views/SessionView.tsx` | Primary view: record, upload, transcription display, live-mode toggle |
+| **LiveTranscriptView** | `views/LiveTranscriptView.tsx` | **NEW** — shared live-transcript area (stream → editable `FindReplaceTextEditor` → idle) |
+| **NotebookView** | `views/NotebookView.tsx` | Audio notebook: calendar, recording list, search, playback, export |
+| **ServerView** | `views/ServerView.tsx` | Docker management, image-tag selection, GPU health |
+| **GpuHealthCard** | `views/GpuHealthCard.tsx` | **NEW** — green/yellow/red GPU status; flags silent CPU fallback |
+| **GpuDiagnosticModal** | `views/GpuDiagnosticModal.tsx` | **NEW** — renders `diagnose-gpu.sh` output with copyable fixes |
+| **ModelManagerView** | `views/ModelManagerView.tsx` | Browse/download/select STT models |
+| **LogsView** | `views/LogsView.tsx` | Real-time server log viewer |
 
-### Modals
+**Modals:** `SettingsModal` (hosts `ServerConfigEditor` + `ModelProfilesPanel` + `EmptyProfileForm`),
+`AboutModal`, `AudioNoteModal` (hosts most recording widgets), `AddNoteModal`, `BugReportModal`,
+`StarPopupModal`, `FullscreenVisualizer`. App.tsx also hosts inline promise-resolver onboarding dialogs
+(model onboarding, dependency install, HuggingFace token, remote-profile chooser).
 
-| Modal | Purpose |
-|-------|---------|
-| `SettingsModal` | App preferences (shortcuts, theme, auth tokens, audio settings) |
-| `AboutModal` | Version info, credits, links |
-| `AudioNoteModal` | Create/view audio notes with transcription |
-| `AddNoteModal` | Quick text note addition |
-| `BugReportModal` | Bug report helper with system info |
-| `ServerConfigEditor` | YAML config editor for server settings |
-| `StarPopupModal` | GitHub star reminder |
-| `FullscreenVisualizer` | Pop-out audio waveform visualizer |
+### Feature Component Groups (NEW — Issue #104 / find-replace / dedup)
 
-### Shared UI Primitives (`components/ui/`)
+| Group | Components | Purpose |
+|-------|-----------|---------|
+| `components/recording/` | `AutoActionStatusBadge`, `ConfidenceChip`, `SpeakerRenameInput`, `DeleteRecordingDialog`, `DownloadButtons`†, `DiarizationReviewView`† | Per-recording widgets (auto-action status, confidence, speaker rename, delete) |
+| `components/profiles/` | `ProfileSelector`, `ModelProfileSelector`, `ModelProfilesPanel`, `EmptyProfileForm`, `TemplatePreviewField` | Profile selection + CRUD UI |
+| `components/editor/` | `FindReplaceTextEditor`, `FindReplaceToolbar` | Reusable transcript editor (3 surfaces) |
+| `components/import/` | `DedupChoiceContainer`, `DedupPromptModal` | "Use existing / Create new" dedup prompt |
 
-10 reusable components:
+† Built-ahead, currently referenced only by tests — present but not yet hosted in a live view (also `AriaLiveRegion`).
 
-| Component | Purpose |
-|-----------|---------|
-| `GlassCard` | Glassmorphism card container with backdrop blur |
-| `Button` | Themed button with variants (primary, secondary, danger) |
-| `AppleSwitch` | iOS-style toggle switch |
-| `CustomSelect` | Accessible dropdown with keyboard navigation |
-| `StatusLight` | Colored indicator dot (green/yellow/red/gray) |
-| `ErrorFallback` | Error boundary fallback UI |
-| `LogTerminal` | Terminal-style log viewer with ANSI color support |
-| `ShortcutCapture` | Keyboard shortcut recorder for settings |
-| `QueuePausedBanner` | Import queue pause indicator |
-| `ActivityNotifications` | Toast-style activity feed (downloads, warnings) |
+### Shared UI Primitives (`components/ui/`, 14)
+
+`GlassCard`, `Button`, `AppleSwitch`, `CustomSelect`, `StatusLight`, `ErrorFallback`, `LogTerminal`,
+`ShortcutCapture`, `QueuePausedBanner`, `ActivityNotifications`, plus **NEW**: `ImageTagChips` (Docker
+image-tag selector chips), `PersistentInfoBanner` (non-dismissing info banner + CTA), `UpdateBanner`
+(in-app dashboard-update banner, 5 states), `UpdateModal` (pre-install decision surface).
 
 ## State Management
 
-### Three-tier state pattern:
+### Three-tier pattern
 
-1. **React Query** — Server data (models, recordings, admin status, server health)
-   - `staleTime` tuned per query (health: 5s, recordings: 30s, models: 60s)
-   - Invalidation on mutations + `useServerEventReactor` for state transitions
-   - File: `src/queryClient.ts`
+1. **React Query** — server data (models, recordings, admin status, health), `staleTime` tuned per query.
+2. **Zustand** — 5 ephemeral client-only stores (selector pattern, `useShallow` for arrays):
+   - `activityStore` — activity/notification feed
+   - `importQueueStore` — upload/import queue + watcher state
+   - `activeProfileStore` **NEW** — active notebook profile id (persisted)
+   - `ariaAnnouncerStore` **NEW** — polite/assertive aria-live messages (self-clears after 5 s)
+   - `dedupChoiceStore` **NEW** — promise-bridge between import queue and `DedupPromptModal`
+3. **React component state** — view-local UI state.
 
-2. **Zustand** — Ephemeral client-only state
-   - `activityStore`: 4-category model (download, server, warning, info) with status lifecycle
-   - `importQueueStore`: Import queue state + async processing logic
-   - Selector pattern: `useStore(selector)` — never subscribe to whole store
-   - `useShallow` for array selectors to prevent unnecessary re-renders
+### `useServerEventReactor`
 
-3. **React component state** — View-local UI state (current tab, form inputs, toggles)
+Transition matrix reacting to server status changes: Docker starting → poll health; server ready →
+invalidate model queries; model loaded → update capability flags; GPU error → degraded-mode banner.
 
-### Key state flow: `useServerEventReactor`
+## Custom Hooks (33+)
 
-Transition matrix that reacts to server status changes:
-- Docker starting → poll for health
-- Server ready → invalidate model queries
-- Model loaded → update capability flags
-- GPU error → show degraded mode banner
+**Core:** `useTranscription`, `useLiveMode`, `useRecording`, `useUpload`, `useDocker` (+`DockerContext`),
+`useServerStatus`, `useServerEventReactor`. **Notebook/search:** `useCalendar`, `useSearch`,
+`useNotebookWatcher`, `useWordHighlighter`, `useImportQueue`, `useSessionImportQueue`, `useSessionWatcher`.
+**System:** `useAdminStatus`, `useAuthTokenSync`, `useBackups`, `useBootstrapDownloads`, `useClipboard`,
+`useConfirm`, `useLanguages`, `useStarPopup`, `useTraySync`, `useClientDebugLogs`.
 
-## Custom Hooks (20+)
+**NEW (Issue #104 / a11y / file I/O):**
 
-| Hook | Purpose | Key Dependencies |
-|------|---------|-----------------|
-| `useTranscription` | WebSocket transcription lifecycle | websocket.ts, React Query |
-| `useLiveMode` | Live mode streaming + model swap | websocket.ts, audioCapture.ts |
-| `useDocker` | Docker container management | Electron IPC |
-| `useServerStatus` | Server health polling + GPU error detection | React Query |
-| `useRecording` | Audio recording (mic capture) | audioCapture.ts |
-| `useUpload` | File upload transcription | API client |
-| `useImportQueue` | Batch import queue processing | importQueueStore |
-| `useSessionImportQueue` | Session-scoped import | importQueueStore |
-| `useCalendar` | Notebook calendar data | React Query |
-| `useSearch` | Full-text search | React Query |
-| `useAdminStatus` | Admin config and feature flags | React Query |
-| `useAuthTokenSync` | Auto-detect auth token from Docker logs | Electron IPC |
-| `useBackups` | Database backup management | React Query |
-| `useBootstrapDownloads` | Bootstrap dependency progress | startupEventWatcher |
-| `useLanguages` | Language list from server | React Query |
-| `useServerEventReactor` | Server state transition matrix | React Query, Zustand |
-| `useNotebookWatcher` | Watch for new recordings | React Query invalidation |
-| `useTraySync` | Sync state to system tray | Electron IPC |
-| `useWordHighlighter` | Word-level highlight during playback | Component state |
-| `useConfirm` | Confirmation dialog | Component state |
+| Hook | Purpose | Feature |
+|------|---------|---------|
+| `useFindReplace` | Find/replace state over a textarea (drives native selection) | Editor |
+| `useRecordingAliases` | Fetch/mutate per-recording speaker aliases (render-time substitution) | Diarization |
+| `useDiarizationConfidence` | Per-turn confidence → `Map<turn_index, confidence>` | Diarization |
+| `useDiarizationReview` | ADR-009 review lifecycle (`open`/`complete`) | Diarization |
+| `useAutoActionRetry` | Mutation to `POST .../auto-actions/retry` | Auto-actions |
+| `useWatcherFilesBridge` | Singleton watcher→import-queue bridge (Issue #94 double-queue fix) | Import |
+| `useFolderPicker` / `useFileSaveDialog` | Native folder / file-save dialogs | File I/O |
+| `useAriaAnnouncer` | Push polite/assertive screen-reader messages | Accessibility |
 
 ## Services Layer (`src/services/`)
 
-| Service | Purpose |
-|---------|---------|
-| `websocket.ts` | WebSocket client with reconnect, auth, binary frame support |
-| `audioCapture.ts` | Web Audio API mic capture (AudioWorklet, PCM Int16) |
-| `modelCapabilities.ts` | Model capability detection (translation, language support) |
-| `modelRegistry.ts` | Known model registry with metadata (size, VRAM, features) |
-| `modelSelection.ts` | Model selection logic for UI dropdowns |
-| `transcriptionFormatters.ts` | Format transcription segments for display |
-| `clientDebugLog.ts` | Client-side debug logging |
+**Existing:** `websocket.ts` (reconnect, auth, binary frames), `audioCapture.ts` (Web Audio AudioWorklet,
+PCM Int16), `modelCapabilities.ts`, `modelRegistry.ts`, `modelSelection.ts`, `transcriptionFormatters.ts`,
+`clientDebugLog.ts`.
 
-## API Client (`src/api/client.ts`)
-
-Fetch-based HTTP client with:
-- Base URL configuration (localhost or remote server)
-- Bearer token auth (auto-attached from settings)
-- Multipart file upload support
-- Error handling with typed responses
+**NEW:** `findReplaceEngine.ts` (pure literal find/replace), `modelProfileStore.ts` (model-profile CRUD in
+electron-store), `profileDefaults.ts` (empty-profile defaults; auto-actions off by default), `transcriptFlatten.ts`
+(segments → editable plain text), `versionUtils.ts` (Docker-tag parse/compare + GHCR repo resolution per runtime).
 
 ## Build Pipeline
 
-### Development
 ```bash
-npm run dev          # Vite dev server (port 3000)
-npm run dev:electron # Vite + Electron together
-```
-
-### Production
-```bash
-npm run build          # Vite production build
-npm run build:electron # Build + TypeScript compile for Electron
+npm run dev:electron   # Vite + Electron together (dev)
+npm run build:electron # Vite build + TypeScript compile
 npm run package:linux  # AppImage
 npm run package:mac    # DMG + ZIP (arm64)
-npm run package:windows # NSIS installer
-```
-
-### Quality
-```bash
-npm run typecheck         # TypeScript + JS type checking
-npm run format:check      # Prettier format check
-npm run ui:contract:check # UI contract validation
-npm run test              # Vitest unit tests
-npm run check             # All quality gates
+npm run package:windows# NSIS installer
+npm run check          # typecheck + format:check + ui:contract:check + test
 ```
 
 ### UI Contract System
 
-CSS class integrity validation:
-1. `ui:contract:extract` — Extract CSS class facts from source
-2. `ui:contract:build` — Build contract YAML
-3. `ui:contract:validate` — Validate against baseline
-4. `ui:contract:check` — Read-only validation (CI-safe)
+CSS class integrity validation: `ui:contract:extract` → `ui:contract:build` → `ui:contract:validate`
+(`--update-baseline`) → `ui:contract:check` (read-only, CI-safe). Run after any UI edit touching CSS classes.
 
 ## Key Design Decisions
 
-- **Relative imports only** — Despite `@/` alias in tsconfig, codebase uses relative paths
+- **Relative imports only** — despite `@/` alias in tsconfig
 - **Components at root** — React components in `dashboard/components/`, logic in `dashboard/src/`
-- **Vite base `'./'`** — Required for Electron `file://` protocol (never change to `/`)
-- **Named exports only** — No default exports in hooks/services
+- **Vite base `'./'`** — required for Electron `file://` protocol (never change to `/`)
+- **Named exports only** — no default exports in hooks/services
 - **ESM modules** — `"type": "module"` in package.json
-- **Selector pattern** — Zustand stores always accessed via selectors, never whole store
+- **Selector pattern** — Zustand stores always accessed via selectors, never the whole store
+- **SessionView never unmounts** — kept alive via `display:none` to preserve WS/audio across tabs

--- a/docs/architecture-server.md
+++ b/docs/architecture-server.md
@@ -1,6 +1,6 @@
 # TranscriptionSuite — Server Architecture
 
-> Generated: 2026-04-05 | Part: server | Type: backend | Python 3.13 / FastAPI
+> Generated: 2026-06-11 | v1.3.6 | Part: server | Type: backend | Python 3.13 / FastAPI
 
 ## Executive Summary
 
@@ -15,7 +15,7 @@ The server is a Python 3.13 FastAPI application that provides speech-to-text tra
 | Server | uvicorn | 0.41.0 | ASGI server |
 | Validation | Pydantic | 2.12.5 | Request/response schemas |
 | Database | SQLAlchemy + aiosqlite | 2.0.48 / 0.22.1 | Async SQLite with FTS5 |
-| Migrations | Alembic | 1.18.4 | Schema versioning (6 versions) |
+| Migrations | Alembic | 1.18.4 | Schema versioning (17 versions) |
 | ML Framework | PyTorch | 2.8.0 | GPU inference (CUDA 12.9) |
 | Diarization | pyannote.audio | 4.0.4 | Speaker identification |
 | Audio | soundfile, scipy, ffmpeg-python | Various | Audio I/O, resampling, conversion |
@@ -53,10 +53,11 @@ Routes are organized by domain, each defining an `APIRouter()` included in `main
 | `health.py` | `/health`, `/ready`, `/api/status` | Health probes, server status |
 | `auth.py` | `/api/auth` | Token-based authentication |
 | `transcription.py` | `/api/transcribe` | File upload transcription, cancel, languages |
-| `notebook.py` | `/api/notebook` | Audio notebook CRUD, calendar, backup, search |
+| `notebook.py` | `/api/notebook` | Audio notebook CRUD, calendar, backup, aliases, diarization-review, auto-actions |
+| `profiles.py` | `/api/profiles` | Transcription/recording profile CRUD (Issue #104) |
 | `search.py` | `/api/search` | Full-text search (FTS5) |
-| `llm.py` | `/api/llm` | LM Studio summarization and chat |
-| `admin.py` | `/api/admin` | Config management, model loading, logs |
+| `llm.py` | `/api/llm` | Local LLM summarization, chat, and conversation CRUD |
+| `admin.py` | `/api/admin` | Config management, model loading, logs, webhook test |
 | `openai_audio.py` | `/v1/audio` | OpenAI-compatible transcription endpoint |
 | `websocket.py` | `/ws` | Longform recording transcription (WebSocket) |
 | `live.py` | `/ws/live` | Real-time live transcription (WebSocket) |
@@ -103,7 +104,13 @@ Central hub for all ML model lifecycle management:
 | MLX Canary | `MLXCanaryBackend` | `*/canary*-mlx` | Yes | Apple Silicon |
 | MLX VibeVoice | `MLXVibeVoiceBackend` | `mlx-community/vibevoice*` | No | Apple Silicon |
 
-**Factory routing** (`factory.py`): `detect_backend_type(model_name)` matches patterns in priority order (first match wins).
+**Factory routing** (`factory.py`): `detect_backend_type(model_name)` matches patterns in priority order
+(first match wins). The `whisper` default resolves at runtime to `WhisperXBackend` (if `whisperx` is
+importable) or `FasterWhisperBackend` (fallback). Notes: `CanaryBackend` subclasses `ParakeetBackend`
+(not `STTBackend` directly); the four MLX backends mix in `MLXThreadAffinityMixin` (`mlx_thread_pin.py`,
+GH #134) to pin GPU ops to one owning thread; `MLXCanaryBackend.supports_translation()` is `False` (the
+`canary-mlx` port is ASR-only). `whisper_backend.py` (`WhisperBackend`) is **legacy/orphaned** — defined
+but not wired into the factory; `FasterWhisperBackend` superseded it.
 
 ### Live Engine (`core/live_engine.py`)
 
@@ -124,22 +131,42 @@ PyAnnote 4.x speaker diarization pipeline:
 - FFmpeg backend: SoX resampler, dynamic range normalization, format conversion
 - CUDA health check: Detect unrecoverable GPU state at startup
 - GPU memory management: `clear_gpu_cache()` after each job
+- Audio hashing: raw + normalized SHA-256 for dedup; multi-channel handling in `core/multitrack.py`
+
+### Issue #104 Subsystems (Audio Notebook QoL)
+
+A cluster of business-logic modules added for the Audio Notebook QoL pack:
+
+| Subsystem | Modules | Purpose |
+|-----------|---------|---------|
+| **Profiles** | `database/profile_repository.py` | Transcription/recording profiles; public/private field separation; snapshotted into jobs |
+| **Speaker aliases** | `core/alias_substitution.py`, `database/alias_repository.py` | Read-time speaker display-name substitution (never mutates stored segments) |
+| **Diarization review** | `core/diarization_confidence.py`, `diarization_review_filter.py`, `diarization_review_lifecycle.py`, `database/diarization_review_repository.py` | Per-turn confidence + ADR-009 `pending→in_review→completed→released` lifecycle |
+| **Auto-actions** | `core/auto_action_coordinator.py`, `auto_action_sweeper.py`, `auto_summary_engine.py`, `database/auto_action_repository.py` | Fire auto-summary/auto-export/webhook per profile; deferred-export sweeper; retry/escalation ladder |
+| **Webhooks (durable)** | `core/webhook_payload.py`, `webhook_url_validation.py`, `services/webhook_worker.py`, `database/webhook_deliveries_repository.py`, `webhook_cleanup.py` | Persist-Before-Deliver outgoing `transcription.completed` webhooks with SSRF allowlist + retry |
+| **Webhooks (legacy)** | `core/webhook.py` | Fire-and-forget `live_sentence`/`longform_complete` (no persistence) |
+| **Misc** | `core/filename_template.py`, `plaintext_export.py`, `hf_token_guard.py`, `multitrack.py` | Export filename templating, FR9 plaintext export, non-ASCII HF-token purge (GH #125), multi-channel transcription |
 
 ## Data Layer
 
 ### Database Schema
 
-**SQLite + FTS5** with 6 migration versions:
+**SQLite + FTS5** with 17 migration versions. Full column-level reference in
+[data-models-server.md](./data-models-server.md).
 
 | Table | Purpose | Key Columns |
 |-------|---------|-------------|
-| `recordings` | Audio notebook entries | id, filename, filepath, title, duration, recorded_at, has_diarization, summary, transcription_backend |
-| `segments` | Transcription segments | id, recording_id, text, start_time, end_time, speaker |
-| `words` | Word-level timestamps | id, segment_id, word, start_time, end_time, confidence |
-| `recordings_fts` | Full-text search index | FTS5 virtual table |
-| `transcription_jobs` | Durability layer | id, status, source, client_name, audio_path, result_text, result_json, delivered, audio_hash |
-| `recordings` | Notebook recordings | id, filename, filepath, title, duration_seconds, recorded_at, imported_at, audio_hash |
-| `chat_history` | LLM conversations | recording_id, messages, model |
+| `recordings` | Audio notebook entries | id, filename, filepath, title, duration_seconds, recorded_at, has_diarization, summary, transcription_backend, audio_hash, normalized_audio_hash, auto_*_status, transcript_corrected |
+| `segments` | Transcription segments | id, recording_id, segment_index, speaker, text, start_time, end_time |
+| `words` | Word-level timestamps | id, recording_id, segment_id, word, start_time, end_time, confidence |
+| `words_fts` | Full-text search index | FTS5 virtual table over `words.word` (synced by triggers) |
+| `conversations` | LLM chat sessions | id, recording_id, title, response_id, model |
+| `messages` | LLM chat history | id, conversation_id, role, content, model, tokens_used |
+| `transcription_jobs` | Durability ledger (TEXT UUID PK) | id, status, source, client_name, audio_path, result_text, result_json, delivered, audio_hash, normalized_audio_hash, job_profile_snapshot |
+| `profiles` | Transcription/recording profiles | id, name, schema_version, public_fields_json, private_field_refs_json |
+| `recording_diarization_review` | Review lifecycle (1:1) | recording_id, status, reviewed_turns_json |
+| `recording_speaker_aliases` | Speaker aliases (1:N) | id, recording_id, speaker_id, alias_name |
+| `webhook_deliveries` | Outgoing-webhook ledger (1:N) | id, recording_id, profile_id, status, attempt_count, payload_json |
 
 #### Audio dedup scope (FR4 / R-EL23)
 
@@ -183,7 +210,13 @@ no shared registry. Cross-user dedup is an explicit non-goal.
 
 **Environment overrides:** `MAIN_TRANSCRIBER_MODEL`, `LIVE_TRANSCRIBER_MODEL`, `DIARIZATION_MODEL`, `LOG_LEVEL`, `INSTALL_WHISPER`, `INSTALL_NEMO`, `INSTALL_VIBEVOICE_ASR`, `HF_TOKEN`, `WHISPERCPP_SERVER_URL`
 
-**Key config sections:** `main_transcriber`, `live_transcriber`, `diarization`, `audio_processing`, `storage`, `durability`, `backup`, `logging`, `webhook`, `remote_server` (TLS)
+**Key config sections:** `longform_recording`, `static_transcription`, `main_transcriber`, `parakeet`,
+`sortformer`, `mlx`, `vibevoice_asr`, `live_transcriber`, `diarization`, `audio_processing`, `storage`,
+`backup`, `local_llm` (OpenAI-compatible LLM — note: not `lm_studio`), `remote_server` (TLS), `logging`,
+`webhook` (legacy global), `stt`, `durability`, `auto_actions`, `webhook_deliveries` (durable per-profile)
+
+> Profiles themselves live in the DB (`profiles` table); per-profile auto-summary/auto-export/webhook
+> settings are profile columns, gated globally by the `auto_actions` and `webhook_deliveries` toggles.
 
 ## Startup Sequence
 
@@ -196,14 +229,16 @@ no shared registry. Cross-user dedup is an explicit non-goal.
 7. CUDA health probe (detect unrecoverable GPU state)
 8. Create ModelManager (lazy import torch)
 9. Preload main transcriber model
-10. Schedule periodic orphan sweep (every 30 min)
-11. Emit startup events to event stream
+10. Schedule periodic orphan sweep (every 30 min) + deferred-export sweeper + webhook retention cleanup
+11. Start the durable WebhookWorker singleton (re-fires `in_flight` deliveries from prior run)
+12. Emit startup events to event stream
 
-**Shutdown:** Cancel cleanup tasks → drain WebSocket sessions (120s timeout) → cleanup models → exit
+**Shutdown:** Cancel cleanup/sweeper tasks → stop WebhookWorker (revert `in_flight` → `pending`) →
+drain WebSocket sessions (120s timeout) → cleanup models → exit
 
 ## Deployment
 
-- **Docker**: Ubuntu 24.04 base, 7 compose variants (base, linux-host, desktop-vm, GPU, GPU-CDI, Vulkan, Podman)
+- **Docker**: Ubuntu 24.04 base, 8 compose variants (base, linux-host, desktop-vm, GPU, GPU-CDI, Vulkan, Vulkan-WSL2, Podman)
 - **Bootstrap**: Python deps installed at first container start into `/runtime/.venv` (not baked into image)
 - **Volumes**: `transcription-data` (database, audio), `huggingface-models` (model cache), `runtime-deps` (venv)
 - **Health check**: `GET /health` every 30s, 600s start period for model downloads

--- a/docs/architecture/dashboard-components.puml
+++ b/docs/architecture/dashboard-components.puml
@@ -14,7 +14,7 @@ skinparam cloudBackgroundColor #45475a
 skinparam cloudBorderColor #89b4fa
 skinparam linetype ortho
 
-title Dashboard Component Tree (Electron React App)
+title Dashboard Component Tree (Electron React App) - v1.3.6
 
 ' ── Root ──────────────────────────────────────────
 package "App.tsx" as root {
@@ -26,51 +26,61 @@ package "App.tsx" as root {
 note right of appInner
   Lifted state:
   currentView, useLiveMode(),
-  clientRunning, isUploading
+  clientRunning, serverIsBusy
+  Singleton bridges: ServerEventReactor,
+  AuthTokenSync, WatcherFilesBridge
 end note
 
 queryProvider -down-> dockerProvider
 dockerProvider -down-> appInner
 
 ' ── Layout ────────────────────────────────────────
-component "Sidebar" as sidebar
+package "Sidebar" as sidebarPkg {
+  component "Sidebar" as sidebar
+  component "ProfileSelector /\nModelProfileSelector" as profileSel
+  sidebar --> profileSel
+}
 
-appInner -down-> sidebar
+appInner -down-> sidebarPkg
 
 ' ── Views + their hooks (grouped) ─────────────────
 package "SessionView" as sessionPkg {
   component "SessionView" as sessionView
+  component "LiveTranscriptView" as liveView
   component "useTranscription" as hookTranscribe
   component "useLiveMode\n(from parent)" as hookLive
-  component "useRecording" as hookRecording
-  component "useUpload" as hookUpload
+  component "useRecording / useUpload" as hookRecording
   component "AudioVisualizer" as audioVis
 
+  sessionView --> liveView
   sessionView --> hookTranscribe
   sessionView --> hookLive
   sessionView --> hookRecording
-  sessionView --> hookUpload
   sessionView --> audioVis
 }
 
 package "NotebookView" as notebookPkg {
   component "NotebookView" as notebookView
-  component "useCalendar" as hookCalendar
-  component "useSearch" as hookSearch
+  component "AudioNoteModal" as audioNote
+  component "useCalendar / useSearch" as hookCalendar
   component "useImportQueue" as hookImport
 
+  notebookView --> audioNote
   notebookView --> hookCalendar
-  notebookView --> hookSearch
   notebookView --> hookImport
 }
 
 package "ServerView" as serverPkg {
   component "ServerView" as serverView
-  component "useDocker" as hookDocker
-  component "useServerStatus" as hookServer
+  component "GpuHealthCard" as gpuCard
+  component "GpuDiagnosticModal" as gpuDiag
+  component "ImageTagChips" as imgTags
+  component "useDocker / useServerStatus" as hookDocker
 
+  serverView --> gpuCard
+  gpuCard --> gpuDiag
+  serverView --> imgTags
   serverView --> hookDocker
-  serverView --> hookServer
 }
 
 package "ModelManagerView" as modelPkg {
@@ -80,7 +90,6 @@ package "ModelManagerView" as modelPkg {
 package "LogsView" as logsPkg {
   component "LogsView" as logsView
   component "LogTerminal" as logTerm
-
   logsView --> logTerm
 }
 
@@ -90,28 +99,50 @@ appInner -down-> serverPkg
 appInner -down-> modelPkg
 appInner -down-> logsPkg
 
-' ── Services (shared) ─────────────────────────────
+' ── Feature component groups (Issue #104) ─────────
+package "Feature Components" as featurePkg {
+  component "recording/\n(AutoActionStatusBadge,\nConfidenceChip,\nSpeakerRenameInput,\nDeleteRecordingDialog)" as recCmp
+  component "profiles/\n(ModelProfilesPanel,\nEmptyProfileForm,\nTemplatePreviewField)" as profCmp
+  component "editor/\n(FindReplaceTextEditor,\nFindReplaceToolbar)" as editCmp
+  component "import/\n(DedupChoiceContainer,\nDedupPromptModal)" as impCmp
+}
+
+audioNote --> recCmp
+liveView --> editCmp
+appInner --> impCmp
+
+' ── Services + Stores (shared) ────────────────────
 package "Services" as services {
   component "API Client\n(client.ts)" as apiClient
-  component "TranscriptionSocket\n(websocket.ts)" as wsService
-  component "AudioCapture\n(audioCapture.ts)" as audioCap
-  component "Model Capabilities /\nModel Selection" as modelSvc
+  component "WebSocket\n(websocket.ts)" as wsService
+  component "AudioCapture" as audioCap
+  component "findReplaceEngine /\nmodelProfileStore /\nversionUtils" as svcNew
+}
+
+package "Zustand Stores (5)" as stores {
+  component "activityStore" as st1
+  component "importQueueStore" as st2
+  component "activeProfileStore" as st3
+  component "ariaAnnouncerStore" as st4
+  component "dedupChoiceStore" as st5
 }
 
 ' Hook → Service wiring (grouped to reduce arrows)
 hookTranscribe -down-> wsService
 hookLive -down-> wsService
 hookRecording -down-> audioCap
-hookUpload -down-> apiClient
-hookSearch -down-> apiClient
+hookImport -down-> st2
 hookCalendar -down-> apiClient
-hookServer -down-> apiClient
+hookDocker -down-> apiClient
+impCmp -down-> st5
+profileSel -down-> st3
+editCmp -down-> svcNew
 
-' ── Modals (simple list) ──────────────────────────
+' ── Modals (App-hosted) ───────────────────────────
 package "Modals" as modals {
-  component "SettingsModal" as settingsModal
-  component "AboutModal" as aboutModal
-  component "AudioNoteModal" as audioNoteModal
+  component "SettingsModal\n(+ ModelProfilesPanel)" as settingsModal
+  component "AboutModal / BugReportModal" as miscModal
+  component "DedupChoiceContainer" as dedupRoot
 }
 
 appInner -down-> modals

--- a/docs/architecture/data-flow.puml
+++ b/docs/architecture/data-flow.puml
@@ -18,7 +18,7 @@ skinparam cloudBorderColor #89b4fa
 skinparam databaseBackgroundColor #313244
 skinparam databaseBorderColor #585b70
 
-title Transcription Data Flows
+title Transcription Data Flows (v1.3.6)
 
 actor User
 participant "Dashboard\n(Electron)" as UI
@@ -28,19 +28,17 @@ participant "FastAPI\nServer" as Server
 participant "Model\nManager" as MM
 participant "STT\nBackend" as STT
 participant "Diarization\nEngine" as Diar
+participant "Auto-Action\n+ Webhook" as Auto
 database "SQLite\n+ FTS5" as DB
+participant "External\nwebhook" as Hook
 
-== Longform Transcription (Record) ==
+== Longform Transcription (Record via /ws) ==
 
 User -> UI : Click "Record"
 UI -> Audio : Start capture (mic)
-Audio -> WS : Open /ws
-WS -> Server : Auth handshake (token)
-Server --> WS : Auth OK
-
-WS -> Server : {start: {language, device, translate}}
-Server -> MM : get_transcription_model()
-MM --> Server : STTBackend instance
+Audio -> WS : Open /ws + auth handshake
+WS -> Server : {start: {language, profile_id?}}
+Server -> DB : create_job() (status=processing)
 
 loop Audio streaming
   Audio -> WS : PCM Int16 binary chunks
@@ -48,83 +46,90 @@ loop Audio streaming
 end
 
 User -> UI : Click "Stop"
-UI -> Audio : Stop capture
 WS -> Server : {stop: true}
-
+Server -> Server : persist audio → /data/recordings/{job_id}.wav
 Server -> STT : transcribe(audio, language, task)
 STT --> Server : (segments[], info)
 
 opt Diarization enabled
   Server -> Diar : diarize(audio)
-  Diar --> Server : speaker segments
-  Server -> Server : merge transcription\n+ diarization
+  Diar --> Server : speaker segments → merge
 end
 
-Server -> DB : Save recording + segments + words
-Server --> WS : {result: {segments, words, language, ...}}
+note over Server, DB
+  Persist-Before-Deliver:
+  save_result() to DB BEFORE sending
+end note
+Server -> DB : save_result()
+alt result <= 1 MB
+  Server --> WS : {type: final, ...}
+  Server -> DB : mark_delivered()
+else result > 1 MB
+  Server --> WS : {type: result_ready, job_id}
+  WS -> Server : GET /api/transcribe/result/{job_id}
+  Server --> WS : result + mark_delivered()
+end
 WS --> UI : Display transcription
-WS -> WS : Close connection
 
-== Longform Transcription (File Upload) ==
+== Notebook Upload + Dedup ==
 
-User -> UI : Upload audio file
-UI -> Server : POST /api/transcribe/upload\n(multipart file)
-Server -> Server : FFmpeg decode to PCM
-Server -> STT : transcribe(audio)
+User -> UI : Upload audio file(s)
+UI -> Server : POST /api/transcribe/import/dedup-check\n(raw + normalized SHA-256)
+Server -> DB : find_duplicates_anywhere()
+Server --> UI : dedup_matches[]
+opt Duplicate found
+  UI -> User : DedupPromptModal (use existing / new)
+end
+UI -> Server : POST /api/notebook/transcribe/upload (202 + job_id)
+Server -> STT : transcribe() (background)
 STT --> Server : (segments[], info)
-Server -> DB : Save recording
-Server --> UI : {recording_id, segments}
+Server -> DB : save_longform_to_database()\n(recordings + segments + words + hashes)
+UI -> Server : poll GET /result/{job_id}
+
+== Auto-Actions + Webhook Delivery ==
+
+note over Server, Auto
+  Triggered when a profile-bound
+  recording completes
+end note
+Server -> Auto : trigger_auto_actions(recording_id, profile_snapshot)
+Auto -> Auto : auto-summary (LLM) + auto-export (file)
+Auto -> DB : webhook_deliveries (status=pending, frozen payload)
+Auto -> DB : mark_in_flight (committed BEFORE POST)
+Auto -> Hook : POST transcription.completed (HTTPS, SSRF-checked)
+alt 2xx
+  Hook --> Auto : success
+  Auto -> DB : mark_success
+else failure
+  Hook --> Auto : non-2xx / timeout
+  Auto -> DB : mark_failed → 30s retry → manual_intervention_required
+end
 
 == Live Mode (Real-time) ==
 
 User -> UI : Toggle "Live Mode"
-UI -> WS : Open /ws/live
-WS -> Server : Auth handshake (token)
-
+UI -> WS : Open /ws/live + auth
 note over Server, MM
-  Model Swap Sequence:
-  1. Unload main transcription model
-  2. Load live model (e.g. whisper-medium)
+  Model Swap: unload main → load live model
+  (Whisper / whisper.cpp only)
 end note
-
-Server -> MM : unload main model
-Server -> MM : load live model
-MM -> STT : load(live_model_name)
-
-WS -> Server : {start: {language, translate}}
+Server -> MM : unload main, load live model
 
 loop Continuous streaming
-  Audio -> WS : PCM Int16 chunks (continuous)
-  WS -> Server : forward audio
-
+  Audio -> WS : PCM Int16 chunks
   Server -> Server : VAD detects speech segment
-
-  alt #543a67 Speech segment complete
+  alt #543a67 Sentence complete
     Server -> STT : transcribe(segment)
-    STT --> Server : (text, timestamps)
-    Server --> WS : {type: "sentence", text: "..."}
-    WS --> UI : Append sentence
+    Server --> WS : {type: sentence, text}
+    Server -> Hook : live_sentence webhook (legacy, fire-and-forget)
   else Partial speech
-    Server --> WS : {type: "partial", text: "..."}
-    WS --> UI : Update partial text
+    Server --> WS : {type: partial, text}
   end
 end
 
 User -> UI : Toggle "Live Mode" off
 WS -> Server : {stop: true}
-
-note over Server, MM
-  Model Restore Sequence:
-  1. Unload live model
-  2. Reload main transcription model
-end note
-
-Server -> MM : unload live model
-Server -> MM : load main model
-MM -> STT : load(main_model_name)
-
-Server -> DB : Save live session
-Server --> WS : {result: final_transcript}
-WS -> WS : Close connection
+Server -> MM : unload live, reload main model
+Server --> WS : {state: STOPPED}
 
 @enduml

--- a/docs/architecture/overview.puml
+++ b/docs/architecture/overview.puml
@@ -20,62 +20,72 @@ skinparam fileBackgroundColor #313244
 skinparam fileBorderColor #585b70
 skinparam linetype ortho
 
-title TranscriptionSuite - System Architecture
+title TranscriptionSuite - System Architecture (v1.3.6)
 
 ' ── Tier 1: Electron ──────────────────────────────
 package "Electron App" as electron #181825 {
   package "Main Process" as elMain {
     component "IPC Bridge" as ipc
     component "Docker Manager" as dockerMgr
+    component "Auto-Update Pipeline\n(installer, checksum,\nrollback)" as updatePipe
     component "System Tray /\nGlobal Shortcuts" as trayShortcuts
   }
 
   package "Renderer (React)" as renderer {
     component "Views\n(Session, Notebook,\nServer, Models, Logs)" as views
+    component "Profiles / Aliases /\nDiarization Review /\nFind-Replace" as featureUI
     component "Sidebar" as sidebar
   }
 
-  package "Services" as services {
+  package "Services + Stores" as services {
     component "API Client" as apiClient
     component "WebSocket Client" as wsClient
     component "Audio Capture" as audioCapture
+    component "Zustand Stores (5)" as stores
   }
 }
 
 ' ── Tier 2: Server ────────────────────────────────
 package "Docker Container" as docker #181825 {
   package "FastAPI (port 9786)" as fastapi {
-    component "REST Routes\n(/api/transcribe, /notebook,\n/search, /llm, /admin, /auth)" as restRoutes
+    component "REST Routes\n(/transcribe, /notebook,\n/profiles, /search, /llm,\n/admin, /auth, /v1/audio)" as restRoutes
     component "WebSocket\n/ws (longform)\n/ws/live (real-time)" as wsEndpoints
   }
 
   package "Core Engine" as core {
     component "Model Manager" as modelMgr
-    component "STT Backends\n(WhisperX, NeMo, VibeVoice,\nwhisper.cpp, MLX variants)" as sttBackends
+    component "STT Backends (10)\n(WhisperX, NeMo, VibeVoice,\nwhisper.cpp, MLX variants)" as sttBackends
     component "Live Engine" as liveEngine
-    component "Diarization\n(PyAnnote)" as diarEngine
+    component "Diarization\n(PyAnnote / Sortformer)" as diarEngine
+    component "Auto-Action Coordinator\n+ Webhook Worker" as autoActions
   }
 }
 
 ' ── Tier 3: Data ──────────────────────────────────
 package "Data Layer" as data #181825 {
-  database "SQLite + FTS5" as db
+  database "SQLite + FTS5\n(11 tables, 17 migrations)" as db
   storage "Model Cache" as modelCache
   file "config.yaml" as configFile
+  storage "Audio recordings\n(/data/recordings)" as audioStore
 }
 
 ' ── External ──────────────────────────────────────
 cloud "HuggingFace Hub" as hfHub
-cloud "GPU (CUDA)" as gpu
+cloud "GPU\n(CUDA/Vulkan/Metal)" as gpu
+cloud "Local LLM\n(LM Studio)" as llm
+cloud "External Webhook\nendpoint" as webhook
+cloud "GitHub Releases" as github
 
 ' ── Connections (minimized) ───────────────────────
 
 ' Electron internal
 views -down-> services
+featureUI -down-> services
 views <-left-> sidebar
 renderer <--> ipc
 trayShortcuts --> ipc
 ipc --> dockerMgr
+updatePipe --> github : "update check\n+ download"
 
 ' Services to Server
 apiClient -down-> restRoutes : "REST"
@@ -87,16 +97,20 @@ restRoutes -down-> core
 wsEndpoints -down-> core
 modelMgr -right-> sttBackends
 liveEngine --> modelMgr
+restRoutes --> autoActions
 
 ' Data access
 restRoutes -down-> db
 core -down-> db
 modelMgr -down-> modelCache
 fastapi -down-> configFile
+core -down-> audioStore
 
 ' External
 modelMgr -down-> hfHub : "download"
 sttBackends -down-> gpu : "inference"
 diarEngine -down-> gpu
+core -down-> llm : "summarize/chat"
+autoActions -down-> webhook : "transcription.completed\n(durable, SSRF-guarded)"
 
 @enduml

--- a/docs/architecture/server-api.puml
+++ b/docs/architecture/server-api.puml
@@ -15,7 +15,7 @@ skinparam linetype ortho
 
 left to right direction
 
-title Server API & Routing (api/main.py)
+title Server API & Routing (api/main.py) - v1.3.6
 
 ' ── Middleware ─────────────────────────────────────
 package "Middleware" as middleware {
@@ -28,40 +28,49 @@ package "Middleware" as middleware {
 component "Lifespan Handler" as lifespan
 
 note bottom of lifespan
-  Startup: logging, init_db(),
-  token store, ModelManager,
-  ML import pre-warm,
-  preload model (GPU)
+  Startup: logging, init_db() (17 migrations),
+  recover orphaned jobs, token store,
+  ModelManager + preload, CUDA probe,
+  sweepers (orphan / deferred-export /
+  webhook retention), WebhookWorker
   --
-  Shutdown: cleanup_models()
+  Shutdown: stop WebhookWorker,
+  drain WS, cleanup_models()
 end note
 
 ' ── Routes ────────────────────────────────────────
 package "REST Routes" as restRoutes {
-  component "/health" as healthRoute
+  component "/health, /api/status" as healthRoute
   component "/api/auth" as authRoute
-  component "/api/transcribe" as transcribeRoute
-  component "/api/notebook" as notebookRoute
+  component "/api/transcribe\n(+ result/retry/dedup)" as transcribeRoute
+  component "/api/notebook\n(+ aliases, review,\nauto-actions)" as notebookRoute
+  component "/api/profiles" as profilesRoute
   component "/api/search" as searchRoute
-  component "/api/llm" as llmRoute
-  component "/api/admin" as adminRoute
+  component "/api/llm\n(+ chat, conversations)" as llmRoute
+  component "/api/admin\n(+ webhook/test)" as adminRoute
+  component "/v1/audio\n(OpenAI-compatible)" as openaiRoute
 }
 
 package "WebSocket" as wsRoutes {
   component "/ws\n(longform)" as wsRoute
   component "/ws/live\n(real-time)" as liveRoute
+  component "/api/admin/models/\nload/stream" as modelStream
 }
 
 ' ── Core ──────────────────────────────────────────
 package "Core Modules" as core {
-  component "ModelManager" as mm
+  component "ModelManager\n(+ JobTracker)" as mm
   component "AudioToText\nRecorder" as engine
   component "LiveMode\nEngine" as liveEng
   component "Diarization\nEngine" as diarEng
-  component "Database" as database
+  component "Auto-Action\nCoordinator" as coord
+  component "Webhook Worker\n(services/)" as worker
+  component "Database +\nRepositories" as database
   component "TokenStore" as tokenStore
   component "Config" as config
 }
+
+cloud "External\nwebhook" as ext
 
 ' ── Wiring ────────────────────────────────────────
 
@@ -72,16 +81,20 @@ authMw -right-> tokenStore
 lifespan --> mm
 lifespan --> database
 lifespan --> config
+lifespan --> worker
 
 ' REST routes to core
 healthRoute --> mm
 authRoute --> tokenStore
 transcribeRoute --> engine
 notebookRoute --> database
+notebookRoute --> coord
+profilesRoute --> database
 searchRoute --> database
 llmRoute --> database
 adminRoute --> mm
 adminRoute --> database
+openaiRoute --> engine
 
 ' WebSocket routes to core
 wsRoute --> engine
@@ -89,5 +102,11 @@ wsRoute --> diarEng
 wsRoute --> mm
 liveRoute --> liveEng
 liveRoute --> mm
+modelStream --> mm
+
+' Auto-action + webhook flow
+coord --> database : "webhook_deliveries\n(pending)"
+worker --> database : "drain + status"
+worker --> ext : "POST (SSRF-guarded)"
 
 @enduml

--- a/docs/architecture/stt-backends.puml
+++ b/docs/architecture/stt-backends.puml
@@ -13,7 +13,7 @@ skinparam stereotypeFontColor #a6adc8
 skinparam cloudBackgroundColor #45475a
 skinparam cloudBorderColor #89b4fa
 
-title STT Backend Subsystem (server/backend/core/stt/)
+title STT Backend Subsystem (server/backend/core/stt/) - 10 active backends
 
 ' ── Data Classes ──────────────────────────────────
 package "Data Types (base.py)" as dataTypes {
@@ -36,6 +36,11 @@ package "Data Types (base.py)" as dataTypes {
     + language: str | None
     + language_probability: float
   }
+
+  class BackendDependencyError <<RuntimeError>> {
+    + backend_type: str
+    + remedy: str
+  }
 }
 
 ' ── Abstract Base ─────────────────────────────────
@@ -44,9 +49,10 @@ abstract class STTBackend <<base.py>> {
   {abstract} + unload()
   {abstract} + is_loaded(): bool
   {abstract} + warmup()
-  {abstract} + transcribe(audio, language, task, ...): (list[BackendSegment], BackendTranscriptionInfo)
+  {abstract} + transcribe(audio, *, language, task, ...): (list[BackendSegment], BackendTranscriptionInfo)
   {abstract} + supports_translation(): bool
   {abstract} + backend_name: str
+  + configure_decode_options(options)
   + preferred_input_sample_rate_hz: int = 16000
   + transcribe_with_diarization(...): DiarizedTranscriptionResult | None
 }
@@ -54,94 +60,76 @@ abstract class STTBackend <<base.py>> {
 ' ── CUDA/Docker Backends ─────────────────────────
 package "CUDA / Docker Backends" as cudaBackends {
   class WhisperXBackend <<whisperx_backend.py>> {
-    + backend_name = "whisperx"
-    + supports_translation(): bool
-    + transcribe_with_diarization(...)
-    -- uses --
-    faster-whisper / WhisperX
-    Integrated diarization support
+    + backend_name = "whisperx"  (default)
+    + supports_translation() = True
+    + transcribe_with_diarization() [integrated single-pass]
   }
 
   class FasterWhisperBackend <<faster_whisper_backend.py>> {
-    + backend_name = "faster_whisper"
-    + supports_translation(): bool
-    -- uses --
-    faster-whisper (no WhisperX)
-    Live Mode on Metal bare-metal
+    + backend_name = "faster_whisper"  (default fallback)
+    + supports_translation() = True
   }
 
   class ParakeetBackend <<parakeet_backend.py>> {
     + backend_name = "parakeet"
     + supports_translation() = False
-    -- uses --
-    NVIDIA NeMo ASR
-    20min chunk splitting
-    CUDA graph workaround
+    -- NVIDIA NeMo ASR, 20min chunking, CUDA-graph workaround
   }
 
   class CanaryBackend <<canary_backend.py>> {
     + backend_name = "canary"
-    + supports_translation() = True
-    -- uses --
-    NVIDIA NeMo Canary
-    20min chunk splitting
-    24 EU target languages
+    + supports_translation() = True  (24 EU targets)
+    -- extends ParakeetBackend
   }
 
   class VibeVoiceASRBackend <<vibevoice_asr_backend.py>> {
     + backend_name = "vibevoice_asr"
     + supports_translation() = False
     + DEFAULT_MAX_CHUNK_DURATION_S = 60
-    -- uses --
-    VibeVoice-ASR
-    Semantic tokenizer
+    + transcribe_with_diarization() [integrated]
   }
 
   class WhisperCppBackend <<whispercpp_backend.py>> {
     + backend_name = "whispercpp"
-    + supports_translation(): bool
-    -- uses --
-    HTTP sidecar (Vulkan GPU)
-    Multipart POST, WAV encoding
-    No in-process model loading
+    + supports_translation() = True
+    -- HTTP sidecar (Vulkan GPU), WAV multipart
+  }
+
+  class WhisperBackend <<whisper_backend.py>> {
+    + backend_name = "whisper"
+    -- DEPRECATED / orphaned: not factory-wired
   }
 }
 
 ' ── MLX / Apple Silicon Backends ─────────────────
 package "MLX / Apple Silicon Backends" as mlxBackends {
+  class MLXThreadAffinityMixin <<mlx_thread_pin.py>> {
+    -- GH#134: pins GPU ops to one owning thread
+    + @mlx_pinned (load/unload/warmup/transcribe)
+    + shutdown_mlx_thread()
+  }
+
   class MLXWhisperBackend <<mlx_whisper_backend.py>> {
     + backend_name = "mlx_whisper"
-    + supports_translation(): bool
-    -- uses --
-    mlx-audio (Metal acceleration)
-    -asr- model naming required
-    alignment_heads monkey-patch
+    + supports_translation() = True
+    -- -asr- model naming required
   }
 
   class MLXParakeetBackend <<mlx_parakeet_backend.py>> {
     + backend_name = "mlx_parakeet"
     + supports_translation() = False
-    -- uses --
-    parakeet-mlx
-    Long-audio chunking
   }
 
   class MLXCanaryBackend <<mlx_canary_backend.py>> {
     + backend_name = "mlx_canary"
-    + supports_translation() = True
-    -- uses --
-    canary-mlx
-    Reuses Parakeet chunking
+    + supports_translation() = False [ASR-only port]
   }
 
   class MLXVibeVoiceBackend <<mlx_vibevoice_backend.py>> {
     + backend_name = "mlx_vibevoice"
     + supports_translation() = False
-    + transcribe_with_diarization(...)
-    -- uses --
-    mlx-audio (native diarization)
-    24 kHz input (resampled internally)
-    JSON segment parsing
+    + transcribe_with_diarization() [native diarization]
+    -- 24 kHz input (resampled internally)
   }
 }
 
@@ -149,86 +137,73 @@ package "MLX / Apple Silicon Backends" as mlxBackends {
 class "factory.py" as factory <<factory>> {
   + detect_backend_type(model_name): str
   + create_backend(model_name): STTBackend
-  + is_parakeet_model(model_name): bool
-  + is_canary_model(model_name): bool
-  + is_nemo_model(model_name): bool
-  + is_vibevoice_asr_model(model_name): bool
-  + is_whispercpp_model(model_name): bool
-  + is_mlx_model(model_name): bool
-  + is_mlx_parakeet_model(model_name): bool
+  + is_parakeet_model / is_canary_model / is_nemo_model
+  + is_vibevoice_asr_model / is_whispercpp_model
+  + is_mlx_model / is_mlx_parakeet_model
 }
 
 note right of factory
   Detection order (first match wins):
-  nvidia/parakeet*         -> "parakeet"
-  nvidia/nemotron-speech*  -> "parakeet"
+  nvidia/parakeet|nemotron-speech -> "parakeet"
   nvidia/canary*           -> "canary"
-  mlx-community/vibevoice* -> "mlx_vibevoice"
+  mlx-community/vibevoice-asr -> "mlx_vibevoice"
   */vibevoice-asr*         -> "vibevoice_asr"
   ggml-*.bin / *.gguf      -> "whispercpp"
   mlx-community/parakeet*  -> "mlx_parakeet"
   */canary*-mlx            -> "mlx_canary"
   mlx-community/*          -> "mlx_whisper"
-  else -> "whisperx" (or
-    "faster_whisper" fallback)
+  else -> "whisper"
+    => WhisperXBackend, or
+       FasterWhisperBackend (no whisperx)
 end note
 
 ' ── Model Manager ─────────────────────────────────
 class ModelManager <<model_manager.py>> {
   - _backend: STTBackend | None
-  - _config: dict
-  + gpu_available: bool
   + load_transcription_model()
   + load_live_model()
-  + unload_transcription_model()
   + get_transcription_model(): STTBackend
   + cleanup_models()
 }
 
-' ── Engine ────────────────────────────────────────
+class TranscriptionJobTracker <<model_manager.py>> {
+  + single-job concurrency / cancel / progress
+}
+
+' ── Engines ───────────────────────────────────────
 class AudioToTextRecorder <<engine.py>> {
   - _backend: STTBackend
   + transcribe_audio(audio, language, ...)
-  -- orchestrates --
-  Backend transcription
-  Progress callbacks
 }
 
 class LiveModeEngine <<live_engine.py>> {
   - _model_manager: ModelManager
-  + start(language, translate, ...)
-  + feed_audio(chunk)
-  + stop(): results
-  -- orchestrates --
-  VAD-based segmentation
-  Real-time partial results
+  + start / feed_audio / stop
 }
 
 ' ── Relationships ─────────────────────────────────
 STTBackend <|-- WhisperXBackend
 STTBackend <|-- FasterWhisperBackend
 STTBackend <|-- ParakeetBackend
-STTBackend <|-- CanaryBackend
+ParakeetBackend <|-- CanaryBackend
 STTBackend <|-- VibeVoiceASRBackend
 STTBackend <|-- WhisperCppBackend
+STTBackend <|.. WhisperBackend : (orphaned)
+
 STTBackend <|-- MLXWhisperBackend
 STTBackend <|-- MLXParakeetBackend
 STTBackend <|-- MLXCanaryBackend
 STTBackend <|-- MLXVibeVoiceBackend
+MLXThreadAffinityMixin <|-- MLXWhisperBackend
+MLXThreadAffinityMixin <|-- MLXParakeetBackend
+MLXThreadAffinityMixin <|-- MLXCanaryBackend
+MLXThreadAffinityMixin <|-- MLXVibeVoiceBackend
 
-factory ..> WhisperXBackend : creates
-factory ..> FasterWhisperBackend : creates
-factory ..> ParakeetBackend : creates
-factory ..> CanaryBackend : creates
-factory ..> VibeVoiceASRBackend : creates
-factory ..> WhisperCppBackend : creates
-factory ..> MLXWhisperBackend : creates
-factory ..> MLXParakeetBackend : creates
-factory ..> MLXCanaryBackend : creates
-factory ..> MLXVibeVoiceBackend : creates
+factory ..> STTBackend : creates (10 active)
 
 ModelManager --> factory : "create_backend()"
 ModelManager *-- STTBackend : "holds active backend"
+ModelManager *-- TranscriptionJobTracker
 
 AudioToTextRecorder --> STTBackend : "transcribe()"
 LiveModeEngine --> ModelManager : "load/unload live model"

--- a/docs/data-models-server.md
+++ b/docs/data-models-server.md
@@ -1,156 +1,313 @@
 # TranscriptionSuite — Data Models (Server)
 
-> Generated: 2026-04-05 | Engine: SQLite + FTS5 (async via aiosqlite + SQLAlchemy)
+> Generated: 2026-06-11 | v1.3.6 | Engine: SQLite + FTS5 (async via aiosqlite + SQLAlchemy; raw `sqlite3` for CRUD)
 
 ## Database Location
 
 - **Docker:** `/data/database/transcription_suite.db`
 - **Local dev:** `<DATA_DIR>/database/transcription_suite.db`
 
-## Schema
+Schema ownership: Alembic migrations `001`–`017` own the schema. `database.py` holds connection
+pragmas, runtime CRUD, and a `_assert_schema_sanity()` contract that fails startup hard if a
+required table/column is missing.
+
+## Schema Overview
+
+The current schema (after migration 017) has **9 base tables** + **1 FTS5 virtual table** (`words_fts`,
+with its SQLite-managed shadow tables) + **3 FTS sync triggers**.
+
+| Table | Kind | Purpose |
+|-------|------|---------|
+| `recordings` | base | Central entity — one row per audio note / imported file |
+| `segments` | base | Speaker turns / time blocks within a recording |
+| `words` | base | Word-level timestamps (FTS source) |
+| `words_fts` | FTS5 virtual | Full-text index over `words.word` |
+| `conversations` | base | LLM chat sessions per recording |
+| `messages` | base | Chat messages within a conversation |
+| `transcription_jobs` | base | Durability ledger — one row per WS/HTTP job (TEXT UUID PK) |
+| `profiles` | base | Transcription/recording profiles (Issue #104) |
+| `recording_diarization_review` | base | Diarization-review lifecycle state (1:1 with recording) |
+| `recording_speaker_aliases` | base | Speaker label → display name (1:N with recording) |
+| `webhook_deliveries` | base | Per-attempt outgoing-webhook delivery ledger (1:N with recording) |
+
+> **Corrections vs. earlier docs:** the FTS table is **`words_fts`** (not `recordings_fts`); there is
+> **no `chat_history` table** — LLM history lives in `conversations` + `messages`.
+
+## Core Tables
 
 ### `recordings` — Audio Notebook Entries
 
-| Column | Type | Constraints | Purpose |
-|--------|------|------------|---------|
-| id | INTEGER | PK, autoincrement | Unique recording ID |
-| filename | TEXT | NOT NULL | Original filename |
-| filepath | TEXT | | Path to stored audio file |
-| title | TEXT | | User-assigned title |
-| duration_seconds | REAL | | Audio duration |
-| recorded_at | TEXT | | Recording timestamp (ISO 8601) |
-| imported_at | TEXT | DEFAULT CURRENT_TIMESTAMP | Import timestamp |
-| word_count | INTEGER | DEFAULT 0 | Total word count |
-| has_diarization | INTEGER | DEFAULT 0 | Has speaker labels (boolean) |
-| summary | TEXT | | AI-generated or user summary |
-| summary_model | TEXT | | LLM model used for summary |
-| transcription_backend | TEXT | | STT backend used (e.g., "whisperx", "parakeet") |
+The central entity. Many columns were bolted on by later migrations (cited).
+
+| Column | Type | Constraints | Purpose | Migr. |
+|--------|------|------------|---------|-------|
+| id | INTEGER | PK, autoincrement | Recording ID | 001 |
+| filename | TEXT | NOT NULL | Audio file name | 001 |
+| filepath | TEXT | NOT NULL, UNIQUE | Absolute path to stored audio (MP3) | 001 |
+| title | TEXT | | Display title (defaults to filename) | 001 |
+| duration_seconds | REAL | NOT NULL | Audio duration | 001 |
+| recorded_at | TIMESTAMP | NOT NULL | When recording was made | 001 |
+| imported_at | TIMESTAMP | DEFAULT CURRENT_TIMESTAMP | When ingested into DB | 001 |
+| word_count | INTEGER | DEFAULT 0 | Cached count of `words` rows | 001 |
+| has_diarization | INTEGER | DEFAULT 0 | Bool: speaker turns present | 001 |
+| summary | TEXT | | AI-generated summary | 001 |
+| summary_model | TEXT | | Model id that produced the summary | 003 |
+| transcription_backend | TEXT | | Normalized backend family (whisper/parakeet/canary/vibevoice_asr) | 005 |
+| audio_hash | TEXT | idx | SHA-256 of raw upload bytes (dedup) | 012 |
+| normalized_audio_hash | TEXT | idx | SHA-256 of normalized 16 kHz mono int16 PCM (format-agnostic dedup) | 013 |
+| auto_summary_status | TEXT | partial idx | Auto-summary lifecycle state | 015 |
+| auto_summary_error | TEXT | | Last auto-summary error | 015 |
+| auto_summary_attempts | INTEGER | NOT NULL DEFAULT 0 | Auto-summary retry count | 015 |
+| auto_summary_completed_at | TIMESTAMP | | Auto-summary success time | 015 |
+| auto_export_status | TEXT | partial idx | Auto-export lifecycle state | 015 |
+| auto_export_error | TEXT | | Last auto-export error | 015 |
+| auto_export_attempts | INTEGER | NOT NULL DEFAULT 0 | Auto-export retry count | 015 |
+| auto_export_path | TEXT | | Path written by auto-export | 015 |
+| auto_export_completed_at | TIMESTAMP | | Auto-export success time | 015 |
+| auto_action_profile_snapshot | TEXT | | Frozen profile JSON used at auto-action time | 015 |
+| transcript_corrected | TEXT | | Non-destructive hand-corrected/flattened transcript; NULL = use original segments | 017 |
+
+Indexes: `idx_recordings_date(recorded_at)`, `idx_recordings_audio_hash`,
+`idx_recordings_normalized_audio_hash`, partial `idx_recordings_auto_summary_status`,
+partial `idx_recordings_auto_export_status`.
+
+> Speaker aliases, diarization-review state, and webhook deliveries are **separate tables**.
+> Auto-action status and `transcript_corrected` are **columns on `recordings`** (1:1 by design).
 
 ### `segments` — Transcription Segments
 
 | Column | Type | Constraints | Purpose |
 |--------|------|------------|---------|
-| id | INTEGER | PK, autoincrement | Unique segment ID |
-| recording_id | INTEGER | FK → recordings.id | Parent recording |
-| text | TEXT | NOT NULL | Segment text content |
-| start_time | REAL | | Start timestamp (seconds) |
-| end_time | REAL | | End timestamp (seconds) |
-| speaker | TEXT | | Speaker label (e.g., "SPEAKER_00") |
+| id | INTEGER | PK, autoincrement | Segment ID |
+| recording_id | INTEGER | NOT NULL, FK → recordings.id ON DELETE CASCADE | Parent recording |
+| segment_index | INTEGER | NOT NULL | Order within recording |
+| speaker | TEXT | | Raw diarization label (e.g. `SPEAKER_00`) |
+| text | TEXT | NOT NULL | Segment text |
+| start_time | REAL | NOT NULL | Start (seconds) |
+| end_time | REAL | NOT NULL | End (seconds) |
 
 ### `words` — Word-Level Timestamps
 
 | Column | Type | Constraints | Purpose |
 |--------|------|------------|---------|
-| id | INTEGER | PK, autoincrement | Unique word ID |
-| segment_id | INTEGER | FK → segments.id | Parent segment |
-| word | TEXT | NOT NULL | Single word |
-| start_time | REAL | | Word start (seconds) |
-| end_time | REAL | | Word end (seconds) |
-| confidence | REAL | | Recognition confidence (0.0-1.0) |
+| id | INTEGER | PK, autoincrement | Word ID (FTS rowid) |
+| recording_id | INTEGER | NOT NULL, FK → recordings.id ON DELETE CASCADE | Parent recording |
+| segment_id | INTEGER | NOT NULL, FK → segments.id ON DELETE CASCADE | Parent segment |
+| word_index | INTEGER | NOT NULL | Order within segment |
+| word | TEXT | NOT NULL | Token text |
+| start_time | REAL | NOT NULL | Word start (seconds) |
+| end_time | REAL | NOT NULL | Word end (seconds) |
+| confidence | REAL | | ASR confidence (0.0–1.0) |
 
-### `recordings_fts` — Full-Text Search Index
+### `words_fts` — Full-Text Search Index
 
-FTS5 virtual table for fast text search across recording titles and segment text.
+FTS5 external-content virtual table: `fts5(word, content='words', content_rowid='id', tokenize='unicode61')`.
+Kept in sync by triggers `words_ai` (after insert), `words_ad` (after delete), `words_au` (after update).
 
-### `transcription_jobs` — Durability Layer (Wave 1)
+### `conversations` / `messages` — LLM Chat
+
+`conversations` (one per recording chat session): `id`, `recording_id` (FK CASCADE), `title`,
+`created_at`, `updated_at`, `response_id` (LM Studio stateful chat, migr. 002), `model`
+(per-conversation override, migr. 007).
+
+`messages` (chat history): `id`, `conversation_id` (FK CASCADE), `role`
+(CHECK in `user`/`assistant`/`system`), `content`, `created_at`, `model` (migr. 003), `tokens_used`.
+
+### `transcription_jobs` — Durability Ledger
+
+Created by migration 006. Adapted from Scriberr. **`id` is a TEXT job UUID**, not an integer.
+
+| Column | Type | Constraints | Purpose | Migr. |
+|--------|------|------------|---------|-------|
+| id | TEXT | PK | Job UUID | 006 |
+| status | TEXT | NOT NULL DEFAULT 'processing' | `processing` → `completed`/`failed` | 006 |
+| source | TEXT | NOT NULL | Origin (websocket / audio / import) | 006 |
+| client_name | TEXT | | Client identifier (undelivered redelivery) | 006 |
+| language | TEXT | | Requested language | 006 |
+| task | TEXT | DEFAULT 'transcribe' | transcribe / translate | 006 |
+| translation_target | TEXT | | Translation target language | 006 |
+| audio_path | TEXT | | Preserved audio path (retry / cleanup) | 006 |
+| result_text | TEXT | | Plain-text result | 006 |
+| result_json | TEXT | | Full structured result (segments/words) | 006 |
+| result_language | TEXT | | Detected language | 006 |
+| duration_seconds | REAL | | Audio duration | 006 |
+| error_message | TEXT | | Failure detail | 006 |
+| delivered | INTEGER | NOT NULL DEFAULT 0 | 1 after successful client delivery | 006 |
+| created_at | TIMESTAMP | NOT NULL DEFAULT CURRENT_TIMESTAMP | Job start | 006 |
+| completed_at | TIMESTAMP | | Completion (ISO format) | 006 |
+| job_profile_snapshot | TEXT | | Frozen profile JSON at job start | 009 |
+| snapshot_schema_version | TEXT | | Profile schema_version at start | 009 |
+| audio_hash | TEXT | idx | SHA-256 raw upload bytes (dedup) | 011 |
+| normalized_audio_hash | TEXT | idx | SHA-256 normalized PCM (dedup) | 013 |
+
+> **Timestamp-format gotcha:** `created_at` uses SQLite `CURRENT_TIMESTAMP` (`"YYYY-MM-DD HH:MM:SS"`,
+> space-separated); `completed_at` is written via `datetime.isoformat()` (`"T"`-separated). Cleanup/orphan
+> queries must match the respective format for correct lexicographic comparison.
+
+## Issue #104 Tables
+
+### `profiles` — Transcription/Recording Profiles (migr. 008)
 
 | Column | Type | Constraints | Purpose |
 |--------|------|------------|---------|
-| id | TEXT | PK | Job UUID |
-| status | TEXT | NOT NULL | `processing`, `completed`, `failed` |
-| source | TEXT | | Job source (e.g., "websocket", "upload", "import") |
-| client_name | TEXT | | Client identifier |
-| language | TEXT | | Source language code |
-| task | TEXT | | Task type ("transcribe" or "translate") |
-| translation_target | TEXT | | Translation target language |
-| audio_path | TEXT | | Path to preserved audio (Wave 2) |
-| result_text | TEXT | | Plain text result |
-| result_json | TEXT | | Full JSON result (segments, words, etc.) |
-| error_message | TEXT | | Error details (if failed) |
-| created_at | TEXT | DEFAULT CURRENT_TIMESTAMP | Job creation time |
-| completed_at | TEXT | | Completion timestamp |
-| delivered | INTEGER | DEFAULT 0 | Client received result (boolean) |
+| id | INTEGER | PK, autoincrement | Profile ID |
+| name | TEXT | NOT NULL | Profile name |
+| description | TEXT | | Free-text description |
+| schema_version | TEXT | NOT NULL | Versioned schema (only `"1.0"` supported) |
+| public_fields_json | TEXT | NOT NULL | Non-sensitive settings (template, destination, toggles, model, prompt, format) |
+| private_field_refs_json | TEXT | | **Keychain reference IDs only** — never plaintext secrets (FR11) |
+| created_at | TIMESTAMP | NOT NULL DEFAULT CURRENT_TIMESTAMP | Created |
+| updated_at | TIMESTAMP | NOT NULL DEFAULT CURRENT_TIMESTAMP | Last write (last-write-wins) |
 
-### `chat_history` — LLM Conversations
+Profiles are **snapshotted** (frozen JSON, no live FK) into `transcription_jobs.job_profile_snapshot`
+(009) and `recordings.auto_action_profile_snapshot` (015), so concurrent profile edits never affect
+in-flight jobs.
 
-Stores LLM chat sessions associated with recordings for summarization and Q&A.
+### `recording_diarization_review` — Review Lifecycle (migr. 010, 1:1)
+
+`recording_id` (PK, FK CASCADE), `status` (CHECK in `pending`/`in_review`/`completed`/`released`),
+`reviewed_turns_json`, `created_at`, `updated_at`. Index `idx_diarization_review_status` powers the
+persistent-banner query. Transition legality is enforced by the ADR-009 lifecycle state machine in
+`core/diarization_review_lifecycle.py`, not by the DB.
+
+### `recording_speaker_aliases` — Speaker Aliases (migr. 014, 1:N)
+
+`id`, `recording_id` (FK CASCADE), `speaker_id` (raw label, e.g. `SPEAKER_00`), `alias_name`
+(display name, stored **verbatim** — no normalize/truncate, R-EL3), `created_at`, `updated_at`,
+**UNIQUE(recording_id, speaker_id)**. Cross-recording uniqueness intentionally not enforced.
+
+### `webhook_deliveries` — Outgoing-Webhook Ledger (migr. 016, 1:N)
+
+| Column | Type | Constraints | Purpose |
+|--------|------|------------|---------|
+| id | INTEGER | PK, autoincrement | Delivery-attempt ID |
+| recording_id | INTEGER | NOT NULL, FK → recordings.id ON DELETE CASCADE | Recording whose event is delivered |
+| profile_id | INTEGER | FK → profiles.id **ON DELETE SET NULL** | Profile config (kept queryable after delete) |
+| status | TEXT | NOT NULL, CHECK | `pending`/`in_flight`/`success`/`failed`/`manual_intervention_required` |
+| attempt_count | INTEGER | NOT NULL DEFAULT 0 | Number of attempts |
+| last_error | TEXT | | Last failure reason |
+| created_at | TIMESTAMP | NOT NULL DEFAULT CURRENT_TIMESTAMP | Row creation (retention age) |
+| last_attempted_at | TIMESTAMP | | Last HTTP attempt |
+| payload_json | TEXT | NOT NULL | Frozen POST body (no-drift across retries) |
+
+Indexes: partial `idx_webhook_deliveries_status` (worker drain over `pending`/`in_flight`),
+`idx_webhook_deliveries_recording`.
 
 ## Entity Relationships
 
 ```
-recordings (1) ──────► (N) segments (1) ──────► (N) words
-    │
-    └─── transcription_jobs (linked by source context, not FK)
-    │
-    └─── chat_history (linked by recording_id)
-    │
-    └─── recordings_fts (FTS5 shadow table)
+recordings (1) ──< segments (N) ──< words (N)        [FK CASCADE]
+words.word ──ext-content──> words_fts                 [synced by triggers ai/ad/au]
+recordings (1) ──< conversations (N) ──< messages (N) [FK CASCADE]
+recordings (1) ──1:1── recording_diarization_review   [FK CASCADE]
+recordings (1) ──< recording_speaker_aliases (N)      [FK CASCADE, UNIQUE(recording_id, speaker_id)]
+recordings (1) ──< webhook_deliveries (N)             [FK CASCADE]
+profiles   (1) ──< webhook_deliveries (N)             [FK SET NULL]
+recordings ⋯⋯ transcription_jobs   (NO FK — separate ledgers; jobs keyed by TEXT UUID)
+profiles   ⋯⋯ snapshots into transcription_jobs + recordings (frozen JSON, no FK)
 ```
 
 ## Migrations
 
-Located in `server/backend/database/migrations/versions/`:
+Located in `server/backend/database/migrations/versions/`. Run automatically on startup via
+`run_migrations()` → Alembic `upgrade head`. **Forward-only from 008 onward** (`downgrade()` raises).
 
-| Version | File | Changes |
-|---------|------|---------|
-| 001 | `001_initial_schema.py` | Base tables: recordings, segments, words, FTS5 index |
-| 002 | `002_add_response_id.py` | Add response_id column |
-| 003 | `003_add_message_model_and_summary_model.py` | Add summary_model to recordings |
-| 004 | `004_schema_sanity_and_segment_backfill.py` | Schema cleanup, backfill segment data |
-| 005 | `005_add_recordings_transcription_backend.py` | Add transcription_backend column |
-| 006 | `006_add_transcription_jobs.py` | Add transcription_jobs table (durability) |
+| Ver | File | Change |
+|-----|------|--------|
+| 001 | `001_initial_schema.py` | recordings, segments, words, words_fts (+3 triggers), conversations, messages |
+| 002 | `002_add_response_id.py` | `conversations.response_id` (LM Studio stateful chat) |
+| 003 | `003_add_message_model_and_summary_model.py` | `recordings.summary_model` + `messages.model` |
+| 004 | `004_schema_sanity_and_segment_backfill.py` | Legacy compat; backfill empty `segments.text` from words |
+| 005 | `005_add_recordings_transcription_backend.py` | `recordings.transcription_backend` |
+| 006 | `006_add_transcription_jobs.py` | `transcription_jobs` table (durability Wave 1) |
+| 007 | `007_add_conversation_model.py` | `conversations.model` (per-conversation override) |
+| 008 | `008_add_profiles_table.py` | `profiles` table |
+| 009 | `009_add_profile_snapshot_to_transcription_jobs.py` | `job_profile_snapshot` + `snapshot_schema_version` |
+| 010 | `010_add_recording_diarization_review.py` | `recording_diarization_review` table |
+| 011 | `011_add_audio_hash_to_transcription_jobs.py` | `transcription_jobs.audio_hash` (raw-byte dedup) |
+| 012 | `012_add_audio_hash_to_recordings.py` | `recordings.audio_hash` (closes notebook-upload dedup gap) |
+| 013 | `013_add_normalized_audio_hash.py` | `normalized_audio_hash` on BOTH jobs + recordings (format-agnostic dedup) |
+| 014 | `014_add_recording_speaker_aliases.py` | `recording_speaker_aliases` table |
+| 015 | `015_add_recording_auto_action_status.py` | 10 auto-action columns on `recordings` + 2 partial indexes |
+| 016 | `016_add_webhook_deliveries.py` | `webhook_deliveries` table |
+| 017 | `017_add_recording_transcript_corrected.py` | `recordings.transcript_corrected` (in-place editing) |
 
-Migrations run automatically on server startup via Alembic.
+## Repository Layer (`database/`)
 
-## Durability System
+| Module | Purpose |
+|--------|---------|
+| `database.py` | Connection mgmt + pragmas, schema bootstrap, recordings/segments/words/conversations/messages CRUD, FTS search, longform save, recordings-side dedup lookup |
+| `job_repository.py` | `transcription_jobs` CRUD (durability). `create_job` → `save_result` → `mark_delivered`/`mark_failed`; `reset_for_retry`, `get_orphaned_jobs`, `get_jobs_for_cleanup`, `find_by_audio_hash` |
+| `profile_repository.py` | `profiles` CRUD; `to_public_dict` strips private refs; `snapshot_profile_at_job_start` |
+| `alias_repository.py` | `recording_speaker_aliases` CRUD; `replace_aliases` (full-replace upsert), `alias_map` |
+| `diarization_review_repository.py` | `recording_diarization_review` CRUD; `update_status`/`update_reviewed_turns` |
+| `auto_action_repository.py` | Auto-action columns on `recordings`; status enums, profile snapshot, `list_pending_auto_actions` |
+| `webhook_deliveries_repository.py` | `webhook_deliveries` CRUD; worker state transitions, `requeue_*`, `count_consecutive_recent_failures`, `cleanup_older_than` |
+| `webhook_cleanup.py` | `periodic_webhook_cleanup` — retention sweep of success/manual rows |
+| `dedup_query.py` | `find_duplicates_anywhere` — merges job + recording hash matches into one list |
+| `audio_cleanup.py` | `periodic_cleanup` — deletes audio files for completed+delivered+old jobs (durability Wave 2) |
+| `backup.py` | `DatabaseBackupManager` — WAL-safe SQLite `.backup()`, rotate (keep 3), verify, restore |
 
-### Job Lifecycle State Machine
+## Durability System (3 Waves)
+
+1. **Wave 1 — Job persistence:** `create_job()` → `save_result()` (persist) → deliver → `mark_delivered()`.
+2. **Wave 2 — Audio preservation:** raw audio saved to `/data/recordings/{job_id}.wav` before transcription;
+   `audio_cleanup.periodic_cleanup()` deletes only completed+delivered audio older than `audio_retention_days`.
+3. **Wave 3 — Orphan recovery:** on startup, `recover_orphaned_jobs()` marks stale `processing` jobs as
+   `failed`; periodic orphan sweep re-checks (guarded by `job_tracker.is_busy()`).
+
+### Job Lifecycle
 
 ```
-create_job()        save_result()     mark_delivered()
-    │                   │                  │
-    ▼                   ▼                  ▼
-┌──────────┐    ┌──────────────┐    ┌──────────────┐
-│processing │───►│  completed   │───►│  delivered   │
-└──────────┘    └──────────────┘    └──────────────┘
-    │                                      
-    │ mark_failed()                        
-    ▼                                      
-┌──────────┐    reset_for_retry()   ┌──────────┐
-│  failed   │◄──────────────────────│  retry   │
-└──────────┘                        └──────────┘
+create_job()       save_result()      mark_delivered()
+    │                  │                   │
+    ▼                  ▼                   ▼
+processing ───────► completed ───────► delivered
+    │
+    │ mark_failed()        reset_for_retry()  (preserves created_at + audio_path)
+    ▼                      ▲
+  failed ──────────────────┘
 ```
 
-### Key Repository Functions (`database/job_repository.py`)
+## Key Data Lifecycles
 
-| Function | Purpose |
-|----------|---------|
-| `create_job()` | Insert new job before transcription starts |
-| `save_result()` | Store result BEFORE delivering to client |
-| `mark_delivered()` | Client confirmed receipt |
-| `mark_failed()` | Transcription failed |
-| `get_recent_undelivered()` | Client polls for missed results |
-| `set_audio_path()` | Link to preserved audio file |
-| `reset_for_retry()` | Re-queue failed job for another attempt |
-| `get_orphaned_jobs()` | Find jobs stuck in "processing" after crash |
-| `get_jobs_for_cleanup()` | Find old delivered jobs for audio cleanup |
+### Audio Dedup (raw + normalized hash, per-user scope)
 
-### Audio Cleanup (`database/audio_cleanup.py`)
+Each upload row carries **two SHA-256 columns**: `audio_hash` (raw upload bytes) and
+`normalized_audio_hash` (16 kHz mono int16 PCM rendered via ffmpeg — catches same content in different
+encodings, e.g. MP3 vs WAV). Both exist on `transcription_jobs` (written by `/api/transcribe/audio` +
+`/import`) and `recordings` (written by `/api/notebook/transcribe/upload`). The dedup-check endpoint
+(`POST /api/transcribe/import/dedup-check`) runs `dedup_query.find_duplicates_anywhere`, which queries
+both tables and ORs both columns. NULL columns never match. Local-DB-only; cross-user dedup is a non-goal.
 
-- Runs at startup, then on interval (default: 24 hours)
-- Deletes completed+delivered recordings older than retention period (default: 7 days)
-- Never deletes audio for failed or undelivered jobs
+### Webhook Delivery (`webhook_deliveries`)
 
-### Backup (`database/backup.py`)
+Producer `create_pending(recording_id, profile_id, payload)` freezes the POST body → worker
+`mark_in_flight` (committed **before** HTTP fire) → `mark_success` (2xx) / `mark_failed` (else, increments
+`attempt_count`). One 30 s auto-retry (`requeue_failed_row`); second consecutive failure →
+`manual_intervention_required` (terminal, surfaced as dashboard badge). Shutdown reverts `in_flight` →
+`pending`. Retention deletes only success/manual rows older than `retention_days`.
 
-- Automatic SQLite backups with configurable retention
-- Location: `/data/database/backups/`
-- Configurable: `backup.enabled`, `backup.max_age_hours`, `backup.max_backups`
+### Auto-Action Status (columns on `recordings`)
+
+Coordinator persists `auto_action_profile_snapshot` → `set_auto_action_status(..., "in_progress")` →
+per-attempt `increment_auto_action_attempts` → terminal `success` (stamps `*_completed_at`) or
+`deferred`/`retry_pending`/`failed`/`held`/`manual_intervention_required`. Sweeper re-drives
+`deferred`/`retry_pending` rows. Status strings validated in the repo (no DB CHECK).
+
+### Diarization Review (`recording_diarization_review`)
+
+`create_review(status="pending")` → user edits → `update_status("in_review")` +
+`update_reviewed_turns(turns_json)` → `completed` → `released` (lifts the auto-summary HOLD). The
+status index powers the persistent review banner.
+
+### `transcript_corrected` (in-place edit / find-replace)
+
+Default source of truth is the rich `segments`+`words` view (`transcript_corrected IS NULL`). On save,
+`update_recording_corrected_transcript(recording_id, transcript)` stores the flattened corrected text;
+the original `segments`/`words` are **never touched** (non-destructive, NFR21). Revert = store NULL.
 
 ## Connection Settings
 
-- Timeout: 30 seconds (lock wait)
-- Busy timeout: 5 seconds (SQLITE_BUSY retry)
-- Multi-thread: `check_same_thread=False`
-- Foreign keys: Enabled
-- WAL mode: For concurrent read access
+- Timeout: 30 s (lock wait); busy timeout: 5 s (SQLITE_BUSY retry)
+- `check_same_thread=False` (multi-thread); foreign keys enabled; WAL mode + `synchronous=NORMAL`

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -1,6 +1,6 @@
 # TranscriptionSuite — Deployment Guide
 
-> Generated: 2026-04-05
+> Generated: 2026-06-11 | v1.3.6
 
 ## Deployment Architecture
 
@@ -26,8 +26,14 @@ The server uses a **layered compose** strategy. The dashboard auto-selects the c
 |------|----------|-----------|
 | `docker-compose.gpu.yml` | NVIDIA (legacy) | `deploy.resources.reservations.devices` with nvidia driver |
 | `docker-compose.gpu-cdi.yml` | NVIDIA (CDI) | CDI device passthrough (`nvidia.com/gpu=all`) |
-| `docker-compose.vulkan.yml` | AMD / Intel | whisper.cpp sidecar with `/dev/dri` Vulkan access |
+| `docker-compose.vulkan.yml` | AMD / Intel (Linux) | whisper.cpp sidecar with `/dev/dri` Vulkan access |
+| `docker-compose.vulkan-wsl2.yml` | AMD / Intel (Windows + WSL2) | whisper.cpp sidecar via `/dev/dxg` GPU-PV (locally-built image) |
 | `podman-compose.gpu.yml` | NVIDIA (Podman) | Podman-specific GPU passthrough |
+
+> **8 compose files total** (base + 5 platform/GPU overlays + podman + vulkan-wsl2). The Vulkan-WSL2 path
+> is opt-in and never enters auto-selection — it requires the locally-built
+> `transcriptionsuite/whisper-cpp-vulkan-wsl2:latest` sidecar (`server/docker/build-vulkan-wsl2.{sh,ps1}`),
+> which is **not** published to GHCR.
 
 ### Common Combinations
 ```bash
@@ -229,8 +235,10 @@ hash-match-skip path. Users flipping to cu126 still rebuild — only the
 non-flipping cu129 path is zero-cost.
 
 ### AMD/Intel Vulkan
-- Vulkan-capable GPU with `/dev/dri` access
-- Uses whisper.cpp sidecar (`ghcr.io/ggml-org/whisper.cpp:main-vulkan`)
+- **Linux:** Vulkan-capable GPU with `/dev/dri` access; whisper.cpp sidecar (`ghcr.io/ggml-org/whisper.cpp:main-vulkan`)
+- **Windows + WSL2 (experimental, opt-in):** GPU paravirtualization via `/dev/dxg`; forces Mesa's `dzn` (Vulkan-on-D3D12)
+  ICD to avoid silent CPU fallback. Requires the locally-built `vulkan-wsl2` sidecar image and Docker Desktop's WSL2 backend.
+  The dashboard surfaces a separate "GPU (Vulkan WSL2 — experimental)" option only when WSL2 + `/dev/dxg` are both detected.
 - Quantized GGUF models only (lower VRAM requirement)
 
 ### Apple Silicon (Metal)
@@ -272,11 +280,13 @@ non-flipping cu129 path is zero-cost.
 
 ## CI/CD Release Pipeline
 
-Triggered by `v*` tag push:
+Triggered by `v*` tag push (manual `workflow_dispatch` adds a **platform selector**:
+`all`/`macos-metal`/`macos`/`linux`/`windows`):
 1. **build-linux** — AppImage + GPG signature
 2. **build-windows** — NSIS installer + GPG signature (3x retry)
 3. **build-macos** — DMG + ZIP + GPG signatures
-4. **create-release** — Draft GitHub Release with all artifacts
+4. **build-macos-metal** — Apple Silicon Metal bundle (sealed last to keep the codesign valid, GH #154)
+5. **create-release** — Draft GitHub Release with all artifacts (+ update manifest for the auto-updater)
 
 ## Keychain fallback (encrypted-file mode)
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -1,6 +1,6 @@
 # TranscriptionSuite — Development Guide
 
-> Generated: 2026-04-05 | See also: [README_DEV.md](./README_DEV.md) for the canonical comprehensive reference
+> Generated: 2026-06-11 | v1.3.6 | See also: [README_DEV.md](./README_DEV.md) for the canonical comprehensive reference
 
 ## Prerequisites
 
@@ -8,7 +8,7 @@
 |------|---------|---------|
 | Python | 3.13.x | Backend (strict: >=3.13,<3.14) |
 | uv | Latest | Python package manager (NEVER pip) |
-| Node.js | 25.7.0 | Dashboard |
+| Node.js | 22.22.3 | Dashboard (engines `>=22 <23`; pinned via `.nvmrc` — Electron/Vitest break on Node ≥23) |
 | npm | Bundled | Dashboard dependencies |
 | Docker | Latest | Server container runtime |
 | ffmpeg | Latest | Audio processing (system install) |
@@ -93,7 +93,7 @@ cd dashboard && npm run package:windows
 bash build/build-electron-mac.sh
 
 # Docker image
-bash build/docker-build-push.sh v1.3.0
+bash build/docker-build-push.sh v1.3.6
 ```
 
 ## Testing
@@ -130,11 +130,12 @@ Automatically run on `git commit`:
 3. **codespell** — Spell checking
 4. **UI contract check** — CSS class integrity validation
 
-### CI/CD Quality Gates
-- **Dashboard quality:** TypeScript type checking + UI contract validation
+### CI/CD Quality Gates (5 workflows)
+- **Dashboard quality:** ESLint banned-API + TypeScript/JS checks + UI contract validation + Lighthouse a11y (≥90)
+- **Backend tests:** pytest on `server/**` changes (Python 3.13, uv, FFmpeg, ruff banned-api gate)
 - **CodeQL:** Python + JavaScript/TypeScript security scanning
-- **Scripts lint:** ShellCheck for bash scripts
-- **Release:** Multi-platform build on tag push
+- **Scripts lint:** ShellCheck (bash) + PowerShell syntax/lint
+- **Release:** Multi-platform build on tag push (+ `workflow_dispatch` platform selector)
 
 ## Configuration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # TranscriptionSuite — Documentation Index
 
-> Generated: 2026-04-05 | Exhaustive scan | v1.3.0
+> Generated: 2026-06-11 | Full rescan (git-diff targeted) | v1.3.6
 
 ## Project Overview
 
@@ -20,6 +20,17 @@
 - **Tech Stack:** Electron 40, React 19, Vite 7, Tailwind 4, Zustand
 - **Root:** `dashboard/`
 
+## Quick Reference
+
+| Metric | Value |
+|--------|-------|
+| STT backends | 10 active (CUDA/CPU + Vulkan sidecar + 4 MLX) |
+| API endpoints | 80+ REST + 3 WebSocket |
+| Database tables | 11 (+ FTS5), 17 migrations |
+| React hooks / Electron modules | 33+ / 24 |
+| Docker compose variants | 8 |
+| CI/CD workflows | 5 |
+
 ## Generated Documentation
 
 - [Project Overview](./project-overview.md)
@@ -35,12 +46,20 @@
 ## Existing Documentation
 
 - [README.md](./README.md) — User-facing README with features, installation, screenshots
-- [README_DEV.md](./README_DEV.md) — Comprehensive developer guide (12 sections, canonical reference)
-- [project-context.md](./project-context.md) — AI agent context with 90 rules and patterns
+- [README_DEV.md](./README_DEV.md) — Comprehensive developer guide (canonical reference)
+- [project-context.md](./project-context.md) — AI agent context with 101 rules and patterns
 - [Architecture Diagrams](./architecture/) — 5 PlantUML diagrams (overview, server API, STT backends, dashboard components, data flows)
 - [Testing Guide](./testing/TESTING.md) — Canonical testing reference
 - [Testing Plan](./testing/TESTING_PLAN.md) — 5-phase testing roadmap
 - [Testing Plan Stage 2](./testing/TESTING_PLAN_STAGE-2.md) — Stage 2 implementation details
+
+## What's New Since v1.3.0
+
+The Audio Notebook QoL pack (Issue #104) and related work added: **profiles** (transcription/recording),
+**speaker aliases**, **diarization review** (per-turn confidence + lifecycle), **auto-actions**
+(auto-summary/auto-export), durable **outgoing webhooks**, in-place **transcript editing with find/replace**,
+experimental **AMD/Intel Vulkan** and **Vulkan-on-Windows (WSL2)** GPU support, and a hardened
+**auto-update installer pipeline**. Schema grew from 6 → 17 migrations (4 new tables).
 
 ## Getting Started
 
@@ -51,13 +70,13 @@
 
 ### For Developers
 1. Clone the repo and run `cd build && uv sync` for tooling
-2. Run `cd dashboard && npm ci` for frontend deps
+2. Run `cd dashboard && npm ci` for frontend deps (Node 22.22.3 — see `.nvmrc`)
 3. Start development: `cd dashboard && npm run dev:electron`
 4. Run backend tests: `cd server/backend && ../../build/.venv/bin/pytest tests/ -v`
 5. See the [Development Guide](./development-guide.md) for detailed instructions
 
 ### For AI Agents
-1. Read [project-context.md](./project-context.md) first — it contains 90 critical rules
+1. Read [project-context.md](./project-context.md) first — it contains 101 critical rules
 2. Read [CLAUDE.md](../CLAUDE.md) for project-specific instructions
 3. Reference architecture docs for the part you're modifying
 4. Run tests after changes: backend pytest, frontend `npm run check`

--- a/docs/integration-architecture.md
+++ b/docs/integration-architecture.md
@@ -1,6 +1,6 @@
 # TranscriptionSuite — Integration Architecture
 
-> Generated: 2026-04-05 | Multi-part: server (backend) + dashboard (desktop)
+> Generated: 2026-06-11 | v1.3.6 | Multi-part: server (backend) + dashboard (desktop)
 
 ## Part Communication Overview
 
@@ -35,11 +35,15 @@ TranscriptionSuite is a client-server application where the **dashboard** (Elect
 └─────────┼──────────────────┼─────────────────────────────┘
           │                  │
           ▼                  ▼
-    ┌───────────┐     ┌───────────┐     ┌───────────┐
-    │ HuggingFace│     │ GPU       │     │ LM Studio │
-    │ Hub        │     │ CUDA/MPS  │     │ (optional)│
-    └───────────┘     └───────────┘     └───────────┘
+    ┌───────────┐  ┌───────────┐  ┌───────────┐  ┌────────────┐
+    │ HuggingFace│  │ GPU       │  │ LM Studio │  │ External   │
+    │ Hub        │  │CUDA/Vulkan│  │ (optional)│  │ webhook    │
+    │            │  │ /Metal    │  │           │  │ endpoint   │
+    └───────────┘  └───────────┘  └───────────┘  └────────────┘
 ```
+
+> The dashboard also reaches **GitHub Releases** (HTTPS) directly for its auto-update installer pipeline
+> (manifest + binary download + SHA-256 verification). See integration points #10 and #11.
 
 ## Integration Points
 
@@ -53,12 +57,13 @@ TranscriptionSuite is a client-server application where the **dashboard** (Elect
 |----------|-----------|---------|
 | Health | `GET /health`, `/ready`, `/api/status` | Server health, readiness, detailed status |
 | Auth | `POST /api/auth/login`, `GET/POST/DELETE /api/auth/tokens` | Token auth, token CRUD |
-| Transcription | `POST /api/transcribe/audio`, `/quick`, `/cancel` | File upload transcription |
-| Notebook | `GET/POST/PATCH/DELETE /api/notebook/recordings/*` | Recording CRUD, calendar, backup |
+| Transcription | `POST /api/transcribe/audio`, `/quick`, `/cancel`, `/import`, `/import/dedup-check`, `/retry/{id}`; `GET /result/{id}`, `/recent` | Upload transcription, dedup, durability result/retry |
+| Notebook | `GET/POST/PUT/PATCH/DELETE /api/notebook/recordings/*` (+ aliases, diarization-review, transcript, auto-actions/retry, reexport) | Recording CRUD, aliases, review, export, auto-actions |
+| Profiles | `GET/POST/PUT/DELETE /api/profiles` | Transcription/recording profile CRUD (Issue #104) |
 | Search | `GET /api/search`, `/search/words`, `/search/recordings` | Full-text search (FTS5) |
-| LLM | `POST /api/llm/process`, `/summarize/{id}` | LM Studio integration |
-| Admin | `GET/PATCH /api/admin/*`, `POST /api/admin/models/load` | Config, model management |
-| OpenAI | `POST /v1/audio/transcriptions` | OpenAI-compatible API |
+| LLM | `POST /api/llm/process`, `/summarize/{id}`, `/chat`; conversation CRUD | Local LLM summarization + chat |
+| Admin | `GET/PATCH /api/admin/*`, `POST /api/admin/models/load`, `/webhook/test` | Config, model management, webhook test |
+| OpenAI | `POST /v1/audio/transcriptions`, `/translations` | OpenAI-compatible API |
 
 ### 2. WebSocket — Longform Transcription (Dashboard → Server)
 
@@ -161,12 +166,36 @@ Client                          Server
 **Purpose:** Vulkan-accelerated Whisper inference for AMD/Intel GPUs
 **Backend:** `WhisperCppBackend` in `stt/backends/whispercpp_backend.py`
 
-### 9. Server → LM Studio (Optional)
+### 9. Server → Local LLM / LM Studio (Optional)
 
 **Protocol:** HTTP (OpenAI-compatible API)
-**Endpoint:** `http://127.0.0.1:1234` (default) or `LM_STUDIO_URL` env
-**Purpose:** Local LLM for transcription summarization and chat
-**Route:** `api/routes/llm.py`
+**Endpoint:** `config.yaml` → `local_llm.base_url` (default `http://127.0.0.1:1234`)
+**Purpose:** Local LLM for transcription summarization, auto-titles, and multi-turn chat
+**Routes:** `api/routes/llm.py` (summarize, process, `/chat`, conversation CRUD)
+
+### 10. Server → External Webhook Endpoint (Outgoing, NEW)
+
+**Protocol:** HTTPS POST (plus `http://localhost` for dev)
+**Producer:** `core/auto_action_coordinator.py` → durable `services/webhook_worker.py`
+**Event:** `transcription.completed` (per profile, when a recording completes)
+**Payload:** versioned (`payload_version="1.0"`, `webhook_version=1`); metadata-default body with
+`transcript_url`/`summary_url`; optional inline `transcript_text` (alias-substituted) when the profile opts in
+**Security (SSRF):** `core/webhook_url_validation.py` — HTTPS-only allowlist that resolves **all** DNS records
+(anti-rebinding) and blocks RFC1918/loopback/link-local/ULA/IPv4-mapped-IPv6; validated at profile-save AND
+pre-fire (TOCTOU re-check)
+**Delivery semantics:** Persist-Before-Deliver via `webhook_deliveries` table (`pending` → committed
+`in_flight` before POST → `success`/`failed`); 10 s timeout, redirects disabled; one 30 s auto-retry, then
+terminal `manual_intervention_required` (surfaced as a dashboard badge); crash recovery re-fires `in_flight`
+rows on boot. A separate **legacy** fire-and-forget webhook (`core/webhook.py`, `config.yaml` → `webhook:`)
+emits `live_sentence`/`longform_complete` with no persistence (tested via `POST /api/admin/webhook/test`).
+
+### 11. Dashboard → GitHub Releases (Auto-Update, NEW)
+
+**Protocol:** HTTPS
+**Client:** `electron/updateManager.ts` + `updateInstaller.ts` (electron-updater)
+**Purpose:** Check for new Dashboard releases, download the platform installer, verify SHA-256 against the
+release manifest, and install — with `compatGuard` server-compat pre-flight, `launchWatchdog` rollback, and a
+`releaseUrl` manual-download fallback. `platformGate`/`wslDetect` choose the strategy per OS/runtime.
 
 ## Shared Data
 
@@ -188,3 +217,5 @@ Client                          Server
 | GPU crash (CUDA error 999) | Server: `cuda_health_check()` at startup | Sets `_cuda_probe_failed` flag, server runs in degraded mode |
 | Docker container crash | Dashboard: crash-safe sentinel (Linux) | Sentinel process (setsid) stops container on Electron PID exit |
 | Large result (>1MB) | Server: payload size check | Sends `result_ready` reference, client fetches via HTTP |
+| Webhook delivery failure | Worker: non-2xx / timeout | One 30 s auto-retry, then `manual_intervention_required`; `in_flight` rows re-fired on boot |
+| Failed Dashboard update launch | Electron: `launchWatchdog` counter | After 3 failed launches, prompt rollback to cached prior installer |

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -1,6 +1,6 @@
 # TranscriptionSuite — Project Overview
 
-> Generated: 2026-04-05 | Version: 1.3.0
+> Generated: 2026-06-11 | Version: 1.3.6
 
 ## What Is TranscriptionSuite?
 
@@ -10,13 +10,18 @@ TranscriptionSuite is a self-hosted, GPU-accelerated speech-to-text platform wit
 
 - **Multi-backend transcription** — 10 STT backends: Whisper (faster-whisper, WhisperX), NVIDIA Parakeet/Canary (NeMo), Microsoft VibeVoice-ASR, whisper.cpp (Vulkan), and MLX variants for Apple Silicon
 - **Live mode** — Real-time streaming transcription with VAD-based speech detection
-- **Speaker diarization** — PyAnnote-based speaker identification with parallel/sequential modes
-- **Audio notebook** — Calendar-based recording management with full-text search (FTS5), export (SRT/VTT/ASS), and playback
+- **Speaker diarization + review** — PyAnnote/Sortformer identification, per-turn confidence, and a keyboard-driven review lifecycle
+- **Speaker aliases** — Per-recording speaker rename applied at read time across transcript, exports, and LLM prompts
+- **Audio notebook** — Calendar-based recording management with full-text search (FTS5), export (TXT/plaintext/SRT/ASS), playback, and LLM chat
+- **Transcript editing** — Non-destructive in-place editing + find/replace across three surfaces
+- **Profiles** — Reusable transcription/recording profiles with auto-summary, auto-export, and webhook delivery
+- **Outgoing webhooks** — Durable, SSRF-guarded `transcription.completed` delivery with retry/escalation
 - **Translation** — Whisper and Canary backends support cross-language translation
-- **LLM summarization** — Local LM Studio integration for transcript summarization
-- **Cross-platform** — Linux (primary), Windows, macOS (with Apple Silicon Metal acceleration)
+- **LLM summarization** — Local OpenAI-compatible (LM Studio) integration for summarization and chat
+- **Cross-platform** — Linux (primary), Windows, macOS (Apple Silicon Metal); experimental AMD/Intel Vulkan + Vulkan-on-Windows (WSL2)
 - **Remote access** — Tailscale TLS support for secure remote transcription
-- **OpenAI-compatible API** — Drop-in replacement endpoint (`/v1/audio/transcriptions`)
+- **OpenAI-compatible API** — Drop-in endpoints (`/v1/audio/transcriptions`, `/translations`)
+- **Auto-update** — Hardened Dashboard installer pipeline (compat pre-flight, SHA-256 verify, rollback)
 - **Durability** — 3-wave system to prevent transcription data loss (persist before deliver)
 
 ## Architecture
@@ -25,31 +30,34 @@ TranscriptionSuite is a self-hosted, GPU-accelerated speech-to-text platform wit
 
 | Part | Technology | Deployment |
 |------|-----------|------------|
-| **Server** (`server/`) | Python 3.13, FastAPI, PyTorch, SQLAlchemy | Docker container (7 compose variants) |
+| **Server** (`server/`) | Python 3.13, FastAPI, PyTorch, SQLAlchemy | Docker container (8 compose variants) |
 | **Dashboard** (`dashboard/`) | TypeScript 5.9, React 19, Electron 40, Tailwind 4 | Desktop app (AppImage/NSIS/DMG) |
 | **Build** (`build/`) | Shell scripts, Python tooling | CI/CD (GitHub Actions) |
 
 ### Communication
 
 ```
-Dashboard ──REST/WebSocket──► Server ──CUDA/Vulkan──► GPU
+Dashboard ──REST/WebSocket──► Server ──CUDA/Vulkan/Metal──► GPU
     │                            │
     │──Docker Compose CLI───►    │──HuggingFace Hub──►
-    │                            │──LM Studio HTTP──►
+    │──GitHub Releases (update)► │──Local LLM HTTP──►
     │◄──fs.watch (events)────    │──whisper.cpp HTTP─►
+                                 │──Outgoing webhook (HTTPS)─►
 ```
 
 ## Quick Reference
 
 | Metric | Value |
 |--------|-------|
-| Source files | 212 (+ 49 test files) |
-| Backend test count | 868+ passing tests |
-| STT backends | 10 (5 CUDA + 1 Vulkan + 4 MLX) |
-| API endpoints | ~50 REST + 2 WebSocket |
-| Custom React hooks | 20+ |
-| Docker compose variants | 7 |
-| CI/CD workflows | 4 (CodeQL, dashboard quality, scripts lint, release) |
+| Source files | ~247 (backend ~96 + frontend 151) |
+| Test files | 130 backend (pytest) + 92 frontend (Vitest) |
+| STT backends | 10 active (CUDA/CPU + Vulkan sidecar + 4 MLX) |
+| API endpoints | 80+ REST + 3 WebSocket |
+| Database tables | 11 (+ FTS5) across 17 migrations |
+| Custom React hooks | 33+ |
+| Electron main modules | 24 |
+| Docker compose variants | 8 |
+| CI/CD workflows | 5 (CodeQL, dashboard quality, scripts lint, backend tests, release) |
 | Supported platforms | Linux, Windows, macOS (arm64) |
 | License | GPL-3.0-or-later |
 

--- a/docs/project-scan-report.json
+++ b/docs/project-scan-report.json
@@ -1,39 +1,51 @@
 {
   "workflow_version": "1.2.0",
   "timestamps": {
-    "started": "2026-04-05T13:45:00Z",
-    "last_updated": "2026-04-05T14:25:00Z",
-    "completed": "2026-04-05T14:25:00Z"
+    "started": "2026-06-11T17:20:00Z",
+    "last_updated": "2026-06-11T17:48:44Z",
+    "completed": "2026-06-11T17:48:44Z"
   },
-  "mode": "initial_scan",
-  "scan_level": "exhaustive",
+  "mode": "full_rescan",
+  "scan_level": "deep",
+  "scan_strategy": "git-diff targeted (309 commits since 2026-04-05) + 5 parallel reconnaissance agents",
   "project_root": "/home/Bill/Code_Projects/Python_Projects/TranscriptionSuite",
   "project_knowledge": "/home/Bill/Code_Projects/Python_Projects/TranscriptionSuite/docs",
+  "previous_scan": {
+    "date": "2026-04-05",
+    "version": "1.3.0",
+    "archived": false,
+    "note": "Prior state file (>24h old) superseded in place by this full_rescan."
+  },
   "completed_steps": [
-    {"step": "step_1", "status": "completed", "timestamp": "2026-04-05T13:50:00Z", "summary": "Classified as multi-part with 2 parts (server=backend, dashboard=desktop) + build tooling"},
-    {"step": "step_2", "status": "completed", "timestamp": "2026-04-05T13:52:00Z", "summary": "Found 17 existing docs (README, README_DEV, project-context, 5 PlantUML diagrams, 3 testing docs, CI workflows)"},
-    {"step": "step_3", "status": "completed", "timestamp": "2026-04-05T13:55:00Z", "summary": "Tech stack: Python 3.13/FastAPI/PyTorch/SQLAlchemy (server) + TypeScript 5.9/React 19/Electron 40/Tailwind 4 (dashboard)"},
-    {"step": "step_4", "status": "completed", "timestamp": "2026-04-05T14:10:00Z", "summary": "Exhaustive scan of 261 files via 3 parallel agents (server: 25 tool calls, dashboard: in progress, build/infra: 41 tool calls)"},
-    {"step": "step_5", "status": "completed", "timestamp": "2026-04-05T14:03:00Z", "summary": "Source tree analysis written with 212 source files + 49 test files"},
-    {"step": "step_6", "status": "completed", "timestamp": "2026-04-05T14:05:00Z", "summary": "Dev/deployment info extracted from CI workflows, pre-commit config, Docker compose"},
-    {"step": "step_7", "status": "completed", "timestamp": "2026-04-05T14:12:00Z", "summary": "Integration architecture: 9 integration points (REST, 2x WS, Docker CLI, fs.watch, HF Hub, GPU, whisper.cpp, LM Studio)"},
-    {"step": "step_8", "status": "completed", "timestamp": "2026-04-05T14:18:00Z", "summary": "Architecture docs written for 2 parts (server + dashboard)"},
-    {"step": "step_9", "status": "completed", "timestamp": "2026-04-05T14:22:00Z", "summary": "6 supporting docs written: project-overview, development-guide, deployment-guide, api-contracts, data-models, integration-architecture"},
-    {"step": "step_10", "status": "completed", "timestamp": "2026-04-05T14:23:00Z", "summary": "Master index generated with links to all 10 generated docs + 7 existing docs"},
-    {"step": "step_11", "status": "completed", "timestamp": "2026-04-05T14:24:00Z", "summary": "Validation complete: 0 incomplete markers, all links verified"},
-    {"step": "step_12", "status": "completed", "timestamp": "2026-04-05T14:25:00Z", "summary": "Workflow complete"}
+    {"step": "router", "status": "completed", "timestamp": "2026-06-11T17:20:00Z", "summary": "State file >24h old + index.md present; user requested full doc update + all PlantUML diagrams → full_rescan, update-in-place"},
+    {"step": "recon", "status": "completed", "timestamp": "2026-06-11T17:32:00Z", "summary": "5 parallel agents enumerated current state: data layer, API surface, core/STT, dashboard, integration/infra"},
+    {"step": "docs", "status": "completed", "timestamp": "2026-06-11T17:44:00Z", "summary": "Updated 9 markdown docs (2 full rewrites, 7 surgical) to reflect v1.3.6"},
+    {"step": "diagrams", "status": "completed", "timestamp": "2026-06-11T17:47:00Z", "summary": "Rewrote all 5 PlantUML diagrams; validated with plantuml -checkonly (exit 0) + rendered 5/5 PNGs"},
+    {"step": "validation", "status": "completed", "timestamp": "2026-06-11T17:48:44Z", "summary": "No incomplete markers; all cross-doc links resolve; diagrams syntax-valid"}
   ],
   "current_step": "completed",
   "findings": {
     "project_classification": "multi-part, 2 parts, Python/FastAPI backend + Electron/React desktop",
-    "technology_stack": "Python 3.13/FastAPI + TypeScript 5.9/React 19/Electron 40",
-    "source_tree": "212 source files + 49 test files",
-    "existing_docs": "17 documentation files",
-    "api_endpoints": "~50 REST + 2 WebSocket endpoints",
-    "stt_backends": "10 (5 CUDA + 1 Vulkan + 4 MLX)",
-    "database_tables": "6 tables (recordings, segments, words, recordings_fts, transcription_jobs, chat_history)",
-    "integration_points": "9 (REST, 2x WS, Docker CLI, fs.watch, HuggingFace, GPU, whisper.cpp, LM Studio)"
+    "version": "1.3.6 (was 1.3.0)",
+    "technology_stack": "Python 3.13/FastAPI + TypeScript 5.9/React 19/Electron 40 (Node pinned 22.22.3)",
+    "source_tree": "~247 source files (backend ~96 + frontend 151), 222 test files (130 backend + 92 frontend)",
+    "api_endpoints": "80+ REST + 3 WebSocket (new: profiles family, dedup-check, retry/recent/dismiss, transcript, aliases, diarization-review, auto-actions/retry, llm chat/conversations)",
+    "stt_backends": "10 active (CUDA/CPU + Vulkan sidecar + 4 MLX); whisper_backend.py is orphaned dead code",
+    "database_tables": "11 tables (+ FTS5) across 17 migrations (was 6); new: profiles, recording_diarization_review, recording_speaker_aliases, webhook_deliveries",
+    "integration_points": "11 (added: outgoing webhook delivery, GitHub auto-update, admin model-load WS stream)",
+    "docker_compose_variants": "8 (added vulkan-wsl2)",
+    "ci_workflows": "5 (added backend-tests)",
+    "major_new_features": "Issue #104 Audio Notebook QoL (profiles, aliases, diarization review, auto-actions, durable webhooks), in-place transcript editing + find/replace, AMD/Vulkan + Vulkan-WSL2 GPU, auto-update installer pipeline"
   },
+  "corrections_applied": [
+    "FTS table is words_fts (not recordings_fts)",
+    "No chat_history table — LLM history is conversations + messages",
+    "whisper_backend.py (WhisperBackend) is orphaned/not factory-wired — backend count stays 10",
+    "CanaryBackend extends ParakeetBackend (not STTBackend)",
+    "MLXCanaryBackend supports_translation() = False (ASR-only port)",
+    "Config section is local_llm (not lm_studio); two webhook systems (legacy webhook + durable webhook_deliveries)",
+    "Node.js pinned to 22.22.3 (dev guide had stale 25.7.0)"
+  ],
   "project_types": [
     {"part_id": "server", "project_type_id": "backend", "display_name": "Python/FastAPI Backend"},
     {"part_id": "dashboard", "project_type_id": "desktop", "display_name": "Electron/React Desktop App"}
@@ -49,7 +61,12 @@
     "development-guide.md",
     "deployment-guide.md",
     "api-contracts-server.md",
-    "data-models-server.md"
+    "data-models-server.md",
+    "architecture/overview.puml",
+    "architecture/server-api.puml",
+    "architecture/stt-backends.puml",
+    "architecture/dashboard-components.puml",
+    "architecture/data-flow.puml"
   ],
-  "resume_instructions": "Workflow complete. All documentation generated."
+  "resume_instructions": "Workflow complete. All documentation and PlantUML diagrams updated to v1.3.6."
 }

--- a/docs/source-tree-analysis.md
+++ b/docs/source-tree-analysis.md
@@ -1,6 +1,6 @@
 # TranscriptionSuite — Source Tree Analysis
 
-> Generated: 2026-04-05 | Scan level: Exhaustive | 212 source files + 49 test files
+> Generated: 2026-06-11 | v1.3.6 | Scan level: Deep (git-diff targeted) | Multi-part: server + dashboard + build
 
 ## Repository Structure
 
@@ -13,72 +13,92 @@ TranscriptionSuite/
 ├── server/                          # Part: backend (Python/FastAPI)
 │   ├── backend/                     # FastAPI application source
 │   │   ├── api/                     # HTTP + WebSocket API layer
-│   │   │   ├── main.py              # ★ App entry point: lifespan, middleware, router registration
-��   │   │   └── routes/              # Route handlers (one file per domain)
-│   │   │       ├── admin.py         #   Config, model loading, logs, diarization, webhooks
-│   │   │       ├��─ auth.py          #   Token-based auth (login, CRUD tokens)
+│   │   │   ├── main.py              # ★ App entry: lifespan, middleware, router registration
+│   │   │   └── routes/              # Route handlers (one file per domain)
+│   │   │       ├── admin.py         #   Config, model loading, logs, diarization, webhook test
+│   │   │       ├── auth.py          #   Token-based auth (login, CRUD tokens)
 │   │   │       ├── health.py        #   /health, /ready, /api/status
-│   │   │       ├── live.py          #   WebSocket /ws/live — real-time streaming transcription
-│   │   │       ├── llm.py           #   LM Studio integration (summarize, process, model mgmt)
-│   │   │       ├── notebook.py      #   Audio notebook CRUD (recordings, calendar, backup)
-│   │   │       ├── openai_audio.py  #   OpenAI-compatible /v1/audio/transcriptions endpoint
-│   │   │       ├��─ search.py        #   Full-text search (FTS5) across recordings
-│   │   │       ├── transcription.py #   File upload transcription, cancel, languages, job results
-│   │   │       ├── utils.py         #   Shared route helpers (client detection, auth)
+│   │   │       ├── live.py          #   WebSocket /ws/live — Live Mode streaming
+│   │   │       ├── llm.py           #   LM Studio: summarize, process, chat, conversations, models
+│   │   │       ├── notebook.py      #   Audio notebook CRUD, aliases, diarization-review, auto-actions
+│   │   │       ├── openai_audio.py  #   OpenAI-compatible /v1/audio/transcriptions + /translations
+│   │   │       ├── profiles.py      #   ★ NEW — transcription/recording profile CRUD (Issue #104)
+│   │   │       ├── search.py        #   Full-text search (FTS5)
+│   │   │       ├── transcription.py #   File upload, cancel, languages, job result/retry/dedup-check
+│   │   │       ├── utils.py         #   Shared route helpers (client detection, auth, WS auth)
 │   │   │       └── websocket.py     #   WebSocket /ws — longform recording transcription
 │   │   ├── config.py                # ServerConfig: YAML + env var + runtime config
 │   │   ├── config_tree.py           # Nested config tree for admin PATCH operations
 │   │   ├── core/                    # Business logic layer
-│   │   │   ├── audio_utils.py       #   Audio loading, resampling, CUDA health check
+│   │   │   ├── audio_utils.py       #   Audio loading, resampling, CUDA health check, hashing
 │   │   │   ├── client_detector.py   #   Client type detection (dashboard vs CLI vs API)
 │   │   │   ├── diarization_engine.py#   Speaker diarization (PyAnnote pipeline)
-│   │   │   ├── download_progress.py #   HuggingFace model download progress tracking
-���   │   │   ├── ffmpeg_utils.py      #   FFmpeg audio conversion/probing
-│   │   │   ├── formatters.py        #   Transcription output formatters (JSON, text, SRT)
-│   │   │   ├── json_utils.py        #   Safe JSON serialization (numpy/tensor types)
+│   │   │   ├── diarization_confidence.py    # ★ NEW — per-turn confidence + alt-speaker ranking
+│   │   │   ├── diarization_review_filter.py # ★ NEW — low-confidence-turn filter (modes)
+│   │   │   ├── diarization_review_lifecycle.py # ★ NEW — ADR-009 review state machine
+│   │   │   ├── sortformer_engine.py #   Sortformer diarization (Apple Silicon, no HF token)
+│   │   │   ├── speaker_merge.py     #   Merge ASR words/segments with diarization (overlap)
+│   │   │   ├── parallel_diarize.py  #   Parallel transcribe + diarize on a thread pool
+│   │   │   ├── alias_substitution.py#   ★ NEW — read-time speaker display-name substitution
+│   │   │   ├── auto_action_coordinator.py # ★ NEW — fires auto-summary/export/webhook per profile
+│   │   │   ├── auto_action_sweeper.py     # ★ NEW — re-fires deferred/retry-pending auto-exports
+│   │   │   ├── auto_summary_engine.py     # ★ NEW — programmatic summarization for auto-actions
+│   │   │   ├── webhook.py           #   Legacy fire-and-forget webhook (live_sentence/longform_complete)
+│   │   │   ├── webhook_payload.py   #   ★ NEW — durable transcription.completed payload builder
+│   │   │   ├── webhook_url_validation.py  # ★ NEW — SSRF allowlist (anti-DNS-rebinding)
+│   │   │   ├── multitrack.py        #   ★ NEW — multi-channel audio → per-channel speaker transcript
+│   │   │   ├── filename_template.py #   ★ NEW — {placeholder} export filename engine + sanitizer
+│   │   │   ├── hf_token_guard.py    #   ★ NEW — purge non-ASCII HF tokens (GH #125)
+│   │   │   ├── plaintext_export.py  #   ★ NEW — FR9 plaintext (one paragraph per speaker turn)
+│   │   │   ├── download_progress.py #   HuggingFace model download progress
+│   │   │   ├── ffmpeg_utils.py      #   FFmpeg audio conversion/probing
+│   │   │   ├── formatters.py        #   Transcription output formatters
+│   │   │   ├── json_utils.py        #   Safe JSON serialization (numpy/tensor)
 │   │   │   ├── live_engine.py       #   Live mode orchestration (VAD + streaming + model swap)
-│   │   │   ├── model_manager.py     #   ★ Model lifecycle: load, unload, swap, preload, GPU mgmt
-���   │   │   ├── parallel_diarize.py  #   Parallel diarization (chunk-based for long audio)
-│   │   │   ├── realtime_engine.py   #   Real-time audio processing engine
-│   │   │   ├── sortformer_engine.py #   Sortformer diarization (NeMo-based)
-│   │   │   ├── speaker_merge.py     #   Merge transcription segments with speaker labels
+│   │   │   ├── model_manager.py     #   ★ Model lifecycle + GPU mgmt + TranscriptionJobTracker
+│   │   │   ├── realtime_engine.py   #   Async WS↔STT bridge for real-time transcription
 │   │   │   ├── startup_events.py    #   Startup event emitter (for Electron fs.watch)
-│   │   │   ├── subtitle_export.py   #   SRT/VTT subtitle export
+│   │   │   ├── subtitle_export.py   #   SRT/VTT/ASS subtitle export
 │   │   │   ├── token_store.py       #   File-backed auth token persistence
-│   │   │   ├── webhook.py           #   Outgoing webhook system (SSRF-safe)
 │   │   │   └── stt/                 #   Speech-to-text subsystem
 │   │   │       ├── engine.py        #   AudioToTextRecorder — orchestrates backend transcription
 │   │   │       ├── capabilities.py  #   Model capability detection (translation, languages)
 │   │   │       ├── vad.py           #   Voice Activity Detection (Silero VAD)
-│   │   │       └── backends/        #   STT backend implementations (10 backends)
-│   │   │           ├── base.py      #     Abstract STTBackend + data types
+│   │   │       └── backends/        #   STT backend implementations
+│   │   │           ├── base.py      #     Abstract STTBackend + data types + BackendDependencyError
 │   │   │           ├── factory.py   #     ★ Backend factory: model name → backend class
-│   │   │           ├── whisperx_backend.py      # WhisperX (faster-whisper + alignment + diarization)
-│   │   │           ├── faster_whisper_backend.py # Lightweight faster-whisper (Live Mode on Metal)
-│   │   │           ├── parakeet_backend.py       # NVIDIA Parakeet (NeMo ASR)
-│   │   │           ├── canary_backend.py         # NVIDIA Canary (NeMo, 24 EU translation targets)
-│   │   │           ├── vibevoice_asr_backend.py  # Microsoft VibeVoice-ASR
-│   │   │           ├── whispercpp_backend.py     # whisper.cpp HTTP sidecar (Vulkan GPU)
-│   │   │           ├── mlx_whisper_backend.py    # MLX Whisper (Apple Silicon)
-│   │   │           ├── mlx_parakeet_backend.py   # MLX Parakeet (Apple Silicon)
-│   │   │           ├── mlx_canary_backend.py     # MLX Canary (Apple Silicon)
-│   │   │           └─��� mlx_vibevoice_backend.py  # MLX VibeVoice (Apple Silicon, native diarization)
+│   │   │           ├── mlx_thread_pin.py     # ★ NEW — MLX Metal cross-thread affinity mixin (GH #134)
+│   │   │           ├── whisperx_backend.py   # WhisperX (default; alignment + diarization)
+│   │   │           ├── faster_whisper_backend.py # Lightweight faster-whisper (default fallback)
+│   │   │           ├── whisper_backend.py    # ⚠ Legacy/orphaned WhisperBackend (not factory-wired)
+│   │   │           ├── parakeet_backend.py   # NVIDIA Parakeet (NeMo ASR)
+│   │   │           ├── canary_backend.py     # NVIDIA Canary (extends ParakeetBackend; 24 EU translation)
+│   │   │           ├── vibevoice_asr_backend.py # Microsoft VibeVoice-ASR
+│   │   │           ├── whispercpp_backend.py    # whisper.cpp HTTP sidecar (Vulkan GPU)
+│   │   │           ├── mlx_whisper_backend.py   # MLX Whisper (Apple Silicon)
+│   │   │           ├── mlx_parakeet_backend.py  # MLX Parakeet (Apple Silicon)
+│   │   │           ├── mlx_canary_backend.py    # MLX Canary (Apple Silicon; ASR-only port)
+│   │   │           └── mlx_vibevoice_backend.py # MLX VibeVoice (Apple Silicon, native diarization)
 │   │   ├── database/               # Data persistence layer
-│   │   │   ├── database.py         #   SQLite + FTS5 (async, aiosqlite + SQLAlchemy)
-│   │   │   ├── job_repository.py   #   Transcription job CRUD (durability layer)
-��   │   │   ├── audio_cleanup.py    #   Completed recording cleanup by retention policy
-│   │   │   ├── backup.py           #   Database backup/restore
-│   │   │   └── migrations/         #   Alembic migrations (6 versions)
-│   │   │       └── versions/
-│   │   │           ├── 001_initial_schema.py
-│   │   │           ├─��� 002_add_response_id.py
-│   │   │           ├── 003_add_message_model_and_summary_model.py
-��   │   │           ├── 004_schema_sanity_and_segment_backfill.py
-│   ��   │           ├── 005_add_recordings_transcription_backend.py
-│   │   │           └── 006_add_transcription_jobs.py
+│   │   │   ├── database.py         #   SQLite + FTS5 (async, aiosqlite + raw sqlite3)
+│   │   │   ├── job_repository.py   #   transcription_jobs CRUD (durability)
+│   │   │   ├── profile_repository.py        # ★ NEW — profiles CRUD + snapshot
+│   │   │   ├── alias_repository.py          # ★ NEW — speaker-alias CRUD
+│   │   │   ├── diarization_review_repository.py # ★ NEW — review-state CRUD
+│   │   │   ├── auto_action_repository.py    # ★ NEW — auto-action status columns
+│   │   │   ├── webhook_deliveries_repository.py # ★ NEW — webhook delivery ledger
+│   │   │   ├── webhook_cleanup.py           # ★ NEW — webhook retention sweep
+│   │   │   ├── dedup_query.py               # ★ NEW — cross-table audio dedup lookup
+│   │   │   ├── audio_cleanup.py    #   Completed-recording audio cleanup by retention
+│   │   │   ├── backup.py           #   Database backup/restore (WAL-safe)
+│   │   │   └── migrations/         #   Alembic migrations (17 versions)
+│   │   │       └── versions/       #   001_initial … 017_add_recording_transcript_corrected
+│   │   ├── services/               # ★ NEW — long-running services
+│   │   │   └── webhook_worker.py   #   ★ NEW — durable webhook delivery worker (lifespan singleton)
+│   │   ├── utils/                  # ★ NEW — backend shared utilities
 │   │   ├── logging/                # Structured logging (structlog wrapping stdlib)
 │   │   │   └── setup.py
-│   │   └── tests/                  # Backend test suite (49 files, 868+ tests)
+│   │   └── tests/                  # Backend test suite (130 test files)
 │   │       ├── conftest.py         #   ★ Critical: _ensure_server_package_alias, fixtures
 │   │       └── test_*.py           #   One test file per source module
 │   ├── config.yaml                 # ★ Central configuration file (all settings)
@@ -90,170 +110,161 @@ TranscriptionSuite/
 │       ├── docker-compose.yml      #   ★ Base compose (service, volumes, env)
 │       ├── docker-compose.linux-host.yml    # Overlay: host networking (Linux)
 │       ├── docker-compose.desktop-vm.yml    # Overlay: bridge + ports (macOS/Windows)
-│       ├── docker-compose.gpu.yml           # Overlay: NVIDIA runtime GPU
-│       ├── docker-compose.gpu-cdi.yml       # Overlay: CDI device passthrough
-│       ├── docker-compose.vulkan.yml        # Overlay: whisper.cpp sidecar (AMD/Intel GPU)
-│       └── podman-compose.gpu.yml           # Overlay: Podman GPU passthrough
+│       ├── docker-compose.gpu.yml           # Overlay: NVIDIA runtime GPU (legacy)
+│       ├── docker-compose.gpu-cdi.yml       # Overlay: NVIDIA CDI device passthrough
+│       ├── docker-compose.vulkan.yml        # Overlay: whisper.cpp sidecar (AMD/Intel, Linux /dev/dri)
+│       ├── docker-compose.vulkan-wsl2.yml   # ★ NEW — whisper.cpp sidecar for Windows+WSL2 (/dev/dxg)
+│       ├── podman-compose.gpu.yml           # Overlay: Podman GPU passthrough
+│       ├── whisper-cpp-vulkan-wsl2.Dockerfile # ★ NEW — locally-built WSL2 Vulkan sidecar image
+│       └── build-vulkan-wsl2.{sh,ps1}       # ★ NEW — build the WSL2 sidecar image
 │
 ├── dashboard/                      # Part: desktop (Electron/React/TypeScript)
-��   ├── App.tsx                     # ★ Root component: providers, routing, lifted state
+│   ├── App.tsx                     # ★ Root component: providers, routing, lifted state, modals
 │   ├── index.tsx                   # React DOM entry point
-│   ├── index.html                  # Vite HTML template
-│   ├── types.ts                    # Shared TypeScript types
 │   ├── components/                 # React components
-│   │   ├── AudioVisualizer.tsx     #   Real-time audio waveform visualization
-│   │   ├── PopOutWindow.tsx        #   Detachable window for transcription output
-│   ��   ├── Sidebar.tsx             #   Navigation sidebar (view switching)
-│   │   ├── ui/                     #   Shared UI primitives (10 components)
+│   │   ├── AriaLiveRegion.tsx      #   ★ NEW — polite/assertive aria-live regions (a11y)
+│   │   ├── AudioVisualizer.tsx     #   Real-time audio waveform (isActive gates rAF loop)
+│   │   ├── PopOutWindow.tsx        #   Detachable window (React portal) for live transcript
+│   │   ├── Sidebar.tsx             #   Nav sidebar (+ Profile/ModelProfile selectors)
+│   │   ├── ui/                     #   Shared UI primitives (14 components)
 │   │   │   ├── ActivityNotifications.tsx  # Toast-style activity feed
-│   │   │   ├── AppleSwitch.tsx           # iOS-style toggle switch
-│   │   │   ├── Button.tsx                # Themed button variants
-│   │   │   ├── CustomSelect.tsx          # Accessible dropdown select
-│   │   │   ��── ErrorFallback.tsx         # Error boundary UI
-│   │   │   ├── GlassCard.tsx             # Glassmorphism card container
-│   │   │   ├── LogTerminal.tsx           # Terminal-style log viewer
-│   │   │   ├── QueuePausedBanner.tsx     # Import queue pause indicator
-│   │   │   ├── ShortcutCapture.tsx       # Keyboard shortcut recorder
-│   │   │   └── StatusLight.tsx           # Colored status indicator dot
-│   │   └── views/                  #   Full-page views and modals
-│   │       ├── SessionView.tsx     #     ★ Main view: recording, transcription, live mode
-│   │       ├── NotebookView.tsx    #     Audio notebook: calendar, search, recordings
-│   │       ├── ServerView.tsx      #     Docker/server management, status, config
-│   │       ├── ModelManagerView.tsx #    Model browser, download, selection
-│   │       ├── ModelManagerTab.tsx  #    Tab within model manager
-│   │       ├── SessionImportTab.tsx #   Batch audio file import
-│   │       ├── LogsView.tsx        #    Server log viewer
-│   │       ├── ServerConfigEditor.tsx #  YAML config editor
-│   │       ├── SettingsModal.tsx    #    App settings (shortcuts, theme, auth)
-│   │       ├── AboutModal.tsx       #    Version/credits dialog
-│   │       ├── AudioNoteModal.tsx   #    Audio note creation
-│   │       ├── AddNoteModal.tsx     #    Quick note addition
-│   │       ├── BugReportModal.tsx   #    Bug report helper
-│   │       ├── FullscreenVisualizer.tsx # Pop-out audio visualizer
-│   │       └── StarPopupModal.tsx   #    GitHub star reminder
-│   ├── electron/                   # Electron main process
+│   │   │   ├── AppleSwitch.tsx / Button.tsx / CustomSelect.tsx / GlassCard.tsx
+│   │   │   ├── ErrorFallback.tsx / LogTerminal.tsx / ShortcutCapture.tsx / StatusLight.tsx
+│   │   │   ├── QueuePausedBanner.tsx
+│   │   │   ├── ImageTagChips.tsx          # ★ NEW — Docker image-tag selector chips
+│   │   │   ├── PersistentInfoBanner.tsx   # ★ NEW — non-dismissing info banner + CTA
+│   │   │   ├── UpdateBanner.tsx           # ★ NEW — in-app dashboard-update banner
+│   │   │   └── UpdateModal.tsx            # ★ NEW — pre-install decision surface
+│   │   ├── views/                  #   Full-page views and modals
+│   │   │   ├── SessionView.tsx     #     ★ Main view: recording, transcription, live mode
+│   │   │   ├── LiveTranscriptView.tsx #  ★ NEW — shared live-transcript area (stream → edit → idle)
+│   │   │   ├── NotebookView.tsx    #     Audio notebook: calendar, search, recordings
+│   │   │   ├── ServerView.tsx      #     Docker/server management, image tags, GPU health
+│   │   │   ├── GpuHealthCard.tsx   #     ★ NEW — GPU status card (CPU-fallback detection)
+│   │   │   ├── GpuDiagnosticModal.tsx #  ★ NEW — diagnose-gpu.sh output renderer
+│   │   │   ├── ModelManagerView.tsx / ModelManagerTab.tsx # Model browser/download
+│   │   │   ├── SessionImportTab.tsx #    Batch audio file import
+│   │   │   ├── LogsView.tsx        #     Server log viewer
+│   │   │   ├── ServerConfigEditor.tsx #  YAML config editor (in Settings)
+│   │   │   ├── SettingsModal.tsx   #     App settings (+ model-profile panel)
+│   │   │   ├── AboutModal.tsx / AddNoteModal.tsx / AudioNoteModal.tsx
+│   │   │   ├── BugReportModal.tsx / FullscreenVisualizer.tsx / StarPopupModal.tsx
+│   │   ├── recording/              #   ★ NEW — per-recording widgets (Issue #104)
+│   │   │   ├── AutoActionStatusBadge.tsx  # Auto-summary/export status + retry
+│   │   │   ├── ConfidenceChip.tsx         # Per-turn diarization-confidence chip
+│   │   │   ├── SpeakerRenameInput.tsx     # Inline speaker rename
+│   │   │   ├── DownloadButtons.tsx        # Transcript/summary download (built-ahead)
+│   │   │   ├── DeleteRecordingDialog.tsx  # Delete + opt-in artifact removal
+│   │   │   └── DiarizationReviewView.tsx  # Low-confidence-turn review (built-ahead)
+│   │   ├── profiles/               #   ★ NEW — profile UI
+│   │   │   ├── ProfileSelector.tsx / ModelProfileSelector.tsx
+│   │   │   ├── ModelProfilesPanel.tsx / EmptyProfileForm.tsx / TemplatePreviewField.tsx
+│   │   ├── editor/                 #   ★ NEW — transcript editing
+│   │   │   ├── FindReplaceTextEditor.tsx  # Reusable textarea + find/replace (3 surfaces)
+│   │   │   └── FindReplaceToolbar.tsx
+│   │   └── import/                 #   ★ NEW — dedup prompt
+│   │       ├── DedupChoiceContainer.tsx   # App-root mount, subscribes to dedup store
+│   │       └── DedupPromptModal.tsx       # "Use existing / Create new" prompt
+│   ├── electron/                   # Electron main process (24 modules)
 │   │   ├── main.ts                 #   ★ BrowserWindow, IPC handlers, app lifecycle
 │   │   ├── preload.ts              #   Context bridge (renderer ↔ main IPC)
+│   │   ├── appState.ts            #    ★ NEW — store accessors (server URL, token, idle)
 │   │   ├── dockerManager.ts        #   Docker Compose lifecycle (start/stop/update)
 │   │   ├── containerRuntime.ts     #   Detect Docker/Podman runtime
 │   │   ├── mlxServerManager.ts     #   macOS bare-metal server management (no Docker)
+│   │   ├── mlxLogSink.ts          #    ★ NEW — persist-and-deliver MLX log pipeline
 │   │   ├── trayManager.ts          #   System tray icon and menu
 │   │   ├── shortcutManager.ts      #   Global keyboard shortcuts
 │   │   ├── waylandShortcuts.ts     #   Wayland-specific shortcut handling
+│   │   ├── clipboardWayland.ts     #   ★ NEW — reliable Wayland clipboard write
 │   │   ├── pasteAtCursor.ts        #   System-wide paste (xdotool/AppleScript)
 │   │   ├── startupEventWatcher.ts  #   Watch server bootstrap events (fs.watch)
-│   │   ├── updateManager.ts        #   Auto-updater (GitHub releases)
-│   │   └── watcherManager.ts       #   Folder watcher for auto-import
+│   │   ├── watcherManager.ts       #   Folder watcher for auto-import
+│   │   ├── wslDetect.ts           #    ★ NEW — WSL2 + /dev/dxg GPU-PV detection
+│   │   ├── platformGate.ts        #    ★ NEW — per-OS install strategy resolver
+│   │   ├── compatGuard.ts         #    ★ NEW — update server-compat pre-flight
+│   │   ├── launchWatchdog.ts      #    ★ NEW — failed-launch counter + rollback trigger
+│   │   ├── installerCache.ts      #    ★ NEW — cache prior installer for rollback
+│   │   ├── updateManager.ts        #   Auto-updater (GitHub releases poll/notify)
+│   │   ├── updateInstaller.ts     #    ★ NEW — electron-updater download/install state machine
+│   │   ├── checksumVerifier.ts    #    ★ NEW — streaming SHA-256 verify of downloads
+│   │   ├── sha256Lookup.ts        #    ★ NEW — resolve expected digest from manifest
+│   │   └── releaseUrl.ts          #    ★ NEW — build/validate GitHub release URLs
 │   ├── src/                        # Application logic layer
-│   │   ├── api/
-│   │   │   ├── client.ts           #   HTTP + WS API client (fetch-based)
-│   │   │   └── types.ts            #   API response/request types
-│   │   ├── hooks/                  #   React hooks (20 hooks)
-│   │   │   ├── useTranscription.ts #     ★ WebSocket transcription lifecycle
-│   │   ��   ├── useLiveMode.ts      #     Live mode (VAD streaming, partial results)
-│   │   │   ├── useDocker.ts        #     Docker container management
-│   │   │   ├── useServerStatus.ts  #     Server health polling + GPU error detection
-│   │   │   ���── useRecording.ts     #     Audio recording (mic capture)
-│   │   │   ├── useUpload.ts        #     File upload transcription
-│   │   │   ├── useImportQueue.ts   #     Batch import queue processing
-│   │   │   ├── useSessionImportQueue.ts # Session-scoped import queue
-│   │   │   ├── useCalendar.ts      #     Notebook calendar data
-│   │   │   ├── useSearch.ts        #     Full-text search
-│   │   │   ├─�� useAdminStatus.ts   #     Admin config and status
-│   │   │   ├── useAuthTokenSync.ts #     Auto-detect auth token from Docker logs
-│   │   │   ├── useBackups.ts       #     Database backup management
-│   │   │   ├── useBootstrapDownloads.ts # Track bootstrap dep downloads
-│   │   │   ├── useClipboard.ts     #     System clipboard operations
-���   │   │   ├── useConfirm.tsx      #     Confirmation dialog hook
-│   │   │   ├── useLanguages.ts     #     Language list from server
-��   │   │   ├── useNotebookWatcher.ts #   Watch for new recordings
-│   │   │   ├── useServerEventReactor.ts # Server state transition matrix
-│   │   │   ├── useSessionWatcher.ts #    Watch active session changes
-│   │   │   ├── useStarPopup.ts     #     GitHub star reminder logic
-│   │   │   ├── useTraySync.ts      #     Sync state to system tray
-│   │   │   ├── useWordHighlighter.ts #   Word-level highlight during playback
-│   │   │   ├── useClientDebugLogs.ts #   Client-side debug logging
-│   │   │   └── DockerContext.tsx    #     React context for Docker state
+│   │   ├── api/                    #   HTTP + WS API client + types
+│   │   ├── hooks/                  #   React hooks (33+)
+│   │   │   ├── useTranscription.ts / useLiveMode.ts / useRecording.ts / useUpload.ts
+│   │   │   ├── useDocker.ts / DockerContext.tsx / useServerStatus.ts / useServerEventReactor.ts
+│   │   │   ├── useImportQueue.ts / useSessionImportQueue.ts / useSessionWatcher.ts
+│   │   │   ├── useWatcherFilesBridge.ts # ★ NEW — singleton watcher→queue bridge (Issue #94)
+│   │   │   ├── useCalendar.ts / useSearch.ts / useNotebookWatcher.ts / useWordHighlighter.ts
+│   │   │   ├── useAdminStatus.ts / useAuthTokenSync.ts / useBackups.ts / useBootstrapDownloads.ts
+│   │   │   ├── useClipboard.ts / useConfirm.tsx / useLanguages.ts / useStarPopup.ts / useTraySync.ts
+│   │   │   ├── useClientDebugLogs.ts
+│   │   │   ├── useFindReplace.ts          # ★ NEW — find/replace over a textarea
+│   │   │   ├── useRecordingAliases.ts     # ★ NEW — per-recording speaker aliases
+│   │   │   ├── useDiarizationConfidence.ts# ★ NEW — per-turn confidence map
+│   │   │   ├── useDiarizationReview.ts     # ★ NEW — ADR-009 review lifecycle
+│   │   │   ├── useAutoActionRetry.ts       # ★ NEW — auto-action retry mutation
+│   │   │   ├── useAriaAnnouncer.ts         # ★ NEW — push aria-live messages
+│   │   │   ├── useFolderPicker.ts          # ★ NEW — native folder dialog
+│   │   │   └── useFileSaveDialog.ts        # ★ NEW — native file-save dialog
 │   │   ├── services/               #   Non-React business logic
-│   │   │   ├── audioCapture.ts     #     Web Audio API mic capture
-│   │   │   ├── websocket.ts        #     WebSocket client (reconnect, auth, binary)
-│   │   │   ├── modelCapabilities.ts #    Model capability detection (translation, etc.)
-│   │   │   ├── modelRegistry.ts    #     Known model registry with metadata
-│   │   ���   ├��─ modelSelection.ts   #     Model selection logic for UI
-│   │   │   ├── transcriptionFormatters.ts # Format segments for display
-│   │   │   └── clientDebugLog.ts   #     Debug log service
-│   │   ├── stores/                 #   Zustand state stores
-│   ���   │   ├── activityStore.ts    #     Activity feed (downloads, warnings, info)
-│   │   │   └��─ importQueueStore.ts #     Import queue state + processing
-│   │   ├── config/
-│   │   │   └── store.ts            #     Electron-store config persistence
+│   │   │   ├── websocket.ts / audioCapture.ts / transcriptionFormatters.ts / clientDebugLog.ts
+│   │   │   ├── modelCapabilities.ts / modelRegistry.ts / modelSelection.ts
+│   │   │   ├── findReplaceEngine.ts        # ★ NEW — pure literal find/replace
+│   │   │   ├── modelProfileStore.ts        # ★ NEW — model-profile CRUD (electron-store)
+│   │   │   ├── profileDefaults.ts          # ★ NEW — empty-profile defaults (Lurker-safe)
+│   │   │   ├── transcriptFlatten.ts        # ★ NEW — segments → editable plain text
+│   │   │   └── versionUtils.ts             # ★ NEW — Docker-tag parse/compare + GHCR repo resolve
+│   │   ├── stores/                 #   Zustand state stores (5)
+│   │   │   ├── activityStore.ts / importQueueStore.ts
+│   │   │   ├── activeProfileStore.ts       # ★ NEW — active notebook profile id
+│   │   │   ├── ariaAnnouncerStore.ts       # ★ NEW — aria-live message state
+│   │   │   └── dedupChoiceStore.ts         # ★ NEW — import↔dedup-prompt promise bridge
 │   │   ├── utils/                  #   Utility functions
-│   │   │   ├── configTree.ts       #     Nested config manipulation
-│   │   │   ├── dockerLogParsing.ts #     Docker log line parsing
-│   │   │   └── transcriptionBackend.ts # Backend type detection
-│   │   ├── types/                  #   TypeScript declarations
-│   │   │   ├── electron.d.ts       #     Electron IPC type definitions
-│   │   │   ├── audio-worklet.d.ts  #     AudioWorklet type shims
-│   │   │   └── runtime.ts          #     Runtime type utilities
+│   │   │   ├── aliasSubstitution.ts / confidenceBuckets.ts / diarizationReviewFilter.ts
+│   │   │   ├── filenameTemplate.ts / a11yLabels.ts / sha256File.ts / transcriptionBackend.ts
+│   │   │   ├── configTree.ts / dockerLogParsing.ts
+│   │   │   ├── blurEffectsBoot.ts / idleAnimationsBoot.ts / idleVisibilityGate.ts # idle/perf (GH #87)
+│   │   │   └── migrateLegacyAppearanceConfig.ts
+│   │   ├── config/store.ts         #   Electron-store config persistence
+│   │   ├── types/                  #   TypeScript declarations (electron.d.ts, etc.)
 │   │   ├── queryClient.ts          #   React Query client configuration
 │   │   └── index.css               #   Global styles (Tailwind entry)
-│   ├── public/
-│   │   └── audio-worklet-processor.js # AudioWorklet for mic capture
-│   ├── scripts/                    # Build & tooling scripts
-│   │   ├── afterPack.cjs           #   Post-packaging hook (electron-builder)
-│   │   ├── dev-electron.mjs        #   Dev mode Electron launcher
-│   │   └── ui-contract/            #   UI contract validation system (6 scripts)
-│   ├── ui-contract/                # UI contract definition
-│   │   └── transcription-suite-ui.contract.yaml
-│   ├── package.json                # NPM dependencies and scripts
-│   ├── tsconfig.json               # TypeScript configuration
-│   ├── vite.config.ts              # Vite bundler config (base: './')
-│   └── vitest.config.ts            # Vitest test runner config
+│   ├── public/                     #   AudioWorklet processor, static assets
+│   ├── scripts/                    #   Build & tooling (afterPack, dev-electron, ui-contract/)
+│   ├── ui-contract/                #   UI contract definition + baseline
+│   ├── package.json / tsconfig.json / vite.config.ts / vitest.config.ts
 │
 ├── build/                          # Build tooling (not a deployable part)
-│   ├── pyproject.toml              #   Build venv deps (ruff, pyright, pytest, bandit)
-│   ├── uv.lock                     #   Locked dependencies for build env
-│   ├── build-electron-linux.sh     #   Linux AppImage packaging
-│   ├── build-electron-mac.sh       #   macOS DMG + ZIP packaging (unsigned)
-│   ├── docker-build-push.sh        #   Docker image build and GHCR push
-│   ├── sign-electron-artifacts.sh  #   GPG signing for release artifacts
-│   ├── setup-macos-metal.sh        #   macOS Metal bare-metal server setup
-│   ├── generate-ico.sh             #   ICO/ICNS icon generation from SVG
-│   ├── entitlements.mac.plist      #   macOS app entitlements (audio, AppleEvents)
-│   └── nvidia-persistence.service  #   Systemd service for NVIDIA persistence
+│   ├── pyproject.toml / uv.lock    #   Build venv deps (ruff, pyright, pytest, bandit)
+│   ├── build-electron-linux.sh / build-electron-mac.sh / docker-build-push.sh
+│   ├── sign-electron-artifacts.sh / setup-macos-metal.sh / generate-ico.sh
+│   ├── entitlements.mac.plist / nvidia-persistence.service
 │
-├── scripts/                        # Standalone utility scripts
-│   └── benchmark_stt.py            #   STT backend benchmarking tool
+├── scripts/                        # Standalone utility scripts (benchmark_stt.py, diagnose-gpu.sh)
 │
 ├── docs/                           # Project documentation
-│   ├── README.md                   #   User-facing README
-│   ├── README_DEV.md               #   ★ Comprehensive developer guide (12 sections)
-│   ├── project-context.md          #   AI agent context (90 rules)
-│   ├── architecture/               #   PlantUML diagrams (5 diagrams)
-│   │   ├── overview.puml           #     System architecture
-│   │   ├── server-api.puml         #     API routing structure
-│   │   ├── stt-backends.puml       #     STT backend class hierarchy
-│   │   ├── dashboard-components.puml #   React component tree
-│   │   └── data-flow.puml          #     Transcription data flows
-│   ├── testing/                    #   Testing documentation
-│   │   ├── TESTING.md              #     Canonical testing reference
-│   │   ├── TESTING_PLAN.md         #     5-phase testing roadmap
-│   │   └── TESTING_PLAN_STAGE-2.md #     Stage 2 details
-│   └── assets/                     #   Logos, screenshots, icons (18 files)
+│   ├── README.md / README_DEV.md   #   User + comprehensive developer guides (existing, canonical)
+│   ├── project-context.md          #   AI agent context (101 rules)
+│   ├── index.md                    #   Master documentation index
+│   ├── architecture/               #   PlantUML diagrams (5)
+│   │   ├── overview.puml / server-api.puml / stt-backends.puml
+│   │   ├── dashboard-components.puml / data-flow.puml
+│   ├── testing/                    #   TESTING.md, TESTING_PLAN.md (+ stage 2)
+│   └── *.md                        #   Generated docs (this set)
 │
 ├── .github/                        # GitHub configuration
-│   ├── workflows/                  #   CI/CD pipelines (4 workflows)
-│   │   ├── codeql-analysis.yml     #     Security scanning
-│   │   ├── dashboard-quality.yml   #     TypeScript + UI contract checks
-│   │   ├── scripts-lint.yml        #     Shell script linting
-│   │   └── release.yml             #     Multi-platform release pipeline
-│   └── codeql/
-│       └── codeql-config.yml       #     CodeQL configuration
+│   └── workflows/                  #   CI/CD pipelines (5 workflows)
+│       ├── release.yml             #     Multi-platform release (+ platform selector)
+│       ├── backend-tests.yml       #     ★ pytest on server/** changes
+│       ├── dashboard-quality.yml   #     TypeScript + UI contract + Lighthouse a11y
+│       ├── codeql-analysis.yml     #     Security scanning (python + js/ts)
+│       └── scripts-lint.yml        #     Shell + PowerShell linting
 │
-├── CLAUDE.md                       # AI assistant instructions
+├── CLAUDE.md / AGENTS.md           # AI assistant instructions
 ├── .pre-commit-config.yaml         # Pre-commit hooks (ruff, codespell, prettier, ui-contract)
-├── .gitignore                      # Git ignore patterns
-├── .dockerignore                   # Docker build context exclusions
 └── LICENSE                         # GPL-3.0-or-later
 ```
 
@@ -261,26 +272,30 @@ TranscriptionSuite/
 
 | Folder | Purpose | Key Entry Points |
 |--------|---------|-----------------|
-| `server/backend/api/` | HTTP/WS request handling | `main.py` → registers all routers |
-| `server/backend/core/stt/backends/` | 10 STT backend implementations | `factory.py` routes model name → backend |
-| `server/backend/core/` | Business logic (model mgmt, live engine, diarization) | `model_manager.py` is the hub |
-| `server/backend/database/` | SQLite persistence + durability layer | `job_repository.py` for transcription jobs |
-| `dashboard/components/views/` | Full-page views (5 main views + 10 modals) | `SessionView.tsx` is the primary view |
-| `dashboard/electron/` | Electron main process (12 modules) | `main.ts` is the entry point |
-| `dashboard/src/hooks/` | React hooks (20+) — each wraps one feature | `useTranscription.ts`, `useLiveMode.ts` |
-| `dashboard/src/services/` | Non-React logic (WebSocket, audio, models) | `websocket.ts`, `audioCapture.ts` |
-| `server/docker/` | 7 compose variants for multi-platform deployment | Base + overlays pattern |
+| `server/backend/api/` | HTTP/WS request handling (12 route files) | `main.py` → registers all routers |
+| `server/backend/core/` | Business logic — model mgmt, engines, webhooks, auto-actions, diarization-review | `model_manager.py` is the hub |
+| `server/backend/core/stt/backends/` | 10 active STT backends (+ factory, base, mlx_thread_pin) | `factory.py` routes model name → backend |
+| `server/backend/database/` | SQLite persistence + durability + 7 repositories | `job_repository.py`, `database.py` |
+| `server/backend/services/` | Long-running background services | `webhook_worker.py` (lifespan singleton) |
+| `dashboard/components/views/` | Full-page views + modals | `SessionView.tsx` is the primary view |
+| `dashboard/components/{recording,profiles,editor,import}/` | Issue #104 feature widgets | Auto-actions, aliases, find/replace, dedup |
+| `dashboard/electron/` | Electron main process (24 modules) | `main.ts` is the entry point |
+| `dashboard/src/hooks/` | React hooks (33+) — one per feature | `useTranscription.ts`, `useLiveMode.ts` |
+| `server/docker/` | 8 compose variants for multi-platform deployment | Base + overlays pattern |
 
 ## Integration Points
 
 | From | To | Protocol | Purpose |
 |------|----|----------|---------|
-| Dashboard → Server | REST | `http(s)://host:9786/api/*` | CRUD, config, upload |
+| Dashboard → Server | REST | `http(s)://host:9786/api/*` | CRUD, config, upload, profiles |
 | Dashboard → Server | WebSocket | `ws(s)://host:9786/ws` | Longform recording transcription |
-| Dashboard → Server | WebSocket | `ws(s)://host:9786/ws/live` | Real-time live transcription |
+| Dashboard → Server | WebSocket | `ws(s)://host:9786/ws/live` | Live Mode transcription |
+| Dashboard → Server | WebSocket | `/api/admin/models/load/stream` | Model-load progress streaming |
 | Dashboard → Docker | CLI (IPC) | `docker compose` via Electron | Container lifecycle management |
+| Dashboard → GitHub | HTTPS | Releases + manifest.json | Auto-update installer pipeline |
 | Server → HuggingFace | HTTPS | HuggingFace Hub API | Model downloads |
-| Server → GPU | CUDA/Vulkan | PyTorch/whisper.cpp | Inference |
-| Server → LM Studio | HTTP | `http://host:1234` | LLM summarization |
+| Server → GPU | CUDA/Vulkan/Metal | PyTorch/MLX/whisper.cpp | Inference |
+| Server → LM Studio | HTTP | `http://127.0.0.1:1234` | LLM summarization + chat |
 | Server → whisper.cpp | HTTP | `http://whisper-server:8080` | Vulkan sidecar transcription |
+| Server → External webhook | HTTPS | Per-profile `transcription.completed` | Durable outgoing webhook delivery |
 | Server → Startup Events | File | `/startup-events/startup-events.jsonl` | Bootstrap progress → Electron |


### PR DESCRIPTION
# docs(bmad): refresh project documentation and all PlantUML diagrams to v1.3.6

## Summary

Full rescan and update of the BMAD `document-project` output set, bringing the generated docs and all
PlantUML diagrams from their **2026-04-05 / v1.3.0** baseline up to the current **v1.3.6** codebase
(309 commits since the last generation). Strategy: git-diff–targeted deep scan + 5 parallel reconnaissance
agents (data layer, API surface, core/STT, dashboard, integration/infra), then surgical update-in-place so
hand-maintained refinements were preserved.

**Docs-only change — no source code touched.** 16 files, +1210 / −890.

## What changed

**Markdown (9 docs)**
- `data-models-server.md` — **full rewrite**: 6→17 migrations, 11 tables (+ FTS5), new tables (`profiles`,
  `webhook_deliveries`, `recording_diarization_review`, `recording_speaker_aliases`), audio-dedup,
  auto-actions, and `transcript_corrected` lifecycles.
- `source-tree-analysis.md` — **full rewrite**: new `services/` + `utils/` backend dirs, `profiles` route,
  new core/db modules, migrations 007–017, `recording/`/`profiles/`/`editor/`/`import/` component groups,
  24 electron modules, 8 compose variants, 5 CI workflows.
- `api-contracts-server.md` — **full rewrite**: Profiles family + ~30 new endpoints (dedup-check,
  retry/recent/dismiss, transcript, aliases, diarization-review/confidence, auto-actions/retry, reexport,
  LLM chat/conversations).
- `architecture-dashboard.md` — **full rewrite**: new views, 14 UI primitives, 33+ hooks, 5 Zustand stores,
  auto-update installer pipeline.
- `architecture-server.md` — migrations 6→17, corrected schema table, Issue #104 subsystems, profiles
  route, config sections, startup sequence.
- `integration-architecture.md` — new integration points: outgoing webhook delivery (#10) and GitHub
  auto-update (#11); corrected `local_llm` config.
- `project-overview.md`, `development-guide.md`, `deployment-guide.md`, `index.md` — v1.3.6, refreshed
  metrics, Node 22.22.3, Vulkan-WSL2 compose variant, release platform selector.

**PlantUML diagrams (all 5)** — `overview`, `server-api`, `stt-backends`, `dashboard-components`,
`data-flow`. All re-validated with `plantuml -checkonly` (exit 0) and rendered to PNG (5/5).

## Factual corrections (the old docs were wrong)

- FTS table is **`words_fts`**, not `recordings_fts`; there is no `chat_history` table (it's
  `conversations` + `messages`).
- **`whisper_backend.py` (`WhisperBackend`) is orphaned dead code** — not wired into the factory; backend
  count remains **10 active**.
- **`CanaryBackend` extends `ParakeetBackend`** (not `STTBackend`); MLX-Canary reports
  `translation=False` (ASR-only port).
- Config section is **`local_llm`** (not `lm_studio`); two webhook systems exist (legacy fire-and-forget +
  durable `webhook_deliveries`).
- Node.js is pinned to **22.22.3** (dev guide had a stale 25.7.0).

## Test plan

- [x] `plantuml -checkonly` passes for all 5 diagrams (exit 0)
- [x] All 5 diagrams render to PNG (5/5)
- [x] No incomplete-documentation markers (`_(To be generated)_`, TBD, TODO) remain
- [x] All cross-document links in `index.md` resolve to existing files
- [x] Pre-commit hooks pass (codespell, large-files, json, merge-conflicts)
- [ ] Maintainer spot-check of the rewritten docs against the current code

## Out of scope / follow-up

- `docs/project-context.md` still lists `Node.js CI version: 25.7.0`. That file is generated by the
  separate `bmad-generate-project-context` skill, so it was intentionally left untouched — fix the line or
  regenerate it in a follow-up if desired.
