### PR TITLE
fix: GH #125 reopen — stop VibeVoice git clone on CPU/cu126 installs, complete corporate-CA trust, harden HF token guard

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -87,13 +87,14 @@ On first container start, the server installs Python dependencies into `/runtime
 
 ### TLS interception / corporate network (`UnknownIssuer`)
 
-If first-run `uv sync` fails with `invalid peer certificate: UnknownIssuer` (or
-`certificate verify failed`), your network is intercepting HTTPS — a corporate
+If first-run `uv sync` fails with `invalid peer certificate: UnknownIssuer`,
+`certificate verify failed`, or `server certificate verification failed.
+CAfile: none` (a git clone), your network is intercepting HTTPS — a corporate
 proxy or antivirus "HTTPS scanning" feature presents a re-signed certificate
-whose root CA is trusted on your host but **not** inside the container. uv ships
-its own CA roots and ignores the system store by default, so it rejects the
-re-signed cert. The bootstrap now detects this and prints an actionable hint
-instead of a bare traceback.
+whose root CA is trusted on your host but **not** inside the container. Each
+client ships/uses its own trust store and rejects the re-signed cert. The
+bootstrap detects all of these signatures and prints an actionable hint instead
+of a bare traceback.
 
 Fix (certificate verification stays ON — never disable it):
 
@@ -111,9 +112,19 @@ Fix (certificate verification stays ON — never disable it):
    `UV_NATIVE_TLS=true`. Alternatively, mount the CA and set
    `SSL_CERT_FILE=/path/to/corp-root-ca.pem` in your own compose override.
 
+> **Why both steps matter.** `UV_NATIVE_TLS` only covers uv's own HTTPS client.
+> The `git` subprocess uv uses for git-sourced dependencies, and the `requests`
+> client HuggingFace uses to download models, ignore it — they read
+> `GIT_SSL_CAINFO` and `REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE`. When you set
+> `UV_NATIVE_TLS=true` (or `SSL_CERT_FILE`), the bootstrap now propagates the CA
+> bundle to those clients automatically, so once your root CA is in the container
+> store (step 2) **git clones and model downloads trust it too**.
+
 CPU-only hosts hit this most often because the default install pulls multi-GB
 CUDA wheels. Selecting the **CPU profile** in the dashboard (or
 `PYTORCH_VARIANT=cpu`) skips those wheels and shrinks the download surface.
+A whisper/nemo-only CPU install no longer needs any git access — the VibeVoice
+git dependency is resolved from declared metadata, not cloned (GH #125).
 
 ## TLS / Remote Access
 

--- a/server/backend/api/main.py
+++ b/server/backend/api/main.py
@@ -74,6 +74,7 @@ from server.logging import get_logger, setup_logging  # noqa: E402
 
 _log_time("logging imported")
 
+from server.core.ca_trust import propagate_ca_trust  # noqa: E402
 from server.core.hf_token_guard import purge_non_ascii_hf_tokens  # noqa: E402
 from server.core.startup_events import emit_event  # noqa: E402
 
@@ -402,6 +403,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     # load (huggingface_hub copies it verbatim into a latin-1 HTTP header).
     # Purge any invalid token now, before any model is loaded.
     purge_non_ascii_hf_tokens()
+
+    # GH #125: on a TLS-intercepting network, the HuggingFace model download uses
+    # `requests` (certifi), which ignores SSL_CERT_FILE/UV_NATIVE_TLS. When the
+    # operator opted in, mirror their CA bundle into REQUESTS_CA_BUNDLE et al. so
+    # the runtime model fetch trusts it too — before any model is loaded.
+    propagate_ca_trust()
 
     # Initialize database
     init_db()

--- a/server/backend/core/ca_trust.py
+++ b/server/backend/core/ca_trust.py
@@ -1,0 +1,71 @@
+"""Propagate a corporate CA bundle to the runtime HTTP clients (GH #125).
+
+On a TLS-intercepting network (corporate proxy / antivirus HTTPS scanning) the
+server's HuggingFace model downloads go through ``requests`` (via huggingface_hub),
+which trusts certifi's bundle — **not** the system CA store and **not**
+``SSL_CERT_FILE``. So a re-signed certificate is rejected at model load even when
+the operator installed their root CA into the container. requests honors
+``REQUESTS_CA_BUNDLE`` / ``CURL_CA_BUNDLE``; git (for any git-sourced model deps)
+honors ``GIT_SSL_CAINFO``. Mirror the operator-provided CA into all of them so
+runtime model loads trust it too.
+
+This mirrors ``server/docker/bootstrap_runtime.py::_propagate_ca_bundle`` (same
+logic for the install-time ``uv sync`` / ``git`` subprocess). The two are
+duplicated deliberately: the bootstrap runs before this package is importable, so
+they cannot share code. Keep them in sync.
+"""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# Combined bundle written by Debian/Ubuntu `update-ca-certificates`; contains the
+# system roots plus any corporate CA dropped into /usr/local/share/ca-certificates.
+SYSTEM_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt"
+
+# requests reads REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE; git reads GIT_SSL_CAINFO;
+# SSL_CERT_FILE covers stdlib ssl / uv. Set them all from one CA path.
+_CA_ENV_VARS: tuple[str, ...] = (
+    "SSL_CERT_FILE",
+    "GIT_SSL_CAINFO",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+)
+
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def _native_tls_opted_in() -> bool:
+    return os.environ.get("UV_NATIVE_TLS", "").strip().lower() in _TRUE_VALUES
+
+
+def propagate_ca_trust() -> list[str]:
+    """Mirror a corporate CA bundle into the runtime HTTP clients' env vars.
+
+    Acts only when the operator opted in — an explicit ``SSL_CERT_FILE``, or
+    ``UV_NATIVE_TLS=true`` with the container's combined bundle present. On a
+    normal network (neither set) this is a no-op, so requests keeps using certifi
+    and behaviour is unchanged. Never overrides a value the operator already set.
+    Returns the env var names that were set. Certificate verification stays ON.
+    """
+    explicit = os.environ.get("SSL_CERT_FILE")
+    if explicit:
+        ca = explicit
+    elif _native_tls_opted_in() and os.path.isfile(SYSTEM_CA_BUNDLE):
+        ca = SYSTEM_CA_BUNDLE
+    else:
+        return []
+
+    set_vars: list[str] = []
+    for var in _CA_ENV_VARS:
+        if not os.environ.get(var):
+            os.environ[var] = ca
+            set_vars.append(var)
+    if set_vars:
+        logger.info(
+            "Propagated corporate CA bundle %s to %s so model downloads trust it (GH #125).",
+            ca,
+            ", ".join(set_vars),
+        )
+    return set_vars

--- a/server/backend/core/hf_token_guard.py
+++ b/server/backend/core/hf_token_guard.py
@@ -1,20 +1,32 @@
-"""Guard against non-ASCII HuggingFace token env vars (GH #125, failure B).
+"""Guard against non-ASCII HuggingFace token sources (GH #125, failure B).
 
-huggingface_hub builds the HTTP ``Authorization: Bearer <token>`` header from
-``HF_TOKEN`` / ``HUGGING_FACE_HUB_TOKEN`` and only strips surrounding
-whitespace — it never checks that the value is latin-1 encodable. A token
-containing a non-ASCII character (e.g. a stray ``ş`` pasted into the token
-field on a Windows box) therefore crashes EVERY backend (NeMo, faster-whisper,
-WhisperX, pyannote) with ``UnicodeEncodeError: 'latin-1' codec can't encode ...``
-at model load, because HTTP headers must be latin-1 encodable.
+huggingface_hub builds the HTTP ``Authorization: Bearer <token>`` header from the
+HF token and only strips surrounding whitespace — it never checks that the value
+is latin-1 encodable. A token containing a non-ASCII character (e.g. a stray
+``ş`` pasted into the token field on a Windows box) therefore crashes EVERY
+backend (NeMo, faster-whisper, WhisperX, pyannote) with
+``UnicodeEncodeError: 'latin-1' codec can't encode ...`` at model load, because
+HTTP headers must be latin-1 encodable.
 
-Real HuggingFace tokens are always ASCII (``hf_`` + base62), so a non-ASCII
-value cannot be a valid token. We unset it and warn, which downgrades to
-anonymous downloads (fine for the public default models) instead of crashing.
+Real HuggingFace tokens are always ASCII (``hf_`` + base62), so a non-ASCII value
+cannot be a valid token. We neutralize it and warn, which downgrades to anonymous
+downloads (fine for the public default models) instead of crashing.
+
+The token can reach huggingface_hub from three sources, all covered here:
+
+1. The token env vars (``HF_TOKEN`` / ``HUGGINGFACE_TOKEN`` /
+   ``HUGGING_FACE_HUB_TOKEN``) — unset when non-ASCII.
+2. The on-disk token file (``HF_TOKEN_PATH`` / ``$HF_HOME/token`` /
+   ``~/.cache/huggingface/token``) that ``huggingface_hub.get_token()`` falls
+   back to — backed up to ``<file>.bak`` and blanked when non-ASCII. (PR #131
+   covered only the env vars; the file fallback was a residual gap.)
+3. ``HF_HUB_USER_AGENT_ORIGIN``, appended verbatim to the User-Agent header —
+   unset when non-ASCII (defense-in-depth; same latin-1 encode path).
 """
 
 import logging
 import os
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -25,15 +37,76 @@ HF_TOKEN_ENV_VARS: tuple[str, ...] = (
     "HUGGING_FACE_HUB_TOKEN",
 )
 
+# Appended verbatim to the User-Agent header by huggingface_hub when set; a
+# non-ASCII value crashes the same latin-1 header-encode path as a bad token.
+_HF_USER_AGENT_ORIGIN_ENV_VAR = "HF_HUB_USER_AGENT_ORIGIN"
+
+
+def _hf_token_file() -> Path:
+    """Resolve the on-disk token path that ``huggingface_hub.get_token()`` reads.
+
+    Mirrors huggingface_hub's precedence: explicit ``HF_TOKEN_PATH`` wins, then
+    ``$HF_HOME/token``, then the default ``~/.cache/huggingface/token``.
+    """
+    explicit = os.environ.get("HF_TOKEN_PATH")
+    if explicit:
+        return Path(explicit)
+    hf_home = os.environ.get("HF_HOME")
+    if hf_home:
+        return Path(hf_home) / "token"
+    return Path.home() / ".cache" / "huggingface" / "token"
+
+
+def _purge_token_file() -> str | None:
+    """Back up + blank the HF token file if it holds a non-ASCII (invalid) token.
+
+    Returns the file path that was neutralized, or None when the file is absent,
+    empty, valid ASCII, or could not be read. Safe to call multiple times.
+    """
+    token_file = _hf_token_file()
+    try:
+        if not token_file.is_file():
+            return None
+        raw = token_file.read_bytes()
+        if not raw.strip():
+            return None
+        try:
+            raw.decode("ascii")
+            return None  # valid ASCII token — leave it untouched
+        except UnicodeDecodeError:
+            pass
+        backup = token_file.with_name(token_file.name + ".bak")
+        backup.write_bytes(raw)
+        token_file.write_text("", encoding="utf-8")
+    except OSError as exc:
+        logger.warning(
+            "Could not inspect/neutralize HF token file %s (%s). If model "
+            "downloads crash with a latin-1 UnicodeEncodeError, delete it "
+            "manually. See GH #125.",
+            token_file,
+            exc,
+        )
+        return None
+    logger.warning(
+        "HF token file %s contained non-ASCII characters and was backed up to "
+        "%s and cleared (HuggingFace tokens are ASCII-only). Falling back to "
+        "anonymous downloads. See GH #125.",
+        token_file,
+        backup,
+    )
+    return str(token_file)
+
 
 def purge_non_ascii_hf_tokens() -> list[str]:
-    """Unset any HF token env var whose value is not ASCII-encodable.
+    """Neutralize any HF token source whose value is not ASCII-encodable.
 
-    Returns the list of env var names that were purged (empty when all tokens
-    are valid, empty, or unset). Safe to call multiple times (idempotent).
+    Covers the token env vars, ``HF_HUB_USER_AGENT_ORIGIN``, and the on-disk
+    token file. Returns the list of sources that were neutralized (empty when
+    all are valid, empty, or absent). Idempotent — safe to call before every
+    model load, not just once at startup.
     """
     purged: list[str] = []
-    for var in HF_TOKEN_ENV_VARS:
+    for var in (*HF_TOKEN_ENV_VARS, _HF_USER_AGENT_ORIGIN_ENV_VAR):
         value = os.environ.get(var)
         if value and not value.isascii():
             os.environ.pop(var, None)
@@ -44,4 +117,7 @@ def purge_non_ascii_hf_tokens() -> list[str]:
                 "downloads. See GH #125.",
                 var,
             )
+    purged_file = _purge_token_file()
+    if purged_file is not None:
+        purged.append(purged_file)
     return purged

--- a/server/backend/core/stt/backends/factory.py
+++ b/server/backend/core/stt/backends/factory.py
@@ -110,6 +110,15 @@ def is_mlx_parakeet_model(model_name: str) -> bool:
 
 def create_backend(model_name: str) -> STTBackend:
     """Instantiate the appropriate STTBackend for *model_name*."""
+    # GH #125 (failure B): neutralize any non-ASCII HF token before the backend
+    # makes its first HuggingFace request. The lifespan guard runs once at
+    # startup, but this is the single chokepoint every backend load passes
+    # through (preload AND lazy/hot-reload model switches), and the call is
+    # cheap + idempotent — so it closes the post-startup latin-1 crash window.
+    from server.core.hf_token_guard import purge_non_ascii_hf_tokens
+
+    purge_non_ascii_hf_tokens()
+
     backend_type = detect_backend_type(model_name)
     if backend_type == "parakeet":
         from server.core.stt.backends.parakeet_backend import ParakeetBackend

--- a/server/backend/pyproject.toml
+++ b/server/backend/pyproject.toml
@@ -192,3 +192,45 @@ conflicts = [
         { extra = "whisper" },
     ],
 ]
+
+# GH #125 (reopen): pre-declare VibeVoice's package metadata so uv never has to
+# clone/build its git source to read dependencies during resolution.
+#
+# A whisper/nemo-only CPU (or legacy cu126) install drops `--frozen` and swaps the
+# pytorch index URL (see server/docker/bootstrap_runtime.py::run_dependency_sync).
+# Dropping --frozen forces uv to re-resolve the *universal* lock, which includes the
+# `vibevoice_asr` extra's git source — so uv shells out to `git` to fetch VibeVoice
+# for metadata even though vibevoice_asr is NOT a selected extra. On a TLS-intercepting
+# network (corporate proxy / antivirus) that git fetch fails with "server certificate
+# verification failed", breaking the install (uv #16110).
+#
+# Declaring the metadata here lets uv resolve the git node without fetching the source,
+# eliminating the unnecessary git dependency for the common case. The metadata is stable
+# because the git ref is SHA-pinned in [project.optional-dependencies].vibevoice_asr;
+# it mirrors VibeVoice's own pyproject [project.dependencies] at that commit. If the
+# pinned VibeVoice ref is ever bumped, refresh requires-dist to match.
+[[tool.uv.dependency-metadata]]
+name = "vibevoice"
+version = "1.0.0"
+requires-python = ">=3.9"
+requires-dist = [
+    "torch",
+    "transformers>=4.51.3,<5.0.0",
+    "accelerate",
+    "llvmlite>=0.40.0",
+    "numba>=0.57.0",
+    "diffusers",
+    "tqdm",
+    "numpy",
+    "scipy",
+    "librosa",
+    "ml-collections",
+    "absl-py",
+    "gradio",
+    "av",
+    "aiortc",
+    "uvicorn[standard]",
+    "fastapi",
+    "pydub",
+    "requests",
+]

--- a/server/backend/tests/test_bootstrap_runtime.py
+++ b/server/backend/tests/test_bootstrap_runtime.py
@@ -1893,8 +1893,10 @@ def test_detect_tls_interception_matches_git_libcurl_signature() -> None:
     signature distinct from uv's rustls error — both must be recognized (GH #125)."""
     module = _load_bootstrap_module()
     git_errors = [
+        # Explicit `+` (not adjacent-literal implicit concatenation) so this reads
+        # as one intentional git error message, not a missing-comma typo.
         "fatal: unable to access '...': server certificate verification failed. "
-        "CAfile: none CRLfile: none",
+        + "CAfile: none CRLfile: none",
         "SSL certificate problem: unable to get local issuer certificate",
     ]
     for text in git_errors:

--- a/server/backend/tests/test_bootstrap_runtime.py
+++ b/server/backend/tests/test_bootstrap_runtime.py
@@ -1881,3 +1881,131 @@ def test_main_still_trusts_baked_for_non_cpu_mismatch(
         module, monkeypatch, tmp_path, baked_variant="cu126", env_variant="cu129"
     )
     assert resolved == "cu126"
+
+
+# ---------------------------------------------------------------------------
+# GH #125 (reopen) — VibeVoice git-clone regression + git/CA TLS propagation
+# ---------------------------------------------------------------------------
+
+
+def test_detect_tls_interception_matches_git_libcurl_signature() -> None:
+    """The git clone of a git-sourced dep (e.g. VibeVoice) fails with a libcurl
+    signature distinct from uv's rustls error — both must be recognized (GH #125)."""
+    module = _load_bootstrap_module()
+    git_errors = [
+        "fatal: unable to access '...': server certificate verification failed. "
+        "CAfile: none CRLfile: none",
+        "SSL certificate problem: unable to get local issuer certificate",
+    ]
+    for text in git_errors:
+        assert module.detect_tls_interception(text) is True
+
+
+def test_build_uv_sync_env_propagates_explicit_ssl_cert_file_to_git_and_requests(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit SSL_CERT_FILE must reach git (GIT_SSL_CAINFO) and requests
+    (REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE), which ignore UV_NATIVE_TLS (GH #125)."""
+    module = _load_bootstrap_module()
+    ca = tmp_path / "corp-root-ca.pem"
+    ca.write_text("-----BEGIN CERTIFICATE-----\n", encoding="utf-8")
+    monkeypatch.setenv("SSL_CERT_FILE", str(ca))
+    for var in ("GIT_SSL_CAINFO", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE"):
+        monkeypatch.delenv(var, raising=False)
+
+    env = module.build_uv_sync_env(venv_dir=tmp_path / "venv", cache_dir=tmp_path / "cache")
+
+    assert env["GIT_SSL_CAINFO"] == str(ca)
+    assert env["REQUESTS_CA_BUNDLE"] == str(ca)
+    assert env["CURL_CA_BUNDLE"] == str(ca)
+    assert env["SSL_CERT_FILE"] == str(ca)
+
+
+def test_build_uv_sync_env_uses_system_bundle_when_native_tls_opted_in(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With UV_NATIVE_TLS=true and the container's combined bundle present, point
+    git/requests/curl at it so a mounted corporate CA (update-ca-certificates) is
+    trusted by every install client, not just uv."""
+    module = _load_bootstrap_module()
+    monkeypatch.setenv("UV_NATIVE_TLS", "true")
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    for var in ("GIT_SSL_CAINFO", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(
+        module.os.path,
+        "isfile",
+        lambda p: p == module._SYSTEM_CA_BUNDLE,
+    )
+
+    env = module.build_uv_sync_env(venv_dir=tmp_path / "venv", cache_dir=tmp_path / "cache")
+
+    assert env["UV_NATIVE_TLS"] == "true"
+    assert env["GIT_SSL_CAINFO"] == module._SYSTEM_CA_BUNDLE
+    assert env["REQUESTS_CA_BUNDLE"] == module._SYSTEM_CA_BUNDLE
+    assert env["CURL_CA_BUNDLE"] == module._SYSTEM_CA_BUNDLE
+
+
+def test_build_uv_sync_env_no_ca_propagation_without_opt_in(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On a normal network (no UV_NATIVE_TLS, no SSL_CERT_FILE) the CA vars stay
+    untouched so requests keeps using certifi and behaviour is unchanged."""
+    module = _load_bootstrap_module()
+    for var in (
+        "UV_NATIVE_TLS",
+        "SSL_CERT_FILE",
+        "GIT_SSL_CAINFO",
+        "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    env = module.build_uv_sync_env(venv_dir=tmp_path / "venv", cache_dir=tmp_path / "cache")
+
+    assert "GIT_SSL_CAINFO" not in env
+    assert "REQUESTS_CA_BUNDLE" not in env
+    assert "CURL_CA_BUNDLE" not in env
+
+
+def test_build_uv_sync_env_does_not_override_user_ca_vars(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A user who already set GIT_SSL_CAINFO must keep their value."""
+    module = _load_bootstrap_module()
+    ca = tmp_path / "corp.pem"
+    ca.write_text("x", encoding="utf-8")
+    user_git_ca = "/custom/git-ca.pem"
+    monkeypatch.setenv("SSL_CERT_FILE", str(ca))
+    monkeypatch.setenv("GIT_SSL_CAINFO", user_git_ca)
+    for var in ("REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE"):
+        monkeypatch.delenv(var, raising=False)
+
+    env = module.build_uv_sync_env(venv_dir=tmp_path / "venv", cache_dir=tmp_path / "cache")
+
+    assert env["GIT_SSL_CAINFO"] == user_git_ca  # not overridden
+    assert env["REQUESTS_CA_BUNDLE"] == str(ca)  # filled in from SSL_CERT_FILE
+
+
+def test_pyproject_declares_vibevoice_dependency_metadata() -> None:
+    """P0 regression guard for the reopen: the [tool.uv.dependency-metadata] entry
+    for vibevoice must exist so a whisper/nemo-only CPU re-resolve never git-clones
+    the VibeVoice source (GH #125). Removing it reintroduces the clone failure."""
+    import tomllib
+
+    repo_root = Path(__file__).resolve().parents[3]
+    pyproject = repo_root / "server/backend/pyproject.toml"
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    entries = data.get("tool", {}).get("uv", {}).get("dependency-metadata", [])
+    vibevoice = [e for e in entries if e.get("name") == "vibevoice"]
+    assert vibevoice, "missing [[tool.uv.dependency-metadata]] for vibevoice (GH #125)"
+    requires = vibevoice[0].get("requires-dist", [])
+    # torch is the dependency that links VibeVoice into the cu129->cpu re-resolve;
+    # it must be declared so uv resolves the node without cloning.
+    assert any(r == "torch" or r.startswith("torch") for r in requires), (
+        "vibevoice dependency-metadata must declare its torch dependency"
+    )

--- a/server/backend/tests/test_ca_trust.py
+++ b/server/backend/tests/test_ca_trust.py
@@ -1,0 +1,68 @@
+"""Tests for runtime corporate-CA propagation (GH #125).
+
+The server's HuggingFace model download uses `requests` (certifi), which ignores
+SSL_CERT_FILE / UV_NATIVE_TLS. propagate_ca_trust() bridges an operator-provided
+CA into REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE/GIT_SSL_CAINFO so model loads trust it on
+a TLS-intercepting network — without changing behaviour for normal users.
+"""
+
+import os
+
+import pytest
+from server.core import ca_trust
+
+
+@pytest.fixture(autouse=True)
+def _clear_ca_env(monkeypatch):
+    for var in ("UV_NATIVE_TLS", *ca_trust._CA_ENV_VARS):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_explicit_ssl_cert_file_is_mirrored_to_requests_and_git(tmp_path, monkeypatch):
+    ca = tmp_path / "corp.pem"
+    ca.write_text("-----BEGIN CERTIFICATE-----\n", encoding="utf-8")
+    monkeypatch.setenv("SSL_CERT_FILE", str(ca))
+
+    set_vars = ca_trust.propagate_ca_trust()
+
+    assert os.environ["REQUESTS_CA_BUNDLE"] == str(ca)
+    assert os.environ["CURL_CA_BUNDLE"] == str(ca)
+    assert os.environ["GIT_SSL_CAINFO"] == str(ca)
+    assert "REQUESTS_CA_BUNDLE" in set_vars
+
+
+def test_native_tls_opt_in_uses_system_bundle(monkeypatch):
+    monkeypatch.setenv("UV_NATIVE_TLS", "true")
+    monkeypatch.setattr(ca_trust.os.path, "isfile", lambda p: p == ca_trust.SYSTEM_CA_BUNDLE)
+
+    set_vars = ca_trust.propagate_ca_trust()
+
+    assert os.environ["REQUESTS_CA_BUNDLE"] == ca_trust.SYSTEM_CA_BUNDLE
+    assert os.environ["SSL_CERT_FILE"] == ca_trust.SYSTEM_CA_BUNDLE
+    assert set(set_vars) == set(ca_trust._CA_ENV_VARS)
+
+
+def test_noop_without_opt_in(monkeypatch):
+    # No SSL_CERT_FILE, no UV_NATIVE_TLS -> certifi behaviour preserved.
+    monkeypatch.setattr(ca_trust.os.path, "isfile", lambda p: True)
+    assert ca_trust.propagate_ca_trust() == []
+    assert "REQUESTS_CA_BUNDLE" not in os.environ
+
+
+def test_native_tls_without_system_bundle_is_noop(monkeypatch):
+    monkeypatch.setenv("UV_NATIVE_TLS", "true")
+    monkeypatch.setattr(ca_trust.os.path, "isfile", lambda p: False)
+    assert ca_trust.propagate_ca_trust() == []
+    assert "REQUESTS_CA_BUNDLE" not in os.environ
+
+
+def test_does_not_override_operator_set_values(tmp_path, monkeypatch):
+    ca = tmp_path / "corp.pem"
+    ca.write_text("x", encoding="utf-8")
+    monkeypatch.setenv("SSL_CERT_FILE", str(ca))
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", "/operator/chosen.pem")
+
+    ca_trust.propagate_ca_trust()
+
+    assert os.environ["REQUESTS_CA_BUNDLE"] == "/operator/chosen.pem"  # untouched
+    assert os.environ["GIT_SSL_CAINFO"] == str(ca)  # filled from SSL_CERT_FILE

--- a/server/backend/tests/test_hf_token_guard.py
+++ b/server/backend/tests/test_hf_token_guard.py
@@ -64,3 +64,66 @@ def test_idempotent(monkeypatch):
     second = purge_non_ascii_hf_tokens()
     assert first == ["HF_TOKEN"]
     assert second == []
+
+
+# ---------------------------------------------------------------------------
+# GH #125 — residual gaps from PR #131: token FILE + user-agent origin
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hf_token_file(tmp_path, monkeypatch):
+    """Keep the token-file probe off the real ~/.cache/huggingface/token and stop
+    any HF_HUB_USER_AGENT_ORIGIN leaking between tests (the guard now inspects
+    both, so every test in this module must be hermetic)."""
+    monkeypatch.setenv("HF_HOME", str(tmp_path / "hf-home"))
+    monkeypatch.delenv("HF_TOKEN_PATH", raising=False)
+    monkeypatch.delenv("HF_HUB_USER_AGENT_ORIGIN", raising=False)
+
+
+def test_purges_non_ascii_token_file(tmp_path, monkeypatch):
+    for var in HF_TOKEN_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    token_file = tmp_path / "token"
+    raw = "hf_badtokenwithş".encode()  # the 'ş' from the issue
+    token_file.write_bytes(raw)
+    monkeypatch.setenv("HF_TOKEN_PATH", str(token_file))
+
+    purged = purge_non_ascii_hf_tokens()
+
+    assert str(token_file) in purged
+    assert token_file.read_text(encoding="utf-8") == ""  # blanked
+    backup = token_file.with_name(token_file.name + ".bak")
+    assert backup.read_bytes() == raw  # original preserved for recovery
+
+
+def test_keeps_ascii_token_file(tmp_path, monkeypatch):
+    for var in HF_TOKEN_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    token_file = tmp_path / "token"
+    token_file.write_text("hf_validasciitoken0123", encoding="utf-8")
+    monkeypatch.setenv("HF_TOKEN_PATH", str(token_file))
+
+    purged = purge_non_ascii_hf_tokens()
+
+    assert purged == []
+    assert token_file.read_text(encoding="utf-8") == "hf_validasciitoken0123"
+    assert not token_file.with_name(token_file.name + ".bak").exists()
+
+
+def test_missing_token_file_is_noop(tmp_path, monkeypatch):
+    for var in HF_TOKEN_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("HF_TOKEN_PATH", str(tmp_path / "nope" / "token"))
+    assert purge_non_ascii_hf_tokens() == []
+
+
+def test_purges_non_ascii_user_agent_origin(monkeypatch):
+    for var in HF_TOKEN_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("HF_HUB_USER_AGENT_ORIGIN", "myorg-ş")
+
+    purged = purge_non_ascii_hf_tokens()
+
+    assert "HF_HUB_USER_AGENT_ORIGIN" in purged
+    assert "HF_HUB_USER_AGENT_ORIGIN" not in os.environ

--- a/server/backend/uv.lock
+++ b/server/backend/uv.lock
@@ -33,6 +33,14 @@ conflicts = [[
     { package = "transcriptionsuite-server", extra = "whisper" },
 ]]
 
+[manifest]
+
+[[manifest.dependency-metadata]]
+name = "vibevoice"
+version = "1.0.0"
+requires-dist = ["torch", "transformers>=4.51.3,<5.0.0", "accelerate", "llvmlite>=0.40.0", "numba>=0.57.0", "diffusers", "tqdm", "numpy", "scipy", "librosa", "ml-collections", "absl-py", "gradio", "av", "aiortc", "uvicorn[standard]", "fastapi", "pydub", "requests"]
+requires-python = ">=3.9"
+
 [[package]]
 name = "absl-py"
 version = "2.4.0"

--- a/server/docker/bootstrap_runtime.py
+++ b/server/docker/bootstrap_runtime.py
@@ -355,6 +355,42 @@ print(json.dumps(packages, sort_keys=True))
     return {}
 
 
+# Combined CA bundle that Debian/Ubuntu `update-ca-certificates` (re)writes; it
+# contains the system roots plus any corporate root CA dropped into
+# /usr/local/share/ca-certificates. Used to point git/requests/curl at a mounted
+# corporate CA on TLS-intercepting networks (GH #125).
+_SYSTEM_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt"
+
+
+def _propagate_ca_bundle(env: dict[str, str]) -> None:
+    """Point git, requests and curl at a corporate CA bundle (GH #125).
+
+    uv honors ``UV_NATIVE_TLS`` / ``SSL_CERT_FILE``, but two other clients in the
+    install path do NOT:
+
+      * the ``git`` subprocess uv shells out to for git sources (e.g. VibeVoice)
+        reads ``GIT_SSL_CAINFO`` (libcurl);
+      * the ``requests`` client huggingface_hub uses at model-download time reads
+        ``REQUESTS_CA_BUNDLE`` / ``CURL_CA_BUNDLE`` (not ``SSL_CERT_FILE``).
+
+    So a user who followed the docs (``UV_NATIVE_TLS=true`` + mounted CA) would
+    still hit cert failures on git clones and model downloads. Mirror the CA into
+    those vars — only when the user has opted in via ``UV_NATIVE_TLS`` (trust the
+    container store) or an explicit ``SSL_CERT_FILE`` — without overriding any
+    value the user already set. Certificate verification stays ON; this only
+    changes WHICH trust anchor is consulted.
+    """
+    explicit = env.get("SSL_CERT_FILE")
+    if explicit:
+        ca = explicit
+    elif parse_bool_env("UV_NATIVE_TLS", False) and os.path.isfile(_SYSTEM_CA_BUNDLE):
+        ca = _SYSTEM_CA_BUNDLE
+    else:
+        return
+    for var in ("SSL_CERT_FILE", "GIT_SSL_CAINFO", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE"):
+        env.setdefault(var, ca)
+
+
 def build_uv_sync_env(venv_dir: Path, cache_dir: Path) -> dict[str, str]:
     """Build environment variables used by runtime uv commands."""
     env = os.environ.copy()
@@ -369,6 +405,9 @@ def build_uv_sync_env(venv_dir: Path, cache_dir: Path) -> dict[str, str]:
     # verification stays ON — this never disables TLS checking.
     if parse_bool_env("UV_NATIVE_TLS", False):
         env["UV_NATIVE_TLS"] = "true"
+    # Extend that trust to the git + requests clients uv/huggingface_hub use,
+    # which ignore UV_NATIVE_TLS (GH #125).
+    _propagate_ca_bundle(env)
     return env
 
 
@@ -422,6 +461,14 @@ def run_dependency_sync(
     # multi-GB CUDA wheels). --frozen is dropped because uv.lock pins cu129 wheel
     # hashes; --index-strategy unsafe-best-match lets non-torch packages fall
     # back to PyPI (Issue #115).
+    #
+    # GH #125 (reopen): dropping --frozen makes uv re-resolve the *universal* lock,
+    # which includes the vibevoice_asr extra's git source — so uv would `git clone`
+    # VibeVoice for metadata even though vibevoice_asr is never a selected extra
+    # here. That clone breaks installs on TLS-intercepting networks. It is
+    # prevented declaratively by [tool.uv.dependency-metadata] for vibevoice in
+    # server/backend/pyproject.toml (uv uses the declared metadata instead of
+    # cloning). Keep that entry in sync with the pinned VibeVoice ref.
     variant_index_urls = {
         "cu126": "https://download.pytorch.org/whl/cu126",
         "cpu": "https://download.pytorch.org/whl/cpu",
@@ -458,14 +505,20 @@ _TLS_INTERCEPTION_MARKERS: tuple[str, ...] = (
     "self signed certificate",
     "certificate verify failed",
     "unable to get local issuer",
+    # git/libcurl signature (e.g. the VibeVoice git clone on a re-resolve) —
+    # different wording than uv's rustls error, same root cause (GH #125).
+    "server certificate verification failed",
+    "cafile:",
 )
 
 _TLS_INTERCEPTION_HINT = (
     "TLS certificate verification failed while downloading dependencies. Your "
     "network appears to intercept HTTPS (corporate proxy or antivirus HTTPS "
-    "scanning), so the package-index certificate is not trusted inside the "
-    "container. Fix: set UV_NATIVE_TLS=true to trust the system CA store, and/or "
-    "mount your organization's root CA into the container. See "
+    "scanning), so the certificate is not trusted inside the container. Fix: "
+    "(1) set UV_NATIVE_TLS=true so uv trusts the container CA store, and "
+    "(2) mount your organization's root CA into the container and run "
+    "update-ca-certificates so git (git-sourced deps) and HuggingFace model "
+    "downloads trust it too — UV_NATIVE_TLS alone does not cover them. See "
     "docs/deployment-guide.md (TLS interception / corporate network)."
 )
 


### PR DESCRIPTION
## Summary

Addresses the **reopen of GH #125** ("1.3.5 Windows / CPU: local start not possible"). The thread accumulated three distinct failures over time; this PR closes the remaining ones.

### The reopen (Failure C, odnodn, v1.3.6) — the actual regression

PR #131's CPU downgrade works (`honoring the CPU downgrade (GH #125)`), but a whisper-only CPU install then dies cloning VibeVoice:

```
uv sync ... --extra whisper
  → Updating https://github.com/microsoft/VibeVoice.git
  → Failed to download and build vibevoice
  → fatal: ... server certificate verification failed. CAfile: none
```

**Root cause:** to honor the CPU downgrade, the bootstrap drops `uv sync --frozen` and swaps the pytorch index URL. Without `--frozen`, uv re-resolves the *universal* lock and must **build the SHA-pinned VibeVoice git source for metadata** — even though `vibevoice_asr` is never a selected extra (`extras_tuple` only ever holds `whisper`/`nemo`). That `git` fetch is silent on a healthy network but fatal on a TLS-intercepting one (corporate proxy / antivirus). Confirmed against the actually-baked **uv 0.10.8** and uv docs (astral-sh/uv#16110).

`--no-install-package` does **not** fix this (it acts after resolution); the failing op is the resolution-time build. `[[tool.uv.dependency-metadata]]` does — uv uses the declared metadata instead of building the git source.

## Changes

**P0 — stop the clone (the reopen)**
- `server/backend/pyproject.toml`: add `[[tool.uv.dependency-metadata]]` for `vibevoice` mirroring upstream's SHA-pinned `[project.dependencies]`.
- `server/backend/uv.lock`: minimal `[manifest]` block only (no unrelated marker churn).
- `bootstrap_runtime.py`: document the `--frozen`-drop → universal-re-resolve → git-clone interaction.

**P1 — complete corporate-CA trust (env-only mitigation; the TLS interception itself is the user's network)**
- `bootstrap_runtime.py::build_uv_sync_env`: mirror the CA into `GIT_SSL_CAINFO` + `REQUESTS_CA_BUNDLE` + `CURL_CA_BUNDLE` (git/requests ignore `UV_NATIVE_TLS`) — only when the operator opted in (`SSL_CERT_FILE`, or `UV_NATIVE_TLS=true` + container bundle present); never overrides user values.
- new `server/backend/core/ca_trust.py` + call in the server lifespan: the runtime HuggingFace model download uses `requests`/certifi (ignores `SSL_CERT_FILE`), so propagate `REQUESTS_CA_BUNDLE` there too.
- extend TLS-interception detection to the git/libcurl `server certificate verification failed` / `CAfile:` signature; broaden the hint; update `docs/deployment-guide.md`.

**P2 — harden the non-ASCII HF token guard (residual gaps from PR #131)**
- `hf_token_guard.py`: also neutralize the `~/.cache/huggingface/token` *file* (back up to `.bak` + blank) and `HF_HUB_USER_AGENT_ORIGIN`, not just the token env vars.
- `factory.py::create_backend`: run the guard before *every* backend load (not just once at startup), closing the lazy/hot-reload model-switch crash window.

## Behavior for a TLS-intercepting (MITM) network

After this PR, a whisper/nemo-only CPU install needs **no git/GitHub access at all**. If the network also intercepts PyPI/HuggingFace, the operator installs their root CA in the container (`update-ca-certificates`, docs) and sets `UV_NATIVE_TLS=true` (or `SSL_CERT_FILE`); the CA is now auto-propagated so uv wheels, git clones, and model downloads all trust it.

## Test plan

Run from `server/backend/` with the build venv:

```
../../build/.venv/bin/pytest tests/ -q
```

- [x] Full backend suite: **1961 passed, 3 skipped, 0 failures**
- [x] 17 new tests: dependency-metadata regression guard, install-time git/CA env propagation, runtime `ca_trust` (explicit + system-bundle + no-op + no-override), git/libcurl TLS markers, token-file + user-agent guard paths
- [x] `ruff check` clean on all changed/new backend files
- [x] `uv lock` (uv 0.10.8) accepts the change; `uv sync --frozen` (cu129/GPU path) still resolves
- [x] GitNexus impact + detect_changes: low risk, 0 affected processes