### PR TITLE
fix(dashboard, ui): stop the duplicate-detection modal from blocking unattended Folder Watch batches (GH-120)

### DIFF
--- a/_bmad-output/implementation-artifacts/investigations/gh-120-investigation.md
+++ b/_bmad-output/implementation-artifacts/investigations/gh-120-investigation.md
@@ -1,0 +1,229 @@
+# Investigation: GH #120 — "Possible duplicate detected" pop-up impedes batch / Folder Watch processing
+
+## Hand-off Brief
+
+1. **What happened.** During unattended Folder Watch / batch import, every re-imported file that
+   matches a previously-transcribed file's audio hash raises a blocking, interactive "Possible
+   duplicate detected" modal that stalls the whole import queue until a human clicks — confirmed
+   reproducible by code path (`dashboard/src/stores/importQueueStore.ts:303`).
+2. **Where the case stands.** **Concluded — bug is STILL PRESENT (High confidence).** Five
+   independent adversarial lenses (frontend, backend, settings/config/env, other-surfaces, git/test
+   history) all failed to refute it; no escape hatch (setting, flag, env, auto-resolve, or job-type
+   branch) exists anywhere. Issue is still OPEN on GitHub; no commit/PR/branch references #120.
+3. **What's needed next.** Add an **unattended duplicate policy** for `session-auto` (Folder Watch)
+   jobs — a per-job choice resolved without the modal (default: *create new*), surfaced as a
+   setting (Ask / Always create new / Always skip). Implementation is a small, well-scoped change.
+
+## Case Info
+
+| Field            | Value                                                                                  |
+| ---------------- | -------------------------------------------------------------------------------------- |
+| Ticket           | GH #120 (OPEN, label: bug). Filed 2026-05-12.                                            |
+| Date opened      | 2026-06-26                                                                              |
+| Status           | Concluded                                                                               |
+| System           | Electron dashboard (React/TS) + FastAPI server. Folder Watch / batch import workflow.   |
+| Evidence sources | GitHub issue + screenshot; current source (dashboard + server); git history; test suite |
+
+## Problem Statement
+
+User ran an overnight batch via "Folder watch". Some files transcribed successfully; the run then
+stopped. To resume, the user created a new watch folder, placed remaining audio files, and waited.
+Instead of processing unattended, a **"Possibe duplicate detected. This recording matches an existing
+one: 'c3b4c22a' from 5/7/2026. Use the existing transcript, or create a new entry?"** modal popped up
+for *each* file, requiring a manual choice every time. Net effect: the batch can no longer run
+unsupervised. (User also asked, secondarily, how to delete the existing recordings.)
+
+## Evidence Inventory
+
+| Source                                   | Status    | Notes                                                                 |
+| ---------------------------------------- | --------- | --------------------------------------------------------------------- |
+| GitHub issue #120 + screenshot           | Available | Modal copy matches `DedupPromptModal.tsx:62,67,77` verbatim           |
+| `dashboard/src/stores/importQueueStore.ts` | Available | Root cause: `processSessionJob` dedup gate (lines 303–329)            |
+| `dashboard/src/stores/dedupChoiceStore.ts` | Available | Promise resolves only via interactive modal — no auto/timeout         |
+| `dashboard/components/import/*`            | Available | `DedupChoiceContainer`, `DedupPromptModal` — purely interactive        |
+| `server/backend/api/routes/transcription.py` | Available | `/import` always returns `dedup_matches` (lines 1247–1261, 1301)      |
+| Dashboard config store / Electron defaults | Available | No dedup policy key (`store.ts`, `main.ts:533`)                        |
+| `SettingsModal.tsx`                       | Available | No dedup/duplicate control                                            |
+| Server `config.py` / `config.yaml`        | Available | No dedup config key; no DEDUP/SKIP_DEDUP env var                      |
+| Test suite (dedup + importQueue)          | Available | Only interactive choice covered; no unattended-bypass test            |
+| Git history (all branches)                | Available | Flow introduced under #104 (`4ac23e60`, 2026-05-04); #120 unaddressed |
+
+## Confirmed Findings
+
+### Finding 1: The dedup gate blocks the import queue for ALL session jobs, including Folder Watch
+
+**Evidence:** `dashboard/src/stores/importQueueStore.ts:303-329`
+
+**Detail:** Inside `processSessionJob`, after `importAndTranscribe`, the code does
+`if (importResponse.dedup_matches?.length) { const choice = await useDedupChoiceStore.getState().requestChoice(...) }`.
+This branch is keyed *only* on `dedup_matches.length` — there is **no** check on `job.type`. The
+serial `processQueue` while-loop (`importQueueStore.ts:418-471`) `await`s `processSessionJob`, so a
+single unanswered modal halts the entire batch.
+
+### Finding 2: Folder Watch (`session-auto`) jobs run the identical blocking path as manual jobs
+
+**Evidence:** `importQueueStore.ts:426` (`isSession = type === 'session-normal' || 'session-auto'`),
+`:437-438` (both routed to `processSessionJob`), `:702` (watcher enqueues `'session-auto'`).
+
+**Detail:** `handleFilesDetected(type:'session')` enqueues `session-auto` jobs that flow through the
+same `processSessionJob`, so unattended watched files hit the same interactive modal as manual imports.
+
+### Finding 3: The dedup-choice promise can only be resolved by a human
+
+**Evidence:** `dashboard/src/stores/dedupChoiceStore.ts:43-63`; `DedupChoiceContainer.tsx:20-23`;
+`App.tsx:821`.
+
+**Detail:** `requestChoice` returns a Promise resolved exclusively by `resolveChoice`, which is called
+only by the interactive `DedupPromptModal` (button click / Esc / backdrop close). There is **no
+timeout, no default choice, no programmatic/unattended resolver.** The queue therefore blocks
+indefinitely until a person clicks.
+
+### Finding 4: The server returns `dedup_matches` unconditionally — no suppression knob
+
+**Evidence:** `server/backend/api/routes/transcription.py:1247-1261` and `:1301`; Form signature at
+`:1153-1164` (no skip/force/auto param); `dedup_query.py:59`; `job_repository.py:114`.
+
+**Detail:** `/api/transcribe/import` computes `audio_hash` + `normalized_audio_hash` and calls
+`find_duplicates_anywhere` whenever either hash exists, returning matches inline. There is no Form
+field, config key, env var, or per-client setting to suppress it. The client
+(`importAndTranscribe`, `client.ts:830-850`) sends no such parameter, and `TranscriptionUploadOptions`
+(`types.ts:104`) defines none.
+
+### Finding 5: No user-facing setting / config / env mitigates this anywhere
+
+**Evidence:** `dashboard/src/config/store.ts` (no dedup key); `dashboard/electron/main.ts:533`
+(`folderWatch.*` = only `sessionPath`/`notebookPath`/`sessionWatchActive`/`notebookWatchActive`);
+`SettingsModal.tsx` (no control); `server` config (no key/env). Exhaustive repo-wide grep for
+~16 plausible knob names returned no real match.
+
+### Finding 6: Issue is unaddressed in code/history; tests don't cover an unattended bypass
+
+**Evidence:** Issue #120 still OPEN. No commit/PR/branch references #120 (git `--all --grep`,
+`git grep`). Flow introduced under **#104**, commit `4ac23e60` (2026-05-04), building on `8839d67e`.
+Tests (`DedupPromptModal.test.tsx`, `dedupChoiceStore.test.ts`, `DedupChoiceContainer.test.tsx`,
+`importQueueStore.test.ts`) cover only the interactive choice; none asserts session-auto auto-resolve.
+
+## Deduced Conclusions
+
+### Deduction 1: The bug is structural, not a regression or matching glitch
+
+**Based on:** Findings 1–6.
+
+**Reasoning:** The interactive modal is the *only* code path that resolves a duplicate, and it is
+reachable by `session-auto` jobs with no differentiation. Dedup detection on the server is
+unconditional whenever audio content matches a prior persisted row (raw or normalized PCM SHA-256).
+The matching itself is correct (exact-content), so the problem isn't false positives — it's that the
+*only* resolution mechanism is a blocking human prompt.
+
+**Conclusion:** Any Folder Watch / batch run that re-imports audio already transcribed in a prior run
+(or duplicated across files) will stall on the modal. This exactly reproduces issue #120.
+
+## Hypothesized Paths
+
+### Hypothesis 1: A double-detection within a single fresh batch could also trigger the prompt
+
+**Status:** Open (not required to confirm the bug; documented for completeness)
+
+**Theory:** Because each `/import` creates a durability row carrying the hash *before* the next file
+is processed, if the watcher were to detect the same file twice (file still being written, rapid
+re-scan), the second import could match the first and prompt — even with no prior run.
+
+**Supporting indicators:** Row-with-hash is created at import time (`transcription.py:1234-1261`).
+
+**Would confirm:** A watcher trace showing the same path emitted twice producing two imports.
+
+**Would refute:** Watcher debounce / seen-set (Issue #94 fixed double-subscription) prevents
+re-emission. Primary mechanism remains "re-import of previously-processed audio".
+
+## Source Code Trace
+
+| Element       | Detail                                                                                              |
+| ------------- | --------------------------------------------------------------------------------------------------- |
+| Error origin  | `dashboard/src/stores/importQueueStore.ts:303-329` — `processSessionJob` dedup gate (blocking await) |
+| Trigger       | Folder Watch enqueues `session-auto` jobs (`importQueueStore.ts:702`); `/import` returns non-empty `dedup_matches` for re-imported audio (`transcription.py:1247-1261,1301`) |
+| Condition     | Imported file's `audio_hash` or `normalized_audio_hash` equals a prior `transcription_jobs`/`recordings` row |
+| Related files | `dedupChoiceStore.ts`, `DedupChoiceContainer.tsx`, `DedupPromptModal.tsx`, `App.tsx:821`, `client.ts:830`, `types.ts:104`, `dedup_query.py`, `job_repository.py`, `database.py` |
+
+## Conclusion
+
+**Confidence: High.** The issue described in GH #120 is **still present** in the current code. The
+"Possible duplicate detected" modal still fires for Folder Watch (`session-auto`) jobs exactly as for
+manual imports, blocking the serial import queue until a human responds. There is **no** auto-resolve
+mode, job-type branch, setting, config key, or env var anywhere that lets a batch run unattended.
+Five independent adversarial lenses each tried and failed to refute this. The bug is confined to the
+**session import surface**; notebook auto-watch (`processNotebookJob`) is unaffected (it never reads
+`dedup_matches`).
+
+## Recommended Next Steps
+
+### Fix direction (investigation stops at diagnosis; this is guidance, not an implementation)
+
+Introduce an **unattended duplicate policy** for auto/batch jobs. Minimal, well-scoped options:
+
+1. **Job-type branch (smallest fix).** In `processSessionJob`, when `job.type === 'session-auto'`,
+   resolve duplicates without the modal — default to `create_new` (preserves the data-loss-averse
+   invariant: never silently drop a transcription). One-branch change at `importQueueStore.ts:303`.
+2. **Policy setting (better UX).** Add `folderWatch.duplicatePolicy: 'ask' | 'create_new' | 'skip'`
+   to the config/Electron defaults and `SettingsModal`. `session-auto` jobs read it and bypass the
+   modal accordingly; `session-normal` keeps `ask`. Wire through `dedupChoiceStore` (add an
+   auto-resolve path) or short-circuit before `requestChoice`.
+3. **(Optional) "Don't ask again this batch"** checkbox on the modal that persists a session-scoped
+   choice — complements either option above.
+
+Add tests asserting `session-auto` jobs do **not** block on the modal (the gap Finding 6 identified).
+
+### Secondary (user's "how do I delete existing recordings?" question)
+
+That is a usage question, not a code fix: existing transcripts/recordings can be removed via the
+dashboard's notebook/session management UI (or by clearing the durability rows). Worth a short doc
+note, but it does not resolve the blocking-prompt defect.
+
+## Reproduction Plan
+
+1. Transcribe a file via session import (manual or Folder Watch) so a `transcription_jobs` row with
+   `audio_hash` is persisted.
+2. Enable Folder Watch on a session folder; drop the **same** audio file (or a different container of
+   identical audio) into it.
+3. Expected (bug): the "Possible duplicate detected" modal appears and the import queue halts until a
+   manual choice — unattended batch is impossible.
+4. Verify fix: with the policy/branch in place, the `session-auto` job auto-resolves (default: creates
+   a new entry) and the queue advances with no modal.
+
+## Side Findings
+
+- `dashboard/src/api/client.ts:785` — `dedupCheck` (the standalone `POST /import/dedup-check`
+  pre-flight endpoint) is **dead code**; nothing in the dashboard calls it. The team built a
+  pre-flight path but shipped only the inline `dedup_matches` flow. (Evidence-graded: Confirmed.)
+- Notebook auto-watch is unaffected — `processNotebookJob` (`importQueueStore.ts:369-408`) never reads
+  `dedup_matches` and the notebook upload endpoint does not populate it (`types.ts:200-204`).
+- Backend hash compute is wrapped in try/except that silently NULLs hashes on failure
+  (`transcription.py:1218-1231`) — a failure mode that *coincidentally* suppresses dedup, not a
+  sanctioned batch mode.
+
+## Follow-up: 2026-06-26 — Fix implemented (TDD)
+
+**Resolution.** Added an unattended duplicate policy so Folder Watch (`session-auto`) imports no
+longer block the queue on the interactive modal.
+
+- `dashboard/src/stores/importQueueStore.ts` — new `DuplicatePolicy` (`'ask' | 'create_new'`) +
+  `resolveDuplicateChoice(jobType, matches)`; `processSessionJob` now calls it instead of always
+  awaiting `requestChoice`. `session-auto` only prompts when policy is `'ask'`; every other case
+  (the `'create_new'` default, an unknown/legacy value, or an IPC read failure) creates a new entry
+  — so a corrupt config can never re-block the queue (would re-introduce #120) or skip a file.
+- `dashboard/electron/main.ts` — `folderWatch.duplicatePolicy` default `'create_new'`.
+- `dashboard/components/views/SettingsModal.tsx` — Settings → App → "Folder Watch" dropdown
+  (Always create a new entry / Ask each time), load+save wiring, load-time value normalization.
+- `dashboard/src/stores/importQueueStore.test.ts` — 6 TDD tests (RED→GREEN).
+
+**`'skip'` deliberately NOT shipped.** A code review flagged that `'skip'`→`'use_existing'` could
+lose data. Verified the cause: `_run_file_import` (`transcription.py:840-843`) "does NOT save to
+database" — import durability rows stay `status='processing'` with `result_text=NULL` forever
+(results live only in the in-memory `job_tracker`). So a session-import dedup match is a bare
+hash anchor with **no retrievable transcript**, and the reviewer's proposed `status='completed'`
+filter would have *excluded all import rows* and broken session dedup. The safe resolution was to
+drop `'skip'` (only `'ask'`/`'create_new'`, both data-loss-safe) rather than build disk
+verification. Legacy `'skip'` values stored by no build are coerced to `'create_new'`.
+
+**Verification.** 1440/1440 frontend tests pass; typecheck (app + electron) + eslint clean.
+UI-contract drift (`ServerView` classes, pre-existing on main, unrelated) handled as a separate
+commit. **Status: Concluded — fixed on branch `fix/gh120-folder-watch-dedup-policy`.**

--- a/dashboard/components/views/SettingsModal.tsx
+++ b/dashboard/components/views/SettingsModal.tsx
@@ -53,6 +53,7 @@ import { ModelProfilesPanel } from '../profiles/ModelProfilesPanel';
 import { useLanguages } from '../../src/hooks/useLanguages';
 import { MAIN_MODEL_PRESETS } from '../../src/services/modelSelection';
 import { CANARY_TRANSLATION_TARGETS } from '../../src/services/modelCapabilities';
+import type { DuplicatePolicy } from '../../src/stores/importQueueStore';
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -67,6 +68,20 @@ const DEFAULT_SHORTCUTS = {
 const REMOTE_PROFILE_OPTIONS = ['Tailscale', 'LAN'] as const;
 const MAIN_MODEL_CUSTOM_OPTION = 'Custom (HuggingFace repo)';
 const MODEL_DEFAULT_LOADING_PLACEHOLDER = 'Loading server default...';
+// GH-120 — Folder Watch duplicate-handling policy. Display order + labels for
+// the App-tab dropdown; values map to importQueueStore's DuplicatePolicy.
+// ('skip' is intentionally not offered — see DuplicatePolicy docs: it could
+// drop a file with no retrievable transcript, violating the data-loss invariant.)
+const DUPLICATE_POLICY_ORDER: DuplicatePolicy[] = ['create_new', 'ask'];
+const DUPLICATE_POLICY_LABELS: Record<DuplicatePolicy, string> = {
+  create_new: 'Always create a new entry',
+  ask: 'Ask each time',
+};
+/** Coerce any stored/legacy value (e.g. a removed 'skip') to a valid policy so
+ *  a corrupt config never blanks the dropdown — defaults to 'create_new'. */
+function normalizeDuplicatePolicy(raw: unknown): DuplicatePolicy {
+  return raw === 'ask' ? 'ask' : 'create_new';
+}
 
 function normalizeConfigString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
@@ -185,6 +200,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
     pasteAtCursor: false,
     blurEffectsEnabled: true,
     idleAnimationsEnabled: false, // GH #87 — default OFF (see idleAnimationsBoot)
+    duplicatePolicy: 'create_new' as DuplicatePolicy, // GH-120 — Folder Watch
   });
   // Issue #87 — track the LAST SAVED Blur effects value so we can revert any
   // unsaved live-preview DOM changes if the modal closes via X without Save.
@@ -412,6 +428,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
                 pasteAtCursor: (cfg['app.pasteAtCursor'] as boolean) ?? prev.pasteAtCursor,
                 blurEffectsEnabled: loadedBlurEffectsEnabled,
                 idleAnimationsEnabled: loadedIdleAnimationsEnabled,
+                duplicatePolicy: normalizeDuplicatePolicy(cfg['folderWatch.duplicatePolicy']),
               }));
               setShortcutSettings((prev) => ({
                 ...prev,
@@ -548,6 +565,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
         ['app.pasteAtCursor', appSettings.pasteAtCursor],
         ['ui.blurEffectsEnabled', appSettings.blurEffectsEnabled],
         ['ui.idleAnimationsEnabled', appSettings.idleAnimationsEnabled],
+        ['folderWatch.duplicatePolicy', appSettings.duplicatePolicy],
         ['shortcuts.startRecording', shortcutSettings.startRecording.trim()],
         ['shortcuts.stopTranscribe', shortcutSettings.stopTranscribe.trim()],
       ];
@@ -920,6 +938,26 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
           }}
           label="Start minimized to system tray"
         />
