### PR TITLE
fix(dashboard): align Wayland/X11 app identity with the portal app id

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -6,6 +6,7 @@
   "author": "homelab-00",
   "type": "module",
   "main": "dist-electron/main.js",
+  "desktopName": "com.transcriptionsuite.dashboard.desktop",
   "engines": {
     "node": ">=22 <23"
   },
@@ -161,7 +162,12 @@
     "linux": {
       "target": "AppImage",
       "category": "Utility",
-      "icon": "../docs/assets/logo.png"
+      "icon": "../docs/assets/logo.png",
+      "desktop": {
+        "entry": {
+          "StartupWMClass": "com.transcriptionsuite.dashboard"
+        }
+      }
     },
     "win": {
       "target": "nsis",


### PR DESCRIPTION
# Follow-up: align Wayland/X11 app identity with the portal app id

Follow-up to #163 (the portal "An app id is required" fix). That PR makes Wayland global shortcuts work by registering the app id `com.transcriptionsuite.dashboard` with the XDG host portal. This PR aligns the app's **other** identity channels (Wayland surface app_id, X11 WM_CLASS, generated `.desktop`) to the same id, so KDE/GNOME can associate the window — and eventually the shortcut entry — with a single consistent application identity.

## Why

The app currently sets no application identity, so Chromium falls through to its built-in default `org.chromium.Chromium` (visible in the `app-org.chromium.Chromium-<pid>.scope` systemd unit in the logs). That means the window isn't grouped under our app and KDE can't resolve our portal-registered id to a friendly app entry.

## Changes (config-only, additive)

1. **`package.json` top-level `desktopName: "com.transcriptionsuite.dashboard.desktop"`** — Electron uses the `.desktop` basename as the Wayland XDG app_id and X11 WM_CLASS (default `${app.name}.desktop`). **Electron 40.10.2 has no `app.setDesktopName()` runtime API** (verified against `node_modules/electron/electron.d.ts` — the only documented lever in this version is this package.json field), so this is done in config rather than `main.ts`. Chosen over `app.setName()`, which would also move `app.getPath('logs')`/`sessionData` and change the menu/notification name.
2. **`build.linux.desktop.entry.StartupWMClass: "com.transcriptionsuite.dashboard"`** — makes the generated/installed `.desktop`'s `StartupWMClass` match the app_id (default would be `TranscriptionSuite`, a mismatch). The nested `{entry:{...}}` shape is the form required by the installed **electron-builder 26.8.1** (verified against `app-builder-lib` source).

## Deliberately NOT done (deferred)

**`linux.executableName`** — this is the change that would rename the *embedded* `.desktop` basename to `com.transcriptionsuite.dashboard.desktop` (the part that fully completes KDE resolution after desktop integration). I left it out because in electron-builder 26.8.1 the AppImage **artifact filename** also derives from `executableName`, which would rename the published asset from `TranscriptionSuite-<ver>.AppImage` and **break the auto-updater/rollback**: `dashboard/electron/installerCache.ts` hardcodes the `TranscriptionSuite-` prefix in `cacheFileName()` / `parseVersionFromFileName()` (lines 84, 99, 102), and the release manifest asset names + sha256 map keys + CI publish naming all key off it. That belongs in a separate, fully-built change that updates `installerCache.ts`, the manifest, and `artifactName` together.

## Honest scope / what this does and doesn't do

- It does **not** change whether global shortcuts fire — that's handled entirely by the portal `Register()` call in #163 (the portal resolves caller identity from the D-Bus Registry, not the Wayland surface app_id).
- For a bare, non-integrated AppImage, KDE does not read the `.desktop` embedded in the squashfs; full shortcut-UI **label** + permission **persistence** additionally need an installed `com.transcriptionsuite.dashboard.desktop` (i.e. the deferred `executableName` change + desktop integration). These changes are the correct, consistent, low-risk down-payment toward that.

## Test plan

- [x] `package.json` valid JSON; `executableName` confirmed unset (artifact naming unchanged).
- [x] `vitest run installerCache.test.ts sha256Lookup.test.ts` → 55/55 (proves no artifact-naming regression).
- [ ] **Needs a real AppImage build on KDE Plasma Wayland to confirm the live identity:** after launch, `systemctl --user list-units 'app-*'` should show `app-com.transcriptionsuite.dashboard-<pid>.scope` (not `org.chromium.Chromium`); check the Wayland app_id via KWin and `xprop WM_CLASS` under XWayland. (electron-builder issue #9103 notes `desktopName` handling can be finicky across versions, so build verification is the real gate.)
