### PR TITLE
fix(apple-silicon): parallel-diarization 500 (_ProgressTqdm) + re-enable pyannote on Metal (#93, #112)

### DIFF
--- a/dashboard/components/__tests__/ServerView.test.tsx
+++ b/dashboard/components/__tests__/ServerView.test.tsx
@@ -270,23 +270,17 @@ describe('[P2] ServerView', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Issue #86 #2 — Pyannote diarization gate on Mac Metal
+// Issue #112 / #86 #2 — Pyannote diarization on Mac Metal (gate REMOVED)
 //
-// Background: pyannote.audio 4.x has no working MPS path
-// (pyannote/pyannote-audio#1886 / #1337 / #1091 — all closed wontfix).
-// On Mac Metal, the dashboard must hide the Pyannote dropdown option,
-// auto-migrate any persisted Pyannote selection to Sortformer, render
-// an inline reason, and warn beside the Custom HF-repo input when its
-// value matches a pyannote pattern.
-//
-// Note on the mid-session profile-toggle row from the spec I/O matrix:
-// the migration useEffect's dependency array includes `isMetal`, so it
-// fires on any false→true transition of `isMetal`. Testing the mount-time
-// case with `runtimeProfile === 'metal'` therefore exercises the same
-// code path as a mid-session toggle from cpu→metal.
+// pyannote.audio 4.x runs on Apple Silicon GPU (MPS) for *inference* — validated
+// on M2 hardware, including >4 speakers (beyond Sortformer's 4-cap). The upstream
+// MPS issues (#1886/#1337/#1091) concern training, not inference. So on Mac Metal
+// the dashboard now OFFERS pyannote: it is no longer hidden, no longer
+// auto-migrated to Sortformer, and shows no "unsupported on Apple Silicon" copy.
+// Sortformer stays the no-token Metal-native default; pyannote is opt-in.
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('Pyannote diarization gate on Mac Metal', () => {
+describe('Pyannote diarization on Mac Metal (gate removed, Issue #112)', () => {
   const SORTFORMER = 'Sortformer (Metal; ≤ 4 speakers)';
   const PYANNOTE = 'pyannote/speaker-diarization-community-1';
   const CUSTOM = 'Custom (HuggingFace repo)';
@@ -330,7 +324,7 @@ describe('Pyannote diarization gate on Mac Metal', () => {
     mockAdminStatus.status = { models: {} };
   });
 
-  it('on Mac Metal with persisted Pyannote, migrates selection to Sortformer and persists it exactly once', async () => {
+  it('on Mac Metal with persisted Pyannote, does NOT migrate the selection to Sortformer', async () => {
     const setSpy = setupElectronAPI({
       'server.runtimeProfile': 'metal',
       'server.diarizationModelSelection': PYANNOTE,
@@ -339,19 +333,18 @@ describe('Pyannote diarization gate on Mac Metal', () => {
 
     render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
 
+    // Pyannote stays selected (appears in the ListboxButton and/or an option).
     await waitFor(() => {
-      expect(setSpy).toHaveBeenCalledWith('server.diarizationModelSelection', SORTFORMER);
+      expect(screen.queryAllByText(PYANNOTE).length).toBeGreaterThanOrEqual(1);
     });
-    // Persistence flows through the existing auto-persist effect — assert that
-    // the SORTFORMER write happens exactly once (the explicit set in the migration
-    // effect was removed as redundant after the edge-case-hunter review).
+    // The old auto-migration to Sortformer must NOT fire on Metal anymore.
     const sortformerWrites = setSpy.mock.calls.filter(
       ([k, v]) => k === 'server.diarizationModelSelection' && v === SORTFORMER,
     );
-    expect(sortformerWrites.length).toBe(1);
+    expect(sortformerWrites.length).toBe(0);
   });
 
-  it('on Mac Metal, removes Pyannote from the dropdown DOM and renders the inline reason', async () => {
+  it('on Mac Metal, Pyannote IS offered and no "unsupported" copy is rendered', async () => {
     setupElectronAPI({
       'server.runtimeProfile': 'metal',
       'server.diarizationModelSelection': SORTFORMER,
@@ -360,18 +353,17 @@ describe('Pyannote diarization gate on Mac Metal', () => {
 
     render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
 
+    // Sortformer is the default selection; pyannote is now a selectable option.
     await waitFor(() => {
-      expect(screen.queryByText(/pyannote.audio MPS path/i)).toBeTruthy();
+      expect(screen.queryAllByText(SORTFORMER).length).toBeGreaterThanOrEqual(1);
     });
-    // The pyannote model option must NOT appear anywhere (dropdown filtered, not selected).
-    expect(screen.queryAllByText(PYANNOTE).length).toBe(0);
-    // Sortformer is selected → appears in both ListboxButton and ListboxOption (>=1 match).
-    expect(screen.queryAllByText(SORTFORMER).length).toBeGreaterThanOrEqual(1);
-    // Custom is an available option (not selected) → appears in dropdown.
+    expect(screen.queryAllByText(PYANNOTE).length).toBeGreaterThanOrEqual(1);
     expect(screen.queryAllByText(CUSTOM).length).toBeGreaterThanOrEqual(1);
+    // The "not supported on Apple Silicon" inline reason is gone.
+    expect(screen.queryByText(/pyannote\.audio MPS path/i)).toBeNull();
   });
 
-  it('on non-Metal profile (cpu), does NOT migrate Pyannote and keeps all three options', async () => {
+  it('on non-Metal profile (cpu), Pyannote remains available and is not migrated', async () => {
     const setSpy = setupElectronAPI({
       'server.runtimeProfile': 'cpu',
       'server.diarizationModelSelection': PYANNOTE,
@@ -380,23 +372,19 @@ describe('Pyannote diarization gate on Mac Metal', () => {
 
     render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
 
-    // Pyannote is selected → appears in both ListboxButton AND ListboxOption.
     await waitFor(() => {
       expect(screen.queryAllByText(PYANNOTE).length).toBeGreaterThanOrEqual(1);
     });
-    // Migration must NOT have fired — `set` was never called with Sortformer for diarization.
     const sortformerSet = setSpy.mock.calls.some(
       ([k, v]) => k === 'server.diarizationModelSelection' && v === SORTFORMER,
     );
     expect(sortformerSet).toBe(false);
-    // Inline reason must NOT be visible on non-Metal.
-    expect(screen.queryByText(/pyannote.audio MPS path/i)).toBeNull();
-    // All three options remain in the dropdown DOM.
+    expect(screen.queryByText(/pyannote\.audio MPS path/i)).toBeNull();
     expect(screen.queryAllByText(SORTFORMER).length).toBeGreaterThanOrEqual(1);
     expect(screen.queryAllByText(CUSTOM).length).toBeGreaterThanOrEqual(1);
   });
 
-  it('on Mac Metal with Custom selection and pyannote-prefixed value, shows the amber warning', async () => {
+  it('on Mac Metal with Custom + pyannote-prefixed value, shows NO unsupported warning', async () => {
     setupElectronAPI({
       'server.runtimeProfile': 'metal',
       'server.diarizationModelSelection': CUSTOM,
@@ -405,48 +393,12 @@ describe('Pyannote diarization gate on Mac Metal', () => {
 
     render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
 
+    // The custom-repo input renders; the old amber "not supported" warning is gone.
     await waitFor(() => {
-      expect(
-        screen.queryByText(/Custom pyannote repos are not supported on Apple Silicon/i),
-      ).toBeTruthy();
+      expect(screen.queryAllByText(CUSTOM).length).toBeGreaterThanOrEqual(1);
     });
-  });
-
-  it('on Mac Metal with Custom selection and a non-pyannote value, does NOT show the warning', async () => {
-    setupElectronAPI({
-      'server.runtimeProfile': 'metal',
-      'server.diarizationModelSelection': CUSTOM,
-      'server.diarizationCustomModel': 'nvidia/sortformer-fork',
-    });
-
-    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
-
-    // Wait for hydration to settle by asserting the inline reason renders (it always does on Metal).
-    await waitFor(() => {
-      expect(screen.queryByText(/pyannote\.audio MPS path/i)).toBeTruthy();
-    });
-    // The custom-input warning must NOT appear for a non-pyannote value.
     expect(
       screen.queryByText(/Custom pyannote repos are not supported on Apple Silicon/i),
     ).toBeNull();
-  });
-
-  it('on Mac Metal with Custom + whitespace-prefixed pyannote value, still shows the warning', async () => {
-    // Edge-case-hunter finding #2: `activeDiarizationModel` at ServerView.tsx:815-819
-    // calls `.trim()` before sending to the server, so a leading-whitespace pyannote
-    // value would otherwise bypass the gate while still reaching the broken backend.
-    setupElectronAPI({
-      'server.runtimeProfile': 'metal',
-      'server.diarizationModelSelection': CUSTOM,
-      'server.diarizationCustomModel': '  pyannote/community  ',
-    });
-
-    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
-
-    await waitFor(() => {
-      expect(
-        screen.queryByText(/Custom pyannote repos are not supported on Apple Silicon/i),
-      ).toBeTruthy();
-    });
   });
 });

--- a/dashboard/components/views/ServerView.tsx
+++ b/dashboard/components/views/ServerView.tsx
@@ -93,9 +93,6 @@ interface ServerViewProps {
 const DIARIZATION_SORTFORMER_OPTION = 'Sortformer (Metal; ≤ 4 speakers)';
 const DIARIZATION_DEFAULT_MODEL = 'pyannote/speaker-diarization-community-1';
 const DIARIZATION_MODEL_CUSTOM_OPTION = 'Custom (HuggingFace repo)';
-// Mac Metal gating: pyannote.audio 4.x has no working MPS path
-// (pyannote/pyannote-audio#1886, #1337, #1091 — all closed wontfix).
-const PYANNOTE_REPO_PATTERN = /^pyannote\//i;
 
 // GGML models for the Vulkan sidecar — computed once from registry. In Vulkan
 // mode these populate the Main Transcriber dropdown (Branch B: the main pick
@@ -348,17 +345,18 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
       LIVE_MODEL_CUSTOM_OPTION,
     ];
   }, []);
-  // Diarization options: omit pyannote on Mac Metal — pyannote.audio MPS path is broken upstream.
+  // Diarization options. Pyannote is offered on Mac Metal too: pyannote.audio 4.x
+  // runs on Apple Silicon GPU (MPS) for *inference* — validated on M2 hardware,
+  // including >4 speakers (beyond Sortformer's 4-cap). The upstream MPS issues
+  // (#1886/#1337/#1091) concern training, not inference. Sortformer stays the
+  // no-token Metal-native default; pyannote is opt-in and needs a HuggingFace token.
   const diarizationOptions = useMemo(
-    () =>
-      isMetal
-        ? [DIARIZATION_SORTFORMER_OPTION, DIARIZATION_MODEL_CUSTOM_OPTION]
-        : [
-            DIARIZATION_SORTFORMER_OPTION,
-            DIARIZATION_DEFAULT_MODEL,
-            DIARIZATION_MODEL_CUSTOM_OPTION,
-          ],
-    [isMetal],
+    () => [
+      DIARIZATION_SORTFORMER_OPTION,
+      DIARIZATION_DEFAULT_MODEL,
+      DIARIZATION_MODEL_CUSTOM_OPTION,
+    ],
+    [],
   );
 
   // Auth token display in Instance Settings
@@ -1064,17 +1062,6 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
     setLiveModelSelection(FALLBACK_LIVE_WHISPER_MODEL);
     setLiveCustomModel('');
   }, [activeLiveModel, localSelectionsHydrated]);
-
-  // Mac Metal: auto-migrate persisted Pyannote diarization choice to Sortformer.
-  // Single effect handles both initial mount AND mid-session profile toggles
-  // (runtimeProfile is hydrated by a separate effect, so we cannot extend the
-  // diarization Promise.all chain). The state change is persisted by the
-  // existing auto-persist effect at line ~1019. See pyannote/pyannote-audio#1886.
-  useEffect(() => {
-    if (!isMetal || !diarizationHydrated) return;
-    if (diarizationModelSelection !== DIARIZATION_DEFAULT_MODEL) return;
-    setDiarizationModelSelection(DIARIZATION_SORTFORMER_OPTION);
-  }, [isMetal, diarizationHydrated, diarizationModelSelection]);
 
   // Metal mode: auto-switch a non-MLX main model to the MLX default.
   useEffect(() => {
@@ -2608,13 +2595,6 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                   className="focus:ring-accent-cyan h-10 w-full rounded-lg border border-white/10 bg-white/5 px-3 text-sm text-white transition-shadow outline-none focus:ring-1"
                   disabled={isRunning}
                 />
-                {isMetal && (
-                  <p className="text-xs text-slate-500 italic">
-                    Pyannote diarization is not supported on Apple Silicon (pyannote.audio MPS path
-                    is broken upstream — see pyannote/pyannote-audio#1886). Sortformer (Metal) is
-                    the recommended diarizer on Mac.
-                  </p>
-                )}
                 {diarizationModelSelection === DIARIZATION_MODEL_CUSTOM_OPTION && (
                   <input
                     type="text"
@@ -2625,17 +2605,6 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                     className={`focus:ring-accent-cyan h-10 w-full rounded-lg border border-white/10 bg-white/5 px-3 text-sm text-white placeholder-slate-500 transition-shadow outline-none focus:ring-1${isRunning ? 'cursor-not-allowed opacity-50' : ''}`}
                   />
                 )}
-                {isMetal &&
-                  diarizationModelSelection === DIARIZATION_MODEL_CUSTOM_OPTION &&
-                  PYANNOTE_REPO_PATTERN.test(diarizationCustomModel.trim()) && (
-                    <div className="flex items-start gap-2 rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
-                      <AlertTriangle size={14} className="mt-0.5 shrink-0" />
-                      <span>
-                        Custom pyannote repos are not supported on Apple Silicon — switch to
-                        Sortformer.
-                      </span>
-                    </div>
-                  )}
               </div>
             </GlassCard>
           </div>

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.0.56",
-  "contract_sha256": "6b58eb185349fec87c1b46830119d3eb7807e1a384efc93edb23a9785066457b",
-  "updated_at": "2026-06-04T17:56:30.279Z"
+  "spec_version": "1.0.57",
+  "contract_sha256": "09c5080a78d68cd01bc7b7664baf5ec0150fea4417670617271471f5b93cead8",
+  "updated_at": "2026-06-25T14:19:14.373Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.0.56
+  spec_version: 1.0.57
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -97,7 +97,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-06-04T17:56:12.601Z
+    generated_at: 2026-06-25T14:18:54.896Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -137,6 +137,7 @@ foundation:
         - "#0f172a"
         - "#104"
         - "#1091"
+        - "#112"
         - "#1337"
         - "#14b8a6"
         - "#1886"
@@ -265,11 +266,8 @@ foundation:
       classes:
         - shadow
         - shadow-[0_0_10px_#22d3ee]
-        - shadow-[0_0_15px_rgba(251,146,60,0.5)]
         - shadow-[0_0_15px_rgba(34,211,238,0.2)]
         - shadow-[0_0_15px_rgba(34,211,238,0.2)]!
-        - shadow-[0_0_15px_rgba(34,211,238,0.5)]
-        - shadow-[0_0_18px_rgba(239,68,68,0.35)]
         - shadow-[0_0_20px_rgba(255,255,255,0.3)]
         - shadow-[0_0_5px_rgba(217,70,239,0.5)]
         - shadow-[0_0_5px_rgba(239,22,238,0.5)]
@@ -359,11 +357,8 @@ foundation:
         - min-w-[5rem]
         - p-[3px]
         - shadow-[0_0_10px_#22d3ee]
-        - shadow-[0_0_15px_rgba(251,146,60,0.5)]
         - shadow-[0_0_15px_rgba(34,211,238,0.2)]
         - shadow-[0_0_15px_rgba(34,211,238,0.2)]!
-        - shadow-[0_0_15px_rgba(34,211,238,0.5)]
-        - shadow-[0_0_18px_rgba(239,68,68,0.35)]
         - shadow-[0_0_20px_rgba(255,255,255,0.3)]
         - shadow-[0_0_5px_rgba(217,70,239,0.5)]
         - shadow-[0_0_5px_rgba(239,22,238,0.5)]
@@ -491,7 +486,6 @@ utility_allowlist:
     - bg-accent-magenta/10
     - bg-accent-orange
     - bg-accent-orange/10
-    - bg-accent-rose/5
     - bg-accent-violet/15
     - bg-amber-400/10
     - bg-amber-400/20
@@ -507,10 +501,10 @@ utility_allowlist:
     - bg-black/50
     - bg-black/60
     - bg-black/70
-    - bg-black/75
     - bg-blue-400
     - bg-blue-400/10
     - bg-blue-400/20
+    - bg-blue-500
     - bg-blue-500/10
     - bg-cyan-400/10
     - bg-cyan-400/20
@@ -531,13 +525,14 @@ utility_allowlist:
     - bg-linear-to-t
     - bg-neutral-700
     - bg-neutral-900
+    - bg-orange-500
     - bg-orange-500/10
+    - bg-purple-500
     - bg-purple-500/10
     - bg-red-400/10
     - bg-red-500
     - bg-red-500/10
     - bg-red-500/20
-    - bg-red-500/25
     - bg-red-500/5
     - bg-slate-400/10
     - bg-slate-500
@@ -562,7 +557,6 @@ utility_allowlist:
     - border
     - border-2
     - border-4
-    - border-accent-amber/30
     - border-accent-cyan/10
     - border-accent-cyan/20
     - border-accent-cyan/30
@@ -603,9 +597,7 @@ utility_allowlist:
     - border-orange-500/20
     - border-r
     - border-red-400/20
-    - border-red-400/40
     - border-red-500/20
-    - border-red-500/25
     - border-slate-400/30
     - border-slate-500/40
     - border-slate-900
@@ -676,7 +668,6 @@ utility_allowlist:
     - gap-8
     - gap-px
     - gap-x-3
-    - gap-y-1
     - grid
     - grid-cols-1
     - grid-cols-2
@@ -731,7 +722,6 @@ utility_allowlist:
     - hover:bg-red-500/10
     - hover:bg-red-500/20
     - hover:bg-red-500/30
-    - hover:bg-red-500/35
     - hover:bg-white/10
     - hover:bg-white/15
     - hover:bg-white/20
@@ -777,7 +767,6 @@ utility_allowlist:
     - leading-relaxed
     - leading-snug
     - leading-tight
-    - leading-whitespace
     - left-0
     - left-3
     - left-4
@@ -815,10 +804,7 @@ utility_allowlist:
     - mb-4
     - mb-6
     - mb-8
-    - md:flex-row
-    - md:grid-cols-2
     - md:grid-cols-4
-    - md:items-center
     - min-h-0
     - min-h-32
     - min-h-full
@@ -833,7 +819,6 @@ utility_allowlist:
     - ml-0.5
     - ml-1
     - ml-2
-    - ml-3
     - ml-auto
     - ml-model
     - mr-1
@@ -883,7 +868,6 @@ utility_allowlist:
     - pb-0
     - pb-1
     - pb-10
-    - pb-2
     - pb-4
     - pb-8
     - pl-0
@@ -901,7 +885,6 @@ utility_allowlist:
     - pr-20
     - pr-3
     - pr-4
-    - pr-5
     - pr-6
     - pr-8
     - pt-0
@@ -938,6 +921,7 @@ utility_allowlist:
     - right-2
     - right-3
     - right-4
+    - right-align
     - ring-0
     - ring-1
     - ring-accent-cyan/20
@@ -1034,7 +1018,6 @@ utility_allowlist:
     - text-orange-400
     - text-orange-500
     - text-purple-400
-    - text-red-100
     - text-red-200
     - text-red-300
     - text-red-400
@@ -1151,11 +1134,8 @@ utility_allowlist:
     - min-w-[5rem]
     - p-[3px]
     - shadow-[0_0_10px_#22d3ee]
-    - shadow-[0_0_15px_rgba(251,146,60,0.5)]
     - shadow-[0_0_15px_rgba(34,211,238,0.2)]
     - shadow-[0_0_15px_rgba(34,211,238,0.2)]!
-    - shadow-[0_0_15px_rgba(34,211,238,0.5)]
-    - shadow-[0_0_18px_rgba(239,68,68,0.35)]
     - shadow-[0_0_20px_rgba(255,255,255,0.3)]
     - shadow-[0_0_5px_rgba(217,70,239,0.5)]
     - shadow-[0_0_5px_rgba(239,22,238,0.5)]

--- a/server/backend/core/download_progress.py
+++ b/server/backend/core/download_progress.py
@@ -146,7 +146,17 @@ class _ProgressTqdm:
     @classmethod
     def get_lock(cls) -> threading.RLock:
         """Return class-level lock (used by ``tqdm.contrib.concurrent.thread_map``)."""
-        if cls._lock is None:
+        # Read defensively with getattr, NOT ``cls._lock``: tqdm's
+        # ``ensure_lock`` (tqdm.contrib.concurrent, used by thread_map inside
+        # huggingface_hub.snapshot_download) ends with ``del tqdm_class._lock``
+        # when it created the lock — removing the class attribute entirely, not
+        # setting it to None. A bare ``cls._lock`` read then raises
+        # ``AttributeError: ... has no attribute '_lock'``. This mirrors real
+        # tqdm's own ``if not hasattr(cls, '_lock')`` guard. The crash surfaced
+        # as intermittent HTTP 500s on the parallel-diarization path, which
+        # interleaves a model-load tqdm-patch window with concurrent HF
+        # snapshot_download calls.
+        if getattr(cls, "_lock", None) is None:
             cls._lock = threading.RLock()
         return cls._lock
 

--- a/server/backend/tests/test_download_progress.py
+++ b/server/backend/tests/test_download_progress.py
@@ -221,6 +221,31 @@ class TestProgressTqdm:
         with pytest.raises(AttributeError):
             bar.__delattr__("nonexistent_attr")
 
+    def test_get_lock_survives_class_attr_deletion(self, mock_emit):
+        """get_lock() must recreate the lock after the class attribute is removed.
+
+        ``tqdm.contrib.concurrent.ensure_lock`` ends with ``del tqdm_class._lock``
+        when it created the lock — deleting the attribute entirely, not setting it
+        to None. A bare ``cls._lock`` read in get_lock() then raises
+        ``AttributeError: type object '_ProgressTqdm' has no attribute '_lock'``,
+        which surfaced as intermittent HTTP 500s on the parallel-diarization path
+        (a model-load tqdm-patch window interleaved with concurrent
+        huggingface_hub.snapshot_download → thread_map → ensure_lock → get_lock).
+        """
+        from server.core.download_progress import _ProgressTqdm
+
+        # Simulate tqdm's ensure_lock cleanup: attribute gone, not just None.
+        if hasattr(_ProgressTqdm, "_lock"):
+            del _ProgressTqdm._lock
+        assert not hasattr(_ProgressTqdm, "_lock")
+
+        lock = _ProgressTqdm.get_lock()  # must NOT raise AttributeError
+        assert isinstance(lock, type(threading.RLock()))
+        # Idempotent: a second call returns the same lock.
+        assert _ProgressTqdm.get_lock() is lock
+        # Cleanup: reset so sibling tests start from a deterministic state.
+        _ProgressTqdm._lock = None
+
     def test_set_postfix_accepts_positional_args(self, mock_emit):
         """Real tqdm.set_postfix has ordered_dict as first positional arg."""
         from server.core.download_progress import _ProgressTqdm


### PR DESCRIPTION
Two fixes found and validated end-to-end on real Apple Silicon (M2 Pro Mac Mini, macOS 26.3.2) while running a full MLX transcription + diarization e2e and sweeping the open Apple-Silicon issues.

## 1. `_ProgressTqdm.get_lock` crash → intermittent HTTP 500 on parallel diarization (fixes #93)

`_ProgressTqdm.get_lock` (`server/backend/core/download_progress.py`) read the class lock as `if cls._lock is None:`. tqdm's `ensure_lock` (`tqdm.contrib.concurrent`, used by `huggingface_hub.thread_map` inside `snapshot_download`) ends with `del tqdm_class._lock` when it created the lock — removing the attribute entirely. The next `get_lock()` then raised `AttributeError: type object '_ProgressTqdm' has no attribute '_lock'` → **HTTP 500**.

- **Trigger:** two model loads through `snapshot_download` under the tqdm-patch window. A **sequential** diarization unloads the main model, so the *next* request's reload is the second load that crashes — which is why it presented as intermittent "diarization doesn't consistently work, especially via Folder Watch" (a repeated batch driver = constant reload churn).
- **Fix:** read defensively with `getattr(cls, "_lock", None)` (mirrors real tqdm's `hasattr` guard).
- **Validation (hardware):** identical request sequence — buggy `get_lock` = **4× HTTP 500** (23 `AttributeError`s in the log); fixed = **6× HTTP 200**. Unit: RED→GREEN regression test `test_get_lock_survives_class_attr_deletion`; 36/36 `download_progress` tests pass.

Not Apple-Silicon-specific in principle, but the MLX model-swap-around-diarization pattern is what exposes it.

## 2. Re-enable Pyannote diarization on Apple Silicon Metal (fixes #112)

The dashboard hid Pyannote on Mac Metal, auto-migrated a persisted choice to Sortformer, and showed an "unsupported on Apple Silicon" warning — citing upstream MPS issues. But those issues (pyannote/pyannote-audio#1886/#1337/#1091) concern **training**, not inference; the backend runs pyannote on **MPS** fine.

- **Validation (hardware):** forced pyannote on MPS with a 6-speaker file → pyannote found **6 speakers** (beyond Sortformer's 4-cap); `Using Sortformer`=0, `pipeline moved to device: mps`, 0 crashes. Token propagates.
- **Change (client only):** `ServerView.tsx` now offers pyannote on Metal, drops the auto-migration effect and the "unsupported"/custom-repo warnings (+ the now-unused `PYANNOTE_REPO_PATTERN`). Sortformer stays the no-token Metal-native default; pyannote is opt-in (needs an HF token). The ServerView gate test suite was rewritten to assert the new behavior; ui-contract baseline refreshed (`spec_version` 1.0.56→1.0.57).

## Also validated on the M2 (no change needed)
- **#88** — diarization over the OpenAI-compat `/v1/audio/transcriptions` route works (`diarized_json`/`verbose_json` return speakers; parallel path 200). Already implemented on `main` (05899af).
- **#86 sub-bug #2** — pyannote-vs-Sortformer is not a code defect: `create_diarization_engine` selects pyannote when the model name contains `pyannote` (`diarization_engine.py:436`); token propagation confirmed.

## Test plan
- [x] Backend: 36/36 `download_progress` tests (incl. new regression) — Linux build venv
- [x] Frontend: ServerView Vitest 8/8, typecheck, eslint, ui-contract (16 checks)
- [x] Hardware: parallel diarization 6/6 HTTP 200; pyannote MPS >4 speakers; OpenAI route diarization
- [x] CI green