### PR TITLE
fix(dashboard): make pasteAtCursor preserve-clipboard reliable on unfocused Wayland

### DIFF
--- a/dashboard/electron/__tests__/clipboardWayland.test.ts
+++ b/dashboard/electron/__tests__/clipboardWayland.test.ts
@@ -62,7 +62,7 @@ vi.mock('electron', () => ({ clipboard: mockClipboard }));
 vi.mock('child_process', () => ({ spawn: mockSpawn, execFile: mockExecFile }));
 vi.mock('../shortcutManager.js', () => ({ isWayland: mockIsWayland }));
 
-import { reliableWriteText, _resetClipboardState } from '../clipboardWayland.js';
+import { reliableWriteText, reliableReadText, _resetClipboardState } from '../clipboardWayland.js';
 
 // ── execFile mock: routes wl-copy --version (probe) and wl-paste (verify) ────
 
@@ -188,5 +188,37 @@ describe('reliableWriteText', () => {
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('wl-clipboard'));
       warnSpy.mockRestore();
     });
+  });
+});
+
+describe('reliableReadText', () => {
+  beforeEach(() => {
+    _resetClipboardState();
+    vi.clearAllMocks();
+    state.realClipboard = 'REAL-VALUE';
+    state.chromiumCache = 'STALE-CHROMIUM-CACHE';
+    state.wlPasteAvailable = true;
+    mockIsWayland.mockReturnValue(true);
+    installExecFileRouter();
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+  });
+
+  it('reads the REAL clipboard via wl-paste on Wayland, not Chromium’s cache', async () => {
+    // The whole point: Chromium readText() can be stale/lie when unfocused.
+    expect(await reliableReadText()).toBe('REAL-VALUE');
+  });
+
+  it('falls back to clipboard.readText() when wl-paste is unavailable on Wayland', async () => {
+    state.wlPasteAvailable = false;
+    expect(await reliableReadText()).toBe('STALE-CHROMIUM-CACHE');
+  });
+
+  it('uses clipboard.readText() directly on non-Wayland', async () => {
+    mockIsWayland.mockReturnValue(false);
+    expect(await reliableReadText()).toBe('STALE-CHROMIUM-CACHE');
   });
 });

--- a/dashboard/electron/__tests__/pasteAtCursor.test.ts
+++ b/dashboard/electron/__tests__/pasteAtCursor.test.ts
@@ -20,14 +20,26 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // ── Hoisted mocks ──────────────────────────────────────────────────────────
 
