### PR TITLE
fix(dashboard): copy transcription to clipboard reliably on unfocused Wayland

### DIFF
--- a/dashboard/electron/__tests__/clipboardWayland.test.ts
+++ b/dashboard/electron/__tests__/clipboardWayland.test.ts
@@ -3,90 +3,108 @@
 /**
  * Tests for clipboardWayland.ts — reliable clipboard write on Wayland.
  *
- * Mocks Electron's clipboard, child_process (spawn/execFile), and the
- * isWayland() helper to test the verify-retry-fallback logic without
- * requiring a running Wayland session.
+ * These tests model the REAL Wayland failure mode proven on KDE/Plasma:
+ * when the Electron window is unfocused, clipboard.writeText() is silently
+ * dropped at the wl_data_device.set_selection layer (no input-event serial),
+ * yet clipboard.readText() still returns the just-written text from Chromium's
+ * in-process cache. A readback self-check therefore CANNOT detect the failure.
+ *
+ * To capture this faithfully the mocks separate two pieces of state:
+ *   - `realClipboard`  — the authoritative system clipboard (what wl-paste sees)
+ *   - `chromiumCache`  — what Electron's clipboard.readText() returns
+ * Electron's writeText updates the real clipboard ONLY when the (test) window
+ * is "focused"; wl-copy updates it unconditionally (focus-independent).
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-// ── Hoisted mocks ──────────────────────────────────────────────────────────
+// ── Mutable system model (driven per-test) ──────────────────────────────────
 
-const { mockClipboard, mockIsWayland, mockSpawn, mockExecFile } = vi.hoisted(() => {
-  const stdinWrite = vi.fn();
-  const stdinEnd = vi.fn();
-  const stdinOn = vi.fn();
-  const onHandler = vi.fn();
-  const killFn = vi.fn();
+const state = vi.hoisted(() => ({
+  realClipboard: '', // authoritative — returned by wl-paste
+  chromiumCache: '', // returned by clipboard.readText()
+  electronWriteReachesSystem: true, // false = window unfocused (masked write)
+  wlCopyAvailable: true,
+  wlPasteAvailable: true,
+}));
 
-  return {
-    mockClipboard: {
-      readText: vi.fn().mockReturnValue(''),
-      writeText: vi.fn(),
-    },
-    mockIsWayland: vi.fn().mockReturnValue(true),
-    mockSpawn: vi.fn().mockReturnValue({
-      stdin: { write: stdinWrite, end: stdinEnd, on: stdinOn },
-      on: onHandler,
-      kill: killFn,
+const { mockClipboard, mockIsWayland, mockSpawn, mockExecFile } = vi.hoisted(() => ({
+  mockClipboard: {
+    readText: vi.fn(() => state.chromiumCache),
+    writeText: vi.fn((t: string) => {
+      state.chromiumCache = t;
+      if (state.electronWriteReachesSystem) state.realClipboard = t;
     }),
-    mockExecFile: vi.fn(),
-  };
-});
-
-vi.mock('electron', () => ({
-  clipboard: mockClipboard,
+  },
+  mockIsWayland: vi.fn().mockReturnValue(true),
+  // wl-copy: spawn a child that takes ownership of the real clipboard when
+  // its stdin is closed (focus-independent, like ext-data-control).
+  mockSpawn: vi.fn((_cmd: string) => {
+    let buf = '';
+    return {
+      stdin: {
+        write: vi.fn((t: string) => {
+          buf = t;
+        }),
+        end: vi.fn(() => {
+          state.realClipboard = buf;
+        }),
+        on: vi.fn(),
+      },
+      on: vi.fn(),
+      kill: vi.fn(),
+    };
+  }),
+  mockExecFile: vi.fn(),
 }));
 
-vi.mock('child_process', () => ({
-  spawn: mockSpawn,
-  execFile: mockExecFile,
-}));
-
-vi.mock('../shortcutManager.js', () => ({
-  isWayland: mockIsWayland,
-}));
+vi.mock('electron', () => ({ clipboard: mockClipboard }));
+vi.mock('child_process', () => ({ spawn: mockSpawn, execFile: mockExecFile }));
+vi.mock('../shortcutManager.js', () => ({ isWayland: mockIsWayland }));
 
 import { reliableWriteText, _resetClipboardState } from '../clipboardWayland.js';
 
-// ── Helpers ────────────────────────────────────────────────────────────────
+// ── execFile mock: routes wl-copy --version (probe) and wl-paste (verify) ────
 
-/** Make `wl-copy --version` probe succeed. */
-function setWlCopyAvailable() {
+function enoent(): NodeJS.ErrnoException {
+  const e = new Error('spawn ENOENT') as NodeJS.ErrnoException;
+  e.code = 'ENOENT';
+  return e;
+}
+
+function installExecFileRouter() {
   mockExecFile.mockImplementation(
-    (_cmd: string, _args: string[], optsOrCb: unknown, maybeCb?: unknown) => {
-      const cb = typeof optsOrCb === 'function' ? optsOrCb : maybeCb;
-      if (typeof cb === 'function') {
-        (cb as (err: Error | null, result?: { stdout: string }) => void)(null, {
-          stdout: 'wl-copy 1.0',
-        });
+    (cmd: string, args: string[], optsOrCb: unknown, maybeCb?: unknown) => {
+      const cb = (typeof optsOrCb === 'function' ? optsOrCb : maybeCb) as
+        | ((err: Error | null, result?: { stdout: string }) => void)
+        | undefined;
+      if (!cb) return;
+      if (cmd === 'wl-copy') {
+        return state.wlCopyAvailable ? cb(null, { stdout: 'wl-copy 1.0' }) : cb(enoent());
       }
+      if (cmd === 'wl-paste') {
+        return state.wlPasteAvailable
+          ? cb(null, { stdout: state.realClipboard })
+          : cb(enoent());
+      }
+      return cb(null, { stdout: '' });
     },
   );
 }
 
-/** Make `wl-copy --version` probe fail with ENOENT (binary not found). */
-function setWlCopyMissing() {
-  mockExecFile.mockImplementation(
-    (_cmd: string, _args: string[], optsOrCb: unknown, maybeCb?: unknown) => {
-      const cb = typeof optsOrCb === 'function' ? optsOrCb : maybeCb;
-      if (typeof cb === 'function') {
-        const err = new Error('spawn wl-copy ENOENT') as NodeJS.ErrnoException;
-        err.code = 'ENOENT';
-        (cb as (err: Error | null) => void)(err);
-      }
-    },
-  );
-}
-
-// ── Tests ──────────────────────────────────────────────────────────────────
+// ── Tests ───────────────────────────────────────────────────────────────────
 
 describe('reliableWriteText', () => {
   beforeEach(() => {
     _resetClipboardState();
     vi.clearAllMocks();
-    // Default: Wayland, Linux
+    state.realClipboard = 'OLD-CLIPBOARD';
+    state.chromiumCache = 'OLD-CLIPBOARD';
+    state.electronWriteReachesSystem = true;
+    state.wlCopyAvailable = true;
+    state.wlPasteAvailable = true;
     mockIsWayland.mockReturnValue(true);
+    installExecFileRouter();
     Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
   });
 
@@ -97,83 +115,78 @@ describe('reliableWriteText', () => {
 
   it('uses clipboard.writeText directly on non-Wayland (passthrough)', async () => {
     mockIsWayland.mockReturnValue(false);
-
     await reliableWriteText('hello');
-
     expect(mockClipboard.writeText).toHaveBeenCalledWith('hello');
-    expect(mockClipboard.writeText).toHaveBeenCalledTimes(1);
     expect(mockSpawn).not.toHaveBeenCalled();
+    expect(state.realClipboard).toBe('hello');
   });
 
   it('uses clipboard.writeText directly on non-Linux platform', async () => {
     Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
-
     await reliableWriteText('hello');
-
     expect(mockClipboard.writeText).toHaveBeenCalledWith('hello');
-    expect(mockClipboard.writeText).toHaveBeenCalledTimes(1);
     expect(mockSpawn).not.toHaveBeenCalled();
   });
 
-  it('returns immediately when first write verifies (happy path)', async () => {
-    mockClipboard.readText.mockReturnValue('transcription result');
-
+  it('on Wayland, writes via wl-copy as the PRIMARY path (not Electron)', async () => {
     await reliableWriteText('transcription result');
-
-    expect(mockClipboard.writeText).toHaveBeenCalledTimes(1);
-    expect(mockClipboard.writeText).toHaveBeenCalledWith('transcription result');
-    expect(mockSpawn).not.toHaveBeenCalled();
-  });
-
-  it('retries once when first verification fails, succeeds on retry', async () => {
-    // First readText returns wrong value (write was dropped), second returns correct
-    mockClipboard.readText.mockReturnValueOnce('stale clipboard').mockReturnValueOnce('my text');
-
-    await reliableWriteText('my text');
-
-    expect(mockClipboard.writeText).toHaveBeenCalledTimes(2);
-    expect(mockSpawn).not.toHaveBeenCalled();
-  });
-
-  it('falls back to wl-copy when both Electron writes fail verification', async () => {
-    mockClipboard.readText.mockReturnValue('stale');
-    setWlCopyAvailable();
-
-    await reliableWriteText('important text');
-
-    expect(mockClipboard.writeText).toHaveBeenCalledTimes(2);
     expect(mockSpawn).toHaveBeenCalledWith('wl-copy', [], {
       stdio: ['pipe', 'ignore', 'ignore'],
     });
-    const spawnResult = mockSpawn.mock.results[0].value;
-    expect(spawnResult.stdin.write).toHaveBeenCalledWith('important text');
-    expect(spawnResult.stdin.end).toHaveBeenCalled();
+    const child = mockSpawn.mock.results[0].value;
+    expect(child.stdin.write).toHaveBeenCalledWith('transcription result');
+    expect(state.realClipboard).toBe('transcription result');
   });
 
-  it('logs warning when wl-copy is not installed and verification fails', async () => {
-    mockClipboard.readText.mockReturnValue('stale');
-    setWlCopyMissing();
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  // THE REGRESSION TEST for the reported bug.
+  it('succeeds even when the window is UNFOCUSED and Electron readback lies (masked write)', async () => {
+    // Window unfocused: Electron writeText is dropped at the system layer, but
+    // clipboard.readText() would still echo the text (the lie that defeated the
+    // old readback verify). wl-copy must be used and the REAL clipboard updated.
+    state.electronWriteReachesSystem = false;
 
-    await reliableWriteText('text');
+    await reliableWriteText('important transcription');
 
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('wl-copy is not installed'));
-    expect(mockSpawn).not.toHaveBeenCalled();
-    warnSpy.mockRestore();
+    expect(mockSpawn).toHaveBeenCalledTimes(1); // wl-copy used
+    expect(state.realClipboard).toBe('important transcription'); // really landed
   });
 
-  it('kills previous wl-copy child before spawning new one', async () => {
-    mockClipboard.readText.mockReturnValue('stale');
-    setWlCopyAvailable();
+  it('does not rely on clipboard.readText() to decide success when wl-copy exists', async () => {
+    // Even if readText echoes (would have passed the old verify), wl-copy is used.
+    state.chromiumCache = 'echoed-by-chromium';
+    await reliableWriteText('echoed-by-chromium');
+    expect(mockSpawn).toHaveBeenCalled();
+  });
 
-    // First write — spawns wl-copy
+  it('kills the previous wl-copy child before spawning a new one', async () => {
     await reliableWriteText('first');
     const firstChild = mockSpawn.mock.results[0].value;
-
-    // Second write — should kill first child
     await reliableWriteText('second');
-
     expect(firstChild.kill).toHaveBeenCalled();
     expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(state.realClipboard).toBe('second');
+  });
+
+  describe('when wl-clipboard is NOT installed', () => {
+    beforeEach(() => {
+      state.wlCopyAvailable = false;
+      state.wlPasteAvailable = false;
+    });
+
+    it('falls back to Electron clipboard.writeText and succeeds when focused', async () => {
+      state.electronWriteReachesSystem = true;
+      await reliableWriteText('via electron');
+      expect(mockClipboard.writeText).toHaveBeenCalledWith('via electron');
+      expect(mockSpawn).not.toHaveBeenCalled();
+      expect(state.realClipboard).toBe('via electron');
+    });
+
+    it('warns that wl-clipboard should be installed when the write cannot be verified', async () => {
+      state.electronWriteReachesSystem = false; // unfocused, no wl-copy → unrecoverable
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      await reliableWriteText('cannot land');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('wl-clipboard'));
+      warnSpy.mockRestore();
+    });
   });
 });

--- a/dashboard/electron/clipboardWayland.ts
+++ b/dashboard/electron/clipboardWayland.ts
@@ -1,10 +1,20 @@
 /**
  * Reliable clipboard write for Wayland.
  *
- * Electron's clipboard.writeText() silently drops writes when Chromium's
- * Ozone Wayland backend lacks a valid input event serial (the focused-window
- * requirement of wl_data_device.set_selection). This module adds a
- * write-verify-retry loop and falls back to wl-copy when Electron fails.
+ * Electron's clipboard.writeText() performs wl_data_device.set_selection, which
+ * the compositor only honors when the window holds a valid input-event serial —
+ * i.e. when it is focused. When the dashboard is UNFOCUSED (e.g. the user copied
+ * something in another app mid-recording and stopped via a global hotkey without
+ * refocusing the window), Chromium's Ozone Wayland backend has no serial and the
+ * write is SILENTLY DROPPED. Critically, clipboard.readText() still returns the
+ * just-written text from Chromium's in-process cache, so a write→readback
+ * self-check cannot detect the failure (verified on KDE Plasma 6 / Ozone Wayland).
+ *
+ * Therefore, on Wayland we prefer `wl-copy`, which sets the selection
+ * focus-independently via the ext-data-control protocol, and we confirm the
+ * result against the REAL clipboard via `wl-paste` — an independent channel that
+ * does not share Chromium's cache. Electron's native write is kept only as a
+ * fallback for systems without wl-clipboard installed.
  *
  * On non-Wayland platforms the native clipboard.writeText() is used directly.
  *
@@ -33,21 +43,84 @@ let wlCopyNegativeProbeAt = 0;
 /** Re-probe interval for negative results (60 seconds). */
 const WL_COPY_NEGATIVE_TTL_MS = 60_000;
 
+/** Whether the "wl-clipboard not installed" degraded-mode warning was emitted. */
+let degradedWaylandWarningEmitted = false;
+
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
 const VERIFY_RETRY_DELAY_MS = 60;
+
+/** Poll interval while confirming the real clipboard via wl-paste. */
+const WL_PASTE_POLL_INTERVAL_MS = 30;
+
+/**
+ * Time budget for confirming a write landed on the real clipboard. wl-copy
+ * acquires the selection slightly after the child is spawned, so we poll rather
+ * than read once.
+ */
+const CLIPBOARD_CONFIRM_BUDGET_MS = 400;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 /**
  * Read clipboard text safely.
  * clipboard.readText() is synchronous in Electron's main process, so it
  * cannot be meaningfully wrapped in a Promise.race timeout. We wrap it in
  * a try/catch to gracefully handle any exceptions from the Ozone backend.
+ *
+ * NOTE: this reads through Chromium and shares its in-process cache, so it
+ * must NOT be used to verify a write succeeded on Wayland — use wl-paste.
  */
 function readClipboardSafe(): string | null {
   try {
     return clipboard.readText();
   } catch {
     return null;
+  }
+}
+
+/**
+ * Read the REAL system clipboard via wl-paste — an independent channel that
+ * does not share Chromium's clipboard cache. Returns the clipboard text, or
+ * null when wl-paste is unavailable / cannot read (so we cannot verify).
+ */
+async function readViaWlPaste(): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('wl-paste', ['--no-newline'], { timeout: 2000 });
+    return stdout;
+  } catch (err: unknown) {
+    // wl-paste exits non-zero on an empty clipboard ("Nothing is copied") but
+    // still yields stdout=''. Treat a present stdout as the value; ENOENT /
+    // timeout (no stdout) means we cannot read independently.
+    const e = err as { stdout?: unknown };
+    if (typeof e.stdout === 'string') return e.stdout;
+    return null;
+  }
+}
+
+/**
+ * Confirm the real system clipboard holds `text`, polling wl-paste until it
+ * matches or the budget elapses. Returns:
+ *   true  — confirmed on the real clipboard
+ *   false — wl-paste worked but never showed `text` within the budget
+ *   null  — wl-paste is unavailable (cannot verify independently)
+ */
+async function confirmClipboard(
+  text: string,
+  budgetMs = CLIPBOARD_CONFIRM_BUDGET_MS,
+): Promise<boolean | null> {
+  const deadline = Date.now() + budgetMs;
+  let everRead = false;
+  for (;;) {
+    const real = await readViaWlPaste();
+    if (real !== null) {
+      everRead = true;
+      if (real === text) return true;
+    }
+    if (Date.now() >= deadline) return everRead ? false : null;
+    await sleep(WL_PASTE_POLL_INTERVAL_MS);
   }
 }
 
@@ -124,7 +197,8 @@ function writeViaWlCopy(text: string): void {
 /**
  * Write text to the clipboard reliably.
  *
- * On Wayland: write → verify → retry once → fall back to wl-copy.
+ * On Wayland: wl-copy (focus-independent) → confirm via wl-paste → Electron
+ * fallback only when wl-clipboard is absent.
  * On other platforms: direct clipboard.writeText() (no overhead).
  */
 export async function reliableWriteText(text: string): Promise<void> {
@@ -133,34 +207,32 @@ export async function reliableWriteText(text: string): Promise<void> {
     return;
   }
 
-  // ── Attempt 1: Electron native write ──────────────────────────────────
-  clipboard.writeText(text);
-
-  const readback1 = readClipboardSafe();
-  if (readback1 === text) return;
-
-  // ── Attempt 2: Retry after short delay ────────────────────────────────
-  await new Promise((resolve) => setTimeout(resolve, VERIFY_RETRY_DELAY_MS));
-  clipboard.writeText(text);
-
-  const readback2 = readClipboardSafe();
-  if (readback2 === text) {
-    console.info('[Clipboard] Wayland: retry succeeded');
-    return;
-  }
-
-  // ── Attempt 3: wl-copy fallback ───────────────────────────────────────
+  // ── Primary path: wl-copy (works whether or not the window is focused) ──
   if (await hasWlCopy()) {
-    console.info('[Clipboard] Wayland: falling back to wl-copy');
     writeViaWlCopy(text);
-    return;
+    const confirmed = await confirmClipboard(text);
+    // true = verified on the real clipboard; null = wl-paste unavailable, so we
+    // cannot verify but trust wl-copy. Only fall through on an explicit false.
+    if (confirmed !== false) return;
+    console.warn(
+      '[Clipboard] Wayland: wl-copy write could not be confirmed on the real ' +
+        'clipboard; falling back to Electron native write.',
+    );
+  } else if (!degradedWaylandWarningEmitted) {
+    degradedWaylandWarningEmitted = true;
+    console.warn(
+      '[Clipboard] Wayland: wl-clipboard is not installed. Clipboard writes may ' +
+        'silently fail when the window is unfocused. Install wl-clipboard for ' +
+        'reliable clipboard support (e.g. sudo pacman -S wl-clipboard / ' +
+        'sudo apt install wl-clipboard).',
+    );
   }
 
-  console.warn(
-    '[Clipboard] Wayland: clipboard write could not be verified and wl-copy is not installed. ' +
-      'Install the wl-clipboard package for reliable clipboard support ' +
-      '(e.g. sudo pacman -S wl-clipboard / sudo apt install wl-clipboard).',
-  );
+  // ── Fallback: Electron native write (reliable only when window is focused) ──
+  clipboard.writeText(text);
+  if (readClipboardSafe() === text) return;
+  await sleep(VERIFY_RETRY_DELAY_MS);
+  clipboard.writeText(text);
 }
 
 /**
@@ -175,4 +247,5 @@ export function _resetClipboardState(): void {
   killPreviousWlCopy();
   wlCopyAvailable = null;
   wlCopyNegativeProbeAt = 0;
+  degradedWaylandWarningEmitted = false;
 }


### PR DESCRIPTION
## Problem

Auto-copy of a completed transcription to the clipboard works when the dashboard is focused, but **fails when the user copied something in another app during recording and then stopped via global hotkey** (so the dashboard is unfocused at copy time). Persistent, repeatedly-attempted bug. Reproduced on Arch / KDE Plasma 6.7 Wayland.

This is a delivery-convenience failure only — the transcription is persisted server-side before the copy runs, so nothing is lost; the copy just silently didn't happen.

## Root cause (proven, not guessed)

On native Wayland (Ozone), `clipboard.writeText()` issues `wl_data_device.set_selection`, which the compositor only honors when the window holds a valid **input-event serial** (i.e. it is focused). When the dashboard is unfocused the write is **silently dropped** — yet `clipboard.readText()` still returns the text from **Chromium's in-process cache**. So `reliableWriteText`'s `readback === text` self-check **always falsely passed**, it returned at Attempt 1, and the focus-independent `wl-copy` fallback **never ran**.

Confirmed with a hidden-window (= unfocused) Electron probe: `clipboard.readText()` returned the sentinel while an independent `wl-paste` read showed the real clipboard unchanged. Corroborated by **zero `[Clipboard]` log lines** ever appearing in `client-debug.log` (the function always early-returned). Every prior fix failed because they all kept "Electron-writes-first, then self-verify" — and that verify reads back through the same Chromium cache, so it is structurally blind to this failure.

## Fix

`dashboard/electron/clipboardWayland.ts`:

- On Wayland, **write via `wl-copy` first** — it sets the selection focus-independently via the `ext-data-control` protocol (no window focus required).
- **Confirm against the real clipboard via `wl-paste`** — an independent channel that does not share Chromium's cache — with bounded polling (`wl-copy` acquires the selection slightly after the child spawns).
- Keep Electron's native `clipboard.writeText()` only as a **fallback** for systems without `wl-clipboard` installed (with a one-time warning recommending installation).
- Never use `clipboard.readText()` to verify a write on Wayland again (documented in code).

Non-Wayland platforms (macOS / Windows / X11) are unchanged — they keep the direct `clipboard.writeText()` path.

## Verification

- New regression test **"succeeds even when the window is UNFOCUSED and Electron readback lies (masked write)"** — fails on old code, passes on new.
- Tests model a faithful **real-clipboard vs Chromium-cache split** so the masked write is captured.
- `8/8` clipboard tests · `458/458` Electron tests · `tsc` clean · ESLint clean (`--max-warnings=0`).
- End-to-end validated on real hardware: Electron's write is dropped while unfocused, and `wl-copy` from the same unfocused process lands on the real clipboard.

## Test plan

- [ ] Build/run on Linux KDE Wayland; start recording, copy text in another app, stop via global hotkey without refocusing the dashboard → transcription lands on the clipboard.
- [ ] Repeat with the dashboard focused (regression check).
- [ ] Verify the `app.autoCopy` copy buttons elsewhere still work.
- [ ] Sanity-check macOS / Windows (unchanged path).

## Known follow-up (intentionally not bundled)

`pasteAtCursor` with `preserveClipboard: true` restores the original clipboard via a direct `clipboard.writeText()`, which is also focus-dependent and could be dropped when unfocused. It only affects standalone paste-with-preserve, not auto-copy, and is out of scope for this fix.