### PR TITLE
fix(dashboard): make Podman-on-Windows server start work (GH #158)

### DIFF
--- a/dashboard/electron/__tests__/containerRuntime.test.ts
+++ b/dashboard/electron/__tests__/containerRuntime.test.ts
@@ -41,7 +41,12 @@ vi.mock('fs', async (importOriginal) => {
 
 // ─── Import after mocks ────────────────────────────────────────────────────
 
-import { detectRuntime, resetDetection } from '../containerRuntime.js';
+import {
+  detectRuntime,
+  resetDetection,
+  getRuntimePathAdditions,
+  getDetectionResult,
+} from '../containerRuntime.js';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -230,5 +235,111 @@ describe('[P1] detectRuntime', () => {
     setExecResponses({});
     const second = await detectRuntime();
     expect(second.runtime).toBeNull();
+  });
+});
+
+// ─── GH #158: Windows compose-provider PATH augmentation ────────────────────
+//
+// On Windows, `podman compose` is a thin wrapper that shells out to an external
+// provider binary (docker-compose.exe), located by searching PATH. If the
+// provider's directory is not on the PATH we hand to `podman`, `podman compose`
+// fails with exit 125 even though `podman` itself works. A GUI Electron process
+// does not always inherit the post-install user PATH, so getRuntimePathAdditions
+// must defensively include the well-known provider locations.
+
+describe('[GH158] getRuntimePathAdditions', () => {
+  const WIN_ENV = {
+    LOCALAPPDATA: 'C:\\Users\\bob\\AppData\\Local',
+    USERPROFILE: 'C:\\Users\\bob',
+    ProgramFiles: 'C:\\Program Files',
+  };
+
+  it('Windows: includes the WindowsApps app-alias provider directory', () => {
+    const dirs = getRuntimePathAdditions('win32', WIN_ENV);
+    expect(dirs).toContain('C:\\Users\\bob\\AppData\\Local\\Microsoft\\WindowsApps');
+  });
+
+  it('Windows: includes both per-user and machine-wide Podman install dirs', () => {
+    const dirs = getRuntimePathAdditions('win32', WIN_ENV);
+    expect(dirs).toContain('C:\\Users\\bob\\AppData\\Local\\Programs\\Podman'); // Podman Desktop
+    expect(dirs).toContain('C:\\Program Files\\RedHat\\Podman'); // machine-wide
+  });
+
+  it('Windows: still includes the Docker Desktop bin dir (compose plugin)', () => {
+    const dirs = getRuntimePathAdditions('win32', WIN_ENV);
+    expect(dirs).toContain('C:\\Program Files\\Docker\\Docker\\resources\\bin');
+  });
+
+  it('Windows: includes the pip --user bin dir for podman-compose', () => {
+    const dirs = getRuntimePathAdditions('win32', WIN_ENV);
+    expect(dirs).toContain('C:\\Users\\bob\\.local\\bin');
+  });
+
+  it('Windows: derives LOCALAPPDATA from USERPROFILE when unset (no crash)', () => {
+    const dirs = getRuntimePathAdditions('win32', { USERPROFILE: 'C:\\Users\\bob' });
+    expect(dirs).toContain('C:\\Users\\bob\\AppData\\Local\\Microsoft\\WindowsApps');
+  });
+
+  it('Windows: tolerates a completely empty environment', () => {
+    expect(() => getRuntimePathAdditions('win32', {})).not.toThrow();
+    // The static ProgramFiles fallbacks are still present.
+    const dirs = getRuntimePathAdditions('win32', {});
+    expect(dirs.some((d) => d.includes('RedHat\\Podman'))).toBe(true);
+  });
+
+  it('Linux: returns the standard unix bin dirs and no Windows paths', () => {
+    const dirs = getRuntimePathAdditions('linux', {});
+    expect(dirs).toEqual(['/usr/local/bin', '/usr/bin', '/bin', '/usr/sbin', '/sbin']);
+    expect(dirs.some((d) => /windowsapps|podman/i.test(d))).toBe(false);
+  });
+
+  it('macOS: returns the standard unix bin dirs (no Windows provider dirs)', () => {
+    const dirs = getRuntimePathAdditions('darwin', {});
+    expect(dirs).toContain('/usr/local/bin');
+    expect(dirs.some((d) => /windowsapps/i.test(d))).toBe(false);
+  });
+});
+
+// ─── GH #158 (review follow-up): in-flight detection de-duplication ─────────
+//
+// getComposeAvailable() became async and now routes through getDetectionResult()
+// in the same renderer Promise.all as available(). getDetectionResult() must
+// memoize the in-flight detection so concurrent cold-start callers share ONE
+// probe pass instead of each spawning their own `<runtime> version` /
+// `<runtime> compose version` subprocesses.
+
+describe('[GH158] getDetectionResult in-flight de-duplication', () => {
+  function countProbe(cmd: string, firstArg: string): number {
+    return mockExecFile.mock.calls.filter(
+      (call) => call[0] === cmd && Array.isArray(call[1]) && call[1][0] === firstArg,
+    ).length;
+  }
+
+  it('concurrent cold-cache calls run detectRuntime() only once', async () => {
+    setExecResponses({
+      'docker version': '24.0.7',
+      'docker compose version': 'Docker Compose v2.24.0',
+    });
+
+    const [a, b] = await Promise.all([getDetectionResult(), getDetectionResult()]);
+
+    // Same resolved result, and the `docker version` probe ran exactly once.
+    expect(a).toBe(b);
+    expect(a.runtime!.kind).toBe('docker');
+    expect(countProbe('docker', 'version')).toBe(1);
+  });
+
+  it('resetDetection() clears the in-flight memo so the next call re-probes', async () => {
+    setExecResponses({
+      'docker version': '24.0.7',
+      'docker compose version': 'Docker Compose v2.24.0',
+    });
+
+    await getDetectionResult();
+    expect(countProbe('docker', 'version')).toBe(1);
+
+    resetDetection();
+    await getDetectionResult();
+    expect(countProbe('docker', 'version')).toBe(2);
   });
 });

--- a/dashboard/electron/__tests__/dockerManagerComposeAvailable.test.ts
+++ b/dashboard/electron/__tests__/dockerManagerComposeAvailable.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment node
+
+/**
+ * GH #158 — getComposeAvailable() must reflect the real detection result.
+ *
+ * Regression test for the Podman-on-Windows race: the renderer used to call
+ * docker.available() (which *sets* the cached compose flag asynchronously) and
+ * docker.getComposeAvailable() (which *read* it synchronously) concurrently in
+ * the same Promise.all. On first mount the read landed before the write and saw
+ * the initial `null` — which the old guard treated as "available" (true) — so
+ * the setup checklist showed "Compose available ✓" while startContainer
+ * simultaneously failed its `_composeAvailable === false` guard.
+ *
+ * The fix makes getComposeAvailable() await detection, so it never returns a
+ * stale value regardless of call ordering.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Hoisted mock state ─────────────────────────────────────────────────────
+
+const { mockGetDetectionResult } = vi.hoisted(() => ({
+  mockGetDetectionResult: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: (name: string) => `/tmp/mock-${name}`,
+    setPath: vi.fn(),
+  },
+}));
+
+vi.mock('electron-store', () => ({
+  default: class MockStore {
+    get() {
+      return undefined;
+    }
+    set() {}
+  },
+}));
+
+// Replace the whole containerRuntime module so detection is fully controlled.
+vi.mock('../containerRuntime.js', () => ({
+  getDetectionResult: mockGetDetectionResult,
+  getContainerRuntime: vi.fn(async () => ({
+    kind: 'podman',
+    bin: 'podman',
+    displayName: 'Podman',
+  })),
+  getRuntimeBin: vi.fn(async () => 'podman'),
+  getSocketPaths: vi.fn(() => ({ system: '', user: () => '', envVar: 'CONTAINER_HOST' })),
+  resolveRootlessSocket: vi.fn(() => null),
+  getRuntimePathAdditions: vi.fn(() => []),
+  resetDetection: vi.fn(),
+}));
+
+import { dockerManager } from '../dockerManager.js';
+
+/** Detection result resolved on a later microtask to mimic real async probing. */
+function asyncDetection(result: Record<string, unknown>) {
+  return () => Promise.resolve().then(() => result);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Reset module-level compose/guidance/runtime caches between tests.
+  dockerManager.retryDetection();
+});
+
+describe('[GH158] dockerManager.getComposeAvailable', () => {
+  it('returns false when detection reports compose missing — even on the first call', async () => {
+    // No prior available() call: with the old synchronous read this returned
+    // `true` (null !== false). The fix awaits detection first.
+    mockGetDetectionResult.mockImplementation(
+      asyncDetection({
+        runtime: { kind: 'podman', bin: 'podman', displayName: 'Podman' },
+        composeAvailable: false,
+        guidance: 'Podman compose provider missing',
+      }),
+    );
+
+    const result = await dockerManager.getComposeAvailable();
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true when detection confirms compose is available', async () => {
+    mockGetDetectionResult.mockImplementation(
+      asyncDetection({
+        runtime: { kind: 'podman', bin: 'podman', displayName: 'Podman' },
+        composeAvailable: true,
+      }),
+    );
+
+    const result = await dockerManager.getComposeAvailable();
+
+    expect(result).toBe(true);
+  });
+
+  it('stays consistent with available() under concurrent calls (no race)', async () => {
+    mockGetDetectionResult.mockImplementation(
+      asyncDetection({
+        runtime: { kind: 'podman', bin: 'podman', displayName: 'Podman' },
+        composeAvailable: false,
+        guidance: 'Podman compose provider missing',
+      }),
+    );
+
+    // Fire both in the same tick, exactly like the useDocker hook's Promise.all.
+    const [available, compose] = await Promise.all([
+      dockerManager.dockerAvailable(),
+      dockerManager.getComposeAvailable(),
+    ]);
+
+    expect(available).toBe(true); // podman runtime present
+    expect(compose).toBe(false); // …but compose provider is not — and we report it
+  });
+
+  it('surfaces the runtime-specific guidance captured during detection', async () => {
+    mockGetDetectionResult.mockImplementation(
+      asyncDetection({
+        runtime: { kind: 'podman', bin: 'podman', displayName: 'Podman' },
+        composeAvailable: false,
+        guidance: 'Install the Podman compose provider and Retry Detection.',
+      }),
+    );
+
+    await dockerManager.getComposeAvailable();
+
+    expect(dockerManager.getDetectionGuidance()).toBe(
+      'Install the Podman compose provider and Retry Detection.',
+    );
+  });
+});