+      </Section>
+      <Section title="Folder Watch">
+        <label className="mb-1.5 block text-xs font-medium tracking-wider text-slate-500 uppercase">
+          When a duplicate is detected
+        </label>
+        <CustomSelect
+          value={DUPLICATE_POLICY_LABELS[appSettings.duplicatePolicy]}
+          onChange={(v) => {
+            const policy =
+              DUPLICATE_POLICY_ORDER.find((p) => DUPLICATE_POLICY_LABELS[p] === v) ?? 'create_new';
+            setAppSettings((prev) => ({ ...prev, duplicatePolicy: policy }));
+            setIsDirty(true);
+          }}
+          options={DUPLICATE_POLICY_ORDER.map((p) => DUPLICATE_POLICY_LABELS[p])}
+        />
+        <p className="mt-2 text-xs text-slate-500">
+          Folder Watch transcribes batches unattended. Choose how it handles a file whose audio
+          matches an existing transcription, instead of pausing to ask for every file. Manual
+          imports always ask.
+        </p>
       </Section>
       <Section title="Appearance">
         <AppleSwitch

--- a/dashboard/electron/main.ts
+++ b/dashboard/electron/main.ts
@@ -534,6 +534,10 @@ const store = new Store({
     'folderWatch.notebookPath': '',
     'folderWatch.sessionWatchActive': false,
     'folderWatch.notebookWatchActive': false,
+    // GH-120 — how Folder Watch resolves a detected duplicate without blocking
+    // the import queue on the interactive modal. 'create_new' | 'ask'.
+    // Default 'create_new': unattended batch never stalls and never drops a file.
+    'folderWatch.duplicatePolicy': 'create_new',
   },
 });
 

