### PR TITLE
fix(dashboard): self-install XDG desktop file so Wayland global shortcuts work on portal 1.22+

### DIFF
--- a/dashboard/electron/__tests__/desktopIntegration.test.ts
+++ b/dashboard/electron/__tests__/desktopIntegration.test.ts
@@ -1,0 +1,275 @@
+// @vitest-environment node
+
+/**
+ * XDG desktop-file self-installation (electron/desktopIntegration.ts).
+ *
+ * The host portal's Registry.Register resolves "<app_id>.desktop" via GLib's
+ * g_desktop_app_info_new() over the XDG applications path, so an AppImage must
+ * install that file itself for Wayland global shortcuts to work. These tests
+ * cover the pure builders and the guarded, idempotent install logic using an
+ * in-memory filesystem — no real $HOME is touched and no live D-Bus is needed.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  DESKTOP_FILE_NAME,
+  applicationsDir,
+  desktopFileTargetPath,
+  quoteExecArg,
+  buildDesktopFileContent,
+  desktopFileMatchesAppImage,
+  ensureDesktopFileInstalled,
+} from '../desktopIntegration.js';
+import { PORTAL_APP_ID } from '../waylandShortcuts.js';
+
+const APPIMAGE = '/home/user/Apps/TranscriptionSuite-1.3.6.AppImage';
+
+// ── In-memory filesystem double ───────────────────────────────────────────────
+
+function makeFakeFs(initial: Record<string, string> = {}) {
+  const files = new Map<string, string>(Object.entries(initial));
+  const mkdirs: string[] = [];
+  const writes: string[] = [];
+  const removes: string[] = [];
+  return {
+    files,
+    mkdirs,
+    writes,
+    removes,
+    existsSync: (p: string) => files.has(p),
+    readFileSync: (p: string, _enc: 'utf8') => {
+      const v = files.get(p);
+      if (v === undefined) throw new Error(`ENOENT: ${p}`);
+      return v;
+    },
+    writeFileSync: (p: string, data: string, _opts: { mode: number }) => {
+      files.set(p, data);
+      writes.push(p);
+    },
+    mkdirSync: (p: string, _opts: { recursive: boolean }) => {
+      mkdirs.push(p);
+    },
+    rmSync: (p: string, _opts: { force: boolean }) => {
+      files.delete(p);
+      removes.push(p);
+    },
+  };
+}
+
+const silentLogger = { log: () => {}, warn: () => {} };
+const homedir = () => '/home/user';
+
+function install(fakeFs: ReturnType<typeof makeFakeFs>, env: NodeJS.ProcessEnv) {
+  return ensureDesktopFileInstalled({
+    platform: 'linux',
+    env,
+    homedir,
+    version: '1.3.6',
+    fileSystem: fakeFs,
+    logger: silentLogger,
+  });
+}
+
+// ── Pure helpers ──────────────────────────────────────────────────────────────
+
+describe('[P2] desktop file naming', () => {
+  it('names the file exactly after the portal app id (load-bearing for portal lookup)', () => {
+    expect(DESKTOP_FILE_NAME).toBe(`${PORTAL_APP_ID}.desktop`);
+  });
+});
+
+describe('[P2] applicationsDir / desktopFileTargetPath', () => {
+  it('falls back to ~/.local/share/applications', () => {
+    expect(applicationsDir({}, homedir)).toBe('/home/user/.local/share/applications');
+  });
+
+  it('honors XDG_DATA_HOME when set', () => {
+    expect(applicationsDir({ XDG_DATA_HOME: '/custom/data' }, homedir)).toBe(
+      '/custom/data/applications',
+    );
+  });
+
+  it('ignores an empty/whitespace XDG_DATA_HOME', () => {
+    expect(applicationsDir({ XDG_DATA_HOME: '   ' }, homedir)).toBe(
+      '/home/user/.local/share/applications',
+    );
+  });
+
+  it('builds the full target path', () => {
+    expect(desktopFileTargetPath({}, homedir)).toBe(
+      `/home/user/.local/share/applications/${PORTAL_APP_ID}.desktop`,
+    );
+  });
+});
+
+describe('[P2] quoteExecArg', () => {
+  it('double-quotes the path', () => {
+    expect(quoteExecArg('/a/b/App.AppImage')).toBe('"/a/b/App.AppImage"');
+  });
+
+  it('escapes reserved characters (" ` $ \\)', () => {
+    expect(quoteExecArg('/a/$x/`y`/"z"/\\w')).toBe('"/a/\\$x/\\`y\\`/\\"z\\"/\\\\w"');
+  });
+});
+
+describe('[P2] buildDesktopFileContent', () => {
+  const content = buildDesktopFileContent({ appImagePath: APPIMAGE, version: '1.3.6' });
+
+  it('is a valid entry with the mandatory keys GLib requires', () => {
+    expect(content.startsWith('[Desktop Entry]\n')).toBe(true);
+    expect(content).toContain('Type=Application');
+    expect(content).toContain('Name=TranscriptionSuite');
+    expect(content).toContain(`Exec="${APPIMAGE}" %U`);
+  });
+
+  it('points TryExec at the raw AppImage path so it self-hides if moved', () => {
+    expect(content).toContain(`TryExec=${APPIMAGE}`);
+  });
+
+  it('sets Icon and StartupWMClass to the app id', () => {
+    expect(content).toContain(`Icon=${PORTAL_APP_ID}`);
+    expect(content).toContain(`StartupWMClass=${PORTAL_APP_ID}`);
+  });
+
+  it('never sets Hidden=true (would make g_desktop_app_info_new return NULL)', () => {
+    expect(content).not.toMatch(/Hidden\s*=\s*true/);
+  });
+
+  it('omits the version line when no version is supplied', () => {
+    expect(buildDesktopFileContent({ appImagePath: APPIMAGE })).not.toContain('X-AppImage-Version');
+  });
+});
+
+describe('[P2] desktopFileMatchesAppImage', () => {
+  it('matches when TryExec points at the same AppImage', () => {
+    const content = buildDesktopFileContent({ appImagePath: APPIMAGE });
+    expect(desktopFileMatchesAppImage(content, APPIMAGE)).toBe(true);
+  });
+
+  it('does not match a different (older) AppImage path', () => {
+    const content = buildDesktopFileContent({
+      appImagePath: '/old/TranscriptionSuite-1.2.0.AppImage',
+    });
+    expect(desktopFileMatchesAppImage(content, APPIMAGE)).toBe(false);
+  });
+});
+
+// ── ensureDesktopFileInstalled — guards ───────────────────────────────────────
+
+describe('[P2] ensureDesktopFileInstalled — guards', () => {
+  it('no-ops on non-linux platforms', () => {
+    const fakeFs = makeFakeFs();
+    const result = ensureDesktopFileInstalled({
+      platform: 'darwin',
+      env: { APPIMAGE },
+      homedir,
+      fileSystem: fakeFs,
+      logger: silentLogger,
+    });
+    expect(result).toBe(false);
+    expect(fakeFs.writes).toHaveLength(0);
+  });
+
+  it('no-ops when APPIMAGE is not set (dev / extracted run)', () => {
+    const fakeFs = makeFakeFs();
+    const result = ensureDesktopFileInstalled({
+      platform: 'linux',
+      env: {},
+      homedir,
+      fileSystem: fakeFs,
+      logger: silentLogger,
+    });
+    expect(result).toBe(false);
+    expect(fakeFs.writes).toHaveLength(0);
+  });
+});
+
+// ── ensureDesktopFileInstalled — install / idempotency ────────────────────────
+
+describe('[P2] ensureDesktopFileInstalled — install', () => {
+  const target = `/home/user/.local/share/applications/${PORTAL_APP_ID}.desktop`;
+
+  it('writes the desktop file pointing at $APPIMAGE on a clean system', () => {
+    const fakeFs = makeFakeFs();
+    const result = install(fakeFs, { APPIMAGE });
+
+    expect(result).toBe(true);
+    expect(fakeFs.writes).toContain(target);
+    const written = fakeFs.files.get(target)!;
+    expect(written).toContain(`Exec="${APPIMAGE}" %U`);
+    expect(written).toContain(`TryExec=${APPIMAGE}`);
+  });
+
+  it('never writes the ephemeral /tmp/.mount_* path even if APPDIR is present', () => {
+    const fakeFs = makeFakeFs();
+    install(fakeFs, { APPIMAGE, APPDIR: '/tmp/.mount_Transc5Ofz9N' });
+    expect(fakeFs.files.get(target)).not.toContain('/tmp/.mount_');
+  });
+
+  it('is idempotent: does not rewrite when the file already targets this AppImage', () => {
+    const fakeFs = makeFakeFs({
+      [target]: buildDesktopFileContent({ appImagePath: APPIMAGE, version: '1.3.6' }),
+    });
+    const result = install(fakeFs, { APPIMAGE });
+
+    expect(result).toBe(true);
+    expect(fakeFs.writes).toHaveLength(0);
+  });
+
+  it('rewrites when an existing file points at an older AppImage path', () => {
+    const fakeFs = makeFakeFs({
+      [target]: buildDesktopFileContent({
+        appImagePath: '/old/TranscriptionSuite-1.2.0.AppImage',
+      }),
+    });
+    const result = install(fakeFs, { APPIMAGE });
+
+    expect(result).toBe(true);
+    expect(fakeFs.writes).toContain(target);
+    expect(fakeFs.files.get(target)).toContain(`TryExec=${APPIMAGE}`);
+  });
+
+  it('returns false and does not throw when the write fails (read-only HOME)', () => {
+    const fakeFs = makeFakeFs();
+    fakeFs.writeFileSync = () => {
+      throw new Error('EROFS: read-only file system');
+    };
+    const warn = vi.fn();
+    const result = ensureDesktopFileInstalled({
+      platform: 'linux',
+      env: { APPIMAGE },
+      homedir,
+      fileSystem: fakeFs,
+      logger: { log: () => {}, warn },
+    });
+
+    expect(result).toBe(false);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});
+
+// ── ensureDesktopFileInstalled — stale file cleanup ───────────────────────────
+
+describe('[P2] ensureDesktopFileInstalled — stale cleanup', () => {
+  const staleTarget = '/home/user/.local/share/applications/transcriptionsuite.desktop';
+
+  it('removes a stale v1.1.0 transcriptionsuite.desktop that is recognisably ours', () => {
+    const fakeFs = makeFakeFs({
+      [staleTarget]:
+        '[Desktop Entry]\nName=TranscriptionSuite\nExec="/old/TranscriptionSuite-1.1.0.AppImage" %u\n',
+    });
+    install(fakeFs, { APPIMAGE });
+
+    expect(fakeFs.removes).toContain(staleTarget);
+    expect(fakeFs.files.has(staleTarget)).toBe(false);
+  });
+
+  it('leaves an unrelated transcriptionsuite.desktop untouched', () => {
+    const unrelated = '[Desktop Entry]\nName=Some Other App\nExec=/usr/bin/other\n';
+    const fakeFs = makeFakeFs({ [staleTarget]: unrelated });
+    install(fakeFs, { APPIMAGE });
+
+    expect(fakeFs.removes).not.toContain(staleTarget);
+    expect(fakeFs.files.get(staleTarget)).toBe(unrelated);
+  });
+});

--- a/dashboard/electron/desktopIntegration.ts
+++ b/dashboard/electron/desktopIntegration.ts
@@ -1,0 +1,231 @@
+/**
+ * XDG desktop-file self-installation for the Linux AppImage build.
+ *
+ * Why this exists
+ * ───────────────
+ * On Wayland we claim a global-shortcuts app id through the XDG host portal's
+ * `org.freedesktop.host.portal.Registry.Register` (see waylandShortcuts.ts).
+ * That portal resolves the supplied app id by asking GLib for
+ * `<app_id>.desktop` via `g_desktop_app_info_new()`, which only searches
+ * `$XDG_DATA_HOME/applications` and `$XDG_DATA_DIRS/applications`. An AppImage's
+ * own desktop file lives inside its ephemeral `/tmp/.mount_*` directory, which
+ * is NOT on that search path, so the lookup fails with
+ * `App info not found for '<app_id>'` and the subsequent
+ * `GlobalShortcuts.CreateSession` is rejected with `An app id is required`.
+ *
+ * Verified against xdg-desktop-portal 1.22.1 source (registry.c, xdp-app-info.c,
+ * xdp-app-info-host.c): `Register` checks only that the desktop file EXISTS — it
+ * never reads the file's Exec/TryExec nor the caller's `/proc/<pid>/exe`. So
+ * installing a desktop file named exactly after the app id, with Exec pointing
+ * at the AppImage, is sufficient for `Register` (and thus CreateSession) to pass.
+ *
+ * First-launch caveat: the portal daemon caches desktop-file lookups and only
+ * refreshes them asynchronously (GLib GFileMonitor / inotify). On the very first
+ * launch — when this file did not previously exist — `Register` can race the
+ * inotify event and still fail; it then succeeds automatically on the next
+ * launch (file pre-exists, cache warm). We therefore install the file as early
+ * as possible (main.ts module load) and rely on registerHostAppId()'s existing
+ * graceful fallback for the rare first-launch miss.
+ *
+ * The desktop-integration layout (target dir, `Exec="$APPIMAGE"`, `TryExec`)
+ * follows the standard AppImage desktop-integration convention used by
+ * appimaged / AppImageLauncher.
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { PORTAL_APP_ID } from './waylandShortcuts.js';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Basename of the desktop file we install — MUST equal `<PORTAL_APP_ID>.desktop`. */
+export const DESKTOP_FILE_NAME = `${PORTAL_APP_ID}.desktop`;
+
+/**
+ * Wrong-basename desktop files shipped by older versions that we clean up so the
+ * portal resolves exactly one identity. (v1.1.0 installed `transcriptionsuite.desktop`,
+ * derived from the lowercased product name, before the reverse-DNS id was adopted.)
+ */
+const STALE_DESKTOP_BASENAMES = ['transcriptionsuite.desktop'] as const;
+
+// ─── Injectable filesystem (keeps the module unit-testable without touching $HOME) ──
+
+interface DesktopFs {
+  existsSync(target: string): boolean;
+  readFileSync(target: string, encoding: 'utf8'): string;
+  writeFileSync(target: string, data: string, options: { mode: number }): void;
+  mkdirSync(target: string, options: { recursive: boolean }): void;
+  rmSync(target: string, options: { force: boolean }): void;
+}
+
+const realFs: DesktopFs = {
+  existsSync: (p) => fs.existsSync(p),
+  readFileSync: (p, enc) => fs.readFileSync(p, enc),
+  writeFileSync: (p, data, opts) => fs.writeFileSync(p, data, opts),
+  mkdirSync: (p, opts) => {
+    fs.mkdirSync(p, opts);
+  },
+  rmSync: (p, opts) => fs.rmSync(p, opts),
+};
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────────
+
+/** The XDG applications directory the host portal searches first. */
+export function applicationsDir(
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = os.homedir,
+): string {
+  const dataHome = env.XDG_DATA_HOME?.trim() || path.join(homedir(), '.local', 'share');
+  return path.join(dataHome, 'applications');
+}
+
+/** Absolute path of the desktop file to install. */
+export function desktopFileTargetPath(
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = os.homedir,
+): string {
+  return path.join(applicationsDir(env, homedir), DESKTOP_FILE_NAME);
+}
+
+/**
+ * Quote a path for a desktop-entry `Exec` field. Per the freedesktop Desktop
+ * Entry spec, arguments with reserved characters are double-quoted and the
+ * characters `"`, backtick, `$` and `\` are backslash-escaped inside the quotes.
+ */
+export function quoteExecArg(value: string): string {
+  const escaped = value.replace(/(["`$\\])/g, '\\$1');
+  return `"${escaped}"`;
+}
+
+interface DesktopFileFields {
+  appImagePath: string;
+  version?: string;
+}
+
+/** Build the `[Desktop Entry]` text. `Exec`/`TryExec` point at the AppImage. */
+export function buildDesktopFileContent({ appImagePath, version }: DesktopFileFields): string {
+  const lines = [
+    '[Desktop Entry]',
+    'Type=Application',
+    'Name=TranscriptionSuite',
+    'Comment=Desktop dashboard for managing TranscriptionSuite server and transcription workflows',
+    `Exec=${quoteExecArg(appImagePath)} %U`,
+    // TryExec carries the raw (unquoted) path; it lets the entry self-hide if the
+    // AppImage is moved or deleted.
+    `TryExec=${appImagePath}`,
+    `Icon=${PORTAL_APP_ID}`,
+    'Terminal=false',
+    'Categories=AudioVideo;Utility;',
+    // Must match Electron's Wayland app_id for correct taskbar grouping.
+    `StartupWMClass=${PORTAL_APP_ID}`,
+    'StartupNotify=true',
+  ];
+  if (version) lines.push(`X-AppImage-Version=${version}`);
+  lines.push(''); // trailing newline
+  return lines.join('\n');
+}
+
+/**
+ * Whether an already-installed desktop file targets the given AppImage path, so
+ * a rewrite can be skipped. Keyed on the raw `TryExec` line (the AppImage path
+ * embeds the version, so a version bump changes the path and forces a refresh).
+ */
+export function desktopFileMatchesAppImage(content: string, appImagePath: string): boolean {
+  return content.includes(`TryExec=${appImagePath}`);
+}
+
+// ─── Install / repair ─────────────────────────────────────────────────────────
+
+interface Logger {
+  log(message: string): void;
+  warn(message: string, err?: unknown): void;
+}
+
+export interface EnsureDesktopFileOptions {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  homedir?: () => string;
+  version?: string;
+  fileSystem?: DesktopFs;
+  logger?: Logger;
+}
+
+function safeRead(fileSystem: DesktopFs, target: string): string {
+  try {
+    return fileSystem.readFileSync(target, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Remove wrong-basename desktop files from earlier versions. Only deletes a file
+ * recognisably ours (its content mentions TranscriptionSuite), so we never nuke
+ * an unrelated entry that happens to share the legacy basename.
+ */
+function removeStaleDesktopFiles(dir: string, fileSystem: DesktopFs, logger: Logger): void {
+  for (const basename of STALE_DESKTOP_BASENAMES) {
+    const stalePath = path.join(dir, basename);
+    try {
+      if (!fileSystem.existsSync(stalePath)) continue;
+      if (!safeRead(fileSystem, stalePath).includes('TranscriptionSuite')) continue;
+      fileSystem.rmSync(stalePath, { force: true });
+      logger.log(`[DesktopIntegration] Removed stale desktop file: ${stalePath}`);
+    } catch (err) {
+      logger.warn(`[DesktopIntegration] Could not remove stale desktop file ${stalePath}:`, err);
+    }
+  }
+}
+
+/**
+ * Install (or repair) the XDG desktop file so the Wayland host portal can resolve
+ * our app id. No-op unless running as a Linux AppImage (`$APPIMAGE` set). Fully
+ * best-effort and non-fatal — any failure (read-only HOME, etc.) is logged and
+ * swallowed so it can never block startup.
+ *
+ * @returns true when the file is present/installed for this AppImage, false when
+ *   skipped (not an AppImage) or on failure.
+ */
+export function ensureDesktopFileInstalled(options: EnsureDesktopFileOptions = {}): boolean {
+  const {
+    platform = process.platform,
+    env = process.env,
+    homedir = os.homedir,
+    version,
+    fileSystem = realFs,
+    logger = console,
+  } = options;
+
+  // AppImage-only: $APPIMAGE is the absolute path of the running .AppImage. In
+  // dev / extracted runs it is unset, and the ephemeral in-mount /tmp/.mount_*
+  // path must never be written into Exec, so we skip entirely.
+  const appImagePath = env.APPIMAGE;
+  if (platform !== 'linux' || !appImagePath) return false;
+
+  try {
+    const dir = applicationsDir(env, homedir);
+    const target = path.join(dir, DESKTOP_FILE_NAME);
+
+    removeStaleDesktopFiles(dir, fileSystem, logger);
+
+    if (
+      fileSystem.existsSync(target) &&
+      desktopFileMatchesAppImage(safeRead(fileSystem, target), appImagePath)
+    ) {
+      // Already installed and pointing at this AppImage — nothing to do.
+      return true;
+    }
+
+    fileSystem.mkdirSync(dir, { recursive: true });
+    fileSystem.writeFileSync(target, buildDesktopFileContent({ appImagePath, version }), {
+      mode: 0o644,
+    });
+    logger.log(`[DesktopIntegration] Installed desktop file: ${target}`);
+    return true;
+  } catch (err) {
+    logger.warn('[DesktopIntegration] Failed to install desktop file (non-fatal):', err);
+    return false;
+  }
+}

--- a/dashboard/electron/main.ts
+++ b/dashboard/electron/main.ts
@@ -49,6 +49,7 @@ import {
   isWaylandPortalActive,
 } from './shortcutManager.js';
 import { pasteAtCursor } from './pasteAtCursor.js';
+import { ensureDesktopFileInstalled } from './desktopIntegration.js';
 import { reliableWriteText, cleanupClipboard } from './clipboardWayland.js';
 import { WatcherManager } from './watcherManager.js';
 
@@ -72,6 +73,15 @@ const __dirname = path.dirname(__filename);
 // or if the wrapper is bypassed.
 if (process.platform === 'linux' && process.env.APPIMAGE) {
   app.commandLine.appendSwitch('no-sandbox');
+
+  // Install an XDG desktop file named after our portal app id into
+  // ~/.local/share/applications so the Wayland GlobalShortcuts host portal can
+  // resolve the app id. Registry.Register looks up "<app_id>.desktop" on the XDG
+  // applications path, but the AppImage's own copy lives off-path under
+  // /tmp/.mount_*. Done here at module load — as early as possible — so the
+  // portal's file monitor has the largest window to see the new file before the
+  // much-later shortcut registration calls Register. Non-fatal best-effort.
+  ensureDesktopFileInstalled({ version: app.getVersion() });
 }
 
 // GlobalShortcutsPortal Chromium feature flag removed — our D-Bus module


### PR DESCRIPTION
## Problem

On KDE Plasma 6 / Wayland with **xdg-desktop-portal 1.22.1**, the AppImage logs:

```
[WaylandShortcuts] Registry.Register failed (continuing without it): DBusError: Could not register app ID: App info not found for 'com.transcriptionsuite.dashboard'
[WaylandShortcuts] Failed to create portal session: DBusError: An app id is required
```

Global shortcuts (`Alt+Ctrl+Z` / `Alt+Ctrl+X`) silently don't work — the `[Shortcuts] Registered …` lines that follow are Electron's `globalShortcut` fallback, which no-ops on Wayland.

## Root cause (verified against xdg-desktop-portal 1.22.1 source)

PRs #163–#165 made the app announce its id via `org.freedesktop.host.portal.Registry.Register('com.transcriptionsuite.dashboard')` to pass the empty-app-id gate added in portal 1.21.0. But portal 1.22's `Register` resolves that id by calling GLib's `g_desktop_app_info_new("com.transcriptionsuite.dashboard.desktop")` with the `REQUIRE_GAPPINFO` flag (`registry.c` → `xdp-app-info.c::xdp_app_info_real_create_gappinfo` → `xdp-app-info-host.c::xdp_app_info_host_new_registered`). That lookup **only searches `$XDG_DATA_HOME/applications` + `$XDG_DATA_DIRS/applications`**.

- The AppImage's own `com.transcriptionsuite.dashboard.desktop` lives inside the ephemeral `/tmp/.mount_*` mount — **off** the XDG search path.
- AppImages don't auto-install their desktop file; only a stale `transcriptionsuite.desktop` (from v1.1.0, wrong basename) was present.

→ `Register` fails *"App info not found"* → the host caller's app-id stays `""` → `GlobalShortcuts.CreateSession` is rejected by the non-empty-app-id gate. #165's `executableName` only fixed the *embedded* basename, not its *installation*.

Importantly, the source confirms `Register` checks **only that the file exists** — it never reads the desktop file's `Exec`/`TryExec` nor the caller's `/proc/<pid>/exe`. So installing a correctly-named file with `Exec` pointing at `$APPIMAGE` is sufficient.

## Fix

New `dashboard/electron/desktopIntegration.ts` → `ensureDesktopFileInstalled()`:

- AppImage-only guard (`linux && process.env.APPIMAGE`).
- Idempotently writes `~/.local/share/applications/com.transcriptionsuite.dashboard.desktop` with `Exec="$APPIMAGE" %U` + `TryExec=$APPIMAGE` (rewrites if the AppImage path changes, e.g. version bump or move).
- Removes the stale v1.1.0 `transcriptionsuite.desktop` (only if its content is recognisably ours).
- Reuses `PORTAL_APP_ID` from `waylandShortcuts.ts` so identity stays single-sourced.
- Fully best-effort / non-fatal (read-only HOME etc. is logged and swallowed).

Wired into `main.ts` at module load, inside the existing `linux && APPIMAGE` block — as early as possible so the portal's GLib `GFileMonitor` has the largest window to pick up the file before the much-later `Register` call.

### First-launch caveat

The portal daemon caches desktop-file lookups and invalidates them asynchronously (GLib `GFileMonitor` / inotify), and `Register` is single-shot per D-Bus connection. So on the **very first** launch (file didn't pre-exist), `Register` can race the inotify event and still fail — then succeeds automatically on the next launch. The existing graceful fallback in `registerHostAppId()` handles this; expect *first-ever launch may need one relaunch*.

### Out of scope (not code-fixable)

KDE shows a one-time BindShortcuts approval dialog, and `xdg-desktop-portal-kde` remembers a prior *deny* (registers with no keys, no re-prompt → System Settings ▸ Shortcuts). Unchanged by this PR.

## Test plan

- [x] `tsc -p electron/tsconfig.json --noEmit` — clean
- [x] `eslint . --max-warnings=0` — clean
- [x] 24 new Vitest cases (`electron/__tests__/desktopIntegration.test.ts`) covering pure builders, guards, idempotency, and stale cleanup with an injected in-memory filesystem
- [x] Full dashboard suite: 1416 tests passing
- [ ] **Manual (needs a real AppImage build on KDE 6.7 / xdp 1.22.1):** build & run; confirm `com.transcriptionsuite.dashboard.desktop` appears in `~/.local/share/applications`, the stale `transcriptionsuite.desktop` is gone, logs show `Registered host app id` → `Session created` (possibly after one relaunch), and the hotkeys fire after approving the KDE dialog.