### PR TITLE
fix(dashboard): set linux.executableName so the AppImage .desktop basename matches the portal app id

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -161,6 +161,7 @@
     "afterPack": "./scripts/afterPack.cjs",
     "linux": {
       "target": "AppImage",
+      "executableName": "com.transcriptionsuite.dashboard",
       "category": "Utility",
       "icon": "../docs/assets/logo.png",
       "desktop": {


### PR DESCRIPTION
# Set `linux.executableName` so the AppImage `.desktop` basename matches the portal app id

Completes the item deferred in #164. PR #163 registers the app id `com.transcriptionsuite.dashboard` with the XDG portal so Wayland global shortcuts work; #164 aligned the runtime Wayland app_id (`desktopName`) and the `.desktop` `StartupWMClass`. The one remaining identity channel is the **`.desktop` file basename itself** — KDE resolves the portal-registered app id to a real `.desktop` entry by basename, which is what gives a correct shortcut label and stable per-app permission persistence.

## Change

One line in `dashboard/package.json` → `build.linux`:

```json
"executableName": "com.transcriptionsuite.dashboard"
```

This makes the embedded/installed `.desktop` basename `com.transcriptionsuite.dashboard.desktop` and the internal Electron binary `com.transcriptionsuite.dashboard`. All four identity channels now agree: `appId` = `desktopName` (basename) = `StartupWMClass` = `executableName` = `com.transcriptionsuite.dashboard`.

## Why this is safe (correcting #164's deferral rationale)

#164 deferred this, citing a fear that `executableName` would rename the published `.AppImage` artifact and break the auto-updater. **That was wrong**, verified against the installed `app-builder-lib` 26.8.1 source:

- **`executableName` does not affect the published artifact name.** `appInfo.js` has two distinct values: `productFilename` (executableName-derived → `.desktop` basename + binary) and `sanitizedProductName` (productName-derived → **artifact** name). The AppImage default pattern is `${productName}-${version}-${arch}.${ext}`, and `${productName}` resolves to `sanitizedProductName` = `"TranscriptionSuite"` (`macroExpander.js:20`, `AppImageTarget.js:37`). So the published asset stays byte-identical.
- **The updater/rollback is decoupled from the asset name anyway.** `installerCache.ts` names its cache file canonically from `ctx.version` (the running app version) and only *suffix*-checks the source path for `.AppImage`. `electron-updater` reads the download filename from `latest-linux.yml` (not a hardcoded template). `resolveExpectedSha256` falls back to a single same-extension match and fails open. CI globs `*.AppImage`. None depend on the exact name.
- **`afterPack.cjs` auto-adapts** — it already reads `context.packager.executableName`, so the `--no-sandbox` wrapper rename follows automatically.

## Deliberately NOT pinning `artifactName`

The mapping suggested also pinning `artifactName: "${productName}-${version}-${arch}.${ext}"` "to be safe." That would actually be **harmful**: setting any `artifactName` flips `isUserForced=true` (`platformPackager.js:553`), disabling `skipDefaultArch` — which would *add* `-x86_64` to today's `TranscriptionSuite-<ver>.AppImage` and rename the asset. Leaving `artifactName` unset is what keeps the name exactly as-is.

## Test plan

- [x] `package.json` valid JSON; `executableName` set; `artifactName` confirmed unset.
- [x] `vitest run installerCache.test.ts sha256Lookup.test.ts waylandShortcuts.test.ts` → 72/72.
- [ ] **Requires a real `npm run package:linux` build to validate** (cannot be done from static analysis):
  - The renamed internal binary `com.transcriptionsuite.dashboard` launches under the AppRun + `afterPack` `--no-sandbox` wrapper (dotted basename is valid; `sanitizeFileName` preserves dots, but confirm AppRun + the `.bin` rename resolve).
  - The published asset filename is **unchanged** (`TranscriptionSuite-<ver>.AppImage`) and `latest-linux.yml`'s `path` matches.
  - `--appimage-extract` shows `com.transcriptionsuite.dashboard.desktop` inside, with `Exec=AppRun ...`.
  - On KDE Wayland (after `.desktop` integration): the portal-registered id resolves to the entry — correct shortcut label + permission persistence.
