### PR TITLE
fix(server): Apple-Silicon stress-test findings — audio decode errors, notebook ffmpeg fallback, Metal GPU status

### DIFF
--- a/server/backend/api/routes/notebook.py
+++ b/server/backend/api/routes/notebook.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 import os
 import re
+import shutil
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -860,7 +861,7 @@ def _run_transcription(
     in model_manager.job_tracker so that clients can poll for completion.
     """
     # Lazy import to avoid loading torch at module import time
-    from server.core.audio_utils import convert_to_mp3, load_audio
+    from server.core.audio_utils import AudioDecodeError, convert_to_mp3, load_audio
 
     try:
         # Progress callback to update job tracker with chunk progress
@@ -939,6 +940,10 @@ def _run_transcription(
                     diar_result.num_speakers,
                 )
 
+            except AudioDecodeError:
+                # A corrupt/undecodable file is not a diarization-token problem —
+                # re-raise the clean error rather than mislabeling it (FINDING #1).
+                raise
             except ValueError as e:
                 logger.error(f"Diarization requires HuggingFace token: {e}")
                 logger.error("Set HUGGINGFACE_TOKEN env var when starting docker compose")
@@ -1059,8 +1064,28 @@ def _run_transcription(
             dest_path = audio_dir / dest_filename
             counter += 1
 
-        # Convert to MP3 for storage efficiency
-        convert_to_mp3(str(tmp_path), str(dest_path))
+        # Convert to MP3 for storage efficiency. If conversion fails (e.g. ffmpeg
+        # is not installed — a stock macOS install has none), fall back to storing
+        # the original audio verbatim so a COMPLETED transcript is never discarded
+        # (persist-before-deliver: the transcript is saved below regardless).
+        # See FINDING #2 (Apple-Silicon stress test).
+        try:
+            convert_to_mp3(str(tmp_path), str(dest_path))
+        except Exception as mp3_err:
+            logger.warning(
+                "MP3 conversion failed (%s); storing the original audio so the "
+                "completed transcript is preserved.",
+                mp3_err,
+            )
+            fallback_suffix = Path(filename or "audio").suffix.lower() or ".wav"
+            dest_filename = f"{original_stem}{fallback_suffix}"
+            dest_path = audio_dir / dest_filename
+            counter = 2
+            while dest_path.exists():
+                dest_filename = f"{original_stem}-{counter}{fallback_suffix}"
+                dest_path = audio_dir / dest_filename
+                counter += 1
+            shutil.copyfile(str(tmp_path), str(dest_path))
 
         # Extract word timestamps from segments
         # Diarization automatically enables word timestamps (they're needed for alignment anyway)

--- a/server/backend/api/routes/transcription.py
+++ b/server/backend/api/routes/transcription.py
@@ -894,7 +894,7 @@ def _run_file_import(
         if use_integrated_diarization:
             # --- Integrated backend single-pass path (e.g. WhisperX, VibeVoice) ---
             try:
-                from server.core.audio_utils import load_audio
+                from server.core.audio_utils import AudioDecodeError, load_audio
 
                 backend_label = getattr(backend, "backend_name", "integrated")
                 logger.info(
@@ -946,6 +946,10 @@ def _run_file_import(
                 # User cancellation must propagate — otherwise we'd silently fall
                 # through to the standard path and waste GPU time re-transcribing
                 # a file the user already cancelled.
+                raise
+            except AudioDecodeError:
+                # A corrupt/undecodable file is not a diarization-token problem —
+                # re-raise the clean error rather than mislabeling it (FINDING #1).
                 raise
             except ValueError as e:
                 logger.error("File import: diarization requires HuggingFace token: %s", e)

--- a/server/backend/core/audio_utils.py
+++ b/server/backend/core/audio_utils.py
@@ -219,6 +219,36 @@ def check_cuda_available() -> bool:
     return torch.cuda.is_available()
 
 
+def check_metal_available() -> bool:
+    """Check if Apple Metal (MPS) GPU acceleration is available.
+
+    The Apple-Silicon counterpart to ``check_cuda_available``. Without this the
+    GPU-availability signal is CUDA-only and reports ``False`` on Apple Silicon
+    even though the MLX/Metal backend runs on the GPU (FINDING #3).
+    """
+    import platform
+    import sys
+
+    if sys.platform != "darwin" or platform.machine() != "arm64":
+        return False
+    if not HAS_TORCH or torch is None:
+        return False
+    try:
+        return bool(torch.backends.mps.is_available())
+    except Exception:
+        return False
+
+
+def check_gpu_available() -> bool:
+    """True when any GPU backend (NVIDIA CUDA or Apple Metal) is usable.
+
+    CUDA is checked first and short-circuits, so the Linux/Windows/Docker CUDA
+    path is unchanged; the Metal check returns ``False`` immediately off Apple
+    Silicon.
+    """
+    return check_cuda_available() or check_metal_available()
+
+
 # Per-device cache for get_cuda_compute_capability.
 # Key: device index; value: (major, minor) or None (query failed / no CUDA).
 _cuda_compute_capability_cache: dict[int, tuple[int, int] | None] = {}
@@ -492,6 +522,21 @@ def convert_to_mp3(
         raise RuntimeError(f"MP3 conversion failed: {e.stderr}") from e
 
 
+AUDIO_DECODE_ERROR_MESSAGE = (
+    "Could not decode audio: the file is empty, corrupt, or in an unsupported format."
+)
+
+
+class AudioDecodeError(ValueError):
+    """Raised when an uploaded audio file cannot be decoded.
+
+    Subclasses ``ValueError`` so the existing route handlers map it to HTTP 400.
+    The message is intentionally generic and NEVER contains the server-side temp
+    path; the raw decoder error (whose message may embed that path) is logged
+    server-side only. See FINDING #1 (Apple-Silicon stress test).
+    """
+
+
 def load_audio_legacy(
     file_path: str,
     target_sample_rate: int = 16000,
@@ -577,19 +622,36 @@ def load_audio(
         logger.warning(f"Could not load config, falling back to legacy backend: {e}")
         backend = "legacy"
 
-    if backend == "ffmpeg":
-        try:
-            from server.core.ffmpeg_utils import load_audio_ffmpeg
+    try:
+        if backend == "ffmpeg":
+            try:
+                from server.core.ffmpeg_utils import load_audio_ffmpeg
 
-            return load_audio_ffmpeg(file_path, target_sample_rate)
-        except ImportError as e:
-            logger.warning(f"ffmpeg-python not available, falling back to legacy: {e}")
+                return load_audio_ffmpeg(file_path, target_sample_rate)
+            except ImportError as e:
+                logger.warning(f"ffmpeg-python not available, falling back to legacy: {e}")
+                return load_audio_legacy(file_path, target_sample_rate)
+            except Exception as e:
+                logger.warning(f"FFmpeg loading failed, falling back to legacy: {e}")
+                return load_audio_legacy(file_path, target_sample_rate)
+        else:
             return load_audio_legacy(file_path, target_sample_rate)
-        except Exception as e:
-            logger.warning(f"FFmpeg loading failed, falling back to legacy: {e}")
-            return load_audio_legacy(file_path, target_sample_rate)
-    else:
-        return load_audio_legacy(file_path, target_sample_rate)
+    except AudioDecodeError:
+        # Already the clean, path-free error — never re-wrap it.
+        raise
+    except ImportError:
+        # Genuine server misconfiguration (e.g. soundfile not installed). Re-raise
+        # so it surfaces as a 500 — its message carries no temp path, nothing leaks.
+        raise
+    except (RuntimeError, OSError, ValueError) as e:
+        # A decode failure: empty/corrupt/unsupported file, or ffmpeg missing. The
+        # raw message (e.g. soundfile.LibsndfileError, which can embed the server-
+        # side temp path) is logged server-side only; we raise a clean, generic
+        # error that route handlers map to HTTP 400 instead of a path-leaking 500
+        # (FINDING #1). ValueError is included so a resampler/decoder ValueError
+        # cannot leak a path either.
+        logger.warning("Audio decode failed (empty, corrupt, or unsupported file): %s", e)
+        raise AudioDecodeError(AUDIO_DECODE_ERROR_MESSAGE) from e
 
 
 def normalize_audio_legacy(audio: np.ndarray, target_db: float = -3.0) -> np.ndarray:

--- a/server/backend/core/model_manager.py
+++ b/server/backend/core/model_manager.py
@@ -204,7 +204,7 @@ class ModelManager:
             config: Full application configuration dict
         """
         # Lazy imports
-        from server.core.audio_utils import check_cuda_available, get_gpu_memory_info
+        from server.core.audio_utils import check_gpu_available, get_gpu_memory_info
 
         self.config = config
         self._transcription_engine: AudioToTextRecorder | None = None
@@ -230,10 +230,15 @@ class ModelManager:
 
         # Check GPU availability
         self._gpu_device_index: int = config.get("transcription", {}).get("gpu_device_index", 0)
-        self.gpu_available = check_cuda_available()
+        self.gpu_available = check_gpu_available()
         if self.gpu_available:
             gpu_info = get_gpu_memory_info(self._gpu_device_index)
-            logger.info(f"GPU available with {gpu_info.get('total_gb', 'unknown')} GB memory")
+            total_gb = gpu_info.get("total_gb")
+            if total_gb:
+                logger.info(f"GPU available with {total_gb} GB memory")
+            else:
+                # Apple Metal / unified memory exposes no dedicated-VRAM figure.
+                logger.info("GPU available (Apple Metal / unified memory)")
         else:
             logger.warning("No GPU available, using CPU for transcription")
 
@@ -939,12 +944,14 @@ class ModelManager:
 
     def get_status(self) -> dict[str, Any]:
         """Get status information about loaded models."""
-        from server.core.audio_utils import get_gpu_memory_info
+        from server.core.audio_utils import check_cuda_available, get_gpu_memory_info
 
         status = {
             "gpu_available": self.gpu_available,
+            # gpu_memory reflects CUDA VRAM; Apple unified memory has no
+            # dedicated-VRAM figure, so it stays null on Metal (FINDING #3).
             "gpu_memory": get_gpu_memory_info(self._gpu_device_index)
-            if self.gpu_available
+            if check_cuda_available()
             else None,
             "transcription": {
                 "selected_model": self.main_model_name,

--- a/server/backend/core/multitrack.py
+++ b/server/backend/core/multitrack.py
@@ -243,7 +243,11 @@ def split_channels(
             # Clean up the file we just created on failure
             Path(tmp.name).unlink(missing_ok=True)
             _cleanup_partials()
-            raise RuntimeError(f"Failed to extract channel {ch_idx}: {exc}") from exc
+            # Don't interpolate the raw subprocess error — it embeds the server-side
+            # temp paths (input + channel output). Log it server-side only and raise
+            # a clean message (FINDING #1 temp-path-leak hygiene).
+            logger.warning("Failed to extract channel %d: %s", ch_idx, exc)
+            raise RuntimeError(f"Failed to extract audio channel {ch_idx}") from exc
 
     return temp_paths
 

--- a/server/backend/tests/test_audio_utils.py
+++ b/server/backend/tests/test_audio_utils.py
@@ -868,3 +868,185 @@ class TestApplySileroVad:
             result = au.apply_silero_vad(audio)
 
         np.testing.assert_array_equal(result, audio)
+
+
+# ── load_audio() decode-error hardening (FINDING #1) ──────────────────────
+
+
+def _raiser(exc):
+    """Return a function that raises ``exc`` when called (test helper)."""
+
+    def _f(*_a, **_kw):
+        raise exc
+
+    return _f
+
+
+class TestLoadAudioDecodeErrors:
+    """load_audio() must convert raw decoder failures — whose messages can embed
+    the server-side temp path — into a clean, path-free AudioDecodeError so the
+    routes return HTTP 400 instead of a 500 leaking internals (FINDING #1)."""
+
+    def _force_legacy(self, monkeypatch):
+        # Make get_config raise so load_audio() selects the legacy backend leg.
+        monkeypatch.setattr("server.config.get_config", _raiser(RuntimeError("no config")))
+
+    def test_libsndfile_error_becomes_clean_audiodecodeerror(self, monkeypatch):
+        import soundfile as sf
+
+        self._force_legacy(monkeypatch)
+        monkeypatch.setattr(
+            au,
+            "load_audio_legacy",
+            _raiser(
+                sf.LibsndfileError(0, prefix="Error opening '/var/folders/zz/tmpSECRET.wav': ")
+            ),
+        )
+        with pytest.raises(au.AudioDecodeError) as exc:
+            au.load_audio("/var/folders/zz/tmpSECRET.wav")
+        assert str(exc.value) == au.AUDIO_DECODE_ERROR_MESSAGE
+        assert "/var/folders" not in str(exc.value)
+        assert "tmpSECRET" not in str(exc.value)
+        # Subclasses ValueError so existing route handlers map it to HTTP 400.
+        assert isinstance(exc.value, ValueError)
+
+    def test_ffmpeg_and_legacy_both_fail_converted(self, monkeypatch):
+        monkeypatch.setattr(
+            "server.core.ffmpeg_utils.load_audio_ffmpeg",
+            _raiser(RuntimeError("Audio loading failed: /tmp/tmpX.wav")),
+        )
+        monkeypatch.setattr(
+            au, "load_audio_legacy", _raiser(RuntimeError("No 'data' chunk marker"))
+        )
+        with pytest.raises(au.AudioDecodeError) as exc:
+            au.load_audio("/tmp/tmpX.wav")
+        assert str(exc.value) == au.AUDIO_DECODE_ERROR_MESSAGE
+        assert "/tmp" not in str(exc.value)
+
+    def test_ffmpeg_not_installed_runtimeerror_converted(self, monkeypatch):
+        self._force_legacy(monkeypatch)
+        monkeypatch.setattr(
+            au,
+            "load_audio_legacy",
+            _raiser(RuntimeError("ffmpeg is not installed or not in PATH")),
+        )
+        with pytest.raises(au.AudioDecodeError):
+            au.load_audio("/tmp/whatever.wav")
+
+    def test_happy_path_passthrough_unchanged(self, monkeypatch):
+        self._force_legacy(monkeypatch)
+        arr = np.zeros(16, dtype=np.float32)
+        monkeypatch.setattr(au, "load_audio_legacy", lambda *_a, **_kw: (arr, 16000))
+        out, sr = au.load_audio("/tmp/ok.wav")
+        assert sr == 16000
+        np.testing.assert_array_equal(out, arr)
+
+    def test_import_error_still_propagates(self, monkeypatch):
+        # A genuine server misconfiguration (soundfile missing) must NOT be
+        # masked as a 400 — and its message carries no temp path anyway.
+        self._force_legacy(monkeypatch)
+        monkeypatch.setattr(
+            au,
+            "load_audio_legacy",
+            _raiser(ImportError("soundfile library is required for audio loading")),
+        )
+        with pytest.raises(ImportError):
+            au.load_audio("/tmp/ok.wav")
+
+    def test_real_empty_file_raises_clean_error(self, tmp_path, monkeypatch):
+        # No loader mocks: exercise the REAL soundfile decode path so the
+        # (RuntimeError, OSError, ValueError) catch tuple is pinned against the
+        # actual library, not a hand-built exception (FINDING #1).
+        self._force_legacy(monkeypatch)
+        p = tmp_path / "tmpEMPTY.wav"
+        p.write_bytes(b"")
+        with pytest.raises(au.AudioDecodeError) as exc:
+            au.load_audio(str(p))
+        assert str(exc.value) == au.AUDIO_DECODE_ERROR_MESSAGE
+        assert "tmpEMPTY" not in str(exc.value)
+        assert str(p) not in str(exc.value)
+
+    def test_real_corrupt_file_raises_clean_error(self, tmp_path, monkeypatch):
+        self._force_legacy(monkeypatch)
+        p = tmp_path / "tmpGARBAGE.wav"
+        p.write_bytes(b"RIFFxxxxWAVEnot actually audio data")
+        with pytest.raises(au.AudioDecodeError) as exc:
+            au.load_audio(str(p))
+        assert str(exc.value) == au.AUDIO_DECODE_ERROR_MESSAGE
+        assert "tmpGARBAGE" not in str(exc.value)
+
+
+# ── Metal / unified-memory GPU detection (FINDING #3) ─────────────────────
+
+
+class TestCheckMetalAvailable:
+    """check_metal_available() reports Apple Metal (MPS) so /api/status no longer
+    claims gpu_available=false on Apple Silicon (FINDING #3)."""
+
+    def test_true_on_apple_silicon_with_mps(self, monkeypatch):
+        import platform as _pf
+        import sys as _sys
+
+        mock_torch = MagicMock()
+        mock_torch.backends.mps.is_available.return_value = True
+        monkeypatch.setattr(_sys, "platform", "darwin")
+        monkeypatch.setattr(_pf, "machine", lambda: "arm64")
+        with patch.object(au, "torch", mock_torch), patch.object(au, "HAS_TORCH", True):
+            assert au.check_metal_available() is True
+        # Pin that MPS specifically is probed (not just MagicMock truthiness).
+        mock_torch.backends.mps.is_available.assert_called_once()
+
+    def test_false_on_non_darwin(self, monkeypatch):
+        import sys as _sys
+
+        monkeypatch.setattr(_sys, "platform", "linux")
+        with patch.object(au, "HAS_TORCH", True):
+            assert au.check_metal_available() is False
+
+    def test_false_on_darwin_intel(self, monkeypatch):
+        import platform as _pf
+        import sys as _sys
+
+        monkeypatch.setattr(_sys, "platform", "darwin")
+        monkeypatch.setattr(_pf, "machine", lambda: "x86_64")
+        with patch.object(au, "HAS_TORCH", True):
+            assert au.check_metal_available() is False
+
+    def test_false_without_torch(self, monkeypatch):
+        import platform as _pf
+        import sys as _sys
+
+        monkeypatch.setattr(_sys, "platform", "darwin")
+        monkeypatch.setattr(_pf, "machine", lambda: "arm64")
+        with patch.object(au, "HAS_TORCH", False):
+            assert au.check_metal_available() is False
+
+    def test_false_when_mps_raises(self, monkeypatch):
+        import platform as _pf
+        import sys as _sys
+
+        mock_torch = MagicMock()
+        mock_torch.backends.mps.is_available.side_effect = RuntimeError("boom")
+        monkeypatch.setattr(_sys, "platform", "darwin")
+        monkeypatch.setattr(_pf, "machine", lambda: "arm64")
+        with patch.object(au, "torch", mock_torch), patch.object(au, "HAS_TORCH", True):
+            assert au.check_metal_available() is False
+
+
+class TestCheckGpuAvailable:
+    """check_gpu_available() is true when EITHER CUDA or Metal is usable."""
+
+    def test_true_if_cuda(self, monkeypatch):
+        monkeypatch.setattr(au, "check_cuda_available", lambda: True)
+        monkeypatch.setattr(au, "check_metal_available", lambda: False)
+        assert au.check_gpu_available() is True
+
+    def test_true_if_metal(self, monkeypatch):
+        monkeypatch.setattr(au, "check_cuda_available", lambda: False)
+        monkeypatch.setattr(au, "check_metal_available", lambda: True)
+        assert au.check_gpu_available() is True
+
+    def test_false_if_neither(self, monkeypatch):
+        monkeypatch.setattr(au, "check_cuda_available", lambda: False)
+        monkeypatch.setattr(au, "check_metal_available", lambda: False)
+        assert au.check_gpu_available() is False

--- a/server/backend/tests/test_model_manager_init.py
+++ b/server/backend/tests/test_model_manager_init.py
@@ -76,6 +76,9 @@ def _build_manager(
             return_value="tiny",
         ),
         patch("server.core.audio_utils.check_cuda_available", return_value=False),
+        # Also stub Metal so gpu_available is host-independent — otherwise the
+        # suite would report gpu_available=True when run on Apple Silicon.
+        patch("server.core.audio_utils.check_metal_available", return_value=False),
         patch("server.core.audio_utils.get_gpu_memory_info", return_value={}),
         patch.dict("os.environ", env, clear=False),
     ):
@@ -306,3 +309,32 @@ class TestGpuStatus:
         mgr = _build_manager(tmp_path)
 
         assert mgr.gpu_available is False
+
+    def test_gpu_available_on_metal_and_gpu_memory_null(self, tmp_path: Path):
+        """FINDING #3: Apple Metal up (CUDA down) -> gpu_available True, but
+        gpu_memory stays null (Apple unified memory has no dedicated-VRAM figure).
+        The gpu_memory assertion pins the get_status() `if check_cuda_available()`
+        decoupling — it would fail if that reverted to `if self.gpu_available`.
+        """
+        from server.core.model_manager import ModelManager
+
+        with (
+            patch(
+                "server.core.model_manager.resolve_main_transcriber_model",
+                return_value="tiny",
+            ),
+            patch("server.core.audio_utils.check_cuda_available", return_value=False),
+            patch("server.core.audio_utils.check_metal_available", return_value=True),
+            patch("server.core.audio_utils.get_gpu_memory_info", return_value={}),
+            patch.dict(
+                "os.environ",
+                {"BOOTSTRAP_STATUS_FILE": str(tmp_path / "nope.json")},
+                clear=False,
+            ),
+        ):
+            mgr = ModelManager({"main_transcriber": {"model": "tiny"}})
+            status = mgr.get_status()
+
+        assert mgr.gpu_available is True
+        assert status["gpu_available"] is True
+        assert status["gpu_memory"] is None

--- a/server/backend/tests/test_multitrack.py
+++ b/server/backend/tests/test_multitrack.py
@@ -373,8 +373,11 @@ class TestSplitChannels:
             return subprocess.CompletedProcess(cmd, 0)
 
         with patch("server.core.multitrack.subprocess.run", side_effect=failing_run):
-            with pytest.raises(RuntimeError, match="Failed to extract channel"):
+            with pytest.raises(RuntimeError, match="Failed to extract audio channel") as exc:
                 split_channels(str(tmp_path / "input.wav"), [0, 1])
+        # The clean message must not interpolate the raw subprocess error (which
+        # embeds the server-side temp paths) — FINDING #1 temp-path-leak hygiene.
+        assert "Command" not in str(exc.value)
 
     def test_cancellation_check_none_is_noop(self, tmp_path: Any) -> None:
         """Explicit None (the default) must preserve pre-change behavior."""

--- a/server/backend/tests/test_notebook_upload_recovery.py
+++ b/server/backend/tests/test_notebook_upload_recovery.py
@@ -185,6 +185,121 @@ class TestNotebookRunTranscription:
         assert "INSTALL_NEMO" in result["remedy"]
         assert result["backend_type"] == "nemo"
 
+    def test_mp3_conversion_failure_preserves_transcript(self, tmp_path: Path, monkeypatch):
+        """FINDING #2: if MP3 conversion fails (e.g. ffmpeg is absent on a stock
+        macOS install), the COMPLETED transcript must still be saved by falling
+        back to storing the original audio — never discarded (persist-before-deliver).
+        """
+        import server.core.audio_utils as au
+        from server.api.routes import notebook as nb_route
+
+        monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+        saved: dict = {}
+
+        def _save(**kw):
+            saved.update(kw)
+            return 99
+
+        monkeypatch.setattr(nb_route, "save_longform_to_database", _save)
+        monkeypatch.setattr(nb_route, "check_time_slot_overlap", lambda *_a, **_kw: None)
+
+        # MP3 conversion fails exactly as it does when ffmpeg is not installed.
+        def _boom(*_a, **_kw):
+            raise RuntimeError("ffmpeg is not installed or not in PATH")
+
+        monkeypatch.setattr(au, "convert_to_mp3", _boom)
+
+        engine = _make_engine()
+        mgr = _ModelManager(engine)
+
+        tmp_file = tmp_path / "input.wav"
+        tmp_file.write_bytes(b"\x00" * 2048)
+
+        nb_route._run_transcription(
+            model_manager=mgr,
+            tmp_path=tmp_file,
+            filename="input.wav",
+            language=None,
+            translation_enabled=False,
+            translation_target_language=None,
+            enable_diarization=False,
+            enable_word_timestamps=True,
+            file_created_at=None,
+            expected_speakers=None,
+            parallel_diarization=None,
+            use_parallel_default=False,
+            title=None,
+            job_id="job-mp3-fallback",
+            event_loop=None,
+        )
+
+        result = mgr.job_tracker.results["job-mp3-fallback"]
+        assert "error" not in result, f"transcript lost on MP3 failure: {result}"
+        assert result["recording_id"] == 99
+        # The fallback stored the ORIGINAL audio so the transcript could be saved.
+        stored = Path(saved["audio_path"])
+        assert stored.exists()
+        assert stored.suffix == ".wav"
+        # Original audio bytes were copied verbatim (durability goal, not a no-op
+        # touch). tmp_file is cleaned up by _run_transcription, so compare to the
+        # known content rather than re-reading the (now-deleted) source.
+        assert stored.read_bytes() == b"\x00" * 2048
+
+    def test_mp3_fallback_dedups_colliding_filename(self, tmp_path: Path, monkeypatch):
+        """The fallback's de-collision loop must not overwrite an existing stored
+        original-audio file (data-loss-adjacent)."""
+        import server.core.audio_utils as au
+        from server.api.routes import notebook as nb_route
+
+        monkeypatch.setenv("DATA_DIR", str(tmp_path))
+        # Pre-create a colliding original so the fallback must pick input-2.wav.
+        audio_dir = tmp_path / "audio"
+        audio_dir.mkdir(parents=True, exist_ok=True)
+        (audio_dir / "input.wav").write_bytes(b"pre-existing")
+
+        saved: dict = {}
+
+        def _save(**kw):
+            saved.update(kw)
+            return 7
+
+        monkeypatch.setattr(nb_route, "save_longform_to_database", _save)
+        monkeypatch.setattr(nb_route, "check_time_slot_overlap", lambda *_a, **_kw: None)
+
+        def _boom(*_a, **_kw):
+            raise RuntimeError("ffmpeg is not installed or not in PATH")
+
+        monkeypatch.setattr(au, "convert_to_mp3", _boom)
+
+        mgr = _ModelManager(_make_engine())
+        tmp_file = tmp_path / "input.wav"
+        tmp_file.write_bytes(b"\x01" * 1024)
+
+        nb_route._run_transcription(
+            model_manager=mgr,
+            tmp_path=tmp_file,
+            filename="input.wav",
+            language=None,
+            translation_enabled=False,
+            translation_target_language=None,
+            enable_diarization=False,
+            enable_word_timestamps=True,
+            file_created_at=None,
+            expected_speakers=None,
+            parallel_diarization=None,
+            use_parallel_default=False,
+            title=None,
+            job_id="job-mp3-collide",
+            event_loop=None,
+        )
+
+        stored = Path(saved["audio_path"])
+        assert stored.name == "input-2.wav"
+        # The pre-existing file was NOT clobbered.
+        assert (audio_dir / "input.wav").read_bytes() == b"pre-existing"
+        assert stored.read_bytes() == b"\x01" * 1024
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # File import (_run_file_import)

--- a/server/backend/tests/test_transcription_durability_routes.py
+++ b/server/backend/tests/test_transcription_durability_routes.py
@@ -457,3 +457,51 @@ class TestDismissTranscriptionResult:
         resp = asyncio.run(transcription.dismiss_transcription_result("job-null", _request()))
 
         assert resp.status_code == 200
+
+
+class TestTranscribeDecodeErrorRouting:
+    """FINDING #1 (route boundary): a decode failure must surface as a clean HTTP
+    400 whose detail contains NO server temp path — not a path-leaking 500."""
+
+    def _request_with_engine(self, engine):
+        job_tracker = SimpleNamespace(
+            try_start_job=lambda _c: (True, "job1", None),
+            is_cancelled=lambda: False,
+            end_job=lambda _j: None,
+        )
+        mm = SimpleNamespace(
+            ensure_transcription_loaded=lambda: None,
+            transcription_engine=engine,
+            job_tracker=job_tracker,
+        )
+        return SimpleNamespace(
+            app=SimpleNamespace(
+                state=SimpleNamespace(
+                    config={"main_transcriber": {"model": "tiny"}},
+                    model_manager=mm,
+                )
+            )
+        )
+
+    def test_audiodecodeerror_maps_to_clean_400(self):
+        import server.core.audio_utils as au
+
+        class _Upload:
+            filename = "bad.wav"
+
+            async def read(self):
+                return b"\x00\x00"
+
+        def _raise_decode(*_a, **_kw):
+            raise au.AudioDecodeError(au.AUDIO_DECODE_ERROR_MESSAGE)
+
+        request = self._request_with_engine(SimpleNamespace(transcribe_file=_raise_decode))
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(transcription.transcribe_quick(request, _Upload()))
+
+        assert exc.value.status_code == 400
+        assert exc.value.detail == au.AUDIO_DECODE_ERROR_MESSAGE
+        # The user-facing detail must never carry the server-side temp path.
+        assert "/tmp" not in exc.value.detail
+        assert "/var/folders" not in exc.value.detail


### PR DESCRIPTION
Fixes three issues found while stress-testing the native macOS **MLX/Metal** build on a real M2 Pro (16 GB, macOS 26.5.1). Each fix is unit- and (where it's the user-facing contract) route-tested, RED→GREEN.

## FINDING #1 — MEDIUM: decode failures leaked the server temp path in an HTTP 500
An empty (0-byte) or corrupt upload made `soundfile` raise `LibsndfileError` (a `RuntimeError` subclass) that escaped `load_audio()` uncaught and was echoed verbatim into the response, e.g. `{"detail":"Error opening '/var/folders/.../tmpXXXX.wav': Format not recognised"}` — a 500 that leaks an internal path.

- `core/audio_utils.py`: new `AudioDecodeError(ValueError)` + static `AUDIO_DECODE_ERROR_MESSAGE`. `load_audio()` wraps its ffmpeg→legacy dispatch and converts `RuntimeError/OSError/ValueError` into the clean error (raw detail logged server-side only). `ImportError` (genuine misconfig) still propagates. Routes already map `ValueError`→`HTTP 400`, so every decode route (`/audio`, `/quick`, `/import`, `/retry`, `/v1/audio/*`, notebook upload) now returns/persists a clean **400** with no path.
- `core/multitrack.py`: `split_channels()` no longer interpolates the raw `subprocess` error (same leak class, reachable via `multitrack=true`).
- `transcription._run_file_import` / `notebook._run_transcription`: re-raise `AudioDecodeError` instead of mislabeling a corrupt file as "diarization requires HuggingFace token".

## FINDING #2 — HIGH (Mac): notebook upload discarded the transcript when ffmpeg was absent
The notebook worker ran `convert_to_mp3()` (hard-requires ffmpeg) **before** `save_longform_to_database()`. On a stock macOS install (no Homebrew ffmpeg) the conversion raised and the **completed transcript was thrown away** — a data-loss path that violates the persist-before-deliver invariant.

- `notebook._run_transcription`: MP3 storage is now best-effort — on failure it falls back to `shutil.copyfile` of the original audio (de-colliding the filename), so the irreplaceable transcript is always saved. (Decoding itself already degrades to soundfile; this was specifically the MP3 *storage* step.)

## FINDING #3 — LOW/cosmetic: `gpu_available:false` on Apple Metal
`/api/status` reported no GPU on Apple Silicon (CUDA-only check) even though MLX runs on the Metal GPU.

- `core/audio_utils.py`: new `check_metal_available()` / `check_gpu_available()`. `ModelManager` uses `check_gpu_available()`; `gpu_memory` stays CUDA-only (null on Metal — no fabricated unified-memory figure). CUDA/Linux/Docker path is unchanged (CUDA is checked first and short-circuits).

## Test plan
- [x] New RED→GREEN tests: decode-error conversion incl. **real** empty/corrupt files, route-level **400 + no-path-leak**, notebook MP3 fallback + de-collision + byte-preservation, Metal/GPU detection, and `ModelManager` gpu-status integration (`gpu_available` true / `gpu_memory` null on Metal).
- [x] Updated `test_multitrack` for the clean error message + no-leak assertion.
- [x] Made the model-manager test helpers Metal-host-independent (the suite is run on real M2 hardware).
- [x] Full backend suite: **1991 passed, 4 skipped** (`build/.venv` pytest); ruff check + format clean on all changed files.
- [x] GitNexus impact (`load_audio` LOW) + `detect_changes` (LOW, 0 affected processes).

## Notes
- Findings were validated on real hardware; #1/#2 were also confirmed end-to-end on the M2 (notebook upload of a WAV failed pre-fix with "ffmpeg is not installed or not in PATH").
- Residual (pre-existing class, out of scope): if `shutil.copyfile` itself fails (disk full/permission) the transcript would still be lost — but those same conditions would also fail the DB write, and `save_longform_to_database` requires a real `audio_path`, so a fuller decouple is a separate change.