### PR TITLE
fix(server, stt): pin SortformerEngine MLX ops to one owning thread + fix model-swap thread leak (GH #124 / #134)

### DIFF
--- a/server/backend/core/model_manager.py
+++ b/server/backend/core/model_manager.py
@@ -802,6 +802,16 @@ class ModelManager:
                 self._diarization_engine.unload()
             except AttributeError:
                 logger.debug("Diarization engine has no unload method")
+            # GH #124 — tear down SortformerEngine's dedicated MLX owning thread so
+            # repeated model swaps don't leak a worker thread per swap. Called from
+            # this (non-owning) thread AFTER unload so the worker isn't shutting
+            # itself down. No-op for engines without the mixin (e.g. pyannote).
+            shutdown_mlx_thread = getattr(self._diarization_engine, "shutdown_mlx_thread", None)
+            if callable(shutdown_mlx_thread):
+                try:
+                    shutdown_mlx_thread()
+                except Exception:
+                    logger.debug("shutdown_mlx_thread failed (non-critical)", exc_info=True)
             self._diarization_engine = None
             clear_gpu_cache()
             logger.info("Diarization model unloaded")

--- a/server/backend/core/sortformer_engine.py
+++ b/server/backend/core/sortformer_engine.py
@@ -18,6 +18,7 @@ from typing import Any
 import numpy as np
 from server.config import get_config
 from server.core.diarization_engine import DiarizationResult, DiarizationSegment
+from server.core.stt.backends.mlx_thread_pin import MLXThreadAffinityMixin, mlx_pinned
 
 logger = logging.getLogger(__name__)
 
@@ -41,11 +42,18 @@ def sortformer_available() -> bool:
     return HAS_MLX_AUDIO
 
 
-class SortformerEngine:
+class SortformerEngine(MLXThreadAffinityMixin):
     """Metal-native speaker diarization via mlx-audio Sortformer.
 
     The interface mirrors :class:`DiarizationEngine` so it can be used as a
     drop-in replacement on Apple Silicon.
+
+    GH #124 — Sortformer is a second Metal-native MLX consumer (the #134 thread
+    pin only covered the four MLX STT backends). The server dispatches diarization
+    on ``asyncio.to_thread`` workers while the engine is materialized elsewhere, so
+    the same cross-thread "no stream (gpu,0)" hazard applies. This engine therefore
+    mixes in :class:`MLXThreadAffinityMixin` and decorates every GPU-touching method
+    with :func:`mlx_pinned`, funnelling all MLX work onto one owning thread.
     """
 
     def __init__(
@@ -63,6 +71,8 @@ class SortformerEngine:
                 "Install with: uv sync --extra mlx"
             )
 
+        # Names the dedicated MLX owning thread (mlx-sortformer-*) for the mixin.
+        self.backend_name = "sortformer"
         self.model_name = model
         self.threshold = threshold
         self.num_speakers = num_speakers
@@ -80,6 +90,7 @@ class SortformerEngine:
 
     # -- lifecycle ---------------------------------------------------------
 
+    @mlx_pinned
     def load(self) -> None:
         """Download (if needed) and load the Sortformer model."""
         if self._loaded:
@@ -90,8 +101,14 @@ class SortformerEngine:
         self._loaded = True
         logger.info("Sortformer model loaded")
 
+    @mlx_pinned
     def unload(self) -> None:
-        """Release model memory."""
+        """Release model memory.
+
+        Runs on the owning MLX thread; the executor itself is torn down separately
+        via :meth:`shutdown_mlx_thread` (called by the model manager) to avoid a
+        worker shutting itself down.
+        """
         if not self._loaded:
             return
         del self._model
@@ -111,6 +128,7 @@ class SortformerEngine:
 
     # -- inference ---------------------------------------------------------
 
+    @mlx_pinned
     def diarize_audio(
         self,
         audio_data: np.ndarray,

--- a/server/backend/tests/test_sortformer_thread_affinity.py
+++ b/server/backend/tests/test_sortformer_thread_affinity.py
@@ -1,0 +1,111 @@
+"""SortformerEngine MLX thread-affinity tests (GH #124 — extends GH #134).
+
+Sortformer is a second Metal-native MLX consumer: the #134 pin covered only the
+four MLX STT backends, but the diarization path dispatches across interchangeable
+``asyncio.to_thread`` workers while the engine is materialized elsewhere, so the
+same cross-thread "no stream (gpu,0)" hazard applies. These tests prove that
+``SortformerEngine`` funnels ``load`` + ``diarize_audio`` onto one dedicated
+owning thread distinct from the callers — WITHOUT mlx-audio or Apple-Silicon
+hardware (fakes record ``threading.get_ident()``).
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import types
+
+import numpy as np
+
+
+def _run_in_new_thread(fn: object) -> dict:
+    box: dict = {}
+
+    def run() -> None:
+        box["tid"] = threading.get_ident()
+        box["ret"] = fn()
+
+    t = threading.Thread(target=run)
+    t.start()
+    t.join()
+    return box
+
+
+class _FakeSeg:
+    def __init__(self, start: float, end: float, speaker: str) -> None:
+        self.start, self.end, self.speaker = start, end, speaker
+
+
+class _FakeResult:
+    def __init__(self, segs: list) -> None:
+        self.segments = segs
+
+
+def _make_engine(monkeypatch, events: list):
+    """Build a SortformerEngine with mlx-audio / soundfile / mlx.core faked out."""
+    import server.core.sortformer_engine as se
+
+    monkeypatch.setattr(se, "HAS_MLX_AUDIO", True)
+
+    class _FakeModel:
+        def generate_stream(self, path, chunk_duration, threshold):  # noqa: ANN001
+            events.append(("generate", threading.get_ident()))
+            yield _FakeResult([_FakeSeg(0.0, 1.0, "0"), _FakeSeg(1.0, 2.0, "1")])
+
+    def _fake_load(name):  # noqa: ANN001
+        events.append(("load", threading.get_ident()))
+        return _FakeModel()
+
+    monkeypatch.setattr(se, "_load_sortformer", _fake_load)
+
+    class _FakeCfg:
+        def get(self, *args, **kwargs):  # noqa: ANN002, ANN003
+            return {}
+
+    monkeypatch.setattr(se, "get_config", lambda: _FakeCfg())
+
+    # diarize_audio / unload do function-level `import soundfile` / `import mlx.core`.
+    fake_sf = types.ModuleType("soundfile")
+    fake_sf.write = lambda *a, **k: None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "soundfile", fake_sf)
+    fake_mlx = types.ModuleType("mlx")
+    fake_core = types.ModuleType("mlx.core")
+    fake_core.clear_cache = lambda: None  # type: ignore[attr-defined]
+    fake_mlx.core = fake_core  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "mlx", fake_mlx)
+    monkeypatch.setitem(sys.modules, "mlx.core", fake_core)
+
+    return se.SortformerEngine()
+
+
+def test_sortformer_inherits_affinity_mixin() -> None:
+    from server.core.sortformer_engine import SortformerEngine
+    from server.core.stt.backends.mlx_thread_pin import MLXThreadAffinityMixin
+
+    assert issubclass(SortformerEngine, MLXThreadAffinityMixin)
+
+
+def test_sortformer_load_and_diarize_share_one_owning_thread(monkeypatch) -> None:
+    events: list[tuple[str, int]] = []
+    engine = _make_engine(monkeypatch, events)
+
+    load_caller = _run_in_new_thread(engine.load)
+    audio = np.zeros(16000, dtype=np.float32)
+    diar_caller = _run_in_new_thread(lambda: engine.diarize_audio(audio, 16000, num_speakers=2))
+
+    owning_ids = {tid for (_, tid) in events}
+    assert len(owning_ids) == 1, "load + generate_stream must run on one owning thread"
+    owning = owning_ids.pop()
+    # The owning thread is still alive (executor not shut down), so it cannot
+    # collide with the now-exited caller threads.
+    assert owning != load_caller["tid"]
+    assert owning != diar_caller["tid"]
+    assert diar_caller["ret"].num_speakers == 2
+
+
+def test_sortformer_shutdown_mlx_thread_is_idempotent(monkeypatch) -> None:
+    events: list[tuple[str, int]] = []
+    engine = _make_engine(monkeypatch, events)
+    engine.load()
+    engine.shutdown_mlx_thread()
+    engine.shutdown_mlx_thread()  # second call must not raise


### PR DESCRIPTION
## Summary

The GH #134 thread pin (`MLXThreadAffinityMixin` + `@mlx_pinned`) funnels MLX GPU work onto one owning thread to avoid the cross-thread `RuntimeError: There is no stream (gpu,0) in current thread` — but it only covered the **four MLX STT backends**. `SortformerEngine` (the default Apple-Silicon diarization engine) is a **second Metal-native MLX consumer** that runs raw `mlx.core` ops (`generate_stream`/`generate`, `clear_cache`) and was **not** pinned.

The server dispatches diarization on `asyncio.to_thread` workers while the engine is materialized on another thread, so the exact same cross-thread hazard applies to the diarization path. It only works today because the upstream MLX 0.31.2 fix masks it; `pyproject` floors only the transitive `parakeet-mlx`/`canary-mlx`/`mlx-audio`, not `mlx` core, so a resolver could pull a regressed `mlx` and silently break Apple-Silicon diarization (fail-open to no speakers).

Also fixes a thread leak: `shutdown_mlx_thread()` had **zero production callers**, so every diarization model swap created a new single-worker thread that was never torn down.

## What changed

- `SortformerEngine` now inherits `MLXThreadAffinityMixin` and decorates `load` / `unload` / `diarize_audio` with `@mlx_pinned` (matching the STT backends). `diarize_file` stays undecorated — it does no direct MLX and calls the pinned `diarize_audio`.
- `ModelManager.unload_diarization_model()` calls `shutdown_mlx_thread()` after `unload()` — from the non-owning caller thread, so the worker isn't shutting itself down. No-op for engines without the mixin (pyannote).

## Test plan

- [x] New `test_sortformer_thread_affinity.py` (3 tests): mixin inheritance, `load`+`diarize_audio` share one owning thread distinct from callers, idempotent `shutdown_mlx_thread`
- [x] Existing `test_mlx_thread_affinity.py` (6) + `test_parallel_diarize.py` still green; 185 diarization/model-manager tests pass; `ruff` clean
- [x] **Hardware E2E on a real M2 Pro**: `load()` on thread A + `diarize_audio()` on thread B both marshal to one owning thread (`owning_tid` ≠ both caller tids), returns 2 speakers with no `no stream (gpu,0)` crash, and `shutdown_mlx_thread` tears the executor down (`executor → None`)

## Note

Flooring `mlx` core in `pyproject` was considered as defense-in-depth but is now redundant: pinning makes diarization correct regardless of the MLX version, so this PR avoids the dependency-resolution churn.