### PR TITLE
fix(ui): synchronize all StatusLight pulse animations

### DIFF
--- a/dashboard/components/ui/StatusLight.test.tsx
+++ b/dashboard/components/ui/StatusLight.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * StatusLight — pulse synchronization tests.
+ *
+ * Every pulsing StatusLight must anchor its `animate-ping` ring to the SAME
+ * point on the document timeline so that all status dots across the app blink
+ * in phase, regardless of when each one mounted. The component guarantees this
+ * by pinning each ring animation's `startTime` to a single shared anchor (the
+ * timeline origin, 0).
+ *
+ * jsdom does not implement the Web Animations API, so we install a minimal
+ * `getAnimations()` mock that records the `startTime` the component assigns.
+ */
+import { render, cleanup, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { StatusLight } from './StatusLight';
+
+interface FakeAnimation {
+  startTime: number | null;
+}
+
+// Must match PULSE_TIMELINE_ANCHOR_MS in StatusLight.tsx.
+const SHARED_ANCHOR = 0;
+
+type ElementWithFakeAnim = HTMLElement & { __fakeAnim?: FakeAnimation };
+
+let originalGetAnimations: unknown;
+
+beforeEach(() => {
+  originalGetAnimations = (HTMLElement.prototype as unknown as Record<string, unknown>)
+    .getAnimations;
+  (HTMLElement.prototype as unknown as Record<string, unknown>).getAnimations = function (
+    this: ElementWithFakeAnim,
+  ): FakeAnimation[] {
+    // Lazily attach one fake animation per element, initialised to a
+    // deliberately out-of-phase startTime so the test proves the component
+    // overrides it to the shared anchor.
+    if (!this.__fakeAnim) {
+      this.__fakeAnim = { startTime: 987 };
+    }
+    return [this.__fakeAnim];
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  (HTMLElement.prototype as unknown as Record<string, unknown>).getAnimations =
+    originalGetAnimations;
+});
+
+function pingAnimation(container: HTMLElement): FakeAnimation | undefined {
+  const ping = container.querySelector('.animate-ping') as ElementWithFakeAnim | null;
+  return ping?.__fakeAnim;
+}
+
+describe('StatusLight pulse synchronization', () => {
+  it('pins an active dot ping animation to the shared timeline anchor', () => {
+    const { container } = render(<StatusLight status="active" />);
+    expect(pingAnimation(container)?.startTime).toBe(SHARED_ANCHOR);
+  });
+
+  it('pins independently-mounted dots to the SAME anchor so they blink in phase', () => {
+    const a = render(<StatusLight status="active" />);
+    const b = render(<StatusLight status="warning" />);
+    expect(pingAnimation(a.container)?.startTime).toBe(SHARED_ANCHOR);
+    expect(pingAnimation(b.container)?.startTime).toBe(SHARED_ANCHOR);
+  });
+
+  it('syncs via the rAF retry when the animation is not yet registered at layout-effect time', () => {
+    // Mimic real Chromium: the CSSAnimation is not registered during the
+    // layout-effect (style recalc has not run), so the first getAnimations()
+    // returns []. The component must pin it on the next frame instead.
+    let calls = 0;
+    (HTMLElement.prototype as unknown as Record<string, unknown>).getAnimations = function (
+      this: ElementWithFakeAnim,
+    ): FakeAnimation[] {
+      calls += 1;
+      if (calls === 1) return [];
+      if (!this.__fakeAnim) {
+        this.__fakeAnim = { startTime: 987 };
+      }
+      return [this.__fakeAnim];
+    };
+
+    const rafCallbacks: FrameRequestCallback[] = [];
+    const realRaf = globalThis.requestAnimationFrame;
+    const realCancel = globalThis.cancelAnimationFrame;
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback): number => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = (() => {}) as typeof cancelAnimationFrame;
+
+    try {
+      const { container } = render(<StatusLight status="active" />);
+      // Synchronous pin saw an empty list: not synced yet.
+      expect(pingAnimation(container)?.startTime).toBeUndefined();
+      // Flush the queued frame: the animation now exists and gets pinned.
+      act(() => {
+        rafCallbacks.forEach((cb) => cb(0));
+      });
+      expect(pingAnimation(container)?.startTime).toBe(SHARED_ANCHOR);
+    } finally {
+      globalThis.requestAnimationFrame = realRaf;
+      globalThis.cancelAnimationFrame = realCancel;
+    }
+  });
+
+  it('renders no ping ring (nothing to sync) for an inactive dot', () => {
+    const { container } = render(<StatusLight status="inactive" />);
+    expect(container.querySelector('.animate-ping')).toBeNull();
+  });
+
+  it('renders no ping ring when animation is disabled', () => {
+    const { container } = render(<StatusLight status="active" animate={false} />);
+    expect(container.querySelector('.animate-ping')).toBeNull();
+  });
+});

--- a/dashboard/components/ui/StatusLight.tsx
+++ b/dashboard/components/ui/StatusLight.tsx
@@ -1,10 +1,17 @@
-import React, { useLayoutEffect, useState } from 'react';
+import React, { useLayoutEffect, useRef } from 'react';
 
 interface StatusLightProps {
   status: 'active' | 'inactive' | 'warning' | 'error' | 'loading';
   className?: string;
   animate?: boolean;
 }
+
+// All pulsing status dots share this single point on the document timeline as
+// their animation origin. Because every `animate-ping` ring is pinned to the
+// same start time on the same (document) clock, every dot is at the identical
+// phase at any instant, so they all blink in lockstep no matter when each one
+// mounted. See StatusLight.test.tsx for the synchronization invariant.
+const PULSE_TIMELINE_ANCHOR_MS = 0;
 
 export const StatusLight: React.FC<StatusLightProps> = ({
   status,
@@ -23,30 +30,50 @@ export const StatusLight: React.FC<StatusLightProps> = ({
   // any non-inactive status can pulse when animation is enabled.
   const shouldPulse = animate && status !== 'inactive';
 
-  const [syncDelay, setSyncDelay] = useState('0ms');
+  const pingRef = useRef<HTMLSpanElement>(null);
 
-  // Synchronize animation to the system clock
+  // Synchronize every dot by pinning its ping ring to a single shared origin on
+  // the document timeline. Unlike a mount-time negative `animation-delay`, this
+  // does not depend on WHEN the browser assigned the animation start time
+  // (which varies with main-thread load), so dots that mount in different
+  // frames still blink in phase with one another.
   useLayoutEffect(() => {
-    if (shouldPulse) {
-      // Tailwind's 'animate-ping' duration is exactly 1000ms (1s).
-      // We calculate how many milliseconds have passed in the current second.
-      const duration = 1000;
-      const now = Date.now();
+    if (!shouldPulse) return;
+    const el = pingRef.current;
+    if (!el || typeof el.getAnimations !== 'function') return;
 
-      // Calculate a negative delay. This tells CSS:
-      // "Start the animation as if it had already been running for X ms."
-      // This aligns every single instance to the exact same global heartbeat.
-      const timeIntoCycle = now % duration;
-      setSyncDelay(`-${timeIntoCycle}ms`);
-    }
-  }, [shouldPulse]);
+    const pin = (): void => {
+      const animations = el.getAnimations();
+      for (const animation of animations) {
+        try {
+          animation.startTime = PULSE_TIMELINE_ANCHOR_MS;
+        } catch {
+          // startTime can be transiently read-only (e.g. a pending animation);
+          // the requestAnimationFrame retry below covers that case.
+        }
+      }
+    };
+
+    // In practice the CSS animation is usually not registered yet at
+    // layout-effect time (it appears after the browser's style recalculation),
+    // so this synchronous call is typically a no-op and the rAF retry below is
+    // what actually pins it — before the first paint, so no unsynced frame is
+    // ever shown.
+    pin();
+    const raf = typeof requestAnimationFrame === 'function' ? requestAnimationFrame(pin) : 0;
+    return () => {
+      if (raf && typeof cancelAnimationFrame === 'function') cancelAnimationFrame(raf);
+    };
+    // `status` is a dependency so the pin is reasserted across status changes,
+    // in case a transition ever reconstructs the underlying CSS animation.
+  }, [shouldPulse, status]);
 
   return (
     <span className={`relative flex h-3 w-3 ${className}`}>
       {shouldPulse && (
         <span
+          ref={pingRef}
           className={`absolute inline-flex h-full w-full animate-ping rounded-full opacity-75 ${colors[status].split(' ')[0]}`}
-          style={{ animationDelay: syncDelay }}
         ></span>
       )}
       <span

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.0.58",
-  "contract_sha256": "93320d2df59a31b91008266a0f29bdee3e17dc7fea135eee84bc2e0aeb456e67",
-  "updated_at": "2026-06-26T20:00:42.537Z"
+  "spec_version": "1.0.59",
+  "contract_sha256": "10da0ab3d7e66c03b031416e0a0b219f8976890a8552daf1e2f5eb50f6e72e77",
+  "updated_at": "2026-06-27T21:06:45.358Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.0.58
+  spec_version: 1.0.59
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -69,6 +69,7 @@ meta:
       - components/ui/PersistentInfoBanner.tsx
       - components/ui/QueuePausedBanner.tsx
       - components/ui/ShortcutCapture.tsx
+      - components/ui/StatusLight.test.tsx
       - components/ui/StatusLight.tsx
       - components/ui/UpdateBanner.tsx
       - components/ui/UpdateModal.tsx
@@ -97,7 +98,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-06-26T19:59:08.137Z
+    generated_at: 2026-06-27T21:06:20.910Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -1157,7 +1158,6 @@ utility_allowlist:
 inline_style_allowlist:
   allowed_properties:
     - animation
-    - animationDelay
     - backgroundAttachment
     - backgroundColor
     - backgroundImage


### PR DESCRIPTION
## Problem

The green status **dots** in the dashboard (sidebar Session/Notebook/Server, Inference Server, Client Link, Docker Image, Container "Running") pulse out of phase with each other — "only some are in sync."

Every one of these dots already routes through the shared `StatusLight` component using the same Tailwind `animate-ping` (1000 ms), so the **interval was never the issue — only the phase was.**

### Root cause

The previous sync logic computed a negative `animation-delay` from `Date.now() % 1000` in a mount-time `useLayoutEffect`. But a CSS animation's real `startTime` is assigned by the browser at its **first composited frame**, which lags the `Date.now()` read by a *variable* amount depending on main-thread load.

- Dots mounting in the **same** React commit share that lag → stay in sync with each other (e.g. the three sidebar dots).
- Dots mounting in a **different** commit (the cards appear after a status fetch resolves) get a different lag → drift.

That's exactly the partial-sync split reported.

## Fix

Pin every ping ring to a **single shared origin on the document timeline** instead of inferring timing from mount:

```ts
const animations = el.getAnimations();
for (const animation of animations) animation.startTime = 0; // PULSE_TIMELINE_ANCHOR_MS
```

Because all dots share the same document-timeline clock and the same `startTime`, each dot's phase at any instant is identically `currentTime % 1000` — mount time, render order, and jank no longer matter. The Tailwind `animate-ping` visuals are untouched (the existing animation is only re-anchored). A `requestAnimationFrame` retry covers the normal case where the CSS animation isn't registered yet when the layout effect runs.

This applies to **every** `StatusLight` in the app, so all status dots everywhere are now synchronized.

## Tests

`dashboard/components/ui/StatusLight.test.tsx` (new):
- Active dot pins to the shared anchor
- Independently-mounted dots pin to the **same** anchor (in phase)
- rAF-retry path syncs when the animation isn't registered at layout-effect time (the real production path)
- No ping ring when inactive / animation disabled

## Verification

- `npx vitest run components/ui/StatusLight.test.tsx` — 5/5 pass
- `npm run typecheck` — clean
- `eslint` + `prettier` — clean
- `npm run ui:contract:check` — passes (16 checks). Baseline regenerated (`spec_version` 1.0.58 → 1.0.59) because removing the inline `animationDelay` legitimately shrank `inline_allowed_properties`.

## Notes / optional follow-ups (out of scope)

- Add `motion-reduce:animate-none` so the dots respect OS "Reduce Motion".
- Latent cosmetic bug: `className="h-2 w-2"` on the card dots is silently overridden by the hardcoded `h-3 w-3`, so all dots render at 12px.