### PR TITLE
fix(stt): chunk long audio in whisper.cpp backend to stop sidecar timeout on 5h+ recordings (#168)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **TranscriptionSuite** (18819 symbols, 31400 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **TranscriptionSuite** (19002 symbols, 31742 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ feat/fix/chore/etc(impacted area e.g. tests, stt, dashboard, ui, server, etc): s
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **TranscriptionSuite** (18819 symbols, 31400 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **TranscriptionSuite** (19002 symbols, 31742 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/docs/project-context.md
+++ b/docs/project-context.md
@@ -149,7 +149,8 @@ durability:
 - **Model passthrough**: `POST /load {"model": model_name}` — `load()` tolerates HTTP failure (sidecar may pre-load)
 - **Diarization**: `transcribe_with_diarization()` returns `None` — falls back to legacy two-step pipeline
 - **Device parameter ignored**: Sidecar container manages Vulkan device via `/dev/dri`
-- **Timeouts**: Inference 300s, load 60s
+- **Long-audio chunking**: Audio longer than `_MAX_CHUNK_DURATION_S` (10 min) is split into chunks, each POSTed to `/inference` separately with timestamp-offset stitching (mirrors the NeMo backends; GH #168). Bounds per-request size/time and emits per-chunk progress.
+- **Timeouts**: Inference timeout scales with chunk duration via `_inference_timeout_for` (floored at 300s, ~2×-realtime headroom); load 60s
 - **Warmup**: Sends 1s of silence (16kHz zeros) to prime Vulkan pipeline
 - **Docker**: `docker-compose.vulkan.yml` adds `whisper-server` sidecar with health check; main container depends on it
 

--- a/server/backend/api/routes/notebook.py
+++ b/server/backend/api/routes/notebook.py
@@ -1085,6 +1085,13 @@ def _run_transcription(
 
         # Save to database
         # Use provided title if given, otherwise database falls back to filename stem
+        if getattr(result, "partial", False):
+            # A chunking backend failed partway through long audio; persist the
+            # completed transcript rather than lose it (GH #168 follow-up).
+            logger.warning(
+                "Saving a PARTIAL transcript for notebook recording: %s",
+                getattr(result, "partial_reason", None),
+            )
         clean_title = title.strip() if title else None
         transcription_backend = detect_backend_type(getattr(engine, "model_name", "") or "")
         recording_id = save_longform_to_database(

--- a/server/backend/api/routes/transcription.py
+++ b/server/backend/api/routes/transcription.py
@@ -177,6 +177,14 @@ async def transcribe_audio(
         sacrificed for DB consistency. See project invariant in CLAUDE.md.
         """
         nonlocal _persisted
+        if result_dict.get("partial"):
+            # A chunking backend failed partway through; we still persist the
+            # completed transcript rather than lose it (GH #168 follow-up).
+            logger.warning(
+                "Persisting a PARTIAL transcript for job %s: %s",
+                sanitize_log_value(db_job_id),
+                sanitize_log_value(result_dict.get("partial_reason")),
+            )
         if db_job_id is None:
             return
         try:

--- a/server/backend/config.py
+++ b/server/backend/config.py
@@ -192,6 +192,12 @@ class ServerConfig:
         ("LIVE_TRANSCRIBER_MODEL", ("live_transcriber", "model")),
         ("DIARIZATION_MODEL", ("diarization", "model")),
         ("WHISPERCPP_SERVER_URL", ("whisper_cpp", "server_url")),
+        ("WHISPERCPP_CHUNK_DURATION_S", ("whisper_cpp", "chunk_duration_s")),
+        ("WHISPERCPP_INFERENCE_TIMEOUT_S", ("whisper_cpp", "inference_timeout_s")),
+        (
+            "WHISPERCPP_TIMEOUT_SECONDS_PER_AUDIO_SECOND",
+            ("whisper_cpp", "timeout_seconds_per_audio_second"),
+        ),
     )
 
     _ENV_LOGGING_OVERRIDES = (

--- a/server/backend/core/stt/backends/base.py
+++ b/server/backend/core/stt/backends/base.py
@@ -24,6 +24,35 @@ class BackendDependencyError(RuntimeError):
         self.remedy = remedy
 
 
+class PartialTranscriptionError(RuntimeError):
+    """Raised by a chunking backend when a chunk fails *after* ≥1 chunk succeeded.
+
+    Carries the transcript completed so far so the engine can persist it instead
+    of discarding the whole job (the project's "avoid data loss at all costs"
+    invariant). A failure on the very first chunk raises the original error
+    instead — there is nothing partial to salvage.
+
+    Attributes:
+        segments: BackendSegment list for the chunks that completed (timestamps
+            already offset onto the global timeline).
+        info: BackendTranscriptionInfo from the first completed chunk.
+        completed_seconds: Seconds of audio successfully transcribed.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        segments: list[BackendSegment],
+        info: BackendTranscriptionInfo,
+        completed_seconds: float,
+    ) -> None:
+        super().__init__(message)
+        self.segments = segments
+        self.info = info
+        self.completed_seconds = completed_seconds
+
+
 @dataclass
 class BackendSegment:
     """Normalized transcription segment returned by any backend."""

--- a/server/backend/core/stt/backends/base.py
+++ b/server/backend/core/stt/backends/base.py
@@ -134,6 +134,17 @@ class STTBackend(abc.ABC):
     def supports_translation(self) -> bool:
         """Return True if this backend supports the ``translate`` task."""
 
+    def supports_cancellation(self) -> bool:
+        """Return True if ``transcribe`` accepts a ``cancellation_check`` and
+        honours it *mid-call* (e.g. between chunks of long audio).
+
+        Default ``False``: the engine then relies on its post-call cancellation
+        check (after ``transcribe`` returns). Backends that chunk long audio can
+        override this so the engine forwards ``cancellation_check`` and the job
+        can stop within a chunk instead of after the whole file.
+        """
+        return False
+
     @property
     def preferred_input_sample_rate_hz(self) -> int:
         """Preferred audio sample rate for this backend's input pipeline."""

--- a/server/backend/core/stt/backends/whispercpp_backend.py
+++ b/server/backend/core/stt/backends/whispercpp_backend.py
@@ -89,16 +89,93 @@ _SIDECAR_INFERENCE_TIMEOUT_MSG = (
 )
 
 
-def _inference_timeout_for(num_samples: int, sample_rate: int) -> int:
+def _inference_timeout_for(
+    num_samples: int,
+    sample_rate: int,
+    floor: int = _INFERENCE_TIMEOUT,
+    factor: float = _TIMEOUT_SECONDS_PER_AUDIO_SECOND,
+) -> int:
     """Per-request httpx read-timeout (seconds), scaled to the chunk's duration.
 
-    Floored at ``_INFERENCE_TIMEOUT``. Because audio is chunked before it reaches
-    the sidecar (see ``WhisperCppBackend.transcribe``), every request is bounded,
-    so scaling the timeout to the chunk length lets a slow or heavily-loaded
-    Vulkan GPU finish without the client giving up prematurely (GH #168 / #153).
+    Floored at ``floor``. Because audio is chunked before it reaches the sidecar
+    (see ``WhisperCppBackend.transcribe``), every request is bounded, so scaling
+    the timeout to the chunk length lets a slow or heavily-loaded Vulkan GPU
+    finish without the client giving up prematurely (GH #168 / #153). ``floor``
+    and ``factor`` default to the module constants but are overridable via config
+    (``WHISPERCPP_INFERENCE_TIMEOUT_S`` / ``WHISPERCPP_TIMEOUT_SECONDS_PER_AUDIO_SECOND``).
     """
     duration_s = num_samples / sample_rate if sample_rate > 0 else 0.0
-    return max(_INFERENCE_TIMEOUT, math.ceil(duration_s * _TIMEOUT_SECONDS_PER_AUDIO_SECOND))
+    return max(floor, math.ceil(duration_s * factor))
+
+
+def _read_whispercpp_setting(env_key: str, cfg_key: str) -> str | None:
+    """Return the raw whisper.cpp setting from env → config → None.
+
+    Mirrors ``_resolve_server_url`` precedence (env wins over config). The value
+    is returned as a stripped string for the caller to parse/validate; ``None``
+    means neither source provided it. Config-read failures are swallowed (the
+    caller falls back to its default).
+    """
+    env_val = os.environ.get(env_key, "").strip()
+    if env_val:
+        return env_val
+    try:
+        from server.config import get_config
+
+        cfg_val = get_config().get("whisper_cpp", cfg_key)
+    except Exception as exc:  # noqa: BLE001 — config must never break transcription
+        logger.debug("Could not read whisper_cpp.%s from config: %s", cfg_key, repr(exc))
+        return None
+    if cfg_val is None:
+        return None
+    text = str(cfg_val).strip()
+    return text or None
+
+
+def _resolve_chunk_duration_config() -> int:
+    """Max chunk duration (seconds) from env → config → default, floored at 60s."""
+    raw = _read_whispercpp_setting("WHISPERCPP_CHUNK_DURATION_S", "chunk_duration_s")
+    if raw is None:
+        return _MAX_CHUNK_DURATION_S
+    try:
+        return max(60, int(float(raw)))
+    except (TypeError, ValueError):
+        logger.warning(
+            "Ignoring invalid whisper.cpp chunk duration %r (expected a number ≥ 60); using %ds",
+            raw,
+            _MAX_CHUNK_DURATION_S,
+        )
+        return _MAX_CHUNK_DURATION_S
+
+
+def _resolve_timeout_config() -> tuple[int, float]:
+    """``(inference_timeout_floor_s, seconds_per_audio_second)`` from env → config → default."""
+    raw_floor = _read_whispercpp_setting("WHISPERCPP_INFERENCE_TIMEOUT_S", "inference_timeout_s")
+    floor = _INFERENCE_TIMEOUT
+    if raw_floor is not None:
+        try:
+            floor = max(60, int(float(raw_floor)))
+        except (TypeError, ValueError):
+            logger.warning(
+                "Ignoring invalid whisper.cpp inference timeout %r (expected a number ≥ 60); using %ds",
+                raw_floor,
+                _INFERENCE_TIMEOUT,
+            )
+
+    raw_factor = _read_whispercpp_setting(
+        "WHISPERCPP_TIMEOUT_SECONDS_PER_AUDIO_SECOND", "timeout_seconds_per_audio_second"
+    )
+    factor = _TIMEOUT_SECONDS_PER_AUDIO_SECOND
+    if raw_factor is not None:
+        try:
+            factor = max(0.5, float(raw_factor))
+        except (TypeError, ValueError):
+            logger.warning(
+                "Ignoring invalid whisper.cpp timeout factor %r (expected a number ≥ 0.5); using %.1f",
+                raw_factor,
+                _TIMEOUT_SECONDS_PER_AUDIO_SECOND,
+            )
+    return floor, factor
 
 
 def _resolve_server_url() -> str:
@@ -358,10 +435,14 @@ class WhisperCppBackend(STTBackend):
         self._model_name: str | None = None
         self._loaded: bool = False
         self._client: httpx.Client | None = None
-        # Audio longer than this (seconds) is split into chunks before being
-        # sent to the sidecar (GH #168). Instance attribute so tests can shrink
-        # it; mirrors ``ParakeetBackend._max_chunk_duration_s``.
+        # Chunking + timeout knobs. Default to the module constants; ``load()``
+        # overrides them from env/config (WHISPERCPP_*). Instance attributes so
+        # tests can shrink them; mirrors ``ParakeetBackend._max_chunk_duration_s``.
+        # Audio longer than ``_max_chunk_duration_s`` (seconds) is split into
+        # chunks before being sent to the sidecar (GH #168).
         self._max_chunk_duration_s: int = _MAX_CHUNK_DURATION_S
+        self._inference_timeout: int = _INFERENCE_TIMEOUT
+        self._timeout_seconds_per_audio_second: float = _TIMEOUT_SECONDS_PER_AUDIO_SECOND
 
     def _ensure_client(self) -> httpx.Client:
         """Return (or create) a persistent httpx.Client.
@@ -385,10 +466,18 @@ class WhisperCppBackend(STTBackend):
     def load(self, model_name: str, device: str, **kwargs: Any) -> None:
         self._server_url = _resolve_server_url()
         self._model_name = model_name
+        # Resolve chunking / timeout knobs once at load time (env → config →
+        # default), mirroring how _resolve_server_url is consumed here.
+        self._max_chunk_duration_s = _resolve_chunk_duration_config()
+        self._inference_timeout, self._timeout_seconds_per_audio_second = _resolve_timeout_config()
         logger.info(
-            "WhisperCppBackend: loading model %s via %s",
+            "WhisperCppBackend: loading model %s via %s "
+            "(chunk=%ds, timeout_floor=%ds, timeout_factor=%.1fx)",
             model_name,
             self._server_url,
+            self._max_chunk_duration_s,
+            self._inference_timeout,
+            self._timeout_seconds_per_audio_second,
         )
 
         client = self._ensure_client()
@@ -569,7 +658,12 @@ class WhisperCppBackend(STTBackend):
         an otherwise-healthy request.
         """
         wav_bytes = _audio_to_wav_bytes(chunk, sample_rate)
-        timeout = _inference_timeout_for(len(chunk), sample_rate)
+        timeout = _inference_timeout_for(
+            len(chunk),
+            sample_rate,
+            self._inference_timeout,
+            self._timeout_seconds_per_audio_second,
+        )
 
         client = self._ensure_client()
         try:

--- a/server/backend/core/stt/backends/whispercpp_backend.py
+++ b/server/backend/core/stt/backends/whispercpp_backend.py
@@ -553,6 +553,7 @@ class WhisperCppBackend(STTBackend):
         word_timestamps: bool = True,
         translation_target_language: str | None = None,  # noqa: ARG002
         progress_callback: Callable[[int, int], None] | None = None,
+        cancellation_check: Callable[[], bool] | None = None,
     ) -> tuple[list[BackendSegment], BackendTranscriptionInfo]:
         # NOTE: the following parameters are part of the STTBackend contract
         # but have no equivalent on whisper.cpp's /inference HTTP form API
@@ -571,6 +572,10 @@ class WhisperCppBackend(STTBackend):
         # ``progress_callback`` IS honoured for chunked (long) audio — one tick
         # per chunk (GH #168). Short audio goes out in a single synchronous POST
         # and so still cannot report sub-call progress.
+        # ``cancellation_check`` IS honoured for chunked audio: it is polled
+        # between chunks (the engine forwards it because supports_cancellation()
+        # is True) so a long job stops within one chunk instead of after the
+        # whole file. A single /inference POST cannot be interrupted mid-flight.
 
         if not self._loaded:
             raise RuntimeError("WhisperCppBackend: model is not loaded")
@@ -620,6 +625,16 @@ class WhisperCppBackend(STTBackend):
         first_info: BackendTranscriptionInfo | None = None
         chunk_data = data
         for i in range(num_chunks):
+            if cancellation_check is not None and cancellation_check():
+                # Lazy import avoids a circular dependency (model_manager imports
+                # backend factories at module load).
+                from server.core.model_manager import TranscriptionCancelledError
+
+                logger.info(
+                    "WhisperCppBackend: transcription cancelled at chunk %d/%d", i + 1, num_chunks
+                )
+                raise TranscriptionCancelledError("Transcription cancelled by user")
+
             start = i * chunk_samples
             chunk = audio[start : min(start + chunk_samples, total_samples)]
             segments, info = self._transcribe_chunk(chunk, audio_sample_rate, chunk_data)
@@ -708,6 +723,10 @@ class WhisperCppBackend(STTBackend):
         return self._parse_response(result)
 
     def supports_translation(self) -> bool:
+        return True
+
+    def supports_cancellation(self) -> bool:
+        # transcribe() polls cancellation_check between chunks (GH #168 follow-up).
         return True
 
     @property

--- a/server/backend/core/stt/backends/whispercpp_backend.py
+++ b/server/backend/core/stt/backends/whispercpp_backend.py
@@ -25,10 +25,14 @@ from server.core.stt.backends.base import (
 logger = logging.getLogger(__name__)
 
 _DEFAULT_SERVER_URL = "http://whisper-server:8080"
-_INFERENCE_TIMEOUT = 300  # seconds — long audio can take a while
-# TODO(GH-62-followup): scale _INFERENCE_TIMEOUT with audio duration. At
-# 300s a ~2h file on a slow Vulkan GPU can legitimately exceed the ceiling
-# and get mis-reported as a sidecar timeout. Provisional: max(300, dur*10).
+# Floor for the per-request httpx timeout. The actual budget scales with chunk
+# duration via ``_inference_timeout_for`` (GH #168 / #153): long audio is split
+# into ``_MAX_CHUNK_DURATION_S`` chunks in ``transcribe``, so each /inference POST
+# is bounded in size and time — replacing the old single un-chunked request whose
+# fixed 300s ceiling a 5h+ file could never satisfy.
+_INFERENCE_TIMEOUT = 300  # seconds — minimum per-request budget
+_MAX_CHUNK_DURATION_S = 10 * 60  # 10 min per /inference POST (mirrors the NeMo backends)
+_TIMEOUT_SECONDS_PER_AUDIO_SECOND = 2.0  # tolerate inference up to ~2× real-time
 _LOAD_TIMEOUT = 60
 
 # whisper-server's own default for beam_size (see
@@ -83,6 +87,18 @@ _SIDECAR_INFERENCE_TIMEOUT_MSG = (
     "the current timeout, or the Vulkan device is under heavy load. Try "
     "shorter audio or check the sidecar container logs."
 )
+
+
+def _inference_timeout_for(num_samples: int, sample_rate: int) -> int:
+    """Per-request httpx read-timeout (seconds), scaled to the chunk's duration.
+
+    Floored at ``_INFERENCE_TIMEOUT``. Because audio is chunked before it reaches
+    the sidecar (see ``WhisperCppBackend.transcribe``), every request is bounded,
+    so scaling the timeout to the chunk length lets a slow or heavily-loaded
+    Vulkan GPU finish without the client giving up prematurely (GH #168 / #153).
+    """
+    duration_s = num_samples / sample_rate if sample_rate > 0 else 0.0
+    return max(_INFERENCE_TIMEOUT, math.ceil(duration_s * _TIMEOUT_SECONDS_PER_AUDIO_SECOND))
 
 
 def _resolve_server_url() -> str:
@@ -342,6 +358,10 @@ class WhisperCppBackend(STTBackend):
         self._model_name: str | None = None
         self._loaded: bool = False
         self._client: httpx.Client | None = None
+        # Audio longer than this (seconds) is split into chunks before being
+        # sent to the sidecar (GH #168). Instance attribute so tests can shrink
+        # it; mirrors ``ParakeetBackend._max_chunk_duration_s``.
+        self._max_chunk_duration_s: int = _MAX_CHUNK_DURATION_S
 
     def _ensure_client(self) -> httpx.Client:
         """Return (or create) a persistent httpx.Client.
@@ -443,7 +463,7 @@ class WhisperCppBackend(STTBackend):
         vad_filter: bool = True,  # noqa: ARG002
         word_timestamps: bool = True,
         translation_target_language: str | None = None,  # noqa: ARG002
-        progress_callback: Callable[[int, int], None] | None = None,  # noqa: ARG002
+        progress_callback: Callable[[int, int], None] | None = None,
     ) -> tuple[list[BackendSegment], BackendTranscriptionInfo]:
         # NOTE: the following parameters are part of the STTBackend contract
         # but have no equivalent on whisper.cpp's /inference HTTP form API
@@ -459,9 +479,9 @@ class WhisperCppBackend(STTBackend):
         #   * translation_target_language — whisper always translates to
         #     English; non-English targets are rejected upstream in
         #     capabilities.py::validate_translation_request.
-        #   * progress_callback — /inference is synchronous, so we cannot
-        #     emit incremental ticks. Caller will only see a single
-        #     final result after the whole file finishes.
+        # ``progress_callback`` IS honoured for chunked (long) audio — one tick
+        # per chunk (GH #168). Short audio goes out in a single synchronous POST
+        # and so still cannot report sub-call progress.
 
         if not self._loaded:
             raise RuntimeError("WhisperCppBackend: model is not loaded")
@@ -473,8 +493,6 @@ class WhisperCppBackend(STTBackend):
             # Nothing to transcribe — return an empty result instead of sending
             # a zero-sample WAV that some sidecar versions error on.
             return [], BackendTranscriptionInfo(language=None, language_probability=0.0)
-
-        wav_bytes = _audio_to_wav_bytes(audio, audio_sample_rate)
 
         data: dict[str, Any] = {
             "response_format": "verbose_json",
@@ -498,22 +516,75 @@ class WhisperCppBackend(STTBackend):
             # form value to that literal (see server.cpp ``req.has_file``).
             data["split_on_word"] = "true"
 
+        # Short audio: one synchronous POST (the original fast path).
+        total_samples = len(audio)
+        chunk_samples = int(self._max_chunk_duration_s * audio_sample_rate)
+        if chunk_samples <= 0 or total_samples <= chunk_samples:
+            return self._transcribe_chunk(audio, audio_sample_rate, data)
+
+        # Long audio: split into bounded chunks and stitch with time offsets so
+        # no single request must cover the whole file (GH #168). Mirrors
+        # ``ParakeetBackend._transcribe_long``.
+        num_chunks = math.ceil(total_samples / chunk_samples)
+        all_segments: list[BackendSegment] = []
+        offset = 0.0
+        first_info: BackendTranscriptionInfo | None = None
+        chunk_data = data
+        for i in range(num_chunks):
+            start = i * chunk_samples
+            chunk = audio[start : min(start + chunk_samples, total_samples)]
+            segments, info = self._transcribe_chunk(chunk, audio_sample_rate, chunk_data)
+
+            if first_info is None:
+                first_info = info
+                # When auto-detecting, lock onto chunk 0's language so a quiet or
+                # ambiguous later chunk can't flip mid-file. A user-pinned
+                # ``language`` is already in ``data`` and is left untouched.
+                if info.language and "language" not in data:
+                    chunk_data = {**data, "language": info.language}
+
+            for seg in segments:
+                seg.start += offset
+                seg.end += offset
+                for word in seg.words:
+                    word["start"] += offset
+                    word["end"] += offset
+
+            all_segments.extend(segments)
+            offset += len(chunk) / audio_sample_rate
+            if progress_callback is not None:
+                progress_callback(i + 1, num_chunks)
+
+        return all_segments, (
+            first_info or BackendTranscriptionInfo(language=None, language_probability=0.0)
+        )
+
+    def _transcribe_chunk(
+        self, chunk: np.ndarray, sample_rate: int, data: dict[str, Any]
+    ) -> tuple[list[BackendSegment], BackendTranscriptionInfo]:
+        """POST a single (already-bounded) audio chunk to /inference and parse it.
+
+        The read-timeout scales with the chunk's duration (floored at
+        ``_INFERENCE_TIMEOUT``) so a slow Vulkan GPU does not false-time-out on
+        an otherwise-healthy request.
+        """
+        wav_bytes = _audio_to_wav_bytes(chunk, sample_rate)
+        timeout = _inference_timeout_for(len(chunk), sample_rate)
+
         client = self._ensure_client()
         try:
             resp = client.post(
                 f"{self._server_url}/inference",
                 files={"file": ("audio.wav", wav_bytes, "audio/wav")},
                 data=data,
-                timeout=_INFERENCE_TIMEOUT,
+                timeout=timeout,
             )
             resp.raise_for_status()
         except (httpx.NetworkError, OSError) as exc:
             raise RuntimeError(_SIDECAR_UNREACHABLE_MSG.format(url=self._server_url)) from exc
         except httpx.TimeoutException as exc:
             raise RuntimeError(
-                _SIDECAR_INFERENCE_TIMEOUT_MSG.format(
-                    url=self._server_url, timeout=_INFERENCE_TIMEOUT
-                )
+                _SIDECAR_INFERENCE_TIMEOUT_MSG.format(url=self._server_url, timeout=timeout)
             ) from exc
         except HttpxHTTPStatusError as exc:
             raise RuntimeError(

--- a/server/backend/core/stt/backends/whispercpp_backend.py
+++ b/server/backend/core/stt/backends/whispercpp_backend.py
@@ -19,6 +19,7 @@ from httpx import HTTPStatusError as HttpxHTTPStatusError
 from server.core.stt.backends.base import (
     BackendSegment,
     BackendTranscriptionInfo,
+    PartialTranscriptionError,
     STTBackend,
 )
 
@@ -637,7 +638,29 @@ class WhisperCppBackend(STTBackend):
 
             start = i * chunk_samples
             chunk = audio[start : min(start + chunk_samples, total_samples)]
-            segments, info = self._transcribe_chunk(chunk, audio_sample_rate, chunk_data)
+            try:
+                segments, info = self._transcribe_chunk(chunk, audio_sample_rate, chunk_data)
+            except Exception as exc:
+                if first_info is None:
+                    # Failed on the very first chunk — nothing to salvage, so the
+                    # original error (timeout/unreachable/etc.) propagates unchanged.
+                    raise
+                # ≥1 chunk already succeeded: surface the completed transcript so
+                # the engine can persist it instead of losing the whole job
+                # (GH #168 follow-up; "avoid data loss at all costs").
+                logger.warning(
+                    "WhisperCppBackend: chunk %d/%d failed (%s); returning %.0fs partial transcript",
+                    i + 1,
+                    num_chunks,
+                    exc,
+                    offset,
+                )
+                raise PartialTranscriptionError(
+                    str(exc),
+                    segments=all_segments,
+                    info=first_info,
+                    completed_seconds=offset,
+                ) from exc
 
             if first_info is None:
                 first_info = info

--- a/server/backend/core/stt/engine.py
+++ b/server/backend/core/stt/engine.py
@@ -78,9 +78,10 @@ class TranscriptionResult:
     segments: list[dict[str, Any]] = field(default_factory=list)
     words: list[dict[str, Any]] = field(default_factory=list)
     num_speakers: int = 0
-    # Set when a chunking backend failed partway through long audio: this result
-    # holds only the chunks that completed (GH #168 follow-up). ``duration`` is
-    # the transcribed span, not the full audio length.
+    # Set when a chunking backend failed partway through long audio: ``segments``
+    # then hold only the chunks that completed, while ``duration`` remains the
+    # full audio length (the recording is that long; ``partial_reason`` conveys
+    # that the transcript is incomplete). GH #168 follow-up.
     partial: bool = False
     partial_reason: str | None = None
 
@@ -964,8 +965,11 @@ class AudioToTextRecorder:
                 full_text_parts = []
 
                 for segment in backend_segments:
-                    # Check for cancellation between segments
-                    if cancellation_check and cancellation_check():
+                    # Check for cancellation between segments. Skip this once we
+                    # already hold a partial result — discarding salvaged work to
+                    # honour a late cancel would violate the "avoid data loss"
+                    # invariant; a chunk failure is already terminal (GH #168).
+                    if not partial and cancellation_check and cancellation_check():
                         from server.core.model_manager import (
                             TranscriptionCancelledError,
                         )

--- a/server/backend/core/stt/engine.py
+++ b/server/backend/core/stt/engine.py
@@ -34,6 +34,7 @@ import numpy as np
 import torch
 from scipy.signal import resample
 from server.config import get_config, resolve_main_transcriber_model
+from server.core.stt.backends.base import PartialTranscriptionError
 from server.core.stt.backends.factory import create_backend, detect_backend_type
 from server.core.stt.capabilities import validate_translation_request
 from server.core.stt.vad import VoiceActivityDetector
@@ -77,6 +78,11 @@ class TranscriptionResult:
     segments: list[dict[str, Any]] = field(default_factory=list)
     words: list[dict[str, Any]] = field(default_factory=list)
     num_speakers: int = 0
+    # Set when a chunking backend failed partway through long audio: this result
+    # holds only the chunks that completed (GH #168 follow-up). ``duration`` is
+    # the transcribed span, not the full audio length.
+    partial: bool = False
+    partial_reason: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for API responses."""
@@ -89,6 +95,8 @@ class TranscriptionResult:
             "duration": round(self.duration, 3),
             "num_speakers": self.num_speakers,
             "total_words": len(self.words),
+            "partial": self.partial,
+            "partial_reason": self.partial_reason,
             "metadata": {"num_segments": len(self.segments)},
         }
 
@@ -917,20 +925,38 @@ class AudioToTextRecorder:
                     cancel_kwargs["cancellation_check"] = cancellation_check
 
                 # Transcribe via backend
-                backend_segments, backend_info = self._backend.transcribe(
-                    audio_data,
-                    audio_sample_rate=sample_rate,
-                    language=lang,
-                    task=effective_task,
-                    beam_size=self.beam_size,
-                    initial_prompt=prompt,
-                    suppress_tokens=self.suppress_tokens,
-                    vad_filter=self.faster_whisper_vad_filter,
-                    word_timestamps=word_timestamps,
-                    translation_target_language=effective_target,
-                    progress_callback=progress_callback,
-                    **cancel_kwargs,
-                )
+                partial = False
+                partial_reason: str | None = None
+                try:
+                    backend_segments, backend_info = self._backend.transcribe(
+                        audio_data,
+                        audio_sample_rate=sample_rate,
+                        language=lang,
+                        task=effective_task,
+                        beam_size=self.beam_size,
+                        initial_prompt=prompt,
+                        suppress_tokens=self.suppress_tokens,
+                        vad_filter=self.faster_whisper_vad_filter,
+                        word_timestamps=word_timestamps,
+                        translation_target_language=effective_target,
+                        progress_callback=progress_callback,
+                        **cancel_kwargs,
+                    )
+                except PartialTranscriptionError as partial_exc:
+                    # A chunking backend failed partway through long audio. Keep
+                    # the completed chunks and fall through to formatting so the
+                    # partial transcript is persisted downstream rather than the
+                    # whole job being lost (GH #168 follow-up).
+                    partial = True
+                    partial_reason = str(partial_exc)
+                    backend_segments = partial_exc.segments
+                    backend_info = partial_exc.info
+                    logger.warning(
+                        "Transcription returned a partial result "
+                        "(%.0fs transcribed before failure): %s",
+                        partial_exc.completed_seconds,
+                        partial_reason,
+                    )
 
                 # Collect results
                 all_segments = []
@@ -985,6 +1011,8 @@ class AudioToTextRecorder:
                     language=backend_info.language,
                     language_probability=backend_info.language_probability,
                     duration=len(audio_data) / sample_rate,
+                    partial=partial,
+                    partial_reason=partial_reason,
                 )
 
             except Exception as e:

--- a/server/backend/core/stt/engine.py
+++ b/server/backend/core/stt/engine.py
@@ -909,6 +909,13 @@ class AudioToTextRecorder:
                     else self.translation_target_language
                 )
 
+                # Forward cancellation to backends that honour it mid-call (e.g.
+                # chunked long-audio backends, which poll it between chunks).
+                # Other backends keep the post-call segment-loop check below.
+                cancel_kwargs = {}
+                if cancellation_check is not None and self._backend.supports_cancellation():
+                    cancel_kwargs["cancellation_check"] = cancellation_check
+
                 # Transcribe via backend
                 backend_segments, backend_info = self._backend.transcribe(
                     audio_data,
@@ -922,6 +929,7 @@ class AudioToTextRecorder:
                     word_timestamps=word_timestamps,
                     translation_target_language=effective_target,
                     progress_callback=progress_callback,
+                    **cancel_kwargs,
                 )
 
                 # Collect results

--- a/server/backend/tests/test_stt_engine_helpers.py
+++ b/server/backend/tests/test_stt_engine_helpers.py
@@ -285,6 +285,74 @@ class TestCancellationForwarding:
         assert "cancellation_check" not in backend.transcribe.call_args.kwargs
 
 
+# ── Partial result handling (GH #168 follow-up) ──────────────────────────
+
+
+class TestPartialResultHandling:
+    """A PartialTranscriptionError from the backend becomes a flagged, *returned*
+    TranscriptionResult (not re-raised) so the route persists the partial."""
+
+    @staticmethod
+    def _make_recorder(backend):
+        import threading
+
+        rec = object.__new__(AudioToTextRecorder)
+        rec.transcription_lock = threading.Lock()
+        rec.model_name = "tiny.en"
+        rec.language = "en"
+        rec.task = "transcribe"
+        rec.translation_target_language = None
+        rec.initial_prompt = None
+        rec.beam_size = 5
+        rec.suppress_tokens = None
+        rec.faster_whisper_vad_filter = True
+        rec.normalize_audio = False
+        rec.ensure_sentence_starting_uppercase = False
+        rec.ensure_sentence_ends_with_period = False
+        rec.state = "transcribing"
+        rec._backend = backend
+        return rec
+
+    def test_partial_error_becomes_flagged_result(self):
+        from server.core.stt.backends.base import (
+            BackendSegment,
+            BackendTranscriptionInfo,
+            PartialTranscriptionError,
+        )
+
+        backend = MagicMock()
+        backend.supports_cancellation.return_value = False
+        backend.transcribe.side_effect = PartialTranscriptionError(
+            "chunk 3 timed out",
+            segments=[BackendSegment(text="hello", start=0.0, end=1.0, words=[])],
+            info=BackendTranscriptionInfo(language="en", language_probability=0.9),
+            completed_seconds=120.0,
+        )
+        rec = self._make_recorder(backend)
+
+        result = rec.transcribe_audio(np.ones(16000, dtype=np.float32) * 0.1, sample_rate=16000)
+
+        assert result.partial is True
+        assert "chunk 3 timed out" in result.partial_reason
+        assert result.text == "hello"
+        assert [s["text"] for s in result.segments] == ["hello"]
+        assert result.language == "en"
+
+    def test_successful_transcription_is_not_partial(self):
+        backend = MagicMock()
+        backend.supports_cancellation.return_value = False
+        backend.transcribe.return_value = (
+            [],
+            types.SimpleNamespace(language="en", language_probability=0.9),
+        )
+        rec = self._make_recorder(backend)
+
+        result = rec.transcribe_audio(np.ones(16000, dtype=np.float32) * 0.1, sample_rate=16000)
+
+        assert result.partial is False
+        assert result.partial_reason is None
+
+
 # ── TranscriptionResult ──────────────────────────────────────────────────
 
 
@@ -314,9 +382,21 @@ class TestTranscriptionResult:
             "duration",
             "num_speakers",
             "total_words",
+            "partial",
+            "partial_reason",
             "metadata",
         }
         assert set(d.keys()) == expected_keys
+
+    def test_partial_fields_default_off(self):
+        d = TranscriptionResult(text="x").to_dict()
+        assert d["partial"] is False
+        assert d["partial_reason"] is None
+
+    def test_partial_fields_carried_through_to_dict(self):
+        d = TranscriptionResult(text="x", partial=True, partial_reason="chunk 3 failed").to_dict()
+        assert d["partial"] is True
+        assert d["partial_reason"] == "chunk 3 failed"
 
     def test_to_dict_text(self):
         r = TranscriptionResult(text="Hello world")

--- a/server/backend/tests/test_stt_engine_helpers.py
+++ b/server/backend/tests/test_stt_engine_helpers.py
@@ -223,6 +223,68 @@ class TestTranscribeGuardsRaiseActionableError:
         assert "Settings" in msg, "must tell the user where"
 
 
+# ── Cancellation forwarding (GH #168 follow-up) ──────────────────────────
+
+
+class TestCancellationForwarding:
+    """transcribe_audio forwards cancellation_check to backend.transcribe() ONLY
+    when the backend advertises supports_cancellation(); otherwise it relies on
+    the post-call segment-loop check."""
+
+    @staticmethod
+    def _make_recorder(backend):
+        import threading
+
+        rec = object.__new__(AudioToTextRecorder)
+        rec.transcription_lock = threading.Lock()
+        rec.model_name = "tiny.en"
+        rec.language = "en"
+        rec.task = "transcribe"
+        rec.translation_target_language = None
+        rec.initial_prompt = None
+        rec.beam_size = 5
+        rec.suppress_tokens = None
+        rec.faster_whisper_vad_filter = True
+        rec.normalize_audio = False
+        rec.ensure_sentence_starting_uppercase = False
+        rec.ensure_sentence_ends_with_period = False
+        rec.state = "transcribing"
+        rec._backend = backend
+        return rec
+
+    @staticmethod
+    def _backend(*, supports: bool):
+        b = MagicMock()
+        b.supports_cancellation.return_value = supports
+        b.transcribe.return_value = (
+            [],
+            types.SimpleNamespace(language="en", language_probability=0.9),
+        )
+        return b
+
+    def test_forwards_cancellation_when_backend_supports_it(self):
+        backend = self._backend(supports=True)
+        rec = self._make_recorder(backend)
+
+        def cb() -> bool:
+            return False
+
+        rec.transcribe_audio(
+            np.ones(16000, dtype=np.float32) * 0.1, sample_rate=16000, cancellation_check=cb
+        )
+        assert backend.transcribe.call_args.kwargs.get("cancellation_check") is cb
+
+    def test_omits_cancellation_when_backend_does_not_support_it(self):
+        backend = self._backend(supports=False)
+        rec = self._make_recorder(backend)
+        rec.transcribe_audio(
+            np.ones(16000, dtype=np.float32) * 0.1,
+            sample_rate=16000,
+            cancellation_check=lambda: False,
+        )
+        assert "cancellation_check" not in backend.transcribe.call_args.kwargs
+
+
 # ── TranscriptionResult ──────────────────────────────────────────────────
 
 

--- a/server/backend/tests/test_stt_engine_helpers.py
+++ b/server/backend/tests/test_stt_engine_helpers.py
@@ -352,6 +352,34 @@ class TestPartialResultHandling:
         assert result.partial is False
         assert result.partial_reason is None
 
+    def test_partial_result_survives_late_cancellation(self):
+        """A cancel racing the post-partial formatting loop must NOT discard the
+        salvaged partial transcript (avoid-data-loss invariant)."""
+        from server.core.stt.backends.base import (
+            BackendSegment,
+            BackendTranscriptionInfo,
+            PartialTranscriptionError,
+        )
+
+        backend = MagicMock()
+        backend.supports_cancellation.return_value = True
+        backend.transcribe.side_effect = PartialTranscriptionError(
+            "chunk 3 timed out",
+            segments=[BackendSegment(text="hello", start=0.0, end=1.0, words=[])],
+            info=BackendTranscriptionInfo(language="en", language_probability=0.9),
+            completed_seconds=120.0,
+        )
+        rec = self._make_recorder(backend)
+
+        result = rec.transcribe_audio(
+            np.ones(16000, dtype=np.float32) * 0.1,
+            sample_rate=16000,
+            cancellation_check=lambda: True,  # cancel is active during formatting
+        )
+
+        assert result.partial is True
+        assert result.text == "hello"  # partial kept despite the active cancel
+
 
 # ── TranscriptionResult ──────────────────────────────────────────────────
 

--- a/server/backend/tests/test_whispercpp_backend.py
+++ b/server/backend/tests/test_whispercpp_backend.py
@@ -1532,6 +1532,79 @@ class TestWhisperCppConfigResolution:
 
 
 # ---------------------------------------------------------------------------
+# WhisperCppBackend — chunk-boundary cancellation (GH #168 follow-up)
+# ---------------------------------------------------------------------------
+
+
+class TestTranscribeCancellation:
+    @staticmethod
+    def _resp(payload: dict) -> MagicMock:
+        return MagicMock(status_code=200, json=MagicMock(return_value=payload))
+
+    def test_supports_cancellation_is_true(self, backend: WhisperCppBackend):
+        assert backend.supports_cancellation() is True
+
+    def test_cancellation_between_chunks_raises_and_stops(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        """A cancel that flips True before chunk 1 stops after chunk 0's POST."""
+        from server.core.model_manager import TranscriptionCancelledError
+
+        loaded_backend._max_chunk_duration_s = 1
+        mock_httpx.post.side_effect = [
+            self._resp({"segments": [], "language": "en"}) for _ in range(3)
+        ]
+        polls = {"n": 0}
+
+        def cancel() -> bool:
+            polls["n"] += 1
+            return polls["n"] > 1  # False before chunk 0, True before chunk 1
+
+        with pytest.raises(TranscriptionCancelledError):
+            loaded_backend.transcribe(
+                np.zeros(3 * 16000, dtype=np.float32), cancellation_check=cancel
+            )
+        assert mock_httpx.post.call_count == 1  # only chunk 0 was sent before the cancel
+
+    def test_cancellation_before_first_chunk_sends_nothing(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        from server.core.model_manager import TranscriptionCancelledError
+
+        loaded_backend._max_chunk_duration_s = 1
+        mock_httpx.post.side_effect = [
+            self._resp({"segments": [], "language": "en"}) for _ in range(3)
+        ]
+        with pytest.raises(TranscriptionCancelledError):
+            loaded_backend.transcribe(
+                np.zeros(3 * 16000, dtype=np.float32), cancellation_check=lambda: True
+            )
+        assert mock_httpx.post.call_count == 0
+
+    def test_none_cancellation_check_completes_all_chunks(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        loaded_backend._max_chunk_duration_s = 1
+        mock_httpx.post.side_effect = [
+            self._resp({"segments": [], "language": "en"}) for _ in range(3)
+        ]
+        loaded_backend.transcribe(np.zeros(3 * 16000, dtype=np.float32))  # no cancellation_check
+        assert mock_httpx.post.call_count == 3
+
+    def test_cancellation_never_true_completes(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        loaded_backend._max_chunk_duration_s = 1
+        mock_httpx.post.side_effect = [
+            self._resp({"segments": [], "language": "en"}) for _ in range(3)
+        ]
+        loaded_backend.transcribe(
+            np.zeros(3 * 16000, dtype=np.float32), cancellation_check=lambda: False
+        )
+        assert mock_httpx.post.call_count == 3
+
+
+# ---------------------------------------------------------------------------
 # WhisperCppBackend — warmup
 # ---------------------------------------------------------------------------
 

--- a/server/backend/tests/test_whispercpp_backend.py
+++ b/server/backend/tests/test_whispercpp_backend.py
@@ -12,11 +12,14 @@ from server.core.stt.backends.whispercpp_backend import (
     _MAX_CHUNK_DURATION_S,
     _MAX_SEGMENTS,
     _MAX_WORDS_PER_SEGMENT,
+    _TIMEOUT_SECONDS_PER_AUDIO_SECOND,
     WhisperCppBackend,
     _audio_to_wav_bytes,
     _coerce_float,
     _inference_timeout_for,
+    _resolve_chunk_duration_config,
     _resolve_server_url,
+    _resolve_timeout_config,
     _sanitize_for_error_preview,
     _sanitize_language_code,
     _validate_server_url,
@@ -1437,6 +1440,95 @@ class TestTranscribeChunking:
         segments, _ = loaded_backend.transcribe(np.zeros(3 * 16000, dtype=np.float32))
         assert [s.text for s in segments] == ["a", "c"]
         assert segments[1].start == 2.0  # offset by the two preceding 1s chunks
+
+
+# ---------------------------------------------------------------------------
+# whisper.cpp config knobs — chunk duration + timeout (GH #168 follow-up)
+# ---------------------------------------------------------------------------
+
+
+class TestWhisperCppConfigResolution:
+    def test_chunk_duration_env_wins_over_config(self):
+        cfg = MagicMock()
+        cfg.get.return_value = 90  # config says 90, env should win
+        with (
+            patch.dict("os.environ", {"WHISPERCPP_CHUNK_DURATION_S": "120"}),
+            patch("server.config.get_config", return_value=cfg),
+        ):
+            assert _resolve_chunk_duration_config() == 120
+
+    def test_chunk_duration_config_used_when_env_absent(self):
+        cfg = MagicMock()
+        cfg.get.return_value = 90
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("server.config.get_config", return_value=cfg),
+        ):
+            assert _resolve_chunk_duration_config() == 90
+
+    def test_chunk_duration_invalid_env_falls_back_to_default(self):
+        with patch.dict("os.environ", {"WHISPERCPP_CHUNK_DURATION_S": "not-a-number"}):
+            assert _resolve_chunk_duration_config() == _MAX_CHUNK_DURATION_S
+
+    def test_chunk_duration_floor_enforced(self):
+        with patch.dict("os.environ", {"WHISPERCPP_CHUNK_DURATION_S": "10"}):
+            assert _resolve_chunk_duration_config() == 60
+
+    def test_chunk_duration_defaults_when_no_source(self):
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("server.config.get_config", side_effect=RuntimeError("no config")),
+        ):
+            assert _resolve_chunk_duration_config() == _MAX_CHUNK_DURATION_S
+
+    def test_timeout_config_env_wins(self):
+        with patch.dict(
+            "os.environ",
+            {
+                "WHISPERCPP_INFERENCE_TIMEOUT_S": "500",
+                "WHISPERCPP_TIMEOUT_SECONDS_PER_AUDIO_SECOND": "3.0",
+            },
+        ):
+            assert _resolve_timeout_config() == (500, 3.0)
+
+    def test_timeout_config_floors_enforced(self):
+        with patch.dict(
+            "os.environ",
+            {
+                "WHISPERCPP_INFERENCE_TIMEOUT_S": "10",  # below 60 floor
+                "WHISPERCPP_TIMEOUT_SECONDS_PER_AUDIO_SECOND": "0.1",  # below 0.5 floor
+            },
+        ):
+            assert _resolve_timeout_config() == (60, 0.5)
+
+    def test_timeout_config_defaults_when_no_source(self):
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("server.config.get_config", side_effect=RuntimeError("no config")),
+        ):
+            assert _resolve_timeout_config() == (
+                _INFERENCE_TIMEOUT,
+                _TIMEOUT_SECONDS_PER_AUDIO_SECOND,
+            )
+
+    def test_load_resolves_config_into_instance_vars(
+        self, backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        """load() must populate the chunk/timeout instance vars from env/config."""
+        mock_httpx.post.return_value = MagicMock(status_code=200)
+        with patch.dict(
+            "os.environ",
+            {
+                "WHISPERCPP_SERVER_URL": "http://test:8080",
+                "WHISPERCPP_CHUNK_DURATION_S": "300",
+                "WHISPERCPP_INFERENCE_TIMEOUT_S": "450",
+                "WHISPERCPP_TIMEOUT_SECONDS_PER_AUDIO_SECOND": "1.5",
+            },
+        ):
+            backend.load("ggml-large-v3.bin", "cpu")
+        assert backend._max_chunk_duration_s == 300
+        assert backend._inference_timeout == 450
+        assert backend._timeout_seconds_per_audio_second == 1.5
 
 
 # ---------------------------------------------------------------------------

--- a/server/backend/tests/test_whispercpp_backend.py
+++ b/server/backend/tests/test_whispercpp_backend.py
@@ -1605,6 +1605,62 @@ class TestTranscribeCancellation:
 
 
 # ---------------------------------------------------------------------------
+# WhisperCppBackend — partial persistence on mid-chunk failure (GH #168 follow-up)
+# ---------------------------------------------------------------------------
+
+
+class TestTranscribePartialPersistence:
+    @staticmethod
+    def _resp(payload: dict) -> MagicMock:
+        return MagicMock(status_code=200, json=MagicMock(return_value=payload))
+
+    def test_mid_chunk_failure_raises_partial_with_completed_work(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        """Chunks 0-1 succeed, chunk 2 times out → PartialTranscriptionError that
+        carries the completed (offset) transcript and the transcribed span."""
+        from server.core.stt.backends.base import PartialTranscriptionError
+
+        loaded_backend._max_chunk_duration_s = 1
+        mock_httpx.post.side_effect = [
+            self._resp({"language": "en", "segments": [{"text": "a", "start": 0.0, "end": 0.5}]}),
+            self._resp({"language": "en", "segments": [{"text": "b", "start": 0.0, "end": 0.5}]}),
+            httpx.ReadTimeout("sidecar died"),  # chunk 2 fails
+        ]
+        with pytest.raises(PartialTranscriptionError) as excinfo:
+            loaded_backend.transcribe(np.zeros(3 * 16000, dtype=np.float32))
+        err = excinfo.value
+        assert [s.text for s in err.segments] == ["a", "b"]
+        assert err.segments[1].start == 1.0  # second chunk offset onto global timeline
+        assert err.completed_seconds == 2.0  # two 1s chunks finished
+        assert err.info.language == "en"
+
+    def test_first_chunk_failure_propagates_original_error(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        """A failure on the very first chunk is a total failure, not a partial."""
+        from server.core.stt.backends.base import PartialTranscriptionError
+
+        loaded_backend._max_chunk_duration_s = 1
+        mock_httpx.post.side_effect = [httpx.ReadTimeout("sidecar died")]  # chunk 0 fails
+        with pytest.raises(RuntimeError) as excinfo:
+            loaded_backend.transcribe(np.zeros(3 * 16000, dtype=np.float32))
+        assert not isinstance(excinfo.value, PartialTranscriptionError)
+        assert "transcription timed out" in str(excinfo.value)
+
+    def test_short_audio_failure_is_not_partial(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        """Single-POST (sub-threshold) failures keep the original error."""
+        from server.core.stt.backends.base import PartialTranscriptionError
+
+        mock_httpx.post.side_effect = httpx.ReadTimeout("boom")
+        with pytest.raises(RuntimeError) as excinfo:
+            loaded_backend.transcribe(np.zeros(16000, dtype=np.float32))  # 1s, single POST
+        assert not isinstance(excinfo.value, PartialTranscriptionError)
+
+
+# ---------------------------------------------------------------------------
 # WhisperCppBackend — warmup
 # ---------------------------------------------------------------------------
 

--- a/server/backend/tests/test_whispercpp_backend.py
+++ b/server/backend/tests/test_whispercpp_backend.py
@@ -8,11 +8,14 @@ import httpx
 import numpy as np
 import pytest
 from server.core.stt.backends.whispercpp_backend import (
+    _INFERENCE_TIMEOUT,
+    _MAX_CHUNK_DURATION_S,
     _MAX_SEGMENTS,
     _MAX_WORDS_PER_SEGMENT,
     WhisperCppBackend,
     _audio_to_wav_bytes,
     _coerce_float,
+    _inference_timeout_for,
     _resolve_server_url,
     _sanitize_for_error_preview,
     _sanitize_language_code,
@@ -1253,6 +1256,187 @@ class TestTranscribe:
         audio = np.zeros(16000, dtype=np.float32)
         with pytest.raises(RuntimeError, match="non-JSON"):
             loaded_backend.transcribe(audio)
+
+
+# ---------------------------------------------------------------------------
+# _inference_timeout_for — duration-scaled per-request timeout (GH #168)
+# ---------------------------------------------------------------------------
+
+
+class TestInferenceTimeoutFor:
+    def test_floors_at_inference_timeout(self):
+        # 10s of audio → 20s scaled, floored up to the 300s minimum.
+        assert _inference_timeout_for(10 * 16000, 16000) == _INFERENCE_TIMEOUT
+
+    def test_scales_above_floor(self):
+        # A 10-min chunk → 600 * 2.0 = 1200s, comfortably above the floor.
+        assert _inference_timeout_for(600 * 16000, 16000) == 1200
+
+    def test_zero_samples_is_floor(self):
+        assert _inference_timeout_for(0, 16000) == _INFERENCE_TIMEOUT
+
+    def test_zero_sample_rate_is_guarded(self):
+        # Must not divide by zero — fall back to the floor.
+        assert _inference_timeout_for(16000, 0) == _INFERENCE_TIMEOUT
+
+    def test_default_chunk_duration_is_ten_minutes(self):
+        assert _MAX_CHUNK_DURATION_S == 10 * 60
+
+
+# ---------------------------------------------------------------------------
+# WhisperCppBackend — long-audio client-side chunking (GH #168)
+# ---------------------------------------------------------------------------
+
+
+class TestTranscribeChunking:
+    """Audio longer than ``_max_chunk_duration_s`` is split into fixed-size
+    chunks, each POSTed to /inference separately, with per-chunk timestamps
+    offset back onto the global timeline. Ports the NeMo ``_transcribe_long``
+    pattern so each request is bounded in size and read-timeout (fixing the
+    300s ceiling on 5h+ files) and the backend can emit progress, which a
+    single synchronous /inference cannot.
+    """
+
+    @staticmethod
+    def _resp(payload: dict) -> MagicMock:
+        return MagicMock(status_code=200, json=MagicMock(return_value=payload))
+
+    def test_short_audio_uses_single_post(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        """Audio at/below the chunk threshold keeps the original single-POST path."""
+        loaded_backend._max_chunk_duration_s = 600  # 1s of audio is well under
+        mock_httpx.post.return_value = self._resp({"segments": [], "language": "en"})
+        loaded_backend.transcribe(np.zeros(16000, dtype=np.float32))
+        assert mock_httpx.post.call_count == 1
+
+    def test_long_audio_splits_into_chunks(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        """Audio longer than the threshold is split into ceil(total/chunk) POSTs."""
+        loaded_backend._max_chunk_duration_s = 1  # 1s chunks
+        mock_httpx.post.side_effect = [
+            self._resp({"segments": [], "language": "en"}) for _ in range(3)
+        ]
+        loaded_backend.transcribe(np.zeros(3 * 16000, dtype=np.float32))
+        assert mock_httpx.post.call_count == 3
+
+    def test_chunk_timestamps_offset_to_global_timeline(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        """Each chunk reports local times 0..x; the stitched output is offset by
+        the cumulative chunk duration (segment AND word level)."""
+        loaded_backend._max_chunk_duration_s = 1
+
+        def payload(i: int) -> dict:
+            return {
+                "language": "en",
+                "segments": [
+                    {
+                        "text": f" seg{i}",
+                        "start": 0.0,
+                        "end": 0.5,
+                        "words": [{"word": f" w{i}", "start": 0.0, "end": 0.5, "probability": 0.9}],
+                    }
+                ],
+            }
+
+        mock_httpx.post.side_effect = [self._resp(payload(i)) for i in range(3)]
+        segments, _ = loaded_backend.transcribe(np.zeros(3 * 16000, dtype=np.float32))
+        assert [s.start for s in segments] == [0.0, 1.0, 2.0]
+        assert [s.end for s in segments] == [0.5, 1.5, 2.5]
+        assert segments[1].words[0]["start"] == 1.0
+        assert segments[1].words[0]["end"] == 1.5
+        assert segments[2].words[0]["start"] == 2.0
+
+    def test_progress_callback_fires_per_chunk(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        loaded_backend._max_chunk_duration_s = 1
+        mock_httpx.post.side_effect = [
+            self._resp({"segments": [], "language": "en"}) for _ in range(3)
+        ]
+        calls: list[tuple[int, int]] = []
+        loaded_backend.transcribe(
+            np.zeros(3 * 16000, dtype=np.float32),
+            progress_callback=lambda cur, total: calls.append((cur, total)),
+        )
+        assert calls == [(1, 3), (2, 3), (3, 3)]
+
+    def test_info_comes_from_first_chunk(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        """Result language/probability is taken from the first chunk's detection."""
+        loaded_backend._max_chunk_duration_s = 1
+        mock_httpx.post.side_effect = [
+            self._resp({"language": "el", "detected_language_probability": 0.83, "segments": []}),
+            self._resp({"language": "en", "detected_language_probability": 0.10, "segments": []}),
+        ]
+        _, info = loaded_backend.transcribe(np.zeros(2 * 16000, dtype=np.float32), language=None)
+        assert info.language == "el"
+        assert info.language_probability == pytest.approx(0.83)
+
+    def test_detected_language_pins_later_chunks(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        """When auto-detecting, chunk 0's language is forwarded to later chunks so a
+        quiet/ambiguous later chunk can't flip the language mid-file."""
+        loaded_backend._max_chunk_duration_s = 1
+        mock_httpx.post.side_effect = [
+            self._resp({"language": "el", "segments": []}) for _ in range(3)
+        ]
+        loaded_backend.transcribe(np.zeros(3 * 16000, dtype=np.float32), language=None)
+        calls = mock_httpx.post.call_args_list
+        assert "language" not in (calls[0].kwargs.get("data") or {})  # chunk 0 auto-detects
+        assert calls[1].kwargs["data"].get("language") == "el"  # pinned thereafter
+        assert calls[2].kwargs["data"].get("language") == "el"
+
+    def test_explicit_language_sent_to_every_chunk(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        """A user-pinned language is sent to every chunk and never overridden."""
+        loaded_backend._max_chunk_duration_s = 1
+        mock_httpx.post.side_effect = [
+            self._resp({"language": "en", "segments": []}) for _ in range(2)
+        ]
+        loaded_backend.transcribe(np.zeros(2 * 16000, dtype=np.float32), language="fr")
+        for call in mock_httpx.post.call_args_list:
+            assert call.kwargs["data"].get("language") == "fr"
+
+    def test_each_chunk_post_uses_scaled_timeout(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        """Every chunk POST carries the duration-scaled timeout (floored at 300)."""
+        loaded_backend._max_chunk_duration_s = 1
+        mock_httpx.post.side_effect = [self._resp({"segments": []}) for _ in range(2)]
+        loaded_backend.transcribe(np.zeros(2 * 16000, dtype=np.float32))
+        expected = _inference_timeout_for(16000, 16000)  # 1s chunk → floored at 300
+        for call in mock_httpx.post.call_args_list:
+            assert call.kwargs.get("timeout") == expected
+
+    def test_single_post_timeout_scales_for_long_subthreshold_audio(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        """A 200s file (< 600s threshold) stays single-POST but its timeout scales past 300."""
+        mock_httpx.post.return_value = self._resp({"segments": []})
+        loaded_backend.transcribe(np.zeros(200 * 16000, dtype=np.float32))
+        assert mock_httpx.post.call_count == 1
+        assert mock_httpx.post.call_args.kwargs.get("timeout") == 400  # max(300, 200 * 2)
+
+    def test_empty_middle_chunk_still_advances_offset(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        """A silent middle chunk (no segments) still advances the offset clock so the
+        third chunk's segments land at the correct global time."""
+        loaded_backend._max_chunk_duration_s = 1
+        mock_httpx.post.side_effect = [
+            self._resp({"language": "en", "segments": [{"text": "a", "start": 0.0, "end": 0.5}]}),
+            self._resp({"language": "en", "segments": []}),  # silence
+            self._resp({"language": "en", "segments": [{"text": "c", "start": 0.0, "end": 0.5}]}),
+        ]
+        segments, _ = loaded_backend.transcribe(np.zeros(3 * 16000, dtype=np.float32))
+        assert [s.text for s in segments] == ["a", "c"]
+        assert segments[1].start == 2.0  # offset by the two preceding 1s chunks
 
 
 # ---------------------------------------------------------------------------

--- a/server/config.yaml
+++ b/server/config.yaml
@@ -148,6 +148,34 @@ parakeet:
     mlx_overlap_duration_s: 15
 
 # ----------------------------------------------------------------------------
+# whisper.cpp Sidecar Settings (Vulkan GPU mode)
+# ----------------------------------------------------------------------------
+# Settings for the out-of-process whisper.cpp HTTP sidecar. Every key here can
+# also be set via its WHISPERCPP_* environment variable (env wins over YAML).
+whisper_cpp:
+    # HTTP URL of the whisper.cpp sidecar. Leave unset to use the env var
+    # WHISPERCPP_SERVER_URL or the built-in default (http://whisper-server:8080).
+    # server_url: http://whisper-server:8080
+
+    # Maximum chunk duration (seconds) for long audio. Audio longer than this is
+    # split into sequential /inference POSTs (GH #168) so no single request can
+    # time out on a multi-hour file. Must be >= 60. Default: 600 (10 minutes).
+    # Env override: WHISPERCPP_CHUNK_DURATION_S
+    chunk_duration_s: 600
+
+    # Minimum per-request read timeout (seconds). The actual timeout scales with
+    # the chunk's duration but never drops below this floor. Raise it for very
+    # slow/loaded Vulkan GPUs. Must be >= 60. Default: 300.
+    # Env override: WHISPERCPP_INFERENCE_TIMEOUT_S
+    inference_timeout_s: 300
+
+    # Timeout scaling: seconds of budget per second of audio. Each request's
+    # timeout = max(inference_timeout_s, ceil(chunk_seconds * this)). Higher
+    # tolerates slower inference. Must be >= 0.5. Default: 2.0 (~2x real-time).
+    # Env override: WHISPERCPP_TIMEOUT_SECONDS_PER_AUDIO_SECOND
+    timeout_seconds_per_audio_second: 2.0
+
+# ----------------------------------------------------------------------------
 # Sortformer Diarization Settings (Apple Silicon only)
 # ----------------------------------------------------------------------------
 # Settings for the MLX Sortformer speaker diarization engine.


### PR DESCRIPTION
## Summary

Fixes #168 (a recurrence of #153) and the three follow-ups deferred from the original fix. The whisper.cpp Vulkan sidecar sent the **entire** audio file as one synchronous, un-chunked POST to `/inference` under a hardcoded 300s timeout, so 5h+ recordings always timed out (a client-side timeout, not a GPU fault).

Five commits, each self-contained:

### 1. Chunk long audio (core fix — `437be52`)
Ports the NeMo `parakeet_backend._transcribe_long` chunk-and-stitch pattern: audio > 10 min is split into chunks, each POSTed separately with timestamp-offset stitching and a duration-scaled per-request timeout. Bounds each request (~19 MB / ~120s vs ~0.5 GB held open for ~1 hour), restores the per-chunk progress bar, and permanently fixes the timeout.

### 2. Config knobs (`abb7f8f`)
`WHISPERCPP_CHUNK_DURATION_S`, `WHISPERCPP_INFERENCE_TIMEOUT_S`, `WHISPERCPP_TIMEOUT_SECONDS_PER_AUDIO_SECOND` via env + a documented `whisper_cpp:` section in `config.yaml` (env → config → default, validated/floored, server-side only). Lets users tune chunking/timeouts for very slow Vulkan GPUs.

### 3. Chunk-boundary cancellation (`7e784d0`)
New `STTBackend.supports_cancellation()` capability (default `False`, whisper.cpp `True`). `transcribe()` polls `cancellation_check` between chunks and raises `TranscriptionCancelledError`, so a long job stops within one chunk instead of after the whole file. The engine forwards `cancellation_check` only to backends that advertise support; all others keep the existing post-call check (3-file change, no base-contract churn).

### 4. Partial persistence (`79f3fa9` + review fix `ef19870`)
If a chunk fails after ≥1 chunk succeeded, the backend raises `PartialTranscriptionError` carrying the completed transcript; the engine formats it through the normal path and **returns** a `TranscriptionResult(partial=True, partial_reason=…)` instead of re-raising — so the existing persist-before-deliver path saves it (no DB migration) and diarization can still run. A first-chunk failure still propagates the original error. A late user-cancel can no longer discard a salvaged partial. Directly serves the "avoid data loss at all costs" invariant.

## Test plan

- [x] **2000 backend tests pass** (3 skipped, 0 failed) — up from 1976 on `main`.
- [x] New coverage: chunking offsets/progress/language-pinning, config resolution, per-chunk cancellation + engine forwarding, partial-raise + partial→flagged-result conversion + late-cancel survival.
- [x] `ruff` clean on all touched files; pre-commit hooks green.
- [x] Independent `python-reviewer` pass on all commits → APPROVE, no CRITICAL/HIGH (two MEDIUMs fixed in `ef19870`).
- [x] `gitnexus` impact reviewed: HIGH blast-radius on `transcribe_audio` is expected (it's the transcription hub); changes are additive/backward-compatible (new `except` is a no-op for non-whisper.cpp backends; new fields default off) and all 9 affected flows pass.
- [ ] Manual E2E on a Vulkan host (needs hardware): >10-min file shows per-chunk progress + full transcript; mid-run cancel stops within a chunk; killing the sidecar mid-run saves a flagged partial.

## Out of scope (noted for later)
Adopting partial-persistence / cancellation in the NeMo/VibeVoice backends (the mechanisms are generic — they can opt in later). A dashboard "⚠ partial" badge. Resume-from-chunk.