--- a/dashboard/src/stores/importQueueStore.test.ts
+++ b/dashboard/src/stores/importQueueStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
 
 // Mock apiClient before importing the store
 vi.mock('../api/client', () => ({
@@ -32,6 +32,13 @@ vi.mock('sonner', () => ({
   },
 }));
 
+// Mock the config store so resolveDuplicateChoice's policy read is deterministic
+// (GH-120). All other exports stay real — only getConfig is stubbed.
+vi.mock('../config/store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../config/store')>();
+  return { ...actual, getConfig: vi.fn() };
+});
+
 // Stub window.electronAPI
 Object.defineProperty(globalThis, 'window', {
   value: globalThis,
@@ -41,6 +48,7 @@ Object.defineProperty(globalThis, 'window', {
 import { toast } from 'sonner';
 import {
   useImportQueueStore,
+  resolveDuplicateChoice,
   selectPendingCount,
   selectCompletedCount,
   selectErrorCount,
@@ -50,6 +58,10 @@ import {
   selectNotebookJobs,
 } from './importQueueStore';
 import type { UnifiedImportJob } from './importQueueStore';
+import { useDedupChoiceStore } from './dedupChoiceStore';
+import { getConfig } from '../config/store';
+import type { DedupMatch } from '../api/types';
+import type { DedupChoice } from '../../components/import/DedupPromptModal';
 
 function resetStore() {
   useImportQueueStore.setState({
@@ -673,6 +685,81 @@ describe('importQueueStore', () => {
       });
       expect(getState().jobs).toHaveLength(1);
       expect(lastJobOptions()?.language).toBe('es');
+    });
+  });
+
+  // ── resolveDuplicateChoice (GH-120 — Folder Watch duplicate policy) ────
+  //
+  // The dedup gate must NOT block unattended Folder Watch (session-auto) jobs
+  // on the interactive modal. session-auto jobs resolve duplicates per the
+  // configured folderWatch.duplicatePolicy; manual (session-normal) jobs always
+  // prompt. Default policy is 'create_new' so batch runs unattended out of the
+  // box without ever silently dropping a file (data-loss invariant).
+
+  describe('resolveDuplicateChoice (GH-120 — Folder Watch duplicate policy)', () => {
+    const MATCHES: DedupMatch[] = [
+      {
+        recording_id: 'c3b4c22a',
+        name: 'prior.mp3',
+        created_at: '2026-05-07T00:00:00Z',
+        source: 'transcription_job',
+      },
+    ];
+    let requestChoiceSpy: Mock<(matches: DedupMatch[]) => Promise<DedupChoice>>;
+
+    beforeEach(() => {
+      // Override the dedup-choice store's interactive resolver so we can assert
+      // whether the modal would have been raised.
+      requestChoiceSpy = vi.fn(
+        (_m: DedupMatch[]): Promise<DedupChoice> => Promise.resolve('create_new'),
+      );
+      useDedupChoiceStore.setState({ requestChoice: requestChoiceSpy });
+      vi.mocked(getConfig).mockReset();
+    });
+
+    it('session-auto with no policy set defaults to create_new WITHOUT prompting (the GH-120 fix)', async () => {
+      vi.mocked(getConfig).mockResolvedValue(undefined);
+      const choice = await resolveDuplicateChoice('session-auto', MATCHES);
+      expect(choice).toBe('create_new');
+      expect(requestChoiceSpy).not.toHaveBeenCalled();
+    });
+
+    it("session-auto with policy 'create_new' resolves create_new without prompting", async () => {
+      vi.mocked(getConfig).mockResolvedValue('create_new');
+      const choice = await resolveDuplicateChoice('session-auto', MATCHES);
+      expect(choice).toBe('create_new');
+      expect(requestChoiceSpy).not.toHaveBeenCalled();
+    });
+
+    it("session-auto with policy 'ask' prompts the user via the interactive modal", async () => {
+      vi.mocked(getConfig).mockResolvedValue('ask');
+      const choice = await resolveDuplicateChoice('session-auto', MATCHES);
+      expect(requestChoiceSpy).toHaveBeenCalledWith(MATCHES);
+      expect(choice).toBe('create_new'); // whatever the modal returned
+    });
+
+    it('session-auto with an unknown/legacy policy value falls back to create_new (never re-blocks, never skips)', async () => {
+      // e.g. a 'skip' value persisted by an earlier build, or a corrupt manual edit.
+      // Must NOT fall through to the modal (that would re-introduce GH-120) and must
+      // NOT skip transcription (that would risk data loss).
+      vi.mocked(getConfig).mockResolvedValue('skip' as never);
+      const choice = await resolveDuplicateChoice('session-auto', MATCHES);
+      expect(choice).toBe('create_new');
+      expect(requestChoiceSpy).not.toHaveBeenCalled();
+    });
+
+    it('session-auto defaults to create_new when the config read throws (no error cascade)', async () => {
+      vi.mocked(getConfig).mockRejectedValue(new Error('IPC unavailable'));
+      const choice = await resolveDuplicateChoice('session-auto', MATCHES);
+      expect(choice).toBe('create_new');
+      expect(requestChoiceSpy).not.toHaveBeenCalled();
+    });
+
+    it('session-normal (manual import) always prompts, ignoring the folder-watch policy', async () => {
+      vi.mocked(getConfig).mockResolvedValue('create_new');
+      const choice = await resolveDuplicateChoice('session-normal', MATCHES);
+      expect(requestChoiceSpy).toHaveBeenCalledWith(MATCHES);
+      expect(choice).toBe('create_new');
     });
   });
 

--- a/dashboard/src/stores/importQueueStore.ts
+++ b/dashboard/src/stores/importQueueStore.ts
@@ -14,12 +14,14 @@ import type {
   FileImportJobResult,
   JobTrackerResult,
   UploadResponse,
+  DedupMatch,
 } from '../api/types';
 import { resolveTranscriptionOutput } from '../services/transcriptionFormatters';
 import { supportsAutoDetect } from '../services/modelCapabilities';
 import { getConfig } from '../config/store';
 import { useDedupChoiceStore } from './dedupChoiceStore';
 import { useAriaAnnouncerStore } from './ariaAnnouncerStore';
+import type { DedupChoice } from '../../components/import/DedupPromptModal';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -213,6 +215,50 @@ function filenameFromPath(filePath: string): string {
   return parts[parts.length - 1] || filePath;
 }
 
+// ─── Duplicate resolution (GH-120) ───────────────────────────────────────────
+
+/** How Folder Watch (session-auto) jobs resolve a server-detected duplicate
+ *  without blocking the import queue on the interactive modal.
+ *
+ *  Only two values are offered. A 'skip'/use-existing policy is deliberately
+ *  NOT supported: a session-import dedup match is a bare audio-hash anchor with
+ *  no retrievable transcript in the DB (the /import worker writes results to the
+ *  in-memory job tracker, never to the durability row — see _run_file_import in
+ *  server/backend/api/routes/transcription.py), so auto-skipping could leave a
+ *  file with no transcript and violate the data-loss invariant. Unattended jobs
+ *  therefore only ever create a new entry or ask. */
+export type DuplicatePolicy = 'ask' | 'create_new';
+
+/** Default when `folderWatch.duplicatePolicy` is unset, unknown, or unreadable:
+ *  create a new entry so an unattended batch never stalls AND never silently
+ *  drops a file (the data-loss invariant). */
+const DEFAULT_DUPLICATE_POLICY: DuplicatePolicy = 'create_new';
+
+/**
+ * Decide how to resolve a server-detected duplicate for a session import.
+ *
+ * Manual imports (`session-normal`) always prompt the user via the interactive
+ * DedupPromptModal. Folder Watch imports (`session-auto`) follow the configured
+ * `folderWatch.duplicatePolicy` so a batch runs unattended (GH-120). Only the
+ * explicit `'ask'` policy falls back to the modal; every other case — the
+ * `'create_new'` default, an unknown/legacy stored value (e.g. a removed
+ * `'skip'`), or an IPC read failure — creates a new entry, so a corrupt config
+ * can never re-block the queue or skip a file.
+ */
+export async function resolveDuplicateChoice(
+  jobType: ImportJobType,
+  matches: DedupMatch[],
+): Promise<DedupChoice> {
+  if (jobType === 'session-auto') {
+    const policy =
+      (await getConfig<DuplicatePolicy>('folderWatch.duplicatePolicy').catch(() => undefined)) ??
+      DEFAULT_DUPLICATE_POLICY;
+    if (policy !== 'ask') return 'create_new';
+    // policy === 'ask' → fall through to the interactive prompt below.
+  }
+  return useDedupChoiceStore.getState().requestChoice(matches);
+}
+
 const POLL_INTERVAL_MS = 5_000;
 const MAX_POLLS = (24 * 60 * 60 * 1000) / POLL_INTERVAL_MS; // 24 hours
 
@@ -297,12 +343,13 @@ async function processSessionJob(
   const { job_id: serverJobId } = importResponse;
 
   // Issue #104, Story 2.4 + Sprint 2 Item 4 — full DedupPromptModal flow.
-  // When the server reports prior matches, await the user's choice via
-  // useDedupChoiceStore. The container component (mounted at App level)
-  // renders the modal and resolves the promise.
+  // When the server reports prior matches, resolve the duplicate. Manual
+  // imports await the user's choice via the interactive modal; Folder Watch
+  // (session-auto) jobs follow folderWatch.duplicatePolicy so a batch runs
+  // unattended instead of blocking the queue on the modal (GH-120).
   if (importResponse.dedup_matches?.length) {
     const first = importResponse.dedup_matches[0];
-    const choice = await useDedupChoiceStore.getState().requestChoice(importResponse.dedup_matches);
+    const choice = await resolveDuplicateChoice(job.type, importResponse.dedup_matches);
 
     if (choice === 'use_existing' || choice === 'cancel') {
       // User picked "Use existing" (or pressed Esc / closed): cancel the
@@ -325,7 +372,7 @@ async function processSessionJob(
       return;
     }
     // 'create_new': continue with the existing happy path.
-    toast.warning(`Duplicate of '${first.name}' detected. Creating a new entry as requested.`);
+    toast.warning(`Duplicate of '${first.name}' detected — creating a new entry.`);
   }
 
   const result = await pollForSessionResult(serverJobId);

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.0.57",
-  "contract_sha256": "09c5080a78d68cd01bc7b7664baf5ec0150fea4417670617271471f5b93cead8",
-  "updated_at": "2026-06-25T14:19:14.373Z"
+  "spec_version": "1.0.58",
+  "contract_sha256": "93320d2df59a31b91008266a0f29bdee3e17dc7fea135eee84bc2e0aeb456e67",
+  "updated_at": "2026-06-26T20:00:42.537Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.0.57
+  spec_version: 1.0.58
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -97,7 +97,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-06-25T14:18:54.896Z
+    generated_at: 2026-06-26T19:59:08.137Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -486,6 +486,7 @@ utility_allowlist:
     - bg-accent-magenta/10
     - bg-accent-orange
     - bg-accent-orange/10
+    - bg-accent-orange/20
     - bg-accent-violet/15
     - bg-amber-400/10
     - bg-amber-400/20
@@ -804,7 +805,9 @@ utility_allowlist:
     - mb-4
     - mb-6
     - mb-8
+    - md:grid-cols-2
     - md:grid-cols-4
+    - md:items-end
     - min-h-0
     - min-h-32
     - min-h-full
@@ -942,6 +945,7 @@ utility_allowlist:
     - rounded-tl-none
     - rounded-tr-none
     - rounded-xl
+    - select-all
     - select-none
     - selectable-text
     - shadow
@@ -985,6 +989,7 @@ utility_allowlist:
     - text-3xl
     - text-accent-cyan
     - text-accent-cyan/70
+    - text-accent-cyan/80
     - text-accent-magenta
     - text-accent-orange
     - text-accent-violet
@@ -994,6 +999,7 @@ utility_allowlist:
     - text-amber-300
     - text-amber-300/60
     - text-amber-300/70
+    - text-amber-300/80
     - text-amber-400
     - text-amber-400/60
     - text-amber-400/80
@@ -1010,11 +1016,11 @@ utility_allowlist:
     - text-emerald-300/70
     - text-emerald-400
     - text-green-400
+    - text-green-400/70
     - text-indigo-400
     - text-left
     - text-lg
     - text-neutral-100
-    - text-orange-200
     - text-orange-400
     - text-orange-500
     - text-purple-400

--- a/docs/README.md
+++ b/docs/README.md
@@ -208,7 +208,12 @@ Pick **Docker** or **Podman** — the app auto-detects whichever is installed (D
    sudo usermod -aG docker $USER
    ```
    Then **log out and back in** (or reboot) for it to take effect.
-3. **NVIDIA GPU:** install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html). Skip this for CPU mode.
+3. **NVIDIA GPU:** install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html), then wire it into Docker and restart the daemon:
+   ```bash
+   sudo nvidia-ctk runtime configure --runtime=docker
+   sudo systemctl restart docker
+   ```
+   Skip this for CPU mode. (If a later driver update breaks GPU access, switch Docker to CDI mode — see [GPU not working after a system update](#gpu-not-working-after-a-system-update-linux).)
 
 **Podman** (4.7+ required for `podman compose`):
 
@@ -221,11 +226,11 @@ Pick **Docker** or **Podman** — the app auto-detects whichever is installed (D
    systemctl --user enable --now podman.socket
    ```
    Without it, compose commands fail with "Cannot connect to the Docker daemon" even though `podman` itself works.
-3. **NVIDIA GPU:** configure CDI (needs nvidia-container-toolkit 1.14+):
+3. **NVIDIA GPU:** install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) (1.14+), then configure CDI by generating the device spec:
    ```bash
    sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
    ```
-   Skip this for CPU mode.
+   The `nvidia-ctk` command is provided by the toolkit, so it must be installed first. Skip this for CPU mode.
 
 Then continue with the shared steps: [§2.5 Download the Dashboard app](#25-download-the-dashboard-app) and [§2.6 Set Up the Server](#26-setting-up-the-server).
 


### PR DESCRIPTION
## Summary

Fixes #120 — the "Possible duplicate detected" pop-up made unattended **Folder Watch / batch** processing impossible: it required a manual choice for every duplicate file and blocked the import queue.

### Root cause
`processSessionJob` (`dashboard/src/stores/importQueueStore.ts`) awaited the interactive `DedupPromptModal` for **every** duplicate, with no differentiation between manual imports and Folder Watch (`session-auto`) jobs. The serial `processQueue` loop awaits each job, so one unanswered modal stalled the whole batch. There was no setting, default, or bypass anywhere. (The blocking flow shipped under #104; #120 was filed ~8 days later.)

## What changed

- **New `folderWatch.duplicatePolicy` setting** — `create_new` (default) or `ask`.
  - New `resolveDuplicateChoice(jobType, matches)` helper; `processSessionJob` calls it instead of unconditionally awaiting the modal.
  - **Folder Watch (`session-auto`) runs unattended by default** — creates a new entry, no modal. Only `ask` falls back to the interactive prompt.
  - **Manual (`session-normal`) imports always prompt** — behaviour unchanged.
  - An unknown/legacy stored value, or an IPC read failure, resolves to `create_new`, so a corrupt config can never re-block the queue or skip a file.
- **Settings → App → "Folder Watch"** dropdown ("When a duplicate is detected"), wired through electron-store with load-time value normalization.
- **README**: clarified NVIDIA Container Toolkit setup (`nvidia-ctk runtime configure` for Docker, `cdi generate` for Podman) + the CDI fallback for post-update GPU breakage.

## Why `skip` is *not* offered

A `skip`/use-existing policy was considered but deliberately dropped: a code review flagged it could lose data, and verification confirmed why. `_run_file_import` never persists results to the DB (it writes only to the in-memory job tracker), so an import durability row stays `status='processing'` / `result_text=NULL` forever — a session-import dedup match is a bare audio-hash anchor with **no retrievable transcript**. Auto-skipping could therefore leave a file with no transcript, violating the project's data-loss invariant. (This also means a `status='completed'` dedup filter would *break* session dedup — so it was not used.) Both shipped options (`create_new`, `ask`) are data-loss-safe.

## Test plan

- [x] **6 new unit tests** for `resolveDuplicateChoice` (RED→GREEN): `create_new` / `ask` / unset-default / unknown-legacy-value / IPC-failure / always-prompt-manual.
- [x] Full frontend suite: **1440/1440 passing**.
- [x] `tsc --noEmit` (app + electron) clean.
- [x] ESLint clean.
- [x] `npm run ui:contract:check` green (passed in the pre-commit hook).
- [ ] Manual smoke: enable Folder Watch, drop a file that matches a prior transcription → batch proceeds without a modal (default `create_new`); set policy to "Ask each time" → modal returns for watched files; manual import of a duplicate still prompts.

## Notes

- This PR also **rebuilds a pre-existing stale UI-contract baseline** (utility classes already used in committed source — e.g. `ServerView` `md:grid-cols-2`, `bg-accent-orange/20` — that were never baselined) and bumps `meta.spec_version` 1.0.57 → 1.0.58. This was unrelated drift already red on `main`; it's bundled here because the contract build is coupled to the UI scan and the pre-commit hook validates each commit in isolation, so it couldn't be split cleanly.
- Investigation case file added at `_bmad-output/implementation-artifacts/investigations/gh-120-investigation.md`.
