### PR TITLE
fix(dashboard, ui): default idle visualizer animations OFF to fix high idle CPU/GPU on Apple Silicon (GH #87 / #124)

### DIFF
--- a/dashboard/components/views/SettingsModal.tsx
+++ b/dashboard/components/views/SettingsModal.tsx
@@ -184,7 +184,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
     runtimeProfile: 'cpu' as RuntimeProfile,
     pasteAtCursor: false,
     blurEffectsEnabled: true,
-    idleAnimationsEnabled: true,
+    idleAnimationsEnabled: false, // GH #87 — default OFF (see idleAnimationsBoot)
   });
   // Issue #87 — track the LAST SAVED Blur effects value so we can revert any
   // unsaved live-preview DOM changes if the modal closes via X without Save.
@@ -392,7 +392,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
               const loadedBlurEffectsEnabled = (cfg['ui.blurEffectsEnabled'] as boolean) ?? true;
               savedBlurEffectsRef.current = loadedBlurEffectsEnabled;
               const loadedIdleAnimationsEnabled =
-                (cfg['ui.idleAnimationsEnabled'] as boolean) ?? true;
+                (cfg['ui.idleAnimationsEnabled'] as boolean) ?? false; // GH #87 — default OFF
               savedIdleAnimationsRef.current = loadedIdleAnimationsEnabled;
               setAppSettings((prev) => ({
                 ...prev,

--- a/dashboard/electron/main.ts
+++ b/dashboard/electron/main.ts
@@ -498,11 +498,12 @@ const store = new Store({
     // installation via Settings → App → Blur effects.
     'ui.blurEffectsEnabled': true,
     /* GH-87 — "Idle animations" toggle, independent of blur. When false,
-       freezes the idle visualizer waves to cut idle CPU/GPU. Default true (ON)
-       on every platform, so the animating design is preserved unless the user
-       opts out via Settings -> App -> Idle animations. Legacy
-       ui.lowIdleUsageEnabled values are migrated client-side at boot. */
-    'ui.idleAnimationsEnabled': true,
+       freezes the idle visualizer waves to cut idle CPU/GPU. Default FALSE (OFF):
+       the waves continuously force compositor/main-thread repaint, measured at
+       ~85% CPU / ~32% GPU at idle on Apple Silicon (M2 Pro). Users opt in via
+       Settings -> App -> Idle animations. Legacy ui.lowIdleUsageEnabled values
+       are migrated client-side at boot. Blur stays ON by default (cheap). */
+    'ui.idleAnimationsEnabled': false,
     'server.host': 'localhost',
     'server.port': 9786,
     'server.https': false,

--- a/dashboard/src/config/store.ts
+++ b/dashboard/src/config/store.ts
@@ -149,7 +149,9 @@ const DEFAULT_CONFIG: ClientConfig = {
   ui: {
     sidebarCollapsed: false,
     blurEffectsEnabled: true,
-    idleAnimationsEnabled: true,
+    // GH #87 — default OFF: idle visualizer waves cost ~85% CPU / ~32% GPU at
+    // idle on Apple Silicon (continuous compositor repaint). Opt-in via Settings.
+    idleAnimationsEnabled: false,
   },
 };
 

--- a/dashboard/src/utils/__tests__/idleAnimationsBoot.test.ts
+++ b/dashboard/src/utils/__tests__/idleAnimationsBoot.test.ts
@@ -1,13 +1,14 @@
 /**
  * idleAnimationsBoot — unit tests for the GH-87 "Idle animations" boot probe.
  *
- * Unlike the old combined "Low idle usage" mode, this defaults ON and is
- * INDEPENDENT of blur: the `data-idle-animations="off"` attribute is applied
- * only when storage holds the literal boolean `false`. Every failure mode
- * (missing storage, missing key, malformed JSON, getItem throwing, any
- * non-false value) must fall through to the documented default (animations
- * ON, no attribute). The function MUST never throw — bootstrap runs before
- * React mounts.
+ * Defaults OFF (GH #87): the idle wave animations continuously force the
+ * compositor/main-thread to repaint (~85% CPU / ~32% GPU at idle on Apple
+ * Silicon), so `data-idle-animations="off"` is applied by default and ONLY the
+ * explicit literal boolean `true` (a deliberate Settings opt-in) leaves the
+ * animations running. Every other value/failure mode (missing storage, missing
+ * key, malformed JSON, getItem throwing, any non-true value) falls through to
+ * the default OFF (attribute set). The function MUST never throw — bootstrap
+ * runs before React mounts.
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -49,27 +50,27 @@ describe('applyIdleAnimationsBoot', () => {
     expect(doc.documentElement.dataset.idleAnimations).toBe('off');
   });
 
-  it('leaves attribute unset when storage holds true', () => {
+  it('leaves attribute unset only when storage holds the explicit true opt-in', () => {
     const storage = makeStorage({ [IDLE_ANIMATIONS_STORAGE_KEY]: 'true' });
     applyIdleAnimationsBoot(storage, doc as unknown as Document);
     expect(doc.documentElement.dataset.idleAnimations).toBeUndefined();
   });
 
-  it('leaves attribute unset when key is absent (first run, default ON)', () => {
+  it('sets off when key is absent (first run, default OFF)', () => {
     const storage = makeStorage();
     applyIdleAnimationsBoot(storage, doc as unknown as Document);
-    expect(doc.documentElement.dataset.idleAnimations).toBeUndefined();
+    expect(doc.documentElement.dataset.idleAnimations).toBe('off');
   });
 
-  it('does not throw and leaves attribute unset on JSON parse failure', () => {
+  it('does not throw and sets off (default) on JSON parse failure', () => {
     const storage = makeStorage({ [IDLE_ANIMATIONS_STORAGE_KEY]: 'not-json' });
     expect(() => applyIdleAnimationsBoot(storage, doc as unknown as Document)).not.toThrow();
-    expect(doc.documentElement.dataset.idleAnimations).toBeUndefined();
+    expect(doc.documentElement.dataset.idleAnimations).toBe('off');
   });
 
-  it('does not throw and leaves attribute unset when storage is null', () => {
+  it('does not throw and sets off (default) when storage is null', () => {
     expect(() => applyIdleAnimationsBoot(null, doc as unknown as Document)).not.toThrow();
-    expect(doc.documentElement.dataset.idleAnimations).toBeUndefined();
+    expect(doc.documentElement.dataset.idleAnimations).toBe('off');
   });
 
   it('does not throw when document is null', () => {
@@ -77,25 +78,25 @@ describe('applyIdleAnimationsBoot', () => {
     expect(() => applyIdleAnimationsBoot(storage, null)).not.toThrow();
   });
 
-  it('does not throw and leaves attribute unset when storage.getItem throws', () => {
+  it('does not throw and sets off (default) when storage.getItem throws', () => {
     const storage: MockStorage = {
       getItem: vi.fn(() => {
         throw new Error('storage disabled');
       }),
     };
     expect(() => applyIdleAnimationsBoot(storage, doc as unknown as Document)).not.toThrow();
-    expect(doc.documentElement.dataset.idleAnimations).toBeUndefined();
+    expect(doc.documentElement.dataset.idleAnimations).toBe('off');
   });
 
-  it('treats non-false JSON values as ON (no attribute set)', () => {
-    // Only the literal boolean `false` should freeze animations.
-    for (const value of ['1', '0', 'null', '"off"']) {
+  it('treats non-true JSON values as OFF (attribute set)', () => {
+    // Only the literal boolean `true` should leave animations running.
+    for (const value of ['1', '0', 'null', '"on"']) {
       const docMock = makeDoc();
       applyIdleAnimationsBoot(
         makeStorage({ [IDLE_ANIMATIONS_STORAGE_KEY]: value }),
         docMock as unknown as Document,
       );
-      expect(docMock.documentElement.dataset.idleAnimations).toBeUndefined();
+      expect(docMock.documentElement.dataset.idleAnimations).toBe('off');
     }
   });
 });
@@ -103,12 +104,12 @@ describe('applyIdleAnimationsBoot', () => {
 /**
  * readPersistedIdleAnimations — used to seed SettingsModal's
  * savedIdleAnimationsRef so the modal close-branch revert agrees with the
- * attribute the boot probe applied. Default true (animations ON) on every
- * failure/missing path; false only for the literal boolean `false`.
+ * attribute the boot probe applied. Default false (animations OFF) on every
+ * failure/missing path; true only for the explicit literal boolean `true`.
  */
 describe('readPersistedIdleAnimations', () => {
-  it('returns true when key is absent', () => {
-    expect(readPersistedIdleAnimations(makeStorage())).toBe(true);
+  it('returns false when key is absent (default OFF)', () => {
+    expect(readPersistedIdleAnimations(makeStorage())).toBe(false);
   });
 
   it('returns false when storage holds the literal string "false"', () => {
@@ -117,29 +118,29 @@ describe('readPersistedIdleAnimations', () => {
     ).toBe(false);
   });
 
-  it('returns true when storage holds true', () => {
+  it('returns true only when storage holds the explicit true opt-in', () => {
     expect(
       readPersistedIdleAnimations(makeStorage({ [IDLE_ANIMATIONS_STORAGE_KEY]: 'true' })),
     ).toBe(true);
   });
 
-  it('returns true when storage is null (no localStorage available)', () => {
-    expect(readPersistedIdleAnimations(null)).toBe(true);
+  it('returns false when storage is null (no localStorage available)', () => {
+    expect(readPersistedIdleAnimations(null)).toBe(false);
   });
 
-  it('returns true on JSON parse failure', () => {
+  it('returns false on JSON parse failure', () => {
     expect(
       readPersistedIdleAnimations(makeStorage({ [IDLE_ANIMATIONS_STORAGE_KEY]: 'not-json' })),
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  it('returns true when storage.getItem throws', () => {
+  it('returns false when storage.getItem throws', () => {
     const storage: MockStorage = {
       getItem: vi.fn(() => {
         throw new Error('storage disabled');
       }),
     };
-    expect(readPersistedIdleAnimations(storage)).toBe(true);
+    expect(readPersistedIdleAnimations(storage)).toBe(false);
   });
 
   it('agrees with applyIdleAnimationsBoot on the same input (state-mirror invariant)', () => {

--- a/dashboard/src/utils/idleAnimationsBoot.ts
+++ b/dashboard/src/utils/idleAnimationsBoot.ts
@@ -18,8 +18,12 @@
  * Save so this synchronous boot-time read sees the latest choice.
  *
  * Default behavior (no entry, parse failure, missing storage, or any
- * access error) is ON — matching the shipped iOS-glass design, so the
- * attribute is only ever applied when the user has explicitly opted out.
+ * access error) is OFF (GH #87) — the idle wave animations are decorative
+ * but continuously force the compositor/main-thread to repaint every frame,
+ * measured at ~85% CPU / ~32% GPU at idle on Apple Silicon (M2 Pro). The
+ * `data-idle-animations="off"` attribute is therefore applied by default,
+ * and only the explicit literal boolean `true` (a deliberate opt-in via
+ * Settings) leaves the animations running.
  */
 
 export const IDLE_ANIMATIONS_STORAGE_KEY = 'ts-config:ui.idleAnimationsEnabled';
@@ -36,23 +40,24 @@ function defaultDocument(): Document | null {
 
 /**
  * Synchronously read the persisted Idle animations choice. Returns the
- * boolean equivalent, defaulting to true (animations ON) for any failure
- * mode: missing storage, missing key, JSON parse failure, or storage.getItem
- * throwing. Used by both `applyIdleAnimationsBoot` (DOM-mutating boot path)
- * and by SettingsModal to seed `savedIdleAnimationsRef` so the modal-close
- * revert branch agrees with the attribute the boot probe actually applied.
+ * boolean equivalent, defaulting to false (animations OFF, GH #87) for any
+ * failure mode: missing storage, missing key, JSON parse failure, or
+ * storage.getItem throwing. Only the explicit literal boolean `true` enables
+ * the animations. Used by both `applyIdleAnimationsBoot` (DOM-mutating boot
+ * path) and by SettingsModal to seed `savedIdleAnimationsRef` so the
+ * modal-close revert branch agrees with the attribute the boot probe applied.
  */
 export function readPersistedIdleAnimations(
   storage: StorageReader | null = defaultStorage(),
 ): boolean {
-  if (!storage) return true;
+  if (!storage) return false;
   try {
     const raw = storage.getItem(IDLE_ANIMATIONS_STORAGE_KEY);
-    if (raw !== null) return JSON.parse(raw) !== false;
+    if (raw !== null) return JSON.parse(raw) === true;
   } catch {
-    // fall through to default ON
+    // fall through to default OFF
   }
-  return true;
+  return false;
 }
 
 export function applyIdleAnimationsBoot(

--- a/dashboard/src/utils/migrateLegacyAppearanceConfig.ts
+++ b/dashboard/src/utils/migrateLegacyAppearanceConfig.ts
@@ -7,8 +7,10 @@
  *   - idle animations OFF  (`ui.idleAnimationsEnabled = false`)
  *   - blur effects OFF     (`ui.blurEffectsEnabled = false`)
  * A legacy value of `false` (the old default) simply means animations ON,
- * which is also the new default, so it maps to `idleAnimationsEnabled=true`
- * and leaves blur untouched.
+ * so it maps to an EXPLICIT `idleAnimationsEnabled=true` (preserving that
+ * user's animating experience) and leaves blur untouched. Note: the NEW
+ * default for users with no legacy or new key at all is OFF (GH #87) — the
+ * explicit migration write is what keeps legacy users' setting intact.
  *
  * Runs synchronously against localStorage BEFORE the boot probes
  * (blurEffectsBoot / idleAnimationsBoot) in `index.tsx`, so the very first


### PR DESCRIPTION
## Summary

Fixes the high idle CPU/GPU reported in #87 (and the umbrella #124 symptom 2). On a real Apple Silicon Mac (M2 Pro, native Metal), the dashboard burned **~90% CPU and ~32% GPU while idle** with no model loaded and no server running.

Root cause (measured on hardware, not just code): the idle audio-visualizer's **three wave animations** (`idle-wave-cyan/magenta/orange`) animate `transform`/`opacity` on SVG `<path>` children. Chromium does **not** promote SVG inner-element transforms to a compositor layer, so they repaint on the main thread every frame. The "glass/blur" effect originally suspected is a red herring (~9% CPU, ~0% GPU).

## Hardware measurement (M2 Pro, idle on Session view)

Isolated via CDP by toggling each appearance setting independently:

| State | Total CPU | GPU HW residency |
|---|---|---|
| blur ON + animations ON (old default) | ~90% | ~32% |
| blur OFF, animations ON | ~82% | — |
| blur ON, animations OFF | **~4.7%** | — |
| both OFF | ~4.4% | **0%** |

Turning the animations off drops idle CPU from ~90% to ~5% and GPU to 0%. A "make it composited" CSS refactor was tested too but only halved the main-thread cost (any continuous 60 fps animation keeps the compositor busy), so the decisive fix is to not animate at idle.

## What changed

- Flip `ui.idleAnimationsEnabled` default **true → false** at every default site: `src/config/store.ts` (`DEFAULT_CONFIG`), `electron/main.ts` (store defaults), `components/views/SettingsModal.tsx` (initial state + load fallback), and the pre-paint `src/utils/idleAnimationsBoot.ts` probe.
- `idleAnimationsBoot` now treats **only an explicit literal `true`** as the opt-in; every other value/failure mode falls through to the new default OFF, so a fresh install renders a static idle visualizer with no flash of animation.
- **Blur effects stay ON by default** (cheap, pure cosmetic flair).
- Existing users keep their setting: the legacy `ui.lowIdleUsageEnabled` migration still writes an explicit value, and any explicitly-saved `idleAnimationsEnabled` is respected.
- Users can re-enable animations any time via **Settings → App → Appearance → Idle animations**.

## Test plan

- [x] `idleAnimationsBoot` unit tests rewritten for default-OFF semantics (15 tests) — green
- [x] Full frontend `vitest` suite — 1429 passed (3 pre-existing macOS-env failures: `pasteAtCursor` Wayland/X11 tools, `startupEventWatcher` fs-watch timing — unrelated)
- [x] `tsc --noEmit` (renderer) + `tsc -p electron/tsconfig.json --noEmit` — clean
- [x] UI contract validate + test — passed (no className changes)
- [x] On a real M2 Pro: fresh config (no stored key) → `data-idle-animations="off"` applied at boot, idle waves frozen, idle CPU/GPU collapse confirmed

## Out of scope

A separate, smaller observation about pulsing `animate-ping` status indicators is tracked independently and needs a non-VNC re-measurement before any change (the figure measured here is likely a VNC-encoding artifact). This PR is limited to the decorative idle wave animations.