### PR TITLE
fix(server, stt): surface swallowed diarization failures on sync /audio + OpenAI routes (GH #127)

### DIFF
--- a/_bmad-output/implementation-artifacts/investigations/gh-127-investigation.md
+++ b/_bmad-output/implementation-artifacts/investigations/gh-127-investigation.md
@@ -1,0 +1,180 @@
+# Investigation: GH #127 — "Diarization silently fails (DiarizationPipeline use_auth_token kwarg)"
+
+> **Mode:** Verification — confirm none of #127's defects remain in current `main`.
+> Code has moved from `server/…` to `server/backend/…` since the v1.3.5 report.
+
+## Hand-off Brief
+
+1. **What happened.** GH #127 (v1.3.5) reported WhisperX diarization silently producing
+   `num_speakers: 0` because `whisperx_backend.py` called `DiarizationPipeline(use_auth_token=token, …)`
+   but whisperx ≥ 3.8 renamed that kwarg to `token`, raising a `TypeError` that was swallowed and
+   logged only as a warning. **(Confirmed against the original report + git history.)**
+2. **Where the case stands.** The exact defect is **fully absent** from current code, **triple-verified**
+   across 5 dimensions (call site, version pins, tests, other diarization paths, failure surfacing).
+   The fix landed via **PR #178 / commit `d5b2e956`** (which credits the follow-up GH #152) and is in
+   `HEAD` ancestry. One **residual, narrower** silent-failure gap remains on two *secondary* surfaces.
+3. **What's needed next.** Nothing required for #127 — it can be closed/confirmed fixed. The residual
+   silent-failure gap on the synchronous `/audio`+`/file` and OpenAI endpoints has now been **hardened in
+   this change** via an `X-Diarization-Status` response header — see **Follow-up: 2026-06-26** below.
+
+## Case Info
+
+| Field            | Value                                                                      |
+| ---------------- | -------------------------------------------------------------------------- |
+| Ticket           | GH #127 ("Diarization silently fails …"), label: bug; reporter `bearkiter-alt` |
+| Date opened      | 2026-05-30 (verification 2026-06-26)                                        |
+| Status           | **Concluded** — exact defect Confirmed-absent; residual gap hardened (Follow-up 2026-06-26) |
+| System           | Reported on TranscriptionSuite v1.3.5, GPU (CUDA), whisperx 3.8.5 / pyannote 4.0.4 |
+| Evidence sources | GH #127 body; current source; git history; `uv.lock`; `pytest`; GH #152 case file; PR #178 |
+
+## Problem Statement (as reported)
+
+`server/core/stt/backends/whisperx_backend.py:327` called
+`DiarizationPipeline(use_auth_token=token, device=self._device)`. The image shipped whisperx 3.8.5 /
+pyannote.audio 4.0.4, where `DiarizationPipeline.__init__` is `(model_name=None, token=None, device="cpu",
+cache_dir=None)` — `use_auth_token` was removed in favour of `token`. The call raised
+`TypeError: … unexpected keyword argument 'use_auth_token'`, caught upstream and logged only as a warning,
+so diarization was silently skipped while `/api/status` reported `diarization: { available: true,
+reason: "ready" }`. Reporter's fix: `use_auth_token=` → `token=`, and update the stale test mocks.
+
+## Verification Result (5 dimensions, each finder + 2 adversarial skeptics, all High confidence)
+
+| # | Dimension | Verdict | Key evidence |
+| - | --------- | ------- | ------------ |
+| 1 | Call site uses correct kwarg | **CLEAN** | `whisperx_backend.py:349` `DiarizationPipeline(token=token, device=self._device)`; no production call passes `use_auth_token=` anywhere |
+| 2 | Dependency versions compatible | **CLEAN** | pin `whisperx>=3.8.1` (`pyproject.toml:67`); `uv.lock` resolves whisperx **3.8.6** + pyannote-audio **4.0.4** deterministically — both `token=` era |
+| 3 | Tests fixed + regression guard | **CLEAN** | 3 mocks model `token=` (`test_whisperx_backend.py:224/467/537`); real-signature guard `test_real_diarization_pipeline_accepts_token_kwarg` (`:580-610`) asserts `token` binds and `use_auth_token` is absent. `pytest`: 17 passed, 1 skipped (guard skips where whisperx not installed) |
+| 4 | Failure no longer silent | **PARTIAL** | Fixed on the file-import + Audio-Notebook paths (structured `diarization_outcome` shipped to client); residual silent gap on sync `/audio`+`/file` and OpenAI endpoints |
+| 5 | No analogous bug in other diar paths | **CLEAN** | `diarization_engine.py:216` `Pipeline.from_pretrained(self.model, token=self.hf_token)`; `bootstrap_runtime.py:1094` `from_pretrained(model, token=token)`; `parallel_diarize.py` delegates (no kwarg surface); VibeVoice backends `del hf_token` (native diarization) |
+
+## Confirmed Findings
+
+### Finding 1 — The exact #127 kwarg defect is gone (Dimensions 1, 2, 5)
+
+`server/backend/core/stt/backends/whisperx_backend.py:349`:
+`diarize_model = DiarizationPipeline(token=token, device=self._device)` — the renamed kwarg.
+Repo-wide, the only `use_auth_token` occurrences are (a) the explanatory comment at
+`whisperx_backend.py:346-348` and (b) the *absence*-asserting guard test at
+`test_whisperx_backend.py:608-609`. No live call uses the removed kwarg. Every other diarization
+pipeline constructor (`diarization_engine.py:216`, `server/docker/bootstrap_runtime.py:1094`) also uses
+`token=`. Locked versions (`uv.lock`: whisperx 3.8.6, pyannote-audio 4.0.4) are in the `token=` era.
+
+### Finding 2 — Regression protection now exists (Dimension 3)
+
+`test_whisperx_backend.py:580-610` (`test_real_diarization_pipeline_accepts_token_kwarg`) introspects the
+*real* `whisperx.diarize.DiarizationPipeline.__init__` signature: it `sig.bind_partial(token=…, device=…)`
+and asserts `"use_auth_token" not in sig.parameters`, failing loudly if whisperx ever reverts. This turns
+the one-off #127 fix into a guard against the whole *class* of kwarg-drift bug (the root failure mode of
+both #127 and its recurrence #152). It is skipped only in the lightweight unit env; it runs in the
+Docker / integration CI where whisperx is installed.
+
+### Finding 3 — The "silent" symptom is fixed where #127 was reported (Dimension 4, partial)
+
+The originally-reported flows (file import + Audio Notebook) now build a structured
+`diarization_outcome = {"requested", "performed", "reason"}` and ship it to the client:
+- `transcription.py:937-938` set `reason="ready"` **only on success**; `:956-958` set `"token_missing"`;
+  `:965` set `"unavailable"` on a generic integrated-diarization failure (and it now logs `logger.error`,
+  not a bare warning), then falls back to the pyannote path; the dict is delivered via the job result at
+  `transcription.py:1064` (`"diarization": diarization_outcome`).
+- `notebook.py` mirrors this (outcome built ~`:888`, shipped ~`:1145`).
+
+So a diarization failure on these surfaces is no longer a fake `"ready"` with no speakers — the client
+receives `performed: false` + a distinct `reason`. (This is exactly the UX gap GH #152's case file flagged
+as its open item #5, now closed for these paths.)
+
+## Residual Gap (narrower than #127, not an active reproduction of it)
+
+`transcription.py` synchronous `transcribe_audio` (POST `/audio`, `/file`) and `openai_audio.py` still
+swallow a *generic* diarization runtime failure:
+- `transcription.py:400-406`: `except Exception:` → `logger.warning(…)` + `diarization = False`, falling
+  through to a non-diarized transcript with **no diarization status field** in `result_dict`.
+- `transcription.py:447`: `if diar_result is not None:` has **no `else`** — when the parallel/sequential
+  diarizer returns `(result, None)` on failure (`parallel_diarize.py:93/250` only `logger.warning` +
+  return `None`), the merge is silently skipped and `num_speakers: 0` is returned with no signal.
+- `openai_audio.py:188-200` / `:234-239`: same swallow; mitigating context — the OpenAI-compatible
+  response schema has no diarization-status field by design.
+
+**Why this is *not* a live #127:** #127's silent failure was *triggered by* the `use_auth_token` TypeError
+on every run. That trigger is gone. The residual gap only fires on *other* diarization runtime failures
+(e.g. CUDA OOM / the 8 GB WSL2 fault from #152, a genuinely missing model). It is a defense-in-depth gap,
+not a reproduction of the reported bug. Also note the token-missing `ValueError` now **re-raises as HTTP
+400** on the sync path (`transcription.py:395-399`), so the most likely misconfiguration *does* surface.
+
+## Source Code Trace
+
+| Element       | Detail                                                                                        |
+| ------------- | --------------------------------------------------------------------------------------------- |
+| Original error origin | `whisperx_backend.py` `DiarizationPipeline(use_auth_token=…)` — **now `token=` at `:349`** |
+| Fix commit    | `d5b2e956` (PR #178, "repair WhisperX single-pass diarization broken by token kwarg rename", credits GH #152); in `HEAD` ancestry |
+| Guard         | `tests/test_whisperx_backend.py:580-610` (real-signature conformance, GH #152)                 |
+| Outcome reporting (fixed) | `transcription.py:888-965` + `:1064`; `notebook.py:~888` + `:~1145`              |
+| Residual silent paths | `transcription.py:400-406` & `:447` (no `else`); `openai_audio.py:188-200` & `:234-239`; `parallel_diarize.py:93/250` |
+
+## Conclusion
+
+**Confidence: High.** Every defect named in GH #127 is absent from current `main`: the call site uses
+`token=`, the locked dependencies (whisperx 3.8.6 / pyannote 4.0.4) are in the renamed-kwarg era, the test
+mocks were corrected, and a real-signature regression guard now fails loudly on any future revert. The
+deeper "silently fails" symptom is resolved on the two surfaces where #127 was reported (file import +
+Audio Notebook). A smaller, *different* silent-degradation pattern persists on the synchronous `/audio`
+endpoint and the OpenAI endpoint for generic (non-token) diarization failures — worth hardening, but not a
+recurrence of #127. **GH #127 can be closed as fixed.**
+
+## Recommended Next Steps
+
+1. **Close / confirm #127** as resolved (fixed by PR #178). Reference this verification.
+2. **Optional hardening (own ticket):** thread a `diarization_outcome`-style signal through the
+   synchronous `transcribe_audio` path and (where the schema allows) the OpenAI endpoint, so a generic
+   diarization failure isn't invisible. Reuse the `transcription.py:888-965` pattern.
+3. **No code change is required to satisfy the #127 report itself.**
+
+## Side Findings
+
+- The `pyproject.toml` whisperx/pyannote pins are lower-bound (`>=`) with no upper cap. A latent (not
+  active) drift risk: a future re-resolve could pick a whisperx that hypothetically reverts the kwarg. The
+  committed `uv.lock` (3.8.6) makes the build deterministic, and the `:608` guard test would catch a
+  revert in CI — so this is acceptable, just noted.
+- Related case file `gh-152-investigation.md` is the deep forensic root-cause analysis that drove PR #178;
+  this file is the post-fix verification counterpart.
+
+## Follow-up: 2026-06-26
+
+### Residual silent-failure gap hardened (Dimension 4 → now clean)
+
+The PARTIAL finding (Dimension 4) — that the synchronous `transcribe_audio` route (`POST /audio`, `/file`)
+and the OpenAI-compatible endpoints still returned `num_speakers: 0` with no signal on a *generic*
+diarization runtime failure — has been fixed in this change.
+
+**Mechanism — `X-Diarization-Status` response header** (`ready` | `unavailable`), set only when diarization
+was requested:
+
+- **Native sync route** (`api/routes/transcription.py`): `transcribe_audio` gained a FastAPI-injected
+  `response: Response = None` param and a nested `_attach_diar_status()` helper applied at all three return
+  sites (multitrack, integrated single-pass, standard). `diarization_requested` is captured *before* any
+  fallback can reset `diarization` to `False`.
+- **OpenAI routes** (`api/routes/openai_audio.py`): new `_set_diarization_status_header()` applied in
+  `create_transcription` and `create_translation` after `_build_response`.
+
+**Why a header, not a body field.** `transcribe_audio` is bound to `response_model=TranscriptionResponse`,
+which **strips any extra body key over real HTTP** (empirically verified — a `result_dict["diarization"]`
+addition was confirmed dropped from the wire response while a header survives). The OpenAI body is a
+standardized schema with no diarization field, so a header is the only non-breaking channel there too.
+The async file-import + Audio-Notebook job paths keep their structured body `diarization_outcome` (a polled
+job result has no response-header channel) — they were intentionally left unchanged.
+
+**"Performed" signal.** Derived from whether the final result carried speaker labels (`num_speakers > 0`),
+which is exactly #127's user-visible symptom and is uniform across every failure path (integrated raise,
+orchestration failure, merge failure, `diar_result is None`). Token-missing on the sync route still surfaces
+as HTTP 400 (`ValueError` re-raise), so the header is reserved for the soft-degrade cases.
+
+**Tests (TDD, RED→GREEN).** `tests/test_audio_route_durability.py::TestDiarizationOutcomeSurfacing` (integrated
+failure→`unavailable`, integrated success→`ready`, no-request→no header, **plus an end-to-end `TestClient`
+test proving the header survives `response_model` serialization** — the regression guard for the body-field
+blind spot) and `tests/test_openai_audio_routes.py::TestDiarizationOutcomeHeaderOverOpenAI` (transcription +
+translation failure→`unavailable`, success→`ready`, no-request→no header). Full backend suite green
+(2002 passed, 4 skipped); ruff clean. Independent code review: APPROVE, no CRITICAL/HIGH.
+
+**Residual (LOW, accepted):** empty/silent audio with diarization requested reports `unavailable` (it
+genuinely produced no speakers); the sync `ready` threshold (`num_speakers > 0`) is marginally stricter than
+file-import's (`diar_result is not None`) on the rare diar-ran-but-merged-zero-speakers path. Neither is a
+correctness defect.

--- a/server/backend/api/routes/openai_audio.py
+++ b/server/backend/api/routes/openai_audio.py
@@ -312,6 +312,23 @@ async def _dispatch_completion_webhook(*, source_label: str, result: Any, filena
     )
 
 
+def _set_diarization_status_header(
+    response: JSONResponse | PlainTextResponse, result: Any, *, requested: bool
+) -> None:
+    """Surface whether a *requested* diarization actually produced speaker labels
+    via an ``X-Diarization-Status`` header (GH #127).
+
+    The OpenAI response body schema has no diarization field, so a swallowed
+    diarization failure would otherwise be invisible — the header lets clients
+    that care detect it (``ready`` vs ``unavailable``) while leaving the
+    standardized body untouched. Not set when diarization was not requested.
+    """
+    if not requested:
+        return
+    performed = (getattr(result, "num_speakers", 0) or 0) > 0
+    response.headers["X-Diarization-Status"] = "ready" if performed else "unavailable"
+
+
 # ------------------------------------------------------------------
 # POST /v1/audio/transcriptions
 # ------------------------------------------------------------------
@@ -412,9 +429,11 @@ async def create_transcription(
             "verbose_json",
             "diarized_json",
         }
-        return _build_response(
+        api_response = _build_response(
             result, response_format, task="transcribe", include_words=include_words
         )
+        _set_diarization_status_header(api_response, result, requested=diarization)
+        return api_response
 
     except TranscriptionCancelledError:
         return _openai_error(500, "Transcription was cancelled", error_type="server_error")
@@ -528,9 +547,11 @@ async def create_translation(
             "verbose_json",
             "diarized_json",
         }
-        return _build_response(
+        api_response = _build_response(
             result, response_format, task="translate", include_words=include_words
         )
+        _set_diarization_status_header(api_response, result, requested=diarization)
+        return api_response
 
     except TranscriptionCancelledError:
         return _openai_error(500, "Transcription was cancelled", error_type="server_error")

--- a/server/backend/api/routes/transcription.py
+++ b/server/backend/api/routes/transcription.py
@@ -16,7 +16,16 @@ import tempfile
 from pathlib import Path
 from typing import Any, Literal
 
-from fastapi import APIRouter, BackgroundTasks, File, Form, HTTPException, Request, UploadFile
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    File,
+    Form,
+    HTTPException,
+    Request,
+    Response,
+    UploadFile,
+)
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from server.api.routes.utils import get_client_name
@@ -76,6 +85,7 @@ class TranscriptionResponse(BaseModel):
 @router.post("/file", response_model=TranscriptionResponse, include_in_schema=False)
 async def transcribe_audio(
     request: Request,
+    response: Response = None,  # noqa: RUF013 — FastAPI injects; used to set the diarization-status header
     file: UploadFile = File(...),  # noqa: B008
     language: str | None = Form(None),
     translation_enabled: bool = Form(False),
@@ -222,6 +232,22 @@ async def transcribe_audio(
         if diarization is None:
             diarization = False
 
+    # Whether the caller asked for diarization, captured BEFORE any failure
+    # path can reset ``diarization`` to False. Lets the integrated/standard
+    # return paths report a swallowed diarization failure to the client via an
+    # ``X-Diarization-Status`` header instead of an unexplained num_speakers: 0
+    # (GH #127). A header is used (not a body field) because this route is bound
+    # to response_model=TranscriptionResponse, which would strip an extra key.
+    diarization_requested = bool(diarization)
+
+    def _attach_diar_status(result_dict: dict[str, Any]) -> dict[str, Any]:
+        """Set X-Diarization-Status (ready|unavailable) when diarization was
+        requested, derived from whether speaker labels were actually produced."""
+        if response is not None and diarization_requested:
+            performed = (result_dict.get("num_speakers") or 0) > 0
+            response.headers["X-Diarization-Status"] = "ready" if performed else "unavailable"
+        return result_dict
+
     # Moved inside the main try/except/finally so that tempfile I/O failures
     # (client disconnect during read, disk full, etc.) trigger mark_failed and
     # end_job via the shared handlers below, instead of leaking a 'processing'
@@ -317,7 +343,7 @@ async def transcribe_audio(
                         _e,
                     )
 
-            return result_dict
+            return _attach_diar_status(result_dict)
 
         # Check if the backend supports single-pass diarization (WhisperX)
         backend = engine._backend
@@ -385,7 +411,7 @@ async def transcribe_audio(
                             _e,
                         )
 
-                return result_dict
+                return _attach_diar_status(result_dict)
 
             except TranscriptionCancelledError:
                 # User cancellation must not be silently converted to "fallback to
@@ -530,7 +556,7 @@ async def transcribe_audio(
                     _e,
                 )
 
-        return result_dict
+        return _attach_diar_status(result_dict)
 
     except ValueError as e:
         # Skip mark_failed if we already persisted a completed result — a later

--- a/server/backend/tests/test_audio_route_durability.py
+++ b/server/backend/tests/test_audio_route_durability.py
@@ -798,3 +798,217 @@ class TestIntegratedDiarizationFallback:
         call = end_job_calls[0]
         assert call["job_id"] == "import-job-abc"
         assert call["result"]["error"] == "Transcription cancelled by user"
+
+
+# ── Diarization-outcome surfacing (GH #127 hardening) ───────────────────────
+#
+# #127: a diarization runtime failure was swallowed and the sync /audio route
+# returned num_speakers: 0 with NO signal to the client. These tests pin the
+# fix: when diarization was *requested*, an ``X-Diarization-Status`` response
+# header reports whether speaker labels were actually produced, so a silent
+# skip is visible. A header is used (not a body field) because the route is
+# bound to ``response_model=TranscriptionResponse``, which strips any extra
+# body key over real HTTP.
+
+
+def _make_diar_engine(monkeypatch, *, num_speakers: int | None, fail: bool):
+    """Build an engine whose integrated diarization either fails or returns
+    ``num_speakers`` speakers (mirrors TestIntegratedDiarizationPath setup).
+
+    ``monkeypatch`` is required so the injected fake ``server.core.stt.engine``
+    module is restored after the test — a raw ``sys.modules`` assignment would
+    leak the stub and break later tests that patch the real engine module.
+    """
+    import sys
+    import types as _types
+    from dataclasses import dataclass, field
+
+    @dataclass
+    class _FakeTranscriptionResult:
+        text: str = ""
+        segments: list = field(default_factory=list)
+        words: list = field(default_factory=list)
+        language: str | None = None
+        language_probability: float = 0.0
+        duration: float = 0.0
+        num_speakers: int = 0
+
+        def to_dict(self) -> dict:
+            return {
+                "text": self.text,
+                "segments": self.segments,
+                "words": self.words,
+                "language": self.language,
+                "language_probability": self.language_probability,
+                "duration": self.duration,
+                "num_speakers": self.num_speakers,
+            }
+
+    fake_engine_mod = _types.ModuleType("server.core.stt.engine")
+    fake_engine_mod.TranscriptionResult = _FakeTranscriptionResult  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "server.core.stt.engine", fake_engine_mod)
+
+    class _DiarBackend:
+        preferred_input_sample_rate_hz = 16000
+        backend_name = "fake-whisperx"
+
+        def transcribe_with_diarization(self, audio_data, *, audio_sample_rate, **kwargs):
+            if fail:
+                raise RuntimeError("diarization model exploded")
+            return SimpleNamespace(
+                segments=[{"text": "hi", "speaker": "S1"}],
+                words=[],
+                language="en",
+                language_probability=0.9,
+                num_speakers=num_speakers,
+            )
+
+    return SimpleNamespace(
+        _backend=_DiarBackend(),
+        beam_size=5,
+        initial_prompt=None,
+        suppress_tokens=None,
+        faster_whisper_vad_filter=False,
+        # Plain-transcription fallback used when integrated diarization fails.
+        transcribe_file=lambda *a, **kw: _ResultStub(num_speakers=0),
+    )
+
+
+def _run_diar_audio(engine, response, monkeypatch, *, diarization=True):
+    from server.core import audio_utils
+
+    monkeypatch.setattr(audio_utils, "load_audio", lambda *a, **kw: ([0.0] * 16000, 16000))
+    req = _request_with_engine(engine)
+    return asyncio.run(
+        transcription.transcribe_audio(
+            request=req,
+            file=_UploadStub(),
+            response=response,
+            language=None,
+            translation_enabled=False,
+            translation_target_language=None,
+            word_timestamps=None,
+            diarization=diarization,
+            expected_speakers=None,
+            parallel_diarization=None,
+            multitrack=False,
+        )
+    )
+
+
+class TestDiarizationOutcomeSurfacing:
+    def test_integrated_failure_sets_unavailable_header(self, repo_mocks, monkeypatch):
+        """Integrated diarization raises → falls back to plain transcription →
+        header reports 'unavailable', not a silent num_speakers: 0."""
+        from starlette.responses import Response
+
+        engine = _make_diar_engine(monkeypatch, num_speakers=None, fail=True)
+        response = Response()
+        result = _run_diar_audio(engine, response, monkeypatch)
+
+        assert result["num_speakers"] == 0
+        assert response.headers.get("X-Diarization-Status") == "unavailable"
+
+    def test_integrated_success_sets_ready_header(self, repo_mocks, monkeypatch):
+        """A successful integrated diarization reports 'ready'."""
+        from starlette.responses import Response
+
+        engine = _make_diar_engine(monkeypatch, num_speakers=2, fail=False)
+        response = Response()
+        result = _run_diar_audio(engine, response, monkeypatch)
+
+        assert result["num_speakers"] == 2
+        assert response.headers.get("X-Diarization-Status") == "ready"
+
+    def test_no_diarization_request_omits_header(self, repo_mocks):
+        """When diarization is not requested, no header is added and the body
+        shape is unchanged."""
+        from starlette.responses import Response
+
+        fake_result = _ResultStub()
+        engine = SimpleNamespace(_backend=None, transcribe_file=lambda *a, **kw: fake_result)
+        req = _request_with_engine(engine)
+        response = Response()
+        result = asyncio.run(
+            transcription.transcribe_audio(
+                request=req,
+                file=_UploadStub(),
+                response=response,
+                language=None,
+                translation_enabled=False,
+                translation_target_language=None,
+                word_timestamps=None,
+                diarization=None,
+                expected_speakers=None,
+                parallel_diarization=None,
+                multitrack=False,
+            )
+        )
+
+        assert "diarization" not in result
+        assert "X-Diarization-Status" not in response.headers
+
+    def test_header_propagates_over_real_http(self, monkeypatch):
+        """End-to-end via TestClient: the X-Diarization-Status header reaches the
+        actual HTTP response, proving response_model=TranscriptionResponse does
+        NOT strip the signal. This is the regression guard for the blind spot a
+        body field would have hit (the direct-call tests above mutate the
+        Response object but never exercise FastAPI's serialization pipeline)."""
+        import io
+
+        from fastapi import FastAPI
+        from starlette.testclient import TestClient
+
+        # No integrated backend → standard parallel/sequential diarization path.
+        engine = SimpleNamespace(
+            _backend=None,
+            transcribe_file=lambda *a, **kw: _ResultStub(num_speakers=0),
+        )
+
+        app = FastAPI()
+        app.include_router(transcription.router)
+        app.state.model_manager = SimpleNamespace(
+            transcription_engine=engine,
+            ensure_transcription_loaded=lambda: engine,
+            job_tracker=SimpleNamespace(
+                try_start_job=lambda _c: (True, "job-http", None),
+                is_cancelled=lambda: False,
+                end_job=lambda _j: None,
+            ),
+        )
+        app.state.config = SimpleNamespace(get=lambda *a, default=None, **kw: default)
+
+        # Orchestrator returns (result, None) → no speaker labels → "unavailable".
+        monkeypatch.setattr(
+            "server.core.parallel_diarize.transcribe_and_diarize",
+            lambda *a, **kw: (_ResultStub(num_speakers=0), None),
+        )
+        monkeypatch.setattr(
+            "server.core.parallel_diarize.transcribe_then_diarize",
+            lambda *a, **kw: (_ResultStub(num_speakers=0), None),
+        )
+        # Neutralize side effects (auth gate, DB, webhook).
+        monkeypatch.setattr(transcription, "_assert_main_model_selected", lambda _r: None)
+        monkeypatch.setattr(transcription, "get_client_name", lambda _r: "test-client")
+        monkeypatch.setattr(transcription, "create_job", lambda **kw: None)
+        monkeypatch.setattr(transcription, "save_result", lambda **kw: None)
+        monkeypatch.setattr(transcription, "mark_delivered", lambda *a, **kw: None)
+        monkeypatch.setattr(transcription, "mark_failed", lambda *a, **kw: None)
+        monkeypatch.setattr(transcription, "set_audio_hash", lambda *a, **kw: None)
+
+        async def _no_webhook(*a, **kw):
+            return None
+
+        monkeypatch.setattr("server.core.webhook.dispatch", _no_webhook)
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            "/audio",
+            files={"file": ("test.wav", io.BytesIO(b"RIFF" + b"\x00" * 100), "audio/wav")},
+            data={"diarization": "true"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.headers.get("X-Diarization-Status") == "unavailable"
+        # Body stays exactly the response_model shape — no extra diarization key.
+        assert "diarization" not in resp.json()

--- a/server/backend/tests/test_openai_audio_routes.py
+++ b/server/backend/tests/test_openai_audio_routes.py
@@ -1085,3 +1085,51 @@ class TestDiarizationOverOpenAI:
         assert all("speaker" not in seg for seg in verbose_body["segments"])
         assert "SPEAKER_" not in resp_srt.text
         assert "Speaker 1:" not in resp_srt.text
+
+
+class TestDiarizationOutcomeHeaderOverOpenAI:
+    """GH #127 hardening: a diarization runtime failure on the OpenAI-compat
+    routes must be visible to the client. The standardized OpenAI response body
+    has no diarization field, so the signal rides on an ``X-Diarization-Status``
+    response header (clients that don't care simply ignore it)."""
+
+    def test_success_sets_ready_header(self, diarization_client):
+        client, _ = diarization_client
+        speaker_result = _make_diarized_result()  # num_speakers == 2
+        with _patch_parallel_diarize((speaker_result, None)):
+            resp = _upload(client, diarization="true", response_format="verbose_json")
+
+        assert resp.status_code == 200
+        assert resp.headers.get("X-Diarization-Status") == "ready"
+
+    def test_failure_sets_unavailable_header(self, diarization_client):
+        client, _ = diarization_client
+        plain = _make_result(num_speakers=0)  # diarization produced no speakers
+        with _patch_parallel_diarize((plain, None)):
+            resp = _upload(client, diarization="true", response_format="json")
+
+        assert resp.status_code == 200
+        # Body stays schema-clean; the failure rides on the header only.
+        assert resp.json() == {"text": "Hello world"}
+        assert resp.headers.get("X-Diarization-Status") == "unavailable"
+
+    def test_translation_failure_sets_unavailable_header(self, diarization_client):
+        client, _ = diarization_client
+        plain = _make_result(num_speakers=0)
+        with _patch_parallel_diarize((plain, None)):
+            resp = _upload(
+                client,
+                path="/v1/audio/translations",
+                diarization="true",
+                response_format="json",
+            )
+
+        assert resp.status_code == 200
+        assert resp.headers.get("X-Diarization-Status") == "unavailable"
+
+    def test_no_diarization_request_omits_header(self, openai_client):
+        client, _ = openai_client
+        resp = _upload(client, response_format="json")
+
+        assert resp.status_code == 200
+        assert "X-Diarization-Status" not in resp.headers


### PR DESCRIPTION
## Summary

GH #127 (*"Diarization silently fails"*) reported that WhisperX diarization returned `num_speakers: 0` with no error, because `DiarizationPipeline(use_auth_token=…)` raised a `TypeError` (whisperx ≥3.8 renamed the kwarg to `token`) that was swallowed and logged only as a warning.

**The exact kwarg defect is already fixed in `main`** (PR #178 / `d5b2e956`, which credits the follow-up GH #152), and I verified it is fully absent from current code — triple-verified across 5 dimensions (call site, version pins, tests, regression guard, other diarization paths). That verification is documented in the new case file `_bmad-output/.../investigations/gh-127-investigation.md`.

This PR addresses the **residual half of the issue's "silent" complaint**: even with the kwarg fixed, a *generic* diarization runtime failure (CUDA OOM, the 8 GB WSL2 fault from #152, a missing model, etc.) on the **synchronous `transcribe_audio` route** (`POST /audio`, `/file`) and the **OpenAI-compatible endpoints** still returned `num_speakers: 0` with no signal to the client. (The async file-import and Audio-Notebook job paths already surface a structured `diarization_outcome` and are unchanged.)

## What changed

- **Native sync route** (`api/routes/transcription.py`): sets an `X-Diarization-Status: ready|unavailable` response header when diarization was requested, via a FastAPI-injected `response` param + a nested `_attach_diar_status()` helper applied at all three return sites (multitrack, integrated single-pass, standard). `diarization_requested` is captured *before* any fallback can reset the flag.
- **OpenAI routes** (`api/routes/openai_audio.py`): `_set_diarization_status_header()` applied in `create_transcription` and `create_translation`.

### Why a header, not a body field
`transcribe_audio` is bound to `response_model=TranscriptionResponse`, which **strips any extra body key over real HTTP** (empirically verified, and now pinned by an end-to-end test). The OpenAI body is a standardized schema with no diarization field. A header surfaces the signal on both without changing any response body — **non-diarization responses are byte-identical**. The "performed" signal is derived from whether speaker labels were produced (`num_speakers > 0`), which matches #127's exact symptom and is uniform across every failure path. Token-missing on the sync route still surfaces as HTTP 400 (`ValueError` re-raise), so the header is reserved for soft-degrade cases.

## Test plan

- [x] `tests/test_audio_route_durability.py::TestDiarizationOutcomeSurfacing` — integrated failure → `unavailable`, integrated success → `ready`, no-request → no header, **plus an end-to-end `TestClient` test proving the header survives `response_model` serialization** (regression guard for the body-field blind spot).
- [x] `tests/test_openai_audio_routes.py::TestDiarizationOutcomeHeaderOverOpenAI` — transcription + translation failure → `unavailable`, success → `ready`, no-request → no header.
- [x] Full backend suite green (2002 passed, 4 skipped); `ruff check` + `ruff format` clean.
- [x] Independent code review: APPROVE, no CRITICAL/HIGH.

Closes the residual silent-failure gap tracked in the GH #127 case file. The original kwarg defect was already resolved by PR #178.