-const { mockExecFile, mockClipboard, mockIsWayland } = vi.hoisted(() => ({
-  mockExecFile: vi.fn(),
-  mockClipboard: {
-    readText: vi.fn().mockReturnValue('original-clipboard'),
-    writeText: vi.fn(),
-  },
-  mockIsWayland: vi.fn().mockReturnValue(false),
-}));
+const { mockExecFile, mockClipboard, mockIsWayland, mockReliableWriteText, mockReliableReadText } =
+  vi.hoisted(() => {
+    const mockClipboard = {
+      readText: vi.fn().mockReturnValue('original-clipboard'),
+      writeText: vi.fn(),
+    };
+    return {
+      mockExecFile: vi.fn(),
+      mockClipboard,
+      mockIsWayland: vi.fn().mockReturnValue(false),
+      // The clipboard module's reliable helpers are mocked but DELEGATE to the
+      // electron clipboard mock, so existing clipboard.{read,write}Text
+      // assertions keep working while we can also assert routing went through
+      // the focus-independent helpers (the fix).
+      mockReliableWriteText: vi.fn(async (text: string) => {
+        mockClipboard.writeText(text);
+      }),
+      mockReliableReadText: vi.fn(async () => mockClipboard.readText()),
+    };
+  });
 
 vi.mock('electron', () => ({
   clipboard: mockClipboard,
@@ -42,7 +54,8 @@ vi.mock('../shortcutManager.js', () => ({
 }));
 
 vi.mock('../clipboardWayland.js', () => ({
-  reliableWriteText: async (text: string) => mockClipboard.writeText(text),
+  reliableWriteText: mockReliableWriteText,
+  reliableReadText: mockReliableReadText,
 }));
 
 // ── Default mock: all commands succeed ─────────────────────────────────────
@@ -119,6 +132,31 @@ describe('[P2] pasteAtCursor', () => {
     const writeCalls = mockClipboard.writeText.mock.calls;
     expect(writeCalls).toHaveLength(1);
     expect(writeCalls[0][0]).toBe('paste me');
+  });
+
+  // Regression: on Wayland the preserve path must snapshot via the
+  // wl-paste-capable reader and restore via the focus-independent writer.
+  // A bare clipboard.readText()/writeText() is unreliable when the window is
+  // unfocused (the masked-write root cause). On the old code the snapshot used
+  // clipboard.readText() directly and the restore used clipboard.writeText()
+  // directly, so neither went through these helpers.
+  it('preserve path snapshots via reliableReadText and restores via reliableWriteText (Wayland)', async () => {
+    mockIsWayland.mockReturnValue(true);
+    mockClipboard.readText.mockReturnValue('user-original');
+    setAllCommandsSucceed();
+
+    vi.useFakeTimers();
+    const promise = pasteAtCursor('pasted text'); // preserveClipboard defaults to true
+    await vi.advanceTimersByTimeAsync(300);
+    await promise;
+    vi.useRealTimers();
+
+    // Snapshot read goes through the independent reader, not a bare clipboard.readText.
+    expect(mockReliableReadText).toHaveBeenCalledTimes(1);
+    // Both the text write AND the restore go through the focus-independent writer.
+    expect(mockReliableWriteText).toHaveBeenCalledTimes(2);
+    expect(mockReliableWriteText).toHaveBeenNthCalledWith(1, 'pasted text');
+    expect(mockReliableWriteText).toHaveBeenLastCalledWith('user-original');
   });
 
   it('throws descriptive error when no paste tools are available (Wayland)', async () => {

--- a/dashboard/electron/clipboardWayland.ts
+++ b/dashboard/electron/clipboardWayland.ts
@@ -236,6 +236,24 @@ export async function reliableWriteText(text: string): Promise<void> {
 }
 
 /**
+ * Read text from the clipboard reliably.
+ *
+ * On Wayland: read the REAL clipboard via wl-paste — an independent channel
+ * that does not share Chromium's cache, which can be stale or echo a previously
+ * dropped write when the window is unfocused (the read-side counterpart of the
+ * masked-write problem). Falls back to Electron's clipboard.readText() when
+ * wl-paste is unavailable. On other platforms: direct clipboard.readText().
+ */
+export async function reliableReadText(): Promise<string> {
+  if (process.platform !== 'linux' || !isWayland()) {
+    return clipboard.readText();
+  }
+  const viaWlPaste = await readViaWlPaste();
+  if (viaWlPaste !== null) return viaWlPaste;
+  return readClipboardSafe() ?? '';
+}
+
+/**
  * Clean up module state. Call on app quit to kill any lingering wl-copy child.
  */
 export function cleanupClipboard(): void {

--- a/dashboard/electron/pasteAtCursor.ts
+++ b/dashboard/electron/pasteAtCursor.ts
@@ -7,11 +7,10 @@
  * Copyright 2025 CJ Pais — MIT License.
  */
 
-import { clipboard } from 'electron';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { isWayland } from './shortcutManager.js';
-import { reliableWriteText } from './clipboardWayland.js';
+import { reliableWriteText, reliableReadText } from './clipboardWayland.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -330,7 +329,9 @@ function sleep(ms: number): Promise<void> {
  */
 export async function pasteAtCursor(text: string, options?: PasteOptions): Promise<void> {
   const preserve = options?.preserveClipboard ?? true;
-  const originalClipboard = preserve ? clipboard.readText() : null;
+  // Snapshot via reliableReadText so we capture the REAL clipboard on Wayland
+  // (Electron's clipboard.readText() can be stale when the window is unfocused).
+  const originalClipboard = preserve ? await reliableReadText() : null;
   await reliableWriteText(text);
   try {
     await sleep(50);
@@ -338,10 +339,13 @@ export async function pasteAtCursor(text: string, options?: PasteOptions): Promi
     await sleep(100);
   } finally {
     if (preserve && originalClipboard !== null) {
-      // Restore uses direct clipboard.writeText — the paste has already been
-      // served, so reliability guarantees are not needed. Using reliableWriteText
-      // here would kill the wl-copy child that may still be serving the paste.
-      clipboard.writeText(originalClipboard);
+      // Restore the user's original clipboard via reliableWriteText so it also
+      // lands when the window is unfocused — a bare clipboard.writeText() is
+      // silently dropped on Wayland without an input-event serial (the same
+      // masked write that breaks auto-copy). The paste has already been served
+      // by the post-paste delay above, so it is safe to hand clipboard
+      // ownership to the restored content here.
+      await reliableWriteText(originalClipboard);
     }
   }
 }


### PR DESCRIPTION
Follow-up to #174 (auto-copy masked-write fix). Addresses the related weakness flagged there in `pasteAtCursor`'s `preserveClipboard` path.

## Problem

`pasteAtCursor` with `preserveClipboard: true` (the **default**) snapshots the clipboard with `clipboard.readText()` and later restores it with a bare `clipboard.writeText(originalClipboard)`. Both are the read/write counterpart of the masked-write bug fixed in #174:

- **Restore** `clipboard.writeText()` is silently dropped on Wayland when the window lacks an input-event serial (unfocused) → the user's original clipboard is **not** restored (it keeps the pasted text).
- **Snapshot** `clipboard.readText()` can return Chromium's stale in-process cache when unfocused → restoring a possibly-wrong value.

So the `preserve` contract is effectively **broken by default** on Wayland. (Today the only production caller passes `preserveClipboard: false`, so the live paste path is unaffected — this hardens the default/contract and any future caller.)

## Fix

`dashboard/electron/clipboardWayland.ts` + `pasteAtCursor.ts`:

- Add a symmetric **`reliableReadText()`** — on Wayland reads the **real** clipboard via `wl-paste` (independent of Chromium's cache), falling back to `clipboard.readText()` when `wl-paste` is unavailable; direct `clipboard.readText()` off Wayland.
- `pasteAtCursor` now **snapshots via `reliableReadText`** and **restores via `reliableWriteText`** (wl-copy primary, focus-independent). The restore happens after the existing post-paste delay, so the paste is already served before clipboard ownership is handed back.
- The `preserveClipboard: false` path (the only one used in production) is **unchanged**.

## Verification

- New `reliableReadText` unit tests (reads real clipboard via wl-paste, falls back when unavailable, direct read off Wayland).
- New `pasteAtCursor` Wayland regression test: snapshot routes through `reliableReadText` and restore routes through `reliableWriteText` (fails on the old bare-`clipboard.*` path).
- `462/462` Electron tests · `tsc` clean · ESLint clean (`--max-warnings=0`).

## Scope / risk

`gitnexus_impact` + `detect_changes`: **LOW** risk, 1 direct caller (the `clipboard:pasteAtCursor` IPC handler, which already catches errors), 0 execution flows affected. Non-Wayland platforms (macOS/Windows/X11) keep the direct clipboard path.

## Test plan

- [ ] On Linux KDE Wayland, exercise a `preserveClipboard: true` paste while the window is unfocused → original clipboard is restored correctly.
- [ ] Confirm the live auto-copy + paste (`preserveClipboard: false`) flow still pastes at cursor as before.