### PR TITLE
fix(dashboard): register host app id with XDG portal so Wayland global shortcuts work

### DIFF
--- a/dashboard/electron/__tests__/waylandShortcuts.test.ts
+++ b/dashboard/electron/__tests__/waylandShortcuts.test.ts
@@ -10,12 +10,14 @@
  * and compositor portal, which jsdom/node cannot provide.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   electronToXdg,
   xdgToElectron,
   isPortalConnected,
   destroyWaylandShortcuts,
+  registerHostAppId,
+  PORTAL_APP_ID,
 } from '../waylandShortcuts.js';
 
 // ── electronToXdg ───────────────────────────────────────────────────────────
@@ -93,5 +95,62 @@ describe('[P2] destroyWaylandShortcuts', () => {
     // Should not throw even when there is no active session
     expect(() => destroyWaylandShortcuts()).not.toThrow();
     expect(isPortalConnected()).toBe(false);
+  });
+});
+
+// ── registerHostAppId ───────────────────────────────────────────────────────
+// Registers the app id with the XDG host portal Registry so GlobalShortcuts
+// CreateSession passes the "An app id is required" frontend gate added in
+// xdg-desktop-portal 1.21.0. Tested with a fake portal object — no live D-Bus.
+
+describe('[P2] registerHostAppId', () => {
+  it('uses a non-empty reverse-DNS app id', () => {
+    expect(PORTAL_APP_ID).toBeTruthy();
+    // Reverse-DNS: at least one dot, no leading dot (xdp_is_valid_app_id rules).
+    expect(PORTAL_APP_ID).toMatch(/^[A-Za-z0-9_-]+(\.[A-Za-z0-9_-]+)+$/);
+  });
+
+  it('calls Registry.Register with the app id and an empty options dict', async () => {
+    const registerSpy = vi.fn().mockResolvedValue(undefined);
+    const fakePortalObj = {
+      getInterface: (name: string) => {
+        if (name === 'org.freedesktop.host.portal.Registry') {
+          return { Register: registerSpy };
+        }
+        throw new Error(`unexpected interface requested: ${name}`);
+      },
+    };
+
+    await registerHostAppId(fakePortalObj);
+
+    expect(registerSpy).toHaveBeenCalledTimes(1);
+    expect(registerSpy).toHaveBeenCalledWith(PORTAL_APP_ID, {});
+  });
+
+  it('does not throw when the Registry interface is absent (older portal < 1.19.4)', async () => {
+    // dbus-next getInterface() throws synchronously when the interface was not
+    // present in the introspection data.
+    const fakePortalObj = {
+      getInterface: () => {
+        throw new Error("Interface 'org.freedesktop.host.portal.Registry' not found");
+      },
+    };
+
+    await expect(registerHostAppId(fakePortalObj)).resolves.toBeUndefined();
+  });
+
+  it('swallows Register rejections (already registered / too late / unknown method)', async () => {
+    for (const message of [
+      'Connection already associated with an application ID',
+      'Registered too late',
+      'org.freedesktop.DBus.Error.UnknownMethod',
+    ]) {
+      const fakePortalObj = {
+        getInterface: () => ({
+          Register: vi.fn().mockRejectedValue(new Error(message)),
+        }),
+      };
+      await expect(registerHostAppId(fakePortalObj)).resolves.toBeUndefined();
+    }
   });
 });

--- a/dashboard/electron/waylandShortcuts.ts
+++ b/dashboard/electron/waylandShortcuts.ts
@@ -134,6 +134,22 @@ const SHORTCUT_DEFS: Array<{ id: string; description: string; action: string }> 
   { id: 'stop-transcribe', description: 'Stop & Transcribe', action: 'stop-recording' },
 ];
 
+/**
+ * App id announced to the XDG host portal Registry before opening a
+ * GlobalShortcuts session.
+ *
+ * Since xdg-desktop-portal 1.21.0 the GlobalShortcuts frontend rejects callers
+ * whose resolved app id is empty with `NotAllowed: "An app id is required"`.
+ * Sandboxed apps (Flatpak/snap) get an id from their sandbox metadata, but an
+ * unsandboxed host app (our AppImage) resolves to "" and is rejected — so we
+ * register an id explicitly via `org.freedesktop.host.portal.Registry.Register`.
+ *
+ * Matches electron-builder `build.appId`. For correct KDE shortcut labels and
+ * stable per-app permission persistence this should also match the installed
+ * `.desktop` basename (packaging follow-up: ship `com.transcriptionsuite.dashboard.desktop`).
+ */
+export const PORTAL_APP_ID = 'com.transcriptionsuite.dashboard';
+
 let bus: any = null;
 let portalProxy: any = null;
 let sessionPath: string | null = null;
@@ -155,6 +171,53 @@ function getRequestToken(): string {
  */
 function senderToPath(sender: string): string {
   return sender.replace(/^:/, '').replace(/\./g, '_');
+}
+
+/**
+ * Announce this D-Bus connection's app id to the XDG host portal Registry.
+ *
+ * Since xdg-desktop-portal 1.21.0 the GlobalShortcuts frontend gate in
+ * `handle_create_session()` rejects callers with an empty app id
+ * (`NotAllowed: "An app id is required"`). Unsandboxed host apps (AppImages)
+ * resolve to an empty id, so we Register an explicit one BEFORE CreateSession,
+ * on the SAME bus connection.
+ *
+ * The Registry interface (note the literal `host` segment) is exported on the
+ * same bus name and object path as GlobalShortcuts, so we read it off the
+ * portal object we already introspected. It must be the FIRST portal method
+ * call on this connection — this module owns a dedicated `bus`, and only
+ * `getProxyObject` (introspection, not a portal method) runs before this, so
+ * the ordering requirement holds.
+ *
+ * Fully defensive: on portals < 1.19.4 the interface is absent and
+ * `getInterface` throws synchronously; `Register` may also reject if the
+ * connection was already registered or registered too late. EVERY such failure
+ * is swallowed and non-fatal — older portals have no gate and work without
+ * registration, so the caller always proceeds to CreateSession regardless.
+ */
+export async function registerHostAppId(portalObj: any): Promise<void> {
+  let registryProxy: any;
+  try {
+    registryProxy = portalObj.getInterface('org.freedesktop.host.portal.Registry');
+  } catch {
+    // Interface not exported → portal older than 1.19.4, which also predates the
+    // "An app id is required" gate (1.21.0). Nothing to do; continue.
+    console.log(
+      '[WaylandShortcuts] host portal Registry unavailable (older portal) — skipping app-id registration',
+    );
+    return;
+  }
+
+  try {
+    // Register(s app_id, a{sv} options) → (). The options vardict is currently
+    // unused by the portal; pass an empty dict.
+    await registryProxy.Register(PORTAL_APP_ID, {});
+    console.log('[WaylandShortcuts] Registered host app id:', PORTAL_APP_ID);
+  } catch (err) {
+    // Treat every rejection the same (already registered / registered too late /
+    // UnknownMethod / NotAllowed): swallow and continue to CreateSession.
+    console.warn('[WaylandShortcuts] Registry.Register failed (continuing without it):', err);
+  }
 }
 
 /**
@@ -198,6 +261,12 @@ export async function initWaylandShortcuts(
       'org.freedesktop.portal.Desktop',
       '/org/freedesktop/portal/desktop',
     );
+
+    // Host apps must announce an app id before any GlobalShortcuts call, or
+    // CreateSession is rejected with "An app id is required" on portal ≥ 1.21.0.
+    // Must run before getInterface/CreateSession so it's the first portal method.
+    await registerHostAppId(portalObj);
+
     portalProxy = portalObj.getInterface('org.freedesktop.portal.GlobalShortcuts');
   } catch (err) {
     console.warn('[WaylandShortcuts] Failed to connect to D-Bus GlobalShortcuts portal:', err);


### PR DESCRIPTION
# Fix: register host app id so Wayland global shortcuts work on xdg-desktop-portal ≥ 1.21.0

## Problem

Launching the AppImage on Wayland logged:

```
[WaylandShortcuts] Failed to create portal session: DBusError: An app id is required
  type: 'org.freedesktop.portal.Error.NotAllowed',
  text: 'An app id is required',
```

The error comes from our own `CreateSession` call to the `org.freedesktop.portal.GlobalShortcuts` portal in `dashboard/electron/waylandShortcuts.ts`.

**Root cause:** **xdg-desktop-portal 1.21.0** (released 2026-01-21, [PR #1817](https://github.com/flatpak/xdg-desktop-portal/pull/1817)) added a frontend gate in `global-shortcuts.c::handle_create_session()` that rejects any caller whose resolved app id is the empty string. A sandboxed app (Flatpak/snap) gets its id from sandbox metadata, but an **unsandboxed host app** like our AppImage has no `.flatpak-info` and is not launched from a properly-named systemd scope, so the portal resolves its id to `""` and rejects the session. The app code didn't change — a portal upgrade made the precondition stricter.

**Why it mattered (not just a noisy log):** on failure the code fell back to Electron's `globalShortcut.register()`, which returns `true` on Wayland but silently no-ops. So the reassuring `[Shortcuts] Registered Alt+Ctrl+Z …` lines were misleading — users actually had **no working global shortcuts**.

## Fix

Host apps must announce their app id via the XDG **host Registry** portal *before* the first GlobalShortcuts call:

- New exported helper `registerHostAppId(portalObj)` calls `org.freedesktop.host.portal.Registry.Register('com.transcriptionsuite.dashboard', {})`.
- The Registry interface (note the literal `host` segment) is exported on the **same** bus name (`org.freedesktop.portal.Desktop`) and **same** object path (`/org/freedesktop/portal/desktop`) as GlobalShortcuts, so we read it off the portal object we already introspected.
- It runs immediately after `getProxyObject` and **before** `getInterface('GlobalShortcuts')` / `CreateSession`, satisfying the "Register must be the first portal method on the connection" requirement (the module owns a dedicated `bus`, and `getProxyObject` is introspection, not a portal method).
- **Fully defensive / non-fatal:** on portals < 1.19.4 the interface is absent (`getInterface` throws synchronously) and is skipped; `Register` may reject if already-registered or registered-too-late — every such failure is swallowed and the code always proceeds to `CreateSession`. Older portals have no gate and work without registration.

**Version note:** the Registry interface shipped in 1.19.4 (Feb 2025); the enforcement gate only in 1.21.0 (Jan 2026). Because gate (1.21.0) > Registry (1.19.4), whenever the gate can fire, `Register` is guaranteed available — no version-probing needed.

## Files changed

- `dashboard/electron/waylandShortcuts.ts` — `PORTAL_APP_ID` constant + `registerHostAppId()` helper + call site in `initWaylandShortcuts`.
- `dashboard/electron/__tests__/waylandShortcuts.test.ts` — 4 new cases.

## Test plan

- [x] `vitest run electron/__tests__/waylandShortcuts.test.ts` → 17/17 pass (4 new).
- [x] Full dashboard suite → 1387/1388 (the one failure is a pre-existing load-dependent timeout in `installerCache.test.ts`, which passes 47/47 in isolation).
- [x] `tsc -p electron/tsconfig.json --noEmit` clean; `eslint` clean.
- [x] `gitnexus detect_changes` → LOW risk, 0 affected processes.
- [ ] **Manual (needs a real build on KDE Plasma Wayland with portal ≥ 1.21.0):** launch the AppImage and confirm the log shows `[WaylandShortcuts] Registered host app id: com.transcriptionsuite.dashboard` → `Session created:` → `Portal integration active`, and that Start/Stop shortcuts appear in System Settings → Shortcuts and fire.

## Follow-up (separate PR)

Align identity channels so KDE shows the right shortcut label and persists permissions stably: make the installed `.desktop` basename `com.transcriptionsuite.dashboard.desktop` and set Electron's Wayland app id via `app.setName(...)` + matching `StartupWMClass`. Does **not** block this fix (the portal does no on-disk `.desktop` check), so global shortcuts work now regardless.
