### PR TITLE
feat(session): add Preview button for last-N-seconds transcription during recording

### DIFF
--- a/_bmad-output/implementation-artifacts/spec-preview-last-n-seconds.md
+++ b/_bmad-output/implementation-artifacts/spec-preview-last-n-seconds.md
@@ -1,0 +1,158 @@
+---
+title: 'Preview last N seconds during main recording'
+type: 'feature'
+created: '2026-06-14'
+status: 'done'
+baseline_commit: '180cfbbaf6bb1939afa0c6da95f45a94fab4acd5'
+context:
+  - '{project-root}/docs/project-context.md'
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** During a long main (longform) recording the user loses their train of thought and has no way to glance back at what they just said — the full transcription only appears after "Stop Recording". They need a quick, in-the-moment reminder.
+
+**Approach:** Add a "Preview" button next to Stop Recording / Cancel that, while recording, asks the server to transcribe only the **last N seconds** of audio already buffered server-side and display it ephemerally in the Main Transcription card (labeled "Preview · last Ns"). N defaults to 20s, user-configurable 10–60s in Settings. The preview is a throwaway UX aid — it never interrupts, alters, or replaces the ongoing recording or its final result.
+
+## Boundaries & Constraints
+
+**Always:**
+- Reuse audio already accumulated in `TranscriptionSession.audio_chunks` (server memory during recording) — slice only the tail, no client-side buffering, no new transport.
+- Run preview as a background task so the WS receive loop keeps consuming incoming audio chunks during transcription.
+- Reuse the session's existing `language`, `translation_enabled`, `translation_target_language` so preview output matches what the final result will look like.
+- Clamp duration defensively on the server to 10–60s regardless of client value.
+- The preview box uses the same visual style/location as the existing result box.
+
+**Ask First:**
+- Any change that would make the preview persist a job, write to the DB, or touch `create_job`/`save_result` — this feature is deliberately ephemeral (see Never).
+- Adding a new STT model load path or changing the model-swap lifecycle.
+
+**Never:**
+- **Never persist preview results** (no `create_job`, no `save_result`, no `transcription_jobs` row). This is the one deliberate exception to the persist-before-deliver invariant — justified because the live recording continues uninterrupted and its full result IS persisted at Stop, and a preview is trivially reproducible. Data-loss invariant is unaffected.
+- Never stop, cancel, mutate, or clear `audio_chunks` / recording state when previewing.
+- Never block the WS message loop on transcription.
+- No new backend config.yaml key — duration is a client setting sent per-request.
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| Happy path | Recording active, ≥N s buffered, `{type:'preview', data:{duration_seconds:20}}` | `preview_result` with `{text, language, requested_seconds, actual_seconds}` for last 20s; recording unaffected | N/A |
+| Short buffer | Recording active, only 6s buffered, request 20s | Transcribe whatever exists; `actual_seconds≈6` | N/A |
+| Out-of-range duration | request `duration_seconds:5` or `900` | Clamp to 10 / 60 before slicing | N/A |
+| Not recording | `preview` received while not recording | `preview_error` "Not recording" | Send error, no crash |
+| No audio yet | Recording active, `audio_chunks` empty | `preview_error` "No audio captured yet" | Send error |
+| Overlapping request | preview already running | Ignore/reject second request | `preview_error` "Preview already in progress" |
+| Transcription throws | engine error mid-preview | `preview_error` with message; recording continues | Catch, log, send error |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `server/backend/api/routes/websocket.py` -- `TranscriptionSession` + `handle_client_message` dispatch (line ~644); add `preview` branch + `preview_transcription()` method; `add_audio_chunk`/`audio_chunks` (88,122), float32 conversion pattern (141-144), engine call pattern (206-262), `self.sample_rate`/`language`/`translation_enabled` attrs. Flip leftover `preview_enabled:False` (489) → True.
+- `server/backend/core/stt/engine.py` -- `AudioToTextRecorder.transcribe_audio(audio_data, sample_rate, language, task, translation_target_language, word_timestamps=False)` (~839) — in-memory primitive for the tail buffer.
+- `server/backend/core/model_manager.py` -- `ensure_transcription_loaded()` (~721) — guarantees model loaded before preview.
+- `dashboard/src/hooks/useTranscription.ts` -- add `preview()` method + preview state; handle `preview_result`/`preview_error` in `handleMessage` (206-272); clear preview in `start`/`reset`; expose in return object (424).
+- `dashboard/components/views/SessionView.tsx` -- add Preview `<Button>` in control group (1681-1712, shown only when `isRecording`); `handlePreview` reading `audio.previewDurationSeconds`; preview display box after the button row (~1719) mirroring result box (1722-1757).
+- `dashboard/components/views/SettingsModal.tsx` -- add numeric input in Client tab mirroring grace-period spinner (~1197-1240); `clientSettings` state/load/save (224,380,529).
+- `dashboard/src/config/store.ts` + `dashboard/electron/main.ts` -- add `audio.previewDurationSeconds` (default 20) to interface, `DEFAULT_CONFIG`, and electron-store defaults.
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `server/backend/api/routes/websocket.py` -- Add `elif msg_type == "preview":` → `asyncio.create_task(session.preview_transcription(int(message.get("data",{}).get("duration_seconds",20))))`. Add `async def preview_transcription(self, duration_seconds)`: guard `is_recording` + non-empty `audio_chunks`; reject if `self._preview_in_progress`; clamp 10–60; slice tail bytes (`bytes_needed = clamped * self.sample_rate * 2`, walk `audio_chunks` from end, drop odd trailing byte); int16→float32 (mirror 141-144); `engine = await asyncio.to_thread(model_manager.ensure_transcription_loaded)`; run `engine.transcribe_audio(..., word_timestamps=False, language=self.language, task/translation from session)` via `run_in_executor`; send `preview_result`; wrap in try/except→`preview_error`; reset flag in `finally`. Set `_preview_in_progress=False` in `__init__`; cancel any preview task in `cleanup`. Flip `preview_enabled` (489) to True.
+- [x] `dashboard/src/hooks/useTranscription.ts` -- Add state `previewText/previewLanguage/previewSeconds/previewLoading/previewError`; `preview(durationSeconds)` guarded on `status==='recording'` and not already loading → `sendJSON({type:'preview',data:{duration_seconds}})`; handle `preview_result`/`preview_error`; clear all preview state in `start()` and `reset()`; expose in return.
+- [x] `dashboard/components/views/SessionView.tsx` -- Add `handlePreview` (read `audio.previewDurationSeconds` via config API, clamp 10–60 default 20, call `transcription.preview`). Add Preview `<Button variant="secondary" className="shrink-0">` (icon `Eye`/`ScanText`) shown when `isRecording`, disabled while `previewLoading`. Add preview box after control row: shown when `previewLoading||previewText||previewError`, header "Preview · last {n}s", spinner while loading, error styled like existing error block, reuse result-box classes.
+- [x] `dashboard/src/config/store.ts`, `dashboard/electron/main.ts` -- Add `audio.previewDurationSeconds: number` default `20`.
+- [x] `dashboard/components/views/SettingsModal.tsx` -- Add "Preview Duration (seconds)" numeric spinner (min 10, max 60, step 5) in Client tab; wire state/load/save; helper text "Seconds of recent audio the Preview button transcribes (10–60)."
+- [x] `server/backend/tests/test_websocket_preview.py` -- Unit-test the I/O matrix: happy path, short buffer, clamp, not-recording, empty-audio, overlap, engine-throws; assert NO `create_job`/`save_result` called. Mock `webrtcvad` via `sys.modules`, build session via `object.__new__`, stub engine `transcribe_audio` + `ensure_transcription_loaded`.
+- [x] `dashboard/src/hooks/useTranscription.test.ts` -- (if hook test exists / else add) assert `preview()` sends correct WS message and `preview_result`/`preview_error` update state.
+
+**Acceptance Criteria:**
+- Given an active recording with ≥20s captured, when the user clicks Preview, then within a few seconds a "Preview · last 20s" box shows the transcribed tail and the recording continues uninterrupted (Stop still produces the full transcript).
+- Given the user set Preview Duration to 45 in Settings, when they click Preview, then the request carries 45 and ~45s are transcribed.
+- Given no preview job is ever written, when a preview runs, then no row appears in `transcription_jobs` and no audio file is created for it.
+- Given the user is not recording, when a `preview` arrives, then the server replies `preview_error` and does not crash.
+
+## Spec Change Log
+
+- **Review iteration 1 (patches, no loopback).** Adversarial review (blind hunter + edge-case hunter + acceptance auditor → PASS). Applied 4 patches without re-derivation: (1) dispatcher refuses to overwrite a live `_preview_task` so `cleanup()` always cancels the real in-flight task; (2) `asyncio.get_running_loop()` replaces deprecated `get_event_loop()`; (3) empty-text preview shows "(no speech detected)" instead of a blank box; (4) preview-loading state resets on the server-`error` message and socket `onError` paths so it can't get stuck. Added `test_dispatch_preview_rejected_while_task_running`. Doc-aligned the settings step (1→5). Rejected as safe/idiomatic: int16-mono byte math and `getattr` translation attrs (mirror existing `process_transcription`; attrs verified set in `start_recording`), clamp duplication (cross-codebase defense-in-depth), shared `transcription_lock` serialization (bounded, no data loss).
+
+## Design Notes
+
+Tail-slice without copying the whole buffer (can be ~100MB for long recordings):
+```python
+need = clamped * self.sample_rate * 2  # int16 mono
+buf, total = [], 0
+for chunk in reversed(self.audio_chunks):
+    buf.append(chunk); total += len(chunk)
+    if total >= need: break
+tail = b"".join(reversed(buf))[-need:]
+if len(tail) % 2: tail = tail[:-1]
+audio = np.frombuffer(tail, dtype=np.int16).astype(np.float32) / 32768.0
+```
+Background task (not inline await) keeps `websocket.receive()` draining audio while the preview transcribes. Snapshot `tail` at task start; later appends to `audio_chunks` are harmless. Frontend gates Preview on `isRecording` only (not connecting/processing) — preview is meaningless once the full result is already coming.
+
+## Verification
+
+**Commands:**
+- `cd server/backend && ../../build/.venv/bin/pytest tests/test_websocket_preview.py -v --tb=short` -- expected: all preview tests pass
+- `cd dashboard && npm run typecheck` -- expected: no type errors
+- `cd dashboard && npx vitest run src/hooks/useTranscription.test.ts` -- expected: pass (if added)
+- `cd dashboard && npm run ui:contract:extract && npm run ui:contract:build && node scripts/ui-contract/validate-contract.mjs --update-baseline && npm run ui:contract:check` -- expected: contract check passes (bump `meta.spec_version` first)
+
+**Manual checks:**
+- Start a real recording, speak ~30s, click Preview → preview box shows recent words; keep talking, click Stop → full transcript unaffected. Change duration in Settings, repeat.
+
+## Suggested Review Order
+
+**Backend — the core (start here)**
+
+- Entry point: slices the tail of the live buffer and transcribes a copy; never persists, never touches recording state.
+  [`websocket.py:140`](../../server/backend/api/routes/websocket.py#L140)
+
+- Dispatch branch: runs the preview as a background task and refuses to overwrite a live one.
+  [`websocket.py:765`](../../server/backend/api/routes/websocket.py#L765)
+
+- Cancels any in-flight preview task on session teardown.
+  [`websocket.py:679`](../../server/backend/api/routes/websocket.py#L679)
+
+- Server-side clamp bounds (10–60s, default 20).
+  [`websocket.py:65`](../../server/backend/api/routes/websocket.py#L65)
+
+**Frontend hook — protocol + state**
+
+- `preview()` sends the WS message; guarded to recording-only and non-overlapping.
+  [`useTranscription.ts:451`](../../dashboard/src/hooks/useTranscription.ts#L451)
+
+- `preview_result` / `preview_error` handlers populate ephemeral state.
+  [`useTranscription.ts:277`](../../dashboard/src/hooks/useTranscription.ts#L277)
+
+**UI — button + display**
+
+- The Preview button (recording-only, disabled while loading).
+  [`SessionView.tsx:1711`](../../dashboard/components/views/SessionView.tsx#L1711)
+
+- The ephemeral preview box (same style as the result box; "(no speech detected)" fallback).
+  [`SessionView.tsx:1748`](../../dashboard/components/views/SessionView.tsx#L1748)
+
+- `handlePreview` reads the configured duration and clamps it.
+  [`SessionView.tsx:870`](../../dashboard/components/views/SessionView.tsx#L870)
+
+**Settings — the duration knob**
+
+- "Preview Duration (seconds)" numeric input in the Client tab.
+  [`SettingsModal.tsx:1247`](../../dashboard/components/views/SettingsModal.tsx#L1247)
+
+- The persisted config key + default (mirrored in electron-store).
+  [`store.ts:31`](../../dashboard/src/config/store.ts#L31)
+
+**Tests (peripheral)**
+
+- Backend: I/O matrix + non-persistence + dispatch guard (14 tests).
+  [`test_websocket_preview.py:79`](../../server/backend/tests/test_websocket_preview.py#L79)
+
+- Frontend: hook preview behaviour (6 tests).
+  [`useTranscription.test.ts:482`](../../dashboard/src/hooks/useTranscription.test.ts#L482)

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -6,6 +6,7 @@ import {
   RefreshCw,
   Languages,
   Copy,
+  Eye,
   Volume2,
   VolumeX,
   Maximize2,
@@ -863,6 +864,15 @@ export const SessionView: React.FC<SessionViewProps> = ({
     }
   }, [transcription, isLinux]);
 
+  // Preview: transcribe the last N seconds (user-configurable, default 20)
+  // so the user can recover their train of thought without stopping. The
+  // duration is clamped to the supported 10–60s range defensively.
+  const handlePreview = useCallback(async () => {
+    const raw = await getConfig<number>('audio.previewDurationSeconds');
+    const seconds = Math.min(60, Math.max(10, raw ?? 20));
+    transcription.preview(seconds);
+  }, [transcription]);
+
   // Copy transcription result to clipboard (prefers the edited text)
   const handleCopyTranscription = useCallback(() => {
     const text = editedResultText ?? transcription.result?.text;
@@ -1698,6 +1708,23 @@ export const SessionView: React.FC<SessionViewProps> = ({
                                 : 'Processing...'
                               : 'Stop Recording'}
                           </Button>
+                          {isRecording && (
+                            <Button
+                              variant="secondary"
+                              className="shrink-0"
+                              icon={
+                                transcription.previewLoading ? (
+                                  <Loader2 size={16} className="animate-spin" />
+                                ) : (
+                                  <Eye size={16} />
+                                )
+                              }
+                              onClick={handlePreview}
+                              disabled={transcription.previewLoading}
+                            >
+                              Preview
+                            </Button>
+                          )}
                           {(isConnecting || isRecording || isProcessing) && (
                             <Button
                               variant="secondary"
@@ -1717,6 +1744,35 @@ export const SessionView: React.FC<SessionViewProps> = ({
                       )}
                     </div>
                   </div>
+
+                  {/* Preview — ephemeral "last N seconds" reminder during recording */}
+                  {isRecording &&
+                    (transcription.previewLoading ||
+                      transcription.previewText !== null ||
+                      transcription.previewError) && (
+                      <div className="space-y-2">
+                        <div className="flex items-center gap-2 text-xs font-medium text-slate-400">
+                          <Eye size={14} className="text-accent-cyan" />
+                          <span>
+                            Preview
+                            {transcription.previewSeconds
+                              ? ` · last ${transcription.previewSeconds}s`
+                              : ''}
+                          </span>
+                        </div>
+                        {transcription.previewError ? (
+                          <div className="rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+                            {transcription.previewError}
+                          </div>
+                        ) : (
+                          <div className="selectable-text custom-scrollbar max-h-72 min-h-[8rem] overflow-y-auto rounded-xl border border-white/5 bg-black/20 p-4 font-mono text-sm leading-relaxed text-slate-300">
+                            {transcription.previewLoading && !transcription.previewText
+                              ? 'Transcribing recent audio…'
+                              : transcription.previewText || '(no speech detected)'}
+                          </div>
+                        )}
+                      </div>
+                    )}
 
                   {/* Transcription Result */}
                   {transcription.result && (

--- a/dashboard/components/views/SettingsModal.tsx
+++ b/dashboard/components/views/SettingsModal.tsx
@@ -223,6 +223,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
 
   const [clientSettings, setClientSettings] = useState({
     gracePeriod: 1.0,
+    previewDurationSeconds: 20,
     constrainSpeakers: true,
     numSpeakers: 2,
     autoAddNotebook: false,
@@ -378,6 +379,8 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
                 port: (cfg['connection.port'] as number) ?? prev.port,
                 useHttps: useRemote ? true : useHttps,
                 gracePeriod: (cfg['audio.gracePeriod'] as number) ?? prev.gracePeriod,
+                previewDurationSeconds:
+                  (cfg['audio.previewDurationSeconds'] as number) ?? prev.previewDurationSeconds,
                 constrainSpeakers:
                   (cfg['diarization.constrainSpeakers'] as boolean) ?? prev.constrainSpeakers,
                 numSpeakers: (cfg['diarization.numSpeakers'] as number) ?? prev.numSpeakers,
@@ -527,6 +530,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
         ['connection.port', clientSettings.port],
         ['connection.useHttps', normalizedUseHttps],
         ['audio.gracePeriod', clientSettings.gracePeriod],
+        ['audio.previewDurationSeconds', clientSettings.previewDurationSeconds],
         ['diarization.constrainSpeakers', clientSettings.constrainSpeakers],
         ['diarization.numSpeakers', clientSettings.numSpeakers],
         ['notebook.autoAdd', clientSettings.autoAddNotebook],
@@ -1237,6 +1241,57 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
               </button>
             </div>
             <p className="mt-1 text-xs text-slate-500">Buffer time before committing a segment.</p>
+          </div>
+          <div>
+            <label className="mb-2 block text-sm font-medium text-slate-300">
+              Preview Duration (seconds)
+            </label>
+            <div className="flex items-center rounded-lg border border-white/10 bg-black/20">
+              <button
+                type="button"
+                onClick={() =>
+                  setClientSettings((prev) => ({
+                    ...prev,
+                    previewDurationSeconds: Math.max(10, prev.previewDurationSeconds - 5),
+                  }))
+                }
+                className="px-3 py-2 text-slate-400 transition-colors select-none hover:text-white"
+              >
+                −
+              </button>
+              <input
+                type="number"
+                min={10}
+                max={60}
+                step={5}
+                value={clientSettings.previewDurationSeconds}
+                onChange={(e) =>
+                  setClientSettings((prev) => ({
+                    ...prev,
+                    previewDurationSeconds: Math.min(
+                      60,
+                      Math.max(10, parseInt(e.target.value, 10) || 20),
+                    ),
+                  }))
+                }
+                className="min-w-0 flex-1 [appearance:textfield] bg-transparent py-2 text-center text-sm text-white focus:outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+              />
+              <button
+                type="button"
+                onClick={() =>
+                  setClientSettings((prev) => ({
+                    ...prev,
+                    previewDurationSeconds: Math.min(60, prev.previewDurationSeconds + 5),
+                  }))
+                }
+                className="px-3 py-2 text-slate-400 transition-colors select-none hover:text-white"
+              >
+                +
+              </button>
+            </div>
+            <p className="mt-1 text-xs text-slate-500">
+              How many seconds of recent audio the Preview button transcribes (10–60).
+            </p>
           </div>
         </div>
       </Section>

--- a/dashboard/electron/main.ts
+++ b/dashboard/electron/main.ts
@@ -464,6 +464,7 @@ const store = new Store({
     'session.mainLanguage': 'Auto Detect',
     'session.liveLanguage': 'Auto Detect',
     'audio.gracePeriod': 1.0,
+    'audio.previewDurationSeconds': 20,
     'diarization.constrainSpeakers': true,
     'diarization.numSpeakers': 2,
     'notebook.autoAdd': false,

--- a/dashboard/src/config/store.ts
+++ b/dashboard/src/config/store.ts
@@ -27,6 +27,8 @@ export interface ClientConfig {
   /** Audio capture settings */
   audio: {
     gracePeriod: number;
+    /** Seconds of recent audio the Preview button transcribes (10–60) */
+    previewDurationSeconds: number;
   };
   /** Session view UI selections */
   session: {
@@ -108,6 +110,7 @@ const DEFAULT_CONFIG: ClientConfig = {
   },
   audio: {
     gracePeriod: 1.0,
+    previewDurationSeconds: 20,
   },
   session: {
     audioSource: 'mic',

--- a/dashboard/src/hooks/useTranscription.test.ts
+++ b/dashboard/src/hooks/useTranscription.test.ts
@@ -477,4 +477,112 @@ describe('[P1] useTranscription', () => {
       expect(lastSocket.handleConfigChanged).not.toHaveBeenCalled();
     });
   });
+
+  // ── Preview (ephemeral last-N-seconds reminder) ─────────────────────
+  describe('preview', () => {
+    it('sends a preview message with the requested duration while recording', async () => {
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+      lastSocket.sendJSON.mockClear();
+
+      act(() => {
+        result.current.preview(30);
+      });
+
+      expect(lastSocket.sendJSON).toHaveBeenCalledWith({
+        type: 'preview',
+        data: { duration_seconds: 30 },
+      });
+      expect(result.current.previewLoading).toBe(true);
+    });
+
+    it('is a no-op when not recording', () => {
+      const { result } = renderHook(() => useTranscription());
+
+      act(() => {
+        result.current.preview(20);
+      });
+
+      const previewCalls = (lastSocket?.sendJSON.mock.calls ?? []).filter(
+        (c) => (c[0] as { type: string }).type === 'preview',
+      );
+      expect(previewCalls).toHaveLength(0);
+      expect(result.current.previewLoading).toBe(false);
+    });
+
+    it('ignores an overlapping request while one is in flight', async () => {
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+      lastSocket.sendJSON.mockClear();
+
+      act(() => {
+        result.current.preview(20);
+        result.current.preview(20);
+      });
+
+      expect(lastSocket.sendJSON).toHaveBeenCalledTimes(1);
+    });
+
+    it('populates preview state on preview_result', async () => {
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+      act(() => {
+        result.current.preview(20);
+      });
+
+      act(() => {
+        lastSocketCbs.onMessage!({
+          type: 'preview_result',
+          data: { text: 'the last words I said', language: 'en', actual_seconds: 20 },
+        });
+      });
+
+      expect(result.current.previewText).toBe('the last words I said');
+      expect(result.current.previewSeconds).toBe(20);
+      expect(result.current.previewLanguage).toBe('en');
+      expect(result.current.previewLoading).toBe(false);
+      expect(result.current.previewError).toBeNull();
+    });
+
+    it('surfaces preview_error and clears loading', async () => {
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+      act(() => {
+        result.current.preview(20);
+      });
+
+      act(() => {
+        lastSocketCbs.onMessage!({
+          type: 'preview_error',
+          data: { message: 'No audio captured yet' },
+        });
+      });
+
+      expect(result.current.previewError).toBe('No audio captured yet');
+      expect(result.current.previewLoading).toBe(false);
+    });
+
+    it('clears preview state on a new start()', async () => {
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+      act(() => {
+        result.current.preview(20);
+      });
+      act(() => {
+        lastSocketCbs.onMessage!({
+          type: 'preview_result',
+          data: { text: 'something', actual_seconds: 20 },
+        });
+      });
+      expect(result.current.previewText).toBe('something');
+
+      act(() => {
+        result.current.start();
+      });
+
+      expect(result.current.previewText).toBeNull();
+      expect(result.current.previewError).toBeNull();
+      expect(result.current.previewLoading).toBe(false);
+    });
+  });
 });

--- a/dashboard/src/hooks/useTranscription.ts
+++ b/dashboard/src/hooks/useTranscription.ts
@@ -59,6 +59,18 @@ export interface TranscriptionState {
   jobId: string | null;
   /** Load an externally-fetched result into the hook (e.g. recovered from DB) */
   loadResult: (result: TranscriptionResult) => void;
+  /** Ephemeral "last N seconds" preview text (null until a preview is requested) */
+  previewText: string | null;
+  /** Detected language of the most recent preview */
+  previewLanguage?: string;
+  /** Actual seconds of audio transcribed by the most recent preview */
+  previewSeconds: number | null;
+  /** Whether a preview request is currently in flight */
+  previewLoading: boolean;
+  /** Error message from the most recent preview attempt */
+  previewError: string | null;
+  /** Request an ephemeral preview of the last `durationSeconds` of audio */
+  preview: (durationSeconds: number) => void;
 }
 
 export function useTranscription(): TranscriptionState {
@@ -72,6 +84,14 @@ export function useTranscription(): TranscriptionState {
     current: number;
     total: number;
   } | null>(null);
+  const [previewText, setPreviewText] = useState<string | null>(null);
+  const [previewLanguage, setPreviewLanguage] = useState<string | undefined>(undefined);
+  const [previewSeconds, setPreviewSeconds] = useState<number | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  // Ref guard so the preview() callback can reject overlapping requests without
+  // a stale-closure read of previewLoading.
+  const previewLoadingRef = useRef(false);
 
   const socketRef = useRef<TranscriptionSocket | null>(null);
   const captureRef = useRef<AudioCapture | null>(null);
@@ -254,6 +274,21 @@ export function useTranscription(): TranscriptionState {
           break;
         }
 
+        case 'preview_result':
+          previewLoadingRef.current = false;
+          setPreviewLoading(false);
+          setPreviewText((msg.data?.text as string) ?? '');
+          setPreviewLanguage(msg.data?.language as string | undefined);
+          setPreviewSeconds((msg.data?.actual_seconds as number) ?? null);
+          setPreviewError(null);
+          break;
+
+        case 'preview_error':
+          previewLoadingRef.current = false;
+          setPreviewLoading(false);
+          setPreviewError((msg.data?.message as string) ?? 'Preview failed');
+          break;
+
         case 'vad_start':
         case 'vad_recording_start':
           setVadActive(true);
@@ -266,6 +301,8 @@ export function useTranscription(): TranscriptionState {
         case 'error':
           setError((msg.data?.message as string) ?? 'Transcription error');
           setStatusTracked('error');
+          previewLoadingRef.current = false;
+          setPreviewLoading(false);
           captureRef.current?.stop();
           setAnalyser(null);
           break;
@@ -290,6 +327,12 @@ export function useTranscription(): TranscriptionState {
       setMuted(false);
       jobIdRef.current = null;
       setJobId(null);
+      setPreviewText(null);
+      setPreviewLanguage(undefined);
+      setPreviewSeconds(null);
+      setPreviewError(null);
+      setPreviewLoading(false);
+      previewLoadingRef.current = false;
       startOptsRef.current = options ?? {};
 
       setStatusTracked('connecting');
@@ -300,6 +343,8 @@ export function useTranscription(): TranscriptionState {
         onError: (err) => {
           setError(err);
           setStatusTracked('error');
+          previewLoadingRef.current = false;
+          setPreviewLoading(false);
           captureRef.current?.stop();
           setAnalyser(null);
         },
@@ -395,7 +440,27 @@ export function useTranscription(): TranscriptionState {
     setProcessingProgress(null);
     jobIdRef.current = null;
     setJobId(null);
+    setPreviewText(null);
+    setPreviewLanguage(undefined);
+    setPreviewSeconds(null);
+    setPreviewError(null);
+    setPreviewLoading(false);
+    previewLoadingRef.current = false;
   }, [setStatusTracked]);
+
+  const preview = useCallback((durationSeconds: number) => {
+    // Preview only makes sense during an active recording; ignore otherwise.
+    if (statusRef.current !== 'recording') return;
+    // Reject overlapping requests (server also guards, this avoids spamming).
+    if (previewLoadingRef.current) return;
+    previewLoadingRef.current = true;
+    setPreviewLoading(true);
+    setPreviewError(null);
+    socketRef.current?.sendJSON({
+      type: 'preview',
+      data: { duration_seconds: durationSeconds },
+    });
+  }, []);
 
   const toggleMute = useCallback(() => {
     setMuted((prev) => {
@@ -436,5 +501,11 @@ export function useTranscription(): TranscriptionState {
     processingProgress,
     jobId,
     loadResult,
+    previewText,
+    previewLanguage,
+    previewSeconds,
+    previewLoading,
+    previewError,
+    preview,
   };
 }

--- a/server/backend/api/routes/websocket.py
+++ b/server/backend/api/routes/websocket.py
@@ -60,6 +60,12 @@ router = APIRouter()
 _connected_sessions: dict[str, "TranscriptionSession"] = {}
 _sessions_lock = asyncio.Lock()
 
+# Preview transcription bounds (ephemeral "last N seconds" reminder feature).
+# Duration is a client setting; clamped server-side regardless of client value.
+_PREVIEW_MIN_SECONDS = 10
+_PREVIEW_MAX_SECONDS = 60
+_PREVIEW_DEFAULT_SECONDS = 20
+
 
 class TranscriptionSession:
     """
@@ -94,6 +100,10 @@ class TranscriptionSession:
         self._realtime_engine: Any | None = None
         self._use_realtime_engine = False
 
+        # Preview transcription (ephemeral "last N seconds" reminder — never persisted)
+        self._preview_in_progress = False
+        self._preview_task: asyncio.Task[None] | None = None
+
         # Job tracking for transcription
         self._current_job_id: str | None = None
 
@@ -126,6 +136,106 @@ class TranscriptionSession:
         # Also feed to realtime engine if using VAD
         if self._use_realtime_engine and self._realtime_engine:
             self._realtime_engine.feed_audio(pcm_data, self.sample_rate)
+
+    async def preview_transcription(self, duration_seconds: int) -> None:
+        """Transcribe the last N seconds of buffered audio as an ephemeral preview.
+
+        This is a throwaway UX aid so the user can recover their train of thought
+        mid-recording. Unlike ``process_transcription()`` it deliberately does NOT
+        persist a job, does NOT create an audio file, and does NOT touch recording
+        state — the live recording keeps streaming and its full result is persisted
+        normally at Stop. Slices only the tail of ``audio_chunks`` and transcribes a
+        copy in a worker thread. Invoked as a background task so the WS receive loop
+        keeps draining incoming audio while this runs.
+        """
+        if self._preview_in_progress:
+            await self.send_message("preview_error", {"message": "Preview already in progress"})
+            return
+        if not self.is_recording:
+            await self.send_message("preview_error", {"message": "Not recording"})
+            return
+        if not self.audio_chunks:
+            await self.send_message("preview_error", {"message": "No audio captured yet"})
+            return
+
+        # No await between the guard checks above and setting the flag here, so the
+        # single-threaded event loop guarantees no two preview tasks pass together.
+        self._preview_in_progress = True
+        try:
+            clamped = max(_PREVIEW_MIN_SECONDS, min(_PREVIEW_MAX_SECONDS, int(duration_seconds)))
+
+            # Slice only the tail of the buffer — avoid copying the whole recording
+            # (can be ~100 MB for long sessions). Int16 mono PCM => 2 bytes/sample.
+            bytes_needed = clamped * self.sample_rate * 2
+            collected: list[bytes] = []
+            total = 0
+            for chunk in reversed(self.audio_chunks):
+                collected.append(chunk)
+                total += len(chunk)
+                if total >= bytes_needed:
+                    break
+            tail = b"".join(reversed(collected))[-bytes_needed:]
+            if len(tail) % 2:  # drop dangling byte so the int16 view is valid
+                tail = tail[:-1]
+            if not tail:
+                await self.send_message("preview_error", {"message": "No audio captured yet"})
+                return
+
+            # Convert Int16 PCM -> float32 [-1.0, 1.0] (mirrors process_transcription)
+            audio_array = np.frombuffer(tail, dtype=np.int16)
+            audio_float = audio_array.astype(np.float32) / 32768.0
+            actual_seconds = round(len(audio_float) / self.sample_rate, 1)
+
+            # ensure_transcription_loaded() lazily (re)loads the model if needed.
+            from server.core.model_manager import get_model_manager
+
+            model_manager = get_model_manager()
+            engine = await asyncio.to_thread(model_manager.ensure_transcription_loaded)
+
+            # Reuse the session's language/translation so the preview reads like the
+            # eventual final result.
+            task = "translate" if getattr(self, "translation_enabled", False) else "transcribe"
+            translation_target = (
+                getattr(self, "translation_target_language", "en") if task == "translate" else None
+            )
+
+            # Run in a worker thread so the asyncio event loop stays responsive.
+            # NB: transcribe_audio() acquires the shared transcription_lock, so a
+            # preview started just before Stop serializes ahead of the final
+            # transcription — bounded and safe (the full result still persists).
+            loop = asyncio.get_running_loop()
+            result = await loop.run_in_executor(
+                None,
+                lambda: engine.transcribe_audio(
+                    audio_float,
+                    sample_rate=self.sample_rate,
+                    language=self.language,
+                    task=task,
+                    translation_target_language=translation_target,
+                    word_timestamps=False,
+                ),
+            )
+
+            # Ephemeral by design — NOT persisted (no create_job/save_result). The
+            # data-loss invariant is unaffected: the live recording's full result is
+            # persisted at Stop, and a preview is trivially reproducible.
+            await self.send_message(
+                "preview_result",
+                {
+                    "text": result.text or "",
+                    "language": result.language,
+                    "requested_seconds": clamped,
+                    "actual_seconds": actual_seconds,
+                },
+            )
+        except asyncio.CancelledError:
+            logger.debug("Preview transcription cancelled for %s", self.client_name)
+            raise
+        except Exception as e:
+            logger.warning("Preview transcription failed for %s: %s", self.client_name, repr(e))
+            await self.send_message("preview_error", {"message": "Preview failed"})
+        finally:
+            self._preview_in_progress = False
 
     async def process_transcription(self) -> None:
         """Process accumulated audio and return transcription."""
@@ -486,7 +596,7 @@ class TranscriptionSession:
             "session_started",
             {
                 "vad_enabled": self._use_realtime_engine,
-                "preview_enabled": False,
+                "preview_enabled": True,
                 "capture_sample_rate_hz": self.sample_rate,
                 "job_id": self._current_job_id,
             },
@@ -560,6 +670,10 @@ class TranscriptionSession:
     async def cleanup(self) -> None:
         """Clean up session resources."""
         from server.core.model_manager import get_model_manager
+
+        # Cancel any in-flight preview task so it doesn't outlive the session
+        if self._preview_task and not self._preview_task.done():
+            self._preview_task.cancel()
 
         # Release any active job
         self._release_job()
@@ -643,6 +757,22 @@ async def handle_client_message(session: TranscriptionSession, message: dict[str
 
     elif msg_type == "get_capabilities":
         await session.send_message("capabilities", session.capabilities.to_dict())
+
+    elif msg_type == "preview":
+        # Ephemeral "last N seconds" reminder. Run as a background task so this
+        # message loop keeps draining incoming audio while the preview transcribes.
+        if session._preview_task is not None and not session._preview_task.done():
+            # A preview is already running. Do NOT overwrite the task handle —
+            # cleanup() must keep a reference to the live one to cancel it.
+            await session.send_message("preview_error", {"message": "Preview already in progress"})
+        else:
+            _data = message.get("data", {}) or {}
+            _raw = _data.get("duration_seconds", _PREVIEW_DEFAULT_SECONDS)
+            try:
+                _dur = int(_raw)
+            except (TypeError, ValueError):
+                _dur = _PREVIEW_DEFAULT_SECONDS
+            session._preview_task = asyncio.create_task(session.preview_transcription(_dur))
 
     else:
         logger.warning(f"Unknown message type: {msg_type}")

--- a/server/backend/tests/test_websocket_preview.py
+++ b/server/backend/tests/test_websocket_preview.py
@@ -1,0 +1,281 @@
+"""Tests for the ephemeral "Preview last N seconds" feature.
+
+Covers TranscriptionSession.preview_transcription() and the `preview` message
+dispatch in handle_client_message(). The defining invariant of this feature is
+that a preview is a THROWAWAY UX aid: it must never persist a job, never create
+an audio file, and never mutate recording state.
+
+Run:  ../../build/.venv/bin/pytest tests/test_websocket_preview.py -v --tb=short
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from server.api.routes import websocket as ws_mod
+from server.core import model_manager as mm_mod
+from starlette.websockets import WebSocketState
+
+# 16 kHz Int16 mono => 2 bytes/sample => 32000 bytes per second.
+_BYTES_PER_SECOND = 16000 * 2
+
+
+def _make_preview_session(
+    *,
+    is_recording: bool = True,
+    audio_chunks: list[bytes] | None = None,
+    sample_rate: int = 16000,
+    translation_enabled: bool = False,
+    preview_in_progress: bool = False,
+) -> ws_mod.TranscriptionSession:
+    """Build a TranscriptionSession for preview tests (bypasses __init__)."""
+    session = object.__new__(ws_mod.TranscriptionSession)
+    session.websocket = MagicMock()
+    session.websocket.client_state = WebSocketState.CONNECTED
+    session.websocket.send_json = AsyncMock()
+    session.client_name = "test-client"
+    session.is_recording = is_recording
+    session.language = None
+    session.audio_chunks = [] if audio_chunks is None else audio_chunks
+    session.sample_rate = sample_rate
+    session.translation_enabled = translation_enabled
+    session.translation_target_language = "en"
+    session._preview_in_progress = preview_in_progress
+    session._preview_task = None
+    session._current_job_id = "job-001"
+    # Capture outbound messages directly.
+    session.send_message = AsyncMock()
+    return session
+
+
+def _patch_engine(monkeypatch, *, text: str = "the last thing I said", raises: bool = False):
+    """Patch model_manager so preview transcription uses a fake engine."""
+    fake_engine = MagicMock()
+    if raises:
+        fake_engine.transcribe_audio.side_effect = RuntimeError("boom")
+    else:
+        fake_engine.transcribe_audio.return_value = SimpleNamespace(
+            text=text, language="en", duration=20.0
+        )
+    fake_manager = MagicMock()
+    fake_manager.ensure_transcription_loaded.return_value = fake_engine
+    # Lazy `from server.core.model_manager import get_model_manager` inside the
+    # method re-reads the attribute from the source module at call time.
+    monkeypatch.setattr(mm_mod, "get_model_manager", lambda: fake_manager)
+    return fake_engine
+
+
+def _last_message(session) -> tuple[str, dict]:
+    """Return (msg_type, data) of the last send_message call."""
+    args, _ = session.send_message.call_args
+    return args[0], (args[1] if len(args) > 1 else {})
+
+
+# ── Happy path ─────────────────────────────────────────────────────────
+
+
+def test_preview_happy_path_returns_text(monkeypatch):
+    fake_engine = _patch_engine(monkeypatch, text="hello there")
+    # 25 seconds of audio buffered; request 20.
+    session = _make_preview_session(audio_chunks=[b"\x00" * (25 * _BYTES_PER_SECOND)])
+
+    asyncio.run(session.preview_transcription(20))
+
+    msg_type, data = _last_message(session)
+    assert msg_type == "preview_result"
+    assert data["text"] == "hello there"
+    assert data["requested_seconds"] == 20
+    assert data["actual_seconds"] == 20.0
+    # Only the last 20s should have been sliced and transcribed.
+    audio_arg = fake_engine.transcribe_audio.call_args.args[0]
+    assert len(audio_arg) == 20 * 16000
+    # Flag reset for the next request.
+    assert session._preview_in_progress is False
+
+
+def test_preview_does_not_persist(monkeypatch):
+    """The defining invariant: preview never writes a job or result."""
+    _patch_engine(monkeypatch)
+    create = MagicMock()
+    save = MagicMock()
+    set_audio = MagicMock()
+    monkeypatch.setattr(ws_mod, "_create_job", create)
+    monkeypatch.setattr(ws_mod, "_save_result", save)
+    monkeypatch.setattr(ws_mod, "_set_audio_path", set_audio)
+    session = _make_preview_session(audio_chunks=[b"\x00" * (25 * _BYTES_PER_SECOND)])
+
+    asyncio.run(session.preview_transcription(20))
+
+    create.assert_not_called()
+    save.assert_not_called()
+    set_audio.assert_not_called()
+
+
+def test_preview_does_not_change_recording_state(monkeypatch):
+    _patch_engine(monkeypatch)
+    session = _make_preview_session(audio_chunks=[b"\x00" * (25 * _BYTES_PER_SECOND)])
+
+    asyncio.run(session.preview_transcription(20))
+
+    assert session.is_recording is True
+
+
+# ── Edge cases from the I/O matrix ─────────────────────────────────────
+
+
+def test_preview_short_buffer_transcribes_what_exists(monkeypatch):
+    fake_engine = _patch_engine(monkeypatch)
+    # Only 6 seconds buffered; request 20.
+    session = _make_preview_session(audio_chunks=[b"\x00" * (6 * _BYTES_PER_SECOND)])
+
+    asyncio.run(session.preview_transcription(20))
+
+    msg_type, data = _last_message(session)
+    assert msg_type == "preview_result"
+    assert data["actual_seconds"] == 6.0
+    audio_arg = fake_engine.transcribe_audio.call_args.args[0]
+    assert len(audio_arg) == 6 * 16000
+
+
+def test_preview_clamps_below_minimum(monkeypatch):
+    fake_engine = _patch_engine(monkeypatch)
+    session = _make_preview_session(audio_chunks=[b"\x00" * (60 * _BYTES_PER_SECOND)])
+
+    asyncio.run(session.preview_transcription(3))
+
+    _, data = _last_message(session)
+    assert data["requested_seconds"] == 10  # clamped up to the 10s floor
+    assert len(fake_engine.transcribe_audio.call_args.args[0]) == 10 * 16000
+
+
+def test_preview_clamps_above_maximum(monkeypatch):
+    fake_engine = _patch_engine(monkeypatch)
+    session = _make_preview_session(audio_chunks=[b"\x00" * (120 * _BYTES_PER_SECOND)])
+
+    asyncio.run(session.preview_transcription(900))
+
+    _, data = _last_message(session)
+    assert data["requested_seconds"] == 60  # clamped down to the 60s ceiling
+    assert len(fake_engine.transcribe_audio.call_args.args[0]) == 60 * 16000
+
+
+def test_preview_rejected_when_not_recording(monkeypatch):
+    _patch_engine(monkeypatch)
+    session = _make_preview_session(is_recording=False, audio_chunks=[b"\x00" * _BYTES_PER_SECOND])
+
+    asyncio.run(session.preview_transcription(20))
+
+    msg_type, data = _last_message(session)
+    assert msg_type == "preview_error"
+    assert "not recording" in data["message"].lower()
+
+
+def test_preview_rejected_when_no_audio(monkeypatch):
+    _patch_engine(monkeypatch)
+    session = _make_preview_session(audio_chunks=[])
+
+    asyncio.run(session.preview_transcription(20))
+
+    msg_type, data = _last_message(session)
+    assert msg_type == "preview_error"
+    assert "no audio" in data["message"].lower()
+
+
+def test_preview_rejected_when_already_in_progress(monkeypatch):
+    _patch_engine(monkeypatch)
+    session = _make_preview_session(
+        audio_chunks=[b"\x00" * (25 * _BYTES_PER_SECOND)], preview_in_progress=True
+    )
+
+    asyncio.run(session.preview_transcription(20))
+
+    msg_type, data = _last_message(session)
+    assert msg_type == "preview_error"
+    assert "in progress" in data["message"].lower()
+
+
+def test_preview_engine_error_sends_error_and_resets_flag(monkeypatch):
+    _patch_engine(monkeypatch, raises=True)
+    session = _make_preview_session(audio_chunks=[b"\x00" * (25 * _BYTES_PER_SECOND)])
+
+    asyncio.run(session.preview_transcription(20))
+
+    msg_type, data = _last_message(session)
+    assert msg_type == "preview_error"
+    assert data["message"] == "Preview failed"
+    assert session._preview_in_progress is False  # reset in finally
+    assert session.is_recording is True  # recording untouched
+
+
+def test_preview_odd_byte_tail_is_trimmed(monkeypatch):
+    """A dangling odd byte must not break the int16 view."""
+    fake_engine = _patch_engine(monkeypatch)
+    # 10 seconds + 1 stray byte.
+    session = _make_preview_session(audio_chunks=[b"\x00" * (10 * _BYTES_PER_SECOND + 1)])
+
+    asyncio.run(session.preview_transcription(20))
+
+    msg_type, _ = _last_message(session)
+    assert msg_type == "preview_result"
+    # Even sample count despite the odd trailing byte.
+    assert len(fake_engine.transcribe_audio.call_args.args[0]) == 10 * 16000
+
+
+# ── Dispatch ───────────────────────────────────────────────────────────
+
+
+def test_dispatch_preview_creates_task_with_parsed_duration(monkeypatch):
+    async def _run():
+        session = _make_preview_session(audio_chunks=[b"\x00" * _BYTES_PER_SECOND])
+        session.preview_transcription = AsyncMock()
+        await ws_mod.handle_client_message(
+            session, {"type": "preview", "data": {"duration_seconds": 30}}
+        )
+        assert session._preview_task is not None
+        await session._preview_task
+        session.preview_transcription.assert_awaited_once_with(30)
+
+    asyncio.run(_run())
+
+
+def test_dispatch_preview_defaults_on_invalid_duration(monkeypatch):
+    async def _run():
+        session = _make_preview_session(audio_chunks=[b"\x00" * _BYTES_PER_SECOND])
+        session.preview_transcription = AsyncMock()
+        await ws_mod.handle_client_message(
+            session, {"type": "preview", "data": {"duration_seconds": "abc"}}
+        )
+        await session._preview_task
+        session.preview_transcription.assert_awaited_once_with(ws_mod._PREVIEW_DEFAULT_SECONDS)
+
+    asyncio.run(_run())
+
+
+def test_dispatch_preview_rejected_while_task_running(monkeypatch):
+    """A live preview task must not be overwritten by a second preview message."""
+
+    async def _run():
+        session = _make_preview_session(audio_chunks=[b"\x00" * _BYTES_PER_SECOND])
+
+        async def _never():
+            await asyncio.sleep(10)
+
+        running = asyncio.create_task(_never())
+        session._preview_task = running
+        session.preview_transcription = AsyncMock()
+        try:
+            await ws_mod.handle_client_message(
+                session, {"type": "preview", "data": {"duration_seconds": 20}}
+            )
+            # The live task handle is preserved; no new preview was started.
+            assert session._preview_task is running
+            session.preview_transcription.assert_not_awaited()
+            msg_type, data = _last_message(session)
+            assert msg_type == "preview_error"
+            assert "in progress" in data["message"].lower()
+        finally:
+            running.cancel()
+
+    asyncio.run(_run())


### PR DESCRIPTION
# Add Preview button for last-N-seconds transcription during recording

## Summary

Adds a **Preview** button to the Main Transcription card in the Session view (next to Stop Recording / Cancel). While a recording is in progress, pressing it transcribes the **last N seconds** of audio and shows the result ephemerally in the same card, labeled "Preview · last Ns" — so you can recover your train of thought mid-recording without stopping.

- Default **20s**, user-configurable **10–60s** in Settings → Client.
- The preview never interrupts, alters, or replaces the ongoing recording or its final result.

## Motivation

During a long recording it's easy to lose your train of thought, and today the full transcription only appears after Stop. This gives a quick, in-the-moment glance at what was just said.

## How it works

The server already accumulates every PCM chunk in `TranscriptionSession.audio_chunks` for the duration of a recording — it just defers processing until Stop. Preview reuses that: it slices only the **tail** of the existing buffer, transcribes a copy in a background task, and returns the text. No client-side rolling buffer and no new audio transport were needed.

- New WebSocket message `preview` → server replies `preview_result {text, language, requested_seconds, actual_seconds}` or `preview_error {message}`.
- Runs as a background `asyncio.create_task` so the receive loop keeps draining incoming audio while the preview transcribes.
- Duration is clamped to 10–60s server-side regardless of the client value; the preview reuses the session's language/translation settings.

### Deliberate durability exception

Preview results are **ephemeral and never persisted** (no `create_job` / `save_result` / audio file). This is the one sanctioned divergence from the project's persist-before-deliver invariant ("AVOID DATA LOSS AT ALL COSTS"), and it's safe because:

- the live recording continues uninterrupted and its **full result is still persisted at Stop**, and
- a preview is trivially reproducible (press again).

The adversarial review (acceptance auditor) explicitly confirmed the data-loss invariant is not endangered.

## Changes

**Backend** (`server/backend/api/routes/websocket.py`)
- `TranscriptionSession.preview_transcription()` — tail-slice (without copying the whole buffer) → int16→float32 → `engine.transcribe_audio()` in a worker thread.
- `preview` branch in `handle_client_message` — background task; refuses to overwrite a live preview task; in-flight task cancelled on session teardown.

**Frontend**
- `dashboard/src/hooks/useTranscription.ts` — `preview()` method + preview state; `preview_result` / `preview_error` handlers; loading state reset on error paths.
- `dashboard/components/views/SessionView.tsx` — Preview button (recording-only, disabled while loading) + ephemeral result box with a "(no speech detected)" fallback.

**Settings**
- `audio.previewDurationSeconds` (default 20) in `dashboard/src/config/store.ts` + `dashboard/electron/main.ts`; numeric input in `SettingsModal.tsx` (Settings → Client).

## Test plan

Automated (all passing):
- [x] Backend: 14 tests in `server/backend/tests/test_websocket_preview.py` — happy path, short buffer, clamp low/high, not-recording, no-audio, overlap guard, engine error, odd-byte trim, dispatch parsing/guard, and **non-persistence assertions**.
- [x] Frontend: 6 tests added to `dashboard/src/hooks/useTranscription.test.ts` (sends correct WS message, populates state on `preview_result`/`preview_error`, no-op when not recording, overlap guard, clears on new start).
- [x] `npm run typecheck`, `npm run lint`, `prettier --check`, UI-contract check — clean.
- [x] Backend durability suite (30 tests) — no regression.

Manual:
- [ ] Start a recording, speak ~30s, click Preview → preview box shows recent words; keep talking, click Stop → full transcript unaffected.
- [ ] Change Preview Duration in Settings (e.g. 45) → next preview transcribes ~45s.
- [ ] Verify no `transcription_jobs` row / audio file is created for a preview.

## Notes

- No backend `config.yaml` change — the duration is a client setting sent per request.
- UI reuses existing CSS-class tokens, so the UI contract baseline did not change.
