### PR TITLE
fix(dashboard, electron): forward HF token to Metal host-side model download (gated models while stopped) (GH #124)

### DIFF
--- a/dashboard/electron/__tests__/mlxServerManager.test.ts
+++ b/dashboard/electron/__tests__/mlxServerManager.test.ts
@@ -563,5 +563,27 @@ describe('[GH #136] MLXServerManager native model cache', () => {
         manager.downloadModelToCache('mlx-community/parakeet-tdt-0.6b-v3'),
       ).rejects.toThrow(/gated model/);
     });
+
+    it('forwards the HF token into the download subprocess env when provided (gated models, GH #124)', async () => {
+      mockExistsSync.mockImplementation(
+        (p: string) => p.includes('uvicorn') || p.includes('python3'),
+      );
+      await manager.downloadModelToCache('pyannote/speaker-diarization-community-1', 'hf_tok123');
+      const call = mockExecFile.mock.calls[0]; // [file, args, options, callback]
+      const options = call[2] as { env?: Record<string, string> };
+      expect(options.env?.HF_TOKEN).toBe('hf_tok123');
+      expect(options.env?.HF_HOME).toBeDefined();
+    });
+
+    it('does not set HF_TOKEN when no token is provided', async () => {
+      delete process.env.HF_TOKEN;
+      mockExistsSync.mockImplementation(
+        (p: string) => p.includes('uvicorn') || p.includes('python3'),
+      );
+      await manager.downloadModelToCache('mlx-community/parakeet-tdt-0.6b-v3');
+      const call = mockExecFile.mock.calls[0];
+      const options = call[2] as { env?: Record<string, string> };
+      expect(options.env?.HF_TOKEN).toBeUndefined();
+    });
   });
 });

--- a/dashboard/electron/main.ts
+++ b/dashboard/electron/main.ts
@@ -2406,7 +2406,9 @@ ipcMain.handle('mlx:getLogs', (_event, tail?: number) => {
 
 // Native model-cache ops for the Metal/MLX profile (no Docker container).
 ipcMain.handle('mlx:downloadModelToCache', async (_event, modelId: string) => {
-  await mlxServerManager.downloadModelToCache(modelId);
+  // GH #124 — forward the stored HF token so gated models download while stopped.
+  const hfToken = (store.get('server.hfToken') as string) || undefined;
+  await mlxServerManager.downloadModelToCache(modelId, hfToken);
 });
 
 ipcMain.handle('mlx:checkModelsCached', async (_event, modelIds: string[]) => {

--- a/dashboard/electron/mlxServerManager.ts
+++ b/dashboard/electron/mlxServerManager.ts
@@ -296,7 +296,7 @@ export class MLXServerManager {
    * MLX venv's Python as an independent subprocess, so it works whether or not
    * the Metal server is running.
    */
-  async downloadModelToCache(modelId: string): Promise<void> {
+  async downloadModelToCache(modelId: string, hfToken?: string): Promise<void> {
     const trimmed = this._assertSafeModelId(modelId);
 
     const python = this._resolveVenvPython();
@@ -314,11 +314,21 @@ export class MLXServerManager {
     const pyCmd =
       'import sys; from huggingface_hub import snapshot_download; ' +
       'snapshot_download(sys.argv[1], cache_dir=sys.argv[2])';
+    const env: Record<string, string> = {
+      ...(process.env as Record<string, string>),
+      HF_HOME: hfHome,
+    };
+    // GH #124 — forward the user's HuggingFace token so GATED models (e.g. the
+    // pyannote diarization repo) can be downloaded while the server is stopped.
+    // The token is otherwise injected only at server start, so this standalone
+    // subprocess never saw it and the "add your token in Settings" hint below was
+    // a dead end for gated repos.
+    if (hfToken) env.HF_TOKEN = hfToken;
     try {
       await execFileAsync(python, ['-c', pyCmd, trimmed, hubDir], {
         maxBuffer: 10 * 1024 * 1024,
         timeout: 600_000, // 10 minutes for large models
-        env: { ...process.env, HF_HOME: hfHome },
+        env,
       });
     } catch (err: unknown) {
       const stderr: string = (err as { stderr?: string })?.stderr ?? '';


### PR DESCRIPTION
## Summary

On Apple Silicon / Metal, models download **host-side** via a standalone `snapshot_download` subprocess (`MLXServerManager.downloadModelToCache`), which works whether or not the Metal server is running. But that subprocess built its env as `{ ...process.env, HF_HOME }` with **no `HF_TOKEN`** — the token was injected *only* at server start. So downloading a **gated** model (e.g. the pyannote diarization repo) while the server was stopped failed with `GatedRepoError`, and the in-app remediation ("add your HuggingFace token in Settings") was a dead end because that stored token never reached the download.

This was surfaced while untangling #124 (Model Manager "can't download models while stopped"); the public-model case already worked, this fixes the gated case.

## What changed

- `mlxServerManager.downloadModelToCache(modelId, hfToken?)` — new optional `hfToken`; injected as `HF_TOKEN` into the subprocess env (mirroring `start()`).
- `main.ts` `mlx:downloadModelToCache` IPC handler now sources `server.hfToken` from the store and passes it through (same source `mlx:start` uses).
- No preload/renderer change — the renderer still calls `downloadModelToCache(modelId)`; the main process supplies the token.

## Test plan

- [x] New unit tests: `HF_TOKEN` is forwarded into the download env when provided, and omitted when unset (28 `mlxServerManager` tests pass)
- [x] `tsc -p electron/tsconfig.json --noEmit` — clean
- [x] **Hardware E2E on a real M2 Pro** (replicating the exact subprocess call): gated `pyannote/segmentation-3.0` → **401 Unauthorized without a token**, **downloads successfully (5.7 MB) once the token is forwarded**
- [x] HF token validity confirmed via `whoami-v2`

## Notes

The gated-error message is unchanged (still guides the user to accept the license and set a token) — now that guidance actually works because the token reaches the download. A follow-up could also filter `requiresRuntime: cuda` rows out of the Metal Model Manager so cuda-only models aren't offered there.