--- a/dashboard/electron/__tests__/dockerManagerCpuModel.test.ts
+++ b/dashboard/electron/__tests__/dockerManagerCpuModel.test.ts
@@ -42,6 +42,7 @@ vi.mock('../containerRuntime.js', () => ({
   resetDetection: vi.fn(),
   resolveRootlessSocket: vi.fn(() => null),
   getSocketPaths: vi.fn(() => ({ docker: '/var/run/docker.sock', podman: null })),
+  getRuntimePathAdditions: vi.fn(() => []),
 }));
 
 import { isNemoModelName, applyCpuModelDefaults } from '../dockerManager.js';

--- a/dashboard/electron/__tests__/dockerManagerPullRetry.test.ts
+++ b/dashboard/electron/__tests__/dockerManagerPullRetry.test.ts
@@ -47,6 +47,7 @@ vi.mock('../containerRuntime.js', () => ({
   resetDetection: vi.fn(),
   resolveRootlessSocket: vi.fn(() => null),
   getSocketPaths: vi.fn(() => ({ docker: '/var/run/docker.sock', podman: null })),
+  getRuntimePathAdditions: vi.fn(() => []),
 }));
 
 vi.mock('child_process', async () => {

--- a/dashboard/electron/containerRuntime.ts
+++ b/dashboard/electron/containerRuntime.ts
@@ -76,15 +76,58 @@ export function getSocketPaths(kind: ContainerRuntimeKind): SocketPaths {
 
 let cachedResult: DetectionResult | null = null;
 
+/**
+ * Directories appended to PATH when resolving container-runtime commands.
+ *
+ * On Windows, Podman's `compose` subcommand is only a thin wrapper that shells
+ * out to an EXTERNAL provider binary (docker-compose.exe / podman-compose.exe),
+ * which podman locates by searching PATH. The provider's directory must
+ * therefore be present in the environment we hand to `podman` — otherwise
+ * `podman compose` fails with exit 125 even though `podman` itself works fine
+ * (GH #158). A GUI Electron process launched from a pre-existing Explorer
+ * session does not always inherit the post-install user PATH a fresh terminal
+ * sees, so we add the well-known provider locations defensively. Every entry is
+ * additive and de-duplicated by the caller; non-existent dirs are harmless.
+ *
+ * Exported (and parameterised on platform/env) so it can be unit-tested without
+ * mutating global process state.
+ */
+export function getRuntimePathAdditions(
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  if (platform !== 'win32') {
+    return ['/usr/local/bin', '/usr/bin', '/bin', '/usr/sbin', '/sbin'];
+  }
+
+  const programFiles = env.ProgramFiles ?? 'C:\\Program Files';
+  const userProfile = env.USERPROFILE ?? null;
+  const localAppData = env.LOCALAPPDATA ?? (userProfile ? `${userProfile}\\AppData\\Local` : null);
+
+  const entries: string[] = [
+    // Docker Desktop bundles the compose plugin here.
+    `${programFiles}\\Docker\\Docker\\resources\\bin`,
+    // Machine-wide Podman install.
+    `${programFiles}\\RedHat\\Podman`,
+  ];
+  if (localAppData) {
+    // App-execution-alias providers (docker-compose.exe) live under WindowsApps.
+    entries.push(`${localAppData}\\Microsoft\\WindowsApps`);
+    // Per-user Podman install (Podman Desktop default location).
+    entries.push(`${localAppData}\\Programs\\Podman`);
+  }
+  if (userProfile) {
+    // `pip install --user podman-compose` drops the shim here.
+    entries.push(`${userProfile}\\.local\\bin`);
+  }
+  return entries;
+}
+
 function buildDetectionEnv(): NodeJS.ProcessEnv {
   const delimiter = path.delimiter;
   const currentPath = process.env.PATH ?? '';
-  const defaultPathEntries =
-    process.platform === 'win32'
-      ? ['C:\\Program Files\\Docker\\Docker\\resources\\bin']
-      : ['/usr/local/bin', '/usr/bin', '/bin', '/usr/sbin', '/sbin'];
   const mergedPath = Array.from(
-    new Set([...currentPath.split(delimiter).filter(Boolean), ...defaultPathEntries]),
+    new Set([...currentPath.split(delimiter).filter(Boolean), ...getRuntimePathAdditions()]),
   ).join(delimiter);
   return { ...process.env, PATH: mergedPath };
 }
@@ -181,10 +224,28 @@ const DOCKER_COMPOSE_MISSING_GUIDANCE =
   'or install Docker Desktop which bundles Compose — ' +
   'then click "Retry Detection" in the app.';
 
-const PODMAN_COMPOSE_MISSING_GUIDANCE =
-  'Podman is running but the compose plugin was not found. ' +
-  'Fix: install podman-compose (pip install podman-compose) or ' +
-  'docker-compose-v2 — then click "Retry Detection" in the app.';
+/**
+ * Guidance shown when Podman is running but its external compose provider was
+ * not found. Platform-aware (GH #158): on Windows the provider is usually
+ * present but unreachable because the app's PATH lacks its directory, so the
+ * advice differs from the Linux "install the package" case.
+ */
+function podmanComposeMissingGuidance(platform: NodeJS.Platform = process.platform): string {
+  if (platform === 'win32') {
+    return (
+      'Podman is running but its Compose provider (docker-compose.exe) was not found. ' +
+      'Install Docker Compose — e.g. via Podman Desktop’s Compose setup, or ' +
+      '`winget install Docker.DockerCompose` — then RESTART Transcription Suite ' +
+      '(launch it from the Start Menu / a fresh terminal so it inherits the updated ' +
+      'PATH) and click "Retry Detection".'
+    );
+  }
+  return (
+    'Podman is running but the compose plugin was not found. ' +
+    'Fix: install podman-compose (pip install podman-compose) or ' +
+    'docker-compose-v2 — then click "Retry Detection" in the app.'
+  );
+}
 
 const PODMAN_SOCKET_GUIDANCE =
   'Podman was detected but its API socket is not active. ' +
@@ -242,7 +303,7 @@ export async function detectRuntime(): Promise<DetectionResult> {
       guidance:
         running && !hasCompose
           ? override === 'podman'
-            ? PODMAN_COMPOSE_MISSING_GUIDANCE
+            ? podmanComposeMissingGuidance()
             : DOCKER_COMPOSE_MISSING_GUIDANCE
           : undefined,
     };
@@ -292,7 +353,7 @@ export async function detectRuntime(): Promise<DetectionResult> {
       binaryFoundButNotRunning: false,
       binaryFound: 'podman',
       composeAvailable: hasCompose,
-      guidance: hasCompose ? undefined : PODMAN_COMPOSE_MISSING_GUIDANCE,
+      guidance: hasCompose ? undefined : podmanComposeMissingGuidance(),
     };
   }
 
@@ -310,14 +371,32 @@ export async function detectRuntime(): Promise<DetectionResult> {
   return { runtime: null, binaryFoundButNotRunning: false, binaryFound: null };
 }
 
+/** In-flight detection promise, memoized so concurrent callers share one probe. */
+let inflightDetection: Promise<DetectionResult> | null = null;
+
 /**
  * Get the cached detection result, running detection if needed.
+ *
+ * Memoizes the in-flight detection promise (not just the resolved value) so that
+ * concurrent cold-cache callers share a single probe pass. Without this, the
+ * renderer's mount-time `Promise.all([available(), …, getComposeAvailable()])`
+ * — both of which route here — would each observe `cachedResult === null`
+ * (it is only assigned after the first `await` resolves) and spawn their own
+ * `<runtime> version` / `<runtime> compose version` subprocesses (GH #158).
  */
 export async function getDetectionResult(): Promise<DetectionResult> {
-  if (!cachedResult) {
-    cachedResult = await detectRuntime();
+  if (cachedResult) return cachedResult;
+  if (!inflightDetection) {
+    inflightDetection = (async () => {
+      try {
+        cachedResult = await detectRuntime();
+        return cachedResult;
+      } finally {
+        inflightDetection = null;
+      }
+    })();
   }
-  return cachedResult;
+  return inflightDetection;
 }
 
 /**
@@ -342,6 +421,7 @@ export async function getRuntimeBin(): Promise<string> {
  */
 export function resetDetection(): void {
   cachedResult = null;
+  inflightDetection = null;
 }
 
 /**

--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -36,6 +36,7 @@ import {
   resetDetection,
   resolveRootlessSocket,
   getSocketPaths,
+  getRuntimePathAdditions,
 } from './containerRuntime.js';
 import { type WslSupport, resetWslSupportCache } from './wslDetect.js';
 
@@ -1356,12 +1357,12 @@ function buildProcessEnv(
 ): NodeJS.ProcessEnv {
   const delimiter = path.delimiter;
   const currentPath = process.env.PATH ?? '';
-  const defaultPathEntries =
-    process.platform === 'win32'
-      ? ['C:\\Program Files\\Docker\\Docker\\resources\\bin']
-      : ['/usr/local/bin', '/usr/bin', '/bin', '/usr/sbin', '/sbin'];
+  // Use the SAME augmentation as runtime detection (containerRuntime.ts) so the
+  // PATH that found `<runtime> compose` during detection is also handed to the
+  // actual compose-up/exec commands — including the Windows compose-provider
+  // directories that make `podman compose` resolvable (GH #158).
   const mergedPath = Array.from(
-    new Set([...currentPath.split(delimiter).filter(Boolean), ...defaultPathEntries]),
+    new Set([...currentPath.split(delimiter).filter(Boolean), ...getRuntimePathAdditions()]),
   ).join(delimiter);
 
   const socketEnv: Record<string, string> = {};
@@ -1476,9 +1477,19 @@ function getDetectionGuidance(): string | null {
   return _detectionGuidance;
 }
 
-function getComposeAvailable(): boolean {
-  // null = not yet detected → assume available (avoid false-negative flicker).
-  // Only return false when compose was explicitly confirmed as missing.
+async function getComposeAvailable(): Promise<boolean> {
+  // Ensure runtime detection has completed so `_composeAvailable` reflects the
+  // real probe result rather than its initial `null`. `dockerAvailable()` is
+  // backed by a cached detection (getDetectionResult), so repeat calls are cheap.
+  //
+  // This closes a race (GH #158): the renderer's useDocker hook called
+  // available() (which *sets* _composeAvailable asynchronously) and
+  // getComposeAvailable() (which *read* it) in the same Promise.all. The
+  // synchronous read landed first and saw `null` — treated as "available" —
+  // so the setup checklist showed "Compose available ✓" while startContainer
+  // simultaneously threw its `_composeAvailable === false` guard.
+  await dockerAvailable();
+  // Only report unavailable when compose was explicitly confirmed missing.
   return _composeAvailable !== false;
 }
 
@@ -2153,12 +2164,15 @@ async function startContainer(options: StartContainerOptions): Promise<string> {
   }
 
   // Guard: bail early with a human-readable message if compose is not available.
+  // Prefer the runtime/platform-specific guidance captured during detection
+  // (Podman-on-Windows gets provider/PATH advice, not Docker/apt advice — GH #158).
+  // `_composeAvailable === false` is only ever set by dockerAvailable(), which
+  // also sets `_detectionGuidance`, so the guidance is reliably populated here.
   if (_composeAvailable === false) {
     throw new Error(
-      'Docker Compose plugin is not installed. ' +
-        'Install it with: sudo apt install docker-compose-v2 (Debian/Ubuntu) ' +
-        'or install Docker Desktop which bundles Compose. ' +
-        'Then click "Retry Detection".',
+      _detectionGuidance ??
+        'The container runtime is running but its Compose plugin/provider was not found. ' +
+          'Install Compose for your runtime, then click "Retry Detection".',
     );
   }
 

--- a/dashboard/src/hooks/useDocker.ts
+++ b/dashboard/src/hooks/useDocker.ts
@@ -186,9 +186,11 @@ export function useDocker(): UseDockerReturn {
         ]);
         setAvailable(ok);
         setDetectionGuidance(guidance);
-        // When Docker is completely absent, compose is also unavailable.
-        // getComposeAvailable() returns true for the ambiguous null state, so
-        // we must explicitly set false here to keep the Start buttons disabled.
+        // getComposeAvailable() now awaits detection (GH #158), so `compose`
+        // reflects the real probe result regardless of call ordering — no more
+        // stale `null → true` race against available(). We still force false
+        // when the runtime is completely absent, to keep the Start buttons
+        // disabled even if the compose probe was inconclusive.
         setComposeAvailable(ok ? compose : false);
         if (ok) {
           docker


### PR DESCRIPTION
Closes #158.

## Summary

On Windows, *Start Local* failed with **"Docker Compose plugin is not installed"** even though the setup checklist showed **"Podman Compose available ✓ / Setup Complete 3/3"**. Root cause reproduced — and the fix validated — on real Podman-on-Windows hardware.

### Root cause
`podman compose` on Windows is only a thin wrapper that shells out to an **external provider** binary (`docker-compose.exe`, which lives in `%LOCALAPPDATA%\Microsoft\WindowsApps`). Podman locates that provider purely by **PATH search** (`podman info` reports no configured `ComposeProviders`). The app's PATH augmentation (`buildDetectionEnv` / `buildProcessEnv`) only ever appended Docker Desktop's bin dir on Windows, so when the provider's directory was not on the Electron process PATH — GUI apps don't always inherit the post-install user PATH a freshly-opened terminal sees — `podman compose version` failed with **exit 125**. Detection then recorded `composeAvailable=false`, and `startContainer` threw the (Docker/apt-flavoured) compose-missing error.

Hardware proof on a Podman 5.8.3 + WSL machine (no `docker` binary installed):

| PATH handed to `podman` | `podman compose version` |
|---|---|
| Podman dir + Docker bin, **WindowsApps stripped** | **exit 125** (provider not found) |
| Podman dir + **WindowsApps** | exit 0 → `Docker Compose version v5.2.0` |

Ruled out: not a timeout (cold first call was 0.55s vs the 5s probe limit, even right after a WSL machine restart) and not `execFile`-without-shell (running the exact probe under Node resolves the WindowsApps alias fine **when its dir is on PATH**).

### Secondary: the false-green checklist
`useDocker` fired `available()` (which *sets* the cached compose flag asynchronously) and `getComposeAvailable()` (which *read* it synchronously, treating the initial `null` as "available") in the same `Promise.all`. The sync read landed first, so the checklist showed compose as available while `startContainer` deterministically failed its guard. The reported "can't install models / Install just advances" is downstream — model download needs a running container.

## Changes

- **`getRuntimePathAdditions(platform, env)`** (new, exported, in `containerRuntime.ts`): on Windows returns the known provider/runtime directories — `WindowsApps`, per-user (`%LOCALAPPDATA%\Programs\Podman`) and machine-wide (`C:\Program Files\RedHat\Podman`) Podman, the Docker Desktop bin dir, and `~/.local/bin`; the standard unix dirs otherwise. Both `buildDetectionEnv()` and `dockerManager.buildProcessEnv()` now route through it, so detection and the actual compose-up/exec commands resolve the provider with the same PATH. The change is **additive and de-duplicated** — a no-op on Linux/macOS and for Docker-on-Windows.
- **`dockerManager.getComposeAvailable()`** now `await`s detection instead of synchronously reading the still-`null` cached flag, closing the checklist race. (The IPC contract was already `Promise<boolean>`, so this is wire-compatible.)
- **`startContainer`'s compose guard** throws the runtime/platform-aware detection guidance instead of a hardcoded Docker/apt message, and the Podman compose-missing guidance is now Windows-aware (provider/PATH advice + a relaunch-for-fresh-PATH hint).
- **`getDetectionResult()`** memoizes the in-flight detection promise so concurrent cold-start callers share a single probe pass instead of each spawning their own `<runtime> version` / `<runtime> compose version` subprocesses (surfaced by adversarial review of this change).

## Test plan

- [x] **509 dashboard tests pass** — new coverage for the Windows PATH augmentation, the `getComposeAvailable` detection-reflecting/race behaviour, and the detection in-flight de-duplication; existing `containerRuntime` mocks updated for the new export.
- [x] `npm run typecheck`, ESLint (`--max-warnings=0`), and Prettier all clean; pre-commit hooks (incl. UI contract) green.
- [x] **Hardware end-to-end:** on a real Podman-on-Windows box, a PATH missing the provider dir fails `podman compose version` with exit 125; applying the `getRuntimePathAdditions` augmentation to that same PATH makes it succeed.

## Known limitation

The fix covers the well-known provider locations. If a user installed the compose provider somewhere genuinely custom that is on neither the inherited PATH nor these defaults, detection will still report it missing — but they now get the correct, Podman/Windows-aware guidance (install/relaunch + Retry Detection) instead of Docker/`apt` advice.