### PR TITLE
feat(stt): SenseVoice (FunASR) backend — Phase 1 (Linux/NVIDIA, transcriber-only)

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -54,7 +54,7 @@ import {
 import { isRuntimeProfile, type RuntimeProfile } from './src/types/runtime';
 
 type HfTokenDecision = 'unset' | 'provided' | 'skipped';
-type MissingFamily = 'whisper' | 'nemo' | 'vibevoice';
+type MissingFamily = 'whisper' | 'nemo' | 'vibevoice' | 'sensevoice';
 
 const HF_TERMS_URL = 'https://huggingface.co/pyannote/speaker-diarization-community-1';
 
@@ -580,11 +580,13 @@ const AppInner: React.FC = () => {
           composeInstallWhisper,
           composeInstallNemo,
           composeInstallVibeVoiceAsr,
+          composeInstallFunasr,
           bootstrapStatus,
         ] = await Promise.all([
           readComposeEnvValue('INSTALL_WHISPER'),
           readComposeEnvValue('INSTALL_NEMO'),
           readComposeEnvValue('INSTALL_VIBEVOICE_ASR'),
+          readComposeEnvValue('INSTALL_FUNASR'),
           getOptionalDependencyBootstrapStatus(),
         ]);
 
@@ -594,6 +596,7 @@ const AppInner: React.FC = () => {
           composeInstallWhisperEnabled: isComposeEnvFlagEnabled(composeInstallWhisper),
           composeInstallNemoEnabled: isComposeEnvFlagEnabled(composeInstallNemo),
           composeInstallVibeVoiceAsrEnabled: isComposeEnvFlagEnabled(composeInstallVibeVoiceAsr),
+          composeInstallFunasrEnabled: isComposeEnvFlagEnabled(composeInstallFunasr),
           bootstrapStatus,
         });
 

--- a/dashboard/components/views/ModelManagerTab.tsx
+++ b/dashboard/components/views/ModelManagerTab.tsx
@@ -35,7 +35,12 @@ const DIARIZATION_DEFAULT_MODEL = 'pyannote/speaker-diarization-community-1';
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 /** Families that require Docker and do not work in Metal mode. */
-const DOCKER_ONLY_FAMILIES: Set<ModelFamily> = new Set(['nemo', 'vibevoice', 'whispercpp']);
+const DOCKER_ONLY_FAMILIES: Set<ModelFamily> = new Set([
+  'nemo',
+  'vibevoice',
+  'whispercpp',
+  'sensevoice',
+]);
 
 export interface ModelManagerTabProps {
   mainModelSelection: string;
@@ -97,6 +102,13 @@ const FAMILY_SECTIONS: FamilySectionConfig[] = [
     borderClass: 'border-l-purple-400',
     badgeClass: 'bg-purple-500/10 text-purple-400',
     headerTextClass: 'text-purple-400',
+  },
+  {
+    family: 'sensevoice',
+    label: 'SenseVoice (FunASR)',
+    borderClass: 'border-l-amber-400',
+    badgeClass: 'bg-amber-500/10 text-amber-400',
+    headerTextClass: 'text-amber-400',
   },
   {
     family: 'mlx',

--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -784,6 +784,7 @@ export interface OptionalDependencyBootstrapStatus {
   whisper?: OptionalDependencyBootstrapFeatureStatus;
   nemo?: OptionalDependencyBootstrapFeatureStatus;
   vibevoiceAsr?: OptionalDependencyBootstrapFeatureStatus;
+  sensevoice?: OptionalDependencyBootstrapFeatureStatus;
 }
 
 interface DockerDfVolumeRow {
@@ -801,6 +802,7 @@ export interface StartContainerOptions {
   installWhisper?: boolean;
   installNemo?: boolean;
   installVibeVoiceAsr?: boolean;
+  installFunasr?: boolean;
   mainTranscriberModel?: string;
   liveTranscriberModel?: string;
   diarizationModel?: string;
@@ -2138,6 +2140,7 @@ async function startContainer(options: StartContainerOptions): Promise<string> {
     installWhisper,
     installNemo,
     installVibeVoiceAsr,
+    installFunasr,
     mainTranscriberModel,
     liveTranscriberModel,
     diarizationModel,
@@ -2342,6 +2345,13 @@ async function startContainer(options: StartContainerOptions): Promise<string> {
     const vibevoiceValue = installVibeVoiceAsr ? 'true' : 'false';
     composeEnv['INSTALL_VIBEVOICE_ASR'] = vibevoiceValue;
     envUpdates['INSTALL_VIBEVOICE_ASR'] = vibevoiceValue;
+  }
+
+  // Pass SenseVoice (FunASR) install preference to the container (optional backend dependency)
+  if (installFunasr !== undefined) {
+    const funasrValue = installFunasr ? 'true' : 'false';
+    composeEnv['INSTALL_FUNASR'] = funasrValue;
+    envUpdates['INSTALL_FUNASR'] = funasrValue;
   }
 
   // Pass ASR model selections to the container (empty string = use config.yaml default)
@@ -2755,13 +2765,15 @@ async function readOptionalDependencyBootstrapStatus(): Promise<OptionalDependen
         whisper?: unknown;
         nemo?: unknown;
         vibevoice_asr?: unknown;
+        sensevoice?: unknown;
       };
     };
 
     const whisper = parseOptionalDependencyBootstrapFeature(parsed.features?.whisper);
     const nemo = parseOptionalDependencyBootstrapFeature(parsed.features?.nemo);
     const vibevoiceAsr = parseOptionalDependencyBootstrapFeature(parsed.features?.vibevoice_asr);
-    if (!whisper && !nemo && !vibevoiceAsr) {
+    const sensevoice = parseOptionalDependencyBootstrapFeature(parsed.features?.sensevoice);
+    if (!whisper && !nemo && !vibevoiceAsr && !sensevoice) {
       return null;
     }
 
@@ -2770,6 +2782,7 @@ async function readOptionalDependencyBootstrapStatus(): Promise<OptionalDependen
       ...(whisper ? { whisper } : {}),
       ...(nemo ? { nemo } : {}),
       ...(vibevoiceAsr ? { vibevoiceAsr } : {}),
+      ...(sensevoice ? { sensevoice } : {}),
     };
   } catch {
     return null;

--- a/dashboard/electron/preload.ts
+++ b/dashboard/electron/preload.ts
@@ -105,6 +105,7 @@ export interface StartContainerOptions {
   installWhisper?: boolean;
   installNemo?: boolean;
   installVibeVoiceAsr?: boolean;
+  installFunasr?: boolean;
   mainTranscriberModel?: string;
   liveTranscriberModel?: string;
   diarizationModel?: string;
@@ -229,6 +230,7 @@ export interface ElectronAPI {
       whisper?: { available: boolean; reason?: string };
       nemo?: { available: boolean; reason?: string };
       vibevoiceAsr?: { available: boolean; reason?: string };
+      sensevoice?: { available: boolean; reason?: string };
     } | null>;
     checkTailscaleCertsExist: () => Promise<boolean>;
     getLogs: (tail?: number) => Promise<string[]>;
@@ -585,6 +587,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
         whisper?: { available: boolean; reason?: string };
         nemo?: { available: boolean; reason?: string };
         vibevoiceAsr?: { available: boolean; reason?: string };
+        sensevoice?: { available: boolean; reason?: string };
       } | null>,
     checkTailscaleCertsExist: () =>
       ipcRenderer.invoke('docker:checkTailscaleCertsExist') as Promise<boolean>,

--- a/dashboard/src/hooks/useDocker.ts
+++ b/dashboard/src/hooks/useDocker.ts
@@ -48,6 +48,7 @@ export interface StartContainerOnboardingOptions {
   installWhisper?: boolean;
   installNemo?: boolean;
   installVibeVoiceAsr?: boolean;
+  installFunasr?: boolean;
   mainTranscriberModel?: string;
   liveTranscriberModel?: string;
   diarizationModel?: string;

--- a/dashboard/src/services/modelCapabilities.test.ts
+++ b/dashboard/src/services/modelCapabilities.test.ts
@@ -6,6 +6,7 @@ import {
   isWhisperModel,
   isWhisperCppModel,
   isVibeVoiceASRModel,
+  isSenseVoiceModel,
   isEnglishOnlyWhisperModel,
   filterLanguagesForModel,
   pickDefaultLanguage,
@@ -14,6 +15,7 @@ import {
   supportsDiarization,
   NEMO_LANGUAGES,
   CANARY_TRANSLATION_TARGETS,
+  SENSEVOICE_LANGUAGES,
 } from './modelCapabilities';
 
 // ---------------------------------------------------------------------------
@@ -436,6 +438,63 @@ describe('supportsTranslation with GGML models', () => {
 
   it('returns false for GGML turbo models', () => {
     expect(supportsTranslation('ggml-large-v3-turbo.bin')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SenseVoice capabilities
+// ---------------------------------------------------------------------------
+describe('SenseVoice capabilities', () => {
+  it('detects SenseVoice model ids', () => {
+    expect(isSenseVoiceModel('iic/SenseVoiceSmall')).toBe(true);
+    expect(isSenseVoiceModel('FunAudioLLM/SenseVoiceSmall')).toBe(true);
+    expect(isSenseVoiceModel('Systran/faster-whisper-large-v3')).toBe(false);
+  });
+
+  it('is not treated as a Whisper model', () => {
+    expect(isWhisperModel('iic/SenseVoiceSmall')).toBe(false);
+  });
+
+  it('does not support translation', () => {
+    expect(supportsTranslation('iic/SenseVoiceSmall')).toBe(false);
+  });
+
+  it('restricts languages to the 5 SenseVoice languages + Auto Detect', () => {
+    const all = ['Auto Detect', 'English', 'Chinese', 'Greek', 'Japanese', 'Korean', 'Cantonese'];
+    const filtered = filterLanguagesForModel(all, 'iic/SenseVoiceSmall');
+    expect(filtered).toEqual([
+      'Auto Detect',
+      'English',
+      'Chinese',
+      'Japanese',
+      'Korean',
+      'Cantonese',
+    ]);
+    expect(filtered).not.toContain('Greek');
+  });
+
+  it('SENSEVOICE_LANGUAGES contains exactly 5 languages', () => {
+    expect(SENSEVOICE_LANGUAGES.size).toBe(5);
+    for (const lang of ['English', 'Chinese', 'Japanese', 'Korean', 'Cantonese']) {
+      expect(SENSEVOICE_LANGUAGES.has(lang)).toBe(true);
+    }
+    expect(SENSEVOICE_LANGUAGES.has('Greek')).toBe(false);
+  });
+
+  it('returns false for null/undefined/empty/whitespace', () => {
+    expect(isSenseVoiceModel(null)).toBe(false);
+    expect(isSenseVoiceModel(undefined)).toBe(false);
+    expect(isSenseVoiceModel('')).toBe(false);
+    expect(isSenseVoiceModel('   ')).toBe(false);
+  });
+
+  it('detects SenseVoice ids case-insensitively', () => {
+    expect(isSenseVoiceModel('IIC/SenseVoiceSmall')).toBe(true);
+    expect(isSenseVoiceModel('iic/SENSEVOICESMALL')).toBe(true);
+  });
+
+  it('supports auto-detect (language auto-detection)', () => {
+    expect(supportsAutoDetect('iic/SenseVoiceSmall')).toBe(true);
   });
 });
 

--- a/dashboard/src/services/modelCapabilities.ts
+++ b/dashboard/src/services/modelCapabilities.ts
@@ -12,6 +12,7 @@ const MLX_PARAKEET_PATTERN = /^mlx-community\/parakeet/i;
 // Matches community Canary MLX ports: eelcor/canary-1b-v2-mlx, Mediform/canary-1b-v2-mlx-q8, qfuxa/canary-mlx, etc.
 const MLX_CANARY_PATTERN = /^[^/]+\/canary[^/]*-mlx/i;
 const MLX_PATTERN = /^mlx-community\//i;
+const SENSEVOICE_PATTERN = /^[^/]+\/sensevoice/i;
 
 /**
  * The 25 European languages supported by NeMo ASR models
@@ -77,6 +78,18 @@ export const CANARY_TRANSLATION_TARGETS: readonly string[] = [
 ];
 
 /**
+ * The 5 first-class languages SenseVoiceSmall actually supports
+ * (despite the model's "50+ languages" marketing). No Greek.
+ */
+export const SENSEVOICE_LANGUAGES: ReadonlySet<string> = new Set([
+  'English',
+  'Chinese',
+  'Japanese',
+  'Korean',
+  'Cantonese',
+]);
+
+/**
  * Returns true if the model is an NVIDIA Parakeet / NeMo ASR-only model.
  */
 export function isParakeetModel(modelName: string | null | undefined): boolean {
@@ -135,7 +148,8 @@ export function isWhisperModel(modelName: string | null | undefined): boolean {
     !isNemoModel(modelName) &&
     !isVibeVoiceASRModel(modelName) &&
     !isWhisperCppModel(modelName) &&
-    !isMLXModel(modelName)
+    !isMLXModel(modelName) &&
+    !isSenseVoiceModel(modelName)
   );
 }
 
@@ -145,6 +159,14 @@ export function isWhisperModel(modelName: string | null | undefined): boolean {
 export function isVibeVoiceASRModel(modelName: string | null | undefined): boolean {
   const name = (modelName ?? '').trim();
   return VIBEVOICE_ASR_PATTERN.test(name);
+}
+
+/**
+ * Returns true if the model is a SenseVoice (FunASR) backend variant.
+ */
+export function isSenseVoiceModel(modelName: string | null | undefined): boolean {
+  const name = (modelName ?? '').trim();
+  return SENSEVOICE_PATTERN.test(name);
 }
 
 /**
@@ -215,6 +237,10 @@ export function filterLanguagesForModel(
   const keepAutoDetect = (l: string): boolean =>
     l !== 'Auto Detect' || supportsAutoDetect(modelName);
 
+  if (isSenseVoiceModel(modelName)) {
+    // SenseVoiceSmall: zh/en/yue/ja/ko only, plus Auto Detect.
+    return languages.filter((l) => l === 'Auto Detect' || SENSEVOICE_LANGUAGES.has(l));
+  }
   if (isVibeVoiceASRModel(modelName)) {
     return languages.filter((l) => l === 'Auto Detect');
   }
@@ -255,6 +281,8 @@ export function supportsTranslation(modelName: string | null | undefined): boole
   if (isMLXCanaryModel(modelName)) return false;
   // VibeVoice-ASR (v1 integration) is ASR+diarization only.
   if (isVibeVoiceASRModel(modelName)) return false;
+  // SenseVoice is ASR-only (5 languages, no translation task).
+  if (isSenseVoiceModel(modelName)) return false;
   if (name.includes('turbo')) return false;
   if (name.endsWith('.en')) return false;
 

--- a/dashboard/src/services/modelRegistry.ts
+++ b/dashboard/src/services/modelRegistry.ts
@@ -13,11 +13,13 @@ import {
   isWhisperCppModel,
   isMLXModel,
   isMLXParakeetModel,
+  isSenseVoiceModel,
 } from './modelCapabilities';
 
 export type ModelFamily =
   | 'whisper'
   | 'nemo'
+  | 'sensevoice'
   | 'vibevoice'
   | 'whispercpp'
   | 'mlx'
@@ -67,6 +69,20 @@ export const MODEL_REGISTRY: ModelInfo[] = [
     parameterCount: '1B',
     huggingfaceUrl: 'https://huggingface.co/nvidia/canary-1b-v2',
     capabilities: { translation: true, liveMode: false, diarization: false, languageCount: 25 },
+    roles: ['main'],
+    requiresRuntime: 'cuda',
+  },
+
+  // ── SenseVoice (FunASR) ──────────────────────────────────────────────────
+  {
+    id: 'iic/SenseVoiceSmall',
+    displayName: 'SenseVoice Small',
+    family: 'sensevoice',
+    description:
+      'Alibaba FunAudioLLM non-autoregressive ASR. Very fast, CPU-capable. 5 languages (zh/en/yue/ja/ko) — no Greek, no translation. Linux/NVIDIA, requires INSTALL_FUNASR=true.',
+    parameterCount: '234M',
+    huggingfaceUrl: 'https://huggingface.co/FunAudioLLM/SenseVoiceSmall',
+    capabilities: { translation: false, liveMode: true, diarization: false, languageCount: 5 },
     roles: ['main'],
     requiresRuntime: 'cuda',
   },
@@ -551,6 +567,7 @@ export function getModelById(id: string): ModelInfo | undefined {
 /** Detect the display family for an arbitrary model ID. */
 export function detectModelFamily(modelId: string): ModelFamily {
   if (isParakeetModel(modelId) || isCanaryModel(modelId)) return 'nemo';
+  if (isSenseVoiceModel(modelId)) return 'sensevoice';
   // MLX check must come before VibeVoice — mlx-community/VibeVoice-ASR-bf16
   // matches both isMLXModel and isVibeVoiceASRModel.
   if (isMLXParakeetModel(modelId) || isMLXModel(modelId)) return 'mlx';

--- a/dashboard/src/services/modelRegistry.ts
+++ b/dashboard/src/services/modelRegistry.ts
@@ -82,7 +82,7 @@ export const MODEL_REGISTRY: ModelInfo[] = [
       'Alibaba FunAudioLLM non-autoregressive ASR. Very fast, CPU-capable. 5 languages (zh/en/yue/ja/ko) — no Greek, no translation. Linux/NVIDIA, requires INSTALL_FUNASR=true.',
     parameterCount: '234M',
     huggingfaceUrl: 'https://huggingface.co/FunAudioLLM/SenseVoiceSmall',
-    capabilities: { translation: false, liveMode: true, diarization: false, languageCount: 5 },
+    capabilities: { translation: false, liveMode: false, diarization: false, languageCount: 5 },
     roles: ['main'],
     requiresRuntime: 'cuda',
   },

--- a/dashboard/src/services/modelSelection.test.ts
+++ b/dashboard/src/services/modelSelection.test.ts
@@ -95,6 +95,10 @@ describe('modelFamilyFromName', () => {
     expect(modelFamilyFromName('microsoft/VibeVoice-ASR')).toBe('vibevoice');
   });
 
+  it('returns sensevoice for SenseVoiceSmall', () => {
+    expect(modelFamilyFromName('iic/SenseVoiceSmall')).toBe('sensevoice');
+  });
+
   it('returns whisper for faster-whisper models', () => {
     expect(modelFamilyFromName('Systran/faster-whisper-large-v3')).toBe('whisper');
   });
@@ -129,6 +133,10 @@ describe('familyDisplayName', () => {
 
   it('returns VibeVoice-ASR for vibevoice', () => {
     expect(familyDisplayName('vibevoice')).toBe('VibeVoice-ASR');
+  });
+
+  it('returns SenseVoice (FunASR) for sensevoice', () => {
+    expect(familyDisplayName('sensevoice')).toBe('SenseVoice (FunASR)');
   });
 });
 
@@ -274,6 +282,7 @@ describe('computeMissingModelFamilies', () => {
         composeInstallWhisperEnabled: false,
         composeInstallNemoEnabled: false,
         composeInstallVibeVoiceAsrEnabled: false,
+        composeInstallFunasrEnabled: false,
         bootstrapStatus: null,
       }),
     ).toEqual([]);
@@ -285,6 +294,7 @@ describe('computeMissingModelFamilies', () => {
       composeInstallWhisperEnabled: false,
       composeInstallNemoEnabled: false,
       composeInstallVibeVoiceAsrEnabled: false,
+      composeInstallFunasrEnabled: false,
       bootstrapStatus: null,
     });
 
@@ -297,6 +307,7 @@ describe('computeMissingModelFamilies', () => {
       composeInstallWhisperEnabled: false,
       composeInstallNemoEnabled: true,
       composeInstallVibeVoiceAsrEnabled: false,
+      composeInstallFunasrEnabled: false,
       bootstrapStatus: null,
     });
 
@@ -309,9 +320,52 @@ describe('computeMissingModelFamilies', () => {
       composeInstallWhisperEnabled: false,
       composeInstallNemoEnabled: false,
       composeInstallVibeVoiceAsrEnabled: false,
+      composeInstallFunasrEnabled: false,
       bootstrapStatus: {
         source: 'runtime-volume-bootstrap-status',
         whisper: { available: true },
+      },
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns sensevoice missing when nothing covers it', () => {
+    const result = computeMissingModelFamilies({
+      mainModel: 'iic/SenseVoiceSmall',
+      composeInstallWhisperEnabled: false,
+      composeInstallNemoEnabled: false,
+      composeInstallVibeVoiceAsrEnabled: false,
+      composeInstallFunasrEnabled: false,
+      bootstrapStatus: null,
+    });
+
+    expect(result).toEqual(['sensevoice']);
+  });
+
+  it('returns empty when the FunASR compose flag covers sensevoice', () => {
+    const result = computeMissingModelFamilies({
+      mainModel: 'iic/SenseVoiceSmall',
+      composeInstallWhisperEnabled: false,
+      composeInstallNemoEnabled: false,
+      composeInstallVibeVoiceAsrEnabled: false,
+      composeInstallFunasrEnabled: true,
+      bootstrapStatus: null,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty when bootstrap status covers sensevoice', () => {
+    const result = computeMissingModelFamilies({
+      mainModel: 'iic/SenseVoiceSmall',
+      composeInstallWhisperEnabled: false,
+      composeInstallNemoEnabled: false,
+      composeInstallVibeVoiceAsrEnabled: false,
+      composeInstallFunasrEnabled: false,
+      bootstrapStatus: {
+        source: 'runtime-volume-bootstrap-status',
+        sensevoice: { available: true },
       },
     });
 
@@ -339,11 +393,16 @@ describe('toInstallFlagPatch', () => {
     expect(toInstallFlagPatch(['vibevoice'])).toEqual({ installVibeVoiceAsr: true });
   });
 
+  it('sets installFunasr for sensevoice family', () => {
+    expect(toInstallFlagPatch(['sensevoice'])).toEqual({ installFunasr: true });
+  });
+
   it('sets all flags for all families', () => {
-    expect(toInstallFlagPatch(['whisper', 'nemo', 'vibevoice'])).toEqual({
+    expect(toInstallFlagPatch(['whisper', 'nemo', 'vibevoice', 'sensevoice'])).toEqual({
       installWhisper: true,
       installNemo: true,
       installVibeVoiceAsr: true,
+      installFunasr: true,
     });
   });
 });
@@ -475,6 +534,7 @@ describe('computeMissingModelFamilies — whispercpp never missing', () => {
       composeInstallWhisperEnabled: false,
       composeInstallNemoEnabled: false,
       composeInstallVibeVoiceAsrEnabled: false,
+      composeInstallFunasrEnabled: false,
       bootstrapStatus: null,
     });
     expect(result).not.toContain('whispercpp');
@@ -487,6 +547,7 @@ describe('computeMissingModelFamilies — whispercpp never missing', () => {
       composeInstallWhisperEnabled: false,
       composeInstallNemoEnabled: false,
       composeInstallVibeVoiceAsrEnabled: false,
+      composeInstallFunasrEnabled: false,
       bootstrapStatus: null,
     });
     expect(result).not.toContain('whispercpp');

--- a/dashboard/src/services/modelSelection.ts
+++ b/dashboard/src/services/modelSelection.ts
@@ -1,6 +1,7 @@
 import {
   isMLXModel,
   isNemoModel,
+  isSenseVoiceModel,
   isVibeVoiceASRModel,
   isWhisperCppModel,
 } from './modelCapabilities';
@@ -74,12 +75,14 @@ export type OptionalDependencyBootstrapStatus = {
   whisper?: OptionalDependencyBootstrapFeatureStatus;
   nemo?: OptionalDependencyBootstrapFeatureStatus;
   vibevoiceAsr?: OptionalDependencyBootstrapFeatureStatus;
+  sensevoice?: OptionalDependencyBootstrapFeatureStatus;
 } | null;
 
 export type InstallFlagPatch = {
   installWhisper?: true;
   installNemo?: true;
   installVibeVoiceAsr?: true;
+  installFunasr?: true;
 };
 
 function normalize(value: string | null | undefined): string {
@@ -106,6 +109,7 @@ export function modelFamilyFromName(value: string | null | undefined): ModelFami
   const modelName = normalizeForModelFamily(value);
   if (!modelName) return 'none';
   if (isNemoModel(modelName)) return 'nemo';
+  if (isSenseVoiceModel(modelName)) return 'sensevoice';
   // MLX check must come before VibeVoice — mlx-community/VibeVoice-ASR-bf16
   // matches both isMLXModel and isVibeVoiceASRModel.
   if (isMLXModel(modelName)) return 'mlx';
@@ -118,6 +122,7 @@ export function familyDisplayName(family: Exclude<ModelFamily, 'none'>): string 
   if (family === 'whisper') return 'faster-whisper';
   if (family === 'nemo') return 'NeMo';
   if (family === 'whispercpp') return 'whisper.cpp';
+  if (family === 'sensevoice') return 'SenseVoice (FunASR)';
   return 'VibeVoice-ASR';
 }
 
@@ -189,6 +194,7 @@ export function computeMissingModelFamilies(options: {
   composeInstallWhisperEnabled: boolean;
   composeInstallNemoEnabled: boolean;
   composeInstallVibeVoiceAsrEnabled: boolean;
+  composeInstallFunasrEnabled: boolean;
   bootstrapStatus: OptionalDependencyBootstrapStatus;
 }): Exclude<ModelFamily, 'none'>[] {
   const requiredFamilies = computeRequiredModelFamilies({
@@ -217,6 +223,12 @@ export function computeMissingModelFamilies(options: {
   ) {
     installedFamilies.add('vibevoice');
   }
+  if (
+    options.composeInstallFunasrEnabled ||
+    options.bootstrapStatus?.sensevoice?.available === true
+  ) {
+    installedFamilies.add('sensevoice');
+  }
 
   return requiredFamilies.filter((family) => !installedFamilies.has(family));
 }
@@ -236,6 +248,10 @@ export function toInstallFlagPatch(
     }
     if (family === 'vibevoice') {
       nextFlags.installVibeVoiceAsr = true;
+      continue;
+    }
+    if (family === 'sensevoice') {
+      nextFlags.installFunasr = true;
       continue;
     }
     // 'whispercpp' — sidecar is self-contained, no install flag needed.

--- a/dashboard/src/types/electron.d.ts
+++ b/dashboard/src/types/electron.d.ts
@@ -43,6 +43,7 @@ interface StartContainerOptions {
   installWhisper?: boolean;
   installNemo?: boolean;
   installVibeVoiceAsr?: boolean;
+  installFunasr?: boolean;
   mainTranscriberModel?: string;
   liveTranscriberModel?: string;
   diarizationModel?: string;
@@ -174,6 +175,7 @@ interface ElectronAPI {
       whisper?: { available: boolean; reason?: string };
       nemo?: { available: boolean; reason?: string };
       vibevoiceAsr?: { available: boolean; reason?: string };
+      sensevoice?: { available: boolean; reason?: string };
     } | null>;
     getLogs: (tail?: number) => Promise<string[]>;
     startLogStream: (tail?: number) => Promise<void>;

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.0.59",
-  "contract_sha256": "10da0ab3d7e66c03b031416e0a0b219f8976890a8552daf1e2f5eb50f6e72e77",
-  "updated_at": "2026-06-27T21:06:45.358Z"
+  "spec_version": "1.0.60",
+  "contract_sha256": "205affbf70519656686f02f6a9db7e0567b2406d9ce18238bb2d02e28ddb968e",
+  "updated_at": "2026-06-28T08:24:20.759Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.0.59
+  spec_version: 1.0.60
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -98,7 +98,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-06-27T21:06:20.910Z
+    generated_at: 2026-06-28T08:24:10.018Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -589,6 +589,7 @@ utility_allowlist:
     - border-l
     - border-l-2
     - border-l-accent-magenta
+    - border-l-amber-400
     - border-l-blue-400
     - border-l-green-400
     - border-l-orange-400

--- a/docs/README_DEV.md
+++ b/docs/README_DEV.md
@@ -153,6 +153,7 @@ Technical documentation for developing and building TranscriptionSuite.
       - [Dependency Logic](#dependency-logic)
       - [Download Flow](#download-flow)
       - [Limitations](#limitations-1)
+    - [8.6 SenseVoice / FunASR Backend](#86-sensevoice--funasr-backend)
   - [9. Dashboard Development](#9-dashboard-development)
     - [9.1 Running from Source](#91-running-from-source)
     - [9.2 Tech Stack](#92-tech-stack)
@@ -527,7 +528,8 @@ TranscriptionSuite/
 │   │   │   │       ├── mlx_whisper_backend.py   # MLX Whisper via mlx-audio (word timestamps, alignment_heads patch)
 │   │   │   │       ├── mlx_parakeet_backend.py  # MLX Parakeet via parakeet-mlx
 │   │   │   │       ├── mlx_canary_backend.py    # MLX Canary via canary-mlx
-│   │   │   │       └── mlx_vibevoice_backend.py # MLX VibeVoice-ASR via mlx-audio (native diarization)
+│   │   │   │       ├── mlx_vibevoice_backend.py # MLX VibeVoice-ASR via mlx-audio (native diarization)
+│   │   │   │       └── sensevoice_backend.py    # Alibaba SenseVoice (FunASR) — zh/en/yue/ja/ko, Linux/NVIDIA, no translation
 │   │   │   ├── diarization_engine.py    # PyAnnote wrapper
 │   │   │   ├── sortformer_engine.py     # Metal-native Sortformer diarization via mlx-audio (no HF token)
 │   │   │   ├── model_manager.py         # Model lifecycle, job tracking
@@ -1275,6 +1277,7 @@ Boost uses `[project.optional-dependencies]` groups in `pyproject.toml`:
 | `whisper` | `faster-whisper`, `ctranslate2`, `whisperx` | `INSTALL_WHISPER=true` **or** configured model name is a faster-whisper variant |
 | `nemo` | `nemo_toolkit[asr]` | `INSTALL_NEMO=true` **or** configured model name is a NeMo/Parakeet variant |
 | `vibevoice_asr` | `vibevoice` (git+ ref) | `INSTALL_VIBEVOICE_ASR=true` **or** configured model name matches the VibeVoice-ASR pattern |
+| `sensevoice` | `funasr>=1.3.12` | `INSTALL_FUNASR=true` **or** configured model name matches `iic/SenseVoice*` |
 
 Extras are part of the **structural fingerprint**. Adding or removing an extra triggers a `rebuild-sync`.
 
@@ -1294,7 +1297,7 @@ This appears in `docker logs` and in the server log file.
 `/runtime/bootstrap-status.json` is written at the end of every bootstrap run. It records:
 
 - The selected sync mode and selection reason.
-- Feature availability for each backend (`whisper`, `nemo`, `vibevoice_asr`, `diarization`).
+- Feature availability for each backend (`whisper`, `nemo`, `vibevoice_asr`, `sensevoice`, `diarization`).
 - A `preload_cache_key` for diarization (so the expensive PyAnnote pipeline load is skipped on restart if nothing changed).
 - Package delta counts and diagnostics.
 
@@ -1329,6 +1332,7 @@ The server's `/api/status` endpoint reads this file to report backend capability
 | `INSTALL_WHISPER` | `false` | Force-enable the `whisper` extra regardless of configured model. |
 | `INSTALL_NEMO` | `false` | Force-enable the `nemo` extra regardless of configured model. |
 | `INSTALL_VIBEVOICE_ASR` | `false` | Force-enable the `vibevoice_asr` extra regardless of configured model. |
+| `INSTALL_FUNASR` | `false` | Force-enable the `sensevoice` extra regardless of configured model. |
 
 **Config reset semantics**
 - Normal image/runtime updates do **not** require deleting `~/.config/TranscriptionSuite` (or platform equivalent).
@@ -2362,7 +2366,8 @@ server/backend/
 │           ├── mlx_whisper_backend.py    # MLX Whisper via mlx-audio (word timestamps, alignment_heads monkey-patch)
 │           ├── mlx_parakeet_backend.py   # MLX Parakeet via parakeet-mlx (long-audio chunking)
 │           ├── mlx_canary_backend.py     # MLX Canary via canary-mlx (multitask, reuses Parakeet chunking)
-│           └── mlx_vibevoice_backend.py  # MLX VibeVoice-ASR via mlx-audio (native diarization, JSON segment parse)
+│           ├── mlx_vibevoice_backend.py  # MLX VibeVoice-ASR via mlx-audio (native diarization, JSON segment parse)
+│           └── sensevoice_backend.py     # Alibaba SenseVoice via FunASR (zh/en/yue/ja/ko; Linux/NVIDIA; no translation)
 ├── database/
 │   ├── database.py               # SQLite + FTS5 operations
 │   ├── job_repository.py         # Transcription job CRUD (persist-before-deliver, retry, recovery)
@@ -2487,6 +2492,22 @@ The existing `downloadModelToCache()` entry point detects GGML files via `isGgml
 - **No translation** for turbo variants - large-v3 and medium GGML models support translation; turbo variants do not.
 - **One model at a time** - model switching requires a server restart (sidecar loads model at startup).
 - **AMD/Intel only** - CUDA users should prefer faster-whisper models for better performance and feature coverage.
+
+### 8.6 SenseVoice / FunASR Backend
+
+**Phase 1: Linux/NVIDIA, transcriber-only.** `sensevoice_backend.py` wraps Alibaba FunAudioLLM's `funasr.AutoModel` (SenseVoiceSmall + `fsmn-vad`) pulling weights from HuggingFace (`hub="hf"`).
+
+**Supported languages:** zh / en / yue / ja / ko only — **no Greek**. No translation. No word-level timestamps (diarization falls back to segment-level via the existing pyannote two-pass pipeline).
+
+**Factory routing:** model IDs matching `^<org>/sensevoice` (case-insensitive) → `detect_backend_type` returns `"sensevoice"` → `SenseVoiceBackend`. The pattern is explicitly excluded from the whisper default path in `factory.py`, `capabilities.py`, `bootstrap_runtime.py`, and the dashboard `isWhisperModel` helper.
+
+**Optional install — gated behind `INSTALL_FUNASR=true`** (mirrors `INSTALL_NEMO`). The `sensevoice` extra (`funasr>=1.3.12`) is defined in `server/backend/pyproject.toml`. If FunASR is not installed, `SenseVoiceBackend.load()` raises `BackendDependencyError`, surfaced to the client as HTTP 503 with a remedy message.
+
+**Feature status** is reported via `ModelManager.get_sensevoice_feature_status()` in `GET /api/status` → `features.sensevoice`. The dashboard gates the install prompt on `INSTALL_FUNASR` (label `'SenseVoice (FunASR)'`).
+
+**Dashboard integration:** model family `'sensevoice'` in `modelRegistry.ts`; capability helpers `isSenseVoiceModel` / `SENSEVOICE_LANGUAGES` in `modelCapabilities.ts`; shown as an amber section in the Model Manager panel (Docker-only; hidden on Metal).
+
+**Out of scope in Phase 1:** FunASR's own diarization, word timestamps, emotion/event tags, sherpa-onnx / SenseVoice.cpp runtimes, Windows/macOS/Apple Silicon support, ModelScope (CN) download.
 
 ---
 

--- a/docs/architecture-server.md
+++ b/docs/architecture-server.md
@@ -208,7 +208,7 @@ no shared registry. Cross-user dedup is an explicit non-goal.
 
 **Source priority:** User config (`~/.config/TranscriptionSuite/`) → Docker mount (`/user-config/`) → Container default → Repo default
 
-**Environment overrides:** `MAIN_TRANSCRIBER_MODEL`, `LIVE_TRANSCRIBER_MODEL`, `DIARIZATION_MODEL`, `LOG_LEVEL`, `INSTALL_WHISPER`, `INSTALL_NEMO`, `INSTALL_VIBEVOICE_ASR`, `HF_TOKEN`, `WHISPERCPP_SERVER_URL`
+**Environment overrides:** `MAIN_TRANSCRIBER_MODEL`, `LIVE_TRANSCRIBER_MODEL`, `DIARIZATION_MODEL`, `LOG_LEVEL`, `INSTALL_WHISPER`, `INSTALL_NEMO`, `INSTALL_VIBEVOICE_ASR`, `INSTALL_FUNASR`, `HF_TOKEN`, `WHISPERCPP_SERVER_URL`
 
 **Key config sections:** `longform_recording`, `static_transcription`, `main_transcriber`, `parakeet`,
 `sortformer`, `mlx`, `vibevoice_asr`, `live_transcriber`, `diarization`, `audio_processing`, `storage`,

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -269,6 +269,7 @@ non-flipping cu129 path is zero-cost.
 | `INSTALL_WHISPER` | false | Install faster-whisper extras |
 | `INSTALL_NEMO` | false | Install NeMo toolkit |
 | `INSTALL_VIBEVOICE_ASR` | false | Install VibeVoice backend |
+| `INSTALL_FUNASR` | false | Install FunASR for SenseVoice models (Linux/NVIDIA) |
 | `PYTORCH_VARIANT` | cu129 | PyTorch wheels: `cu129`, `cu126` (legacy GPU), or `cpu` (no CUDA, GH #125) |
 | `UV_NATIVE_TLS` | false | Trust the system CA store for `uv` (corporate TLS interception, GH #125) |
 | `TLS_ENABLED` | false | Enable HTTPS + auth |

--- a/docs/project-context.md
+++ b/docs/project-context.md
@@ -130,6 +130,7 @@ durability:
   - `nvidia/canary*` → CanaryBackend (NeMo, Docker)
   - `mlx-community/vibevoice-asr*` → MLXVibeVoiceBackend (Apple Silicon) — checked before generic VibeVoice
   - `[user]/vibevoice-asr*` → VibeVoiceASRBackend
+  - `iic/SenseVoice*` (or any `<org>/sensevoice*`) → SenseVoiceBackend (FunASR; Linux/NVIDIA only; zh/en/yue/ja/ko; no translation; requires `INSTALL_FUNASR=true`)
   - GGML pattern (`ggml-*.bin`, `.gguf`) → WhisperCppBackend
   - `mlx-community/parakeet*` → MLXParakeetBackend (Apple Silicon)
   - `[user]/canary*-mlx` → MLXCanaryBackend (Apple Silicon)
@@ -274,6 +275,7 @@ durability:
 - **Python 3.13 lhotse patch**: `_patch_sampler_for_python313()` in ParakeetBackend — required for NeMo compatibility
 - **VibeVoice OOM**: `DEFAULT_MAX_CHUNK_DURATION_S = 60` (1 minute) — was 600s, caused CUDA OOM on 12GB GPU. Never increase without GPU memory testing
 - **NeMo requires `INSTALL_NEMO=true`** env var in Docker — not installed by default
+- **SenseVoice (FunASR) requires `INSTALL_FUNASR=true`** env var in Docker — not installed by default; Linux/NVIDIA only
 
 #### GPU Crash Resilience
 - **CUDA health probe**: `cuda_health_check()` in `audio_utils.py` runs at startup between prewarm and ModelManager init

--- a/docs/superpowers/plans/2026-06-24-sensevoice-phase1-linux-nvidia.md
+++ b/docs/superpowers/plans/2026-06-24-sensevoice-phase1-linux-nvidia.md
@@ -1,0 +1,1376 @@
+# SenseVoice (FunASR) STT Backend — Phase 1 (Linux / NVIDIA, transcriber-only) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Alibaba FunAudioLLM's **SenseVoice** model as a new STT backend (`iic/SenseVoiceSmall`) that transcribes on Linux/NVIDIA via the `funasr` PyTorch pipeline, selectable like any other model, with **no** new diarization code (existing pyannote two-pass remains available).
+
+**Architecture:** SenseVoice plugs into the existing backend-factory pattern. A new `SenseVoiceBackend(STTBackend)` wraps `funasr.AutoModel` (SenseVoiceSmall + `fsmn-vad`), returns normalised `BackendSegment`s, and is reached when the model name matches `^<org>/sensevoice…`. Install is gated behind a new `INSTALL_FUNASR` env var mirroring `INSTALL_NEMO`. The dashboard learns the model's capabilities (5 languages, no translation). This is a vertical slice: backend + routing + capability flags + install gate + feature status + UI registry + smoke test.
+
+**Tech Stack:** Python 3.13, `funasr>=1.3.12`, PyTorch (already present for pyannote), FastAPI; TypeScript/React dashboard; pytest (build venv) + Vitest (Node 22).
+
+**Explicitly OUT of scope for Phase 1** (deferred to later phases): FunASR's own CAM++ diarization (`transcribe_with_diarization`), word-level timestamps, emotion/audio-event tags as a product feature, sherpa-onnx / SenseVoice.cpp runtimes, Windows / macOS / Apple-Silicon, ModelScope (CN) download path. SenseVoice **cannot transcribe Greek** — it is a specialist (zh/en/yue/ja/ko), not a Whisper replacement.
+
+---
+
+## Scope Check
+
+This is a single subsystem (one new STT backend on one platform). It produces working, testable software on its own and does not need to be split further.
+
+## File Structure
+
+**New files:**
+- `server/backend/core/stt/backends/sensevoice_backend.py` — the `SenseVoiceBackend` class (funasr wrapper). One responsibility: SenseVoice transcription behind the `STTBackend` interface.
+- `server/backend/tests/test_sensevoice_backend.py` — unit tests (funasr stubbed via `sys.modules`).
+- `server/backend/tests/test_sensevoice_routing.py` — factory + capability + bootstrap-helper routing tests.
+
+**Modified files:**
+- `server/backend/core/stt/backends/factory.py` — pattern + `detect_backend_type` branch + `create_backend` branch + `is_sensevoice_model` helper.
+- `server/backend/core/stt/capabilities.py` — pattern + `supports_english_translation` returns `False`.
+- `server/backend/pyproject.toml` — `sensevoice` optional-dependency extra.
+- `server/docker/bootstrap_runtime.py` — `is_sensevoice_model_name`, exclude from `is_whisper_model_name`, `check_funasr_import`, `INSTALL_FUNASR` install block, `sensevoice` in features dict + cache-reuse list.
+- `server/backend/core/model_manager.py` — `_initialize_sensevoice_feature_status` + `get_sensevoice_feature_status`.
+- `server/config.yaml` — document SenseVoice model id + `INSTALL_FUNASR`.
+- `dashboard/src/services/modelCapabilities.ts` — `SENSEVOICE_PATTERN`, `isSenseVoiceModel`, language filter, translation flag, exclude from `isWhisperModel`.
+- `dashboard/src/services/modelCapabilities.test.ts` — Vitest coverage.
+- `dashboard/src/services/modelRegistry.ts` — `'sensevoice'` family + registry entry.
+- `docs/project-context.md`, `README_DEV.md` — note the new backend.
+
+---
+
+## Task 0: Feature branch
+
+- [ ] **Step 1: Create the branch**
+
+Run:
+```bash
+cd /home/Bill/Code_Projects/Python_Projects/TranscriptionSuite
+git checkout -b feature/sensevoice-asr-phase1
+```
+Expected: `Switched to a new branch 'feature/sensevoice-asr-phase1'`
+
+---
+
+## Task 1: Capability flags (`capabilities.py`)
+
+**Files:**
+- Modify: `server/backend/core/stt/capabilities.py:9-13` (patterns), `:64-66` region (translation guard)
+- Test: `server/backend/tests/test_sensevoice_routing.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/backend/tests/test_sensevoice_routing.py`:
+```python
+"""Routing + capability tests for the SenseVoice (FunASR) backend."""
+
+from __future__ import annotations
+
+import pytest
+
+
+# --- capabilities.py -------------------------------------------------------
+
+class TestSenseVoiceCapabilities:
+    def test_sensevoice_has_no_translation(self) -> None:
+        from server.core.stt.capabilities import supports_english_translation
+
+        assert supports_english_translation("iic/SenseVoiceSmall") is False
+        assert supports_english_translation("FunAudioLLM/SenseVoiceSmall") is False
+
+    def test_sensevoice_supports_auto_detect(self) -> None:
+        from server.core.stt.capabilities import supports_auto_detect
+
+        assert supports_auto_detect("iic/SenseVoiceSmall") is True
+
+    def test_sensevoice_translate_request_rejected(self) -> None:
+        from server.core.stt.capabilities import validate_translation_request
+
+        with pytest.raises(ValueError, match="does not support translation"):
+            validate_translation_request(
+                model_name="iic/SenseVoiceSmall",
+                task="translate",
+                translation_target_language="en",
+            )
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_sensevoice_routing.py::TestSenseVoiceCapabilities -v --tb=short`
+Expected: FAIL — `supports_english_translation("iic/SenseVoiceSmall")` currently returns `True` (unknown model default).
+
+- [ ] **Step 3: Add the pattern**
+
+In `server/backend/core/stt/capabilities.py`, after line 13 (`_MLX_CANARY_PATTERN = …`), add:
+```python
+# SenseVoice (FunAudioLLM) — any "<org>/sensevoice…" repo id.
+_SENSEVOICE_PATTERN = re.compile(r"^[^/]+/sensevoice", re.IGNORECASE)
+```
+
+- [ ] **Step 4: Return False for translation**
+
+In `supports_english_translation`, immediately after the VibeVoice block (after line 66, the `return False` for `_VIBEVOICE_ASR_PATTERN`), add:
+```python
+    # SenseVoice (FunASR) is ASR-only in Phase 1 — no translate task.
+    if _SENSEVOICE_PATTERN.match(name):
+        return False
+```
+
+- [ ] **Step 5: Run the test and confirm it passes**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_sensevoice_routing.py::TestSenseVoiceCapabilities -v --tb=short`
+Expected: 3 passed. (`validate_translation_request` already raises because it calls `supports_english_translation`.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/backend/core/stt/capabilities.py server/backend/tests/test_sensevoice_routing.py
+git commit -m "feat(stt): mark SenseVoice as ASR-only (no translation) in capabilities"
+```
+
+---
+
+## Task 2: Factory routing (`factory.py`)
+
+**Files:**
+- Modify: `server/backend/core/stt/backends/factory.py` (pattern @ ~26, detect branch @ ~59, helper @ ~93, create branch @ ~136)
+- Test: `server/backend/tests/test_sensevoice_routing.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/backend/tests/test_sensevoice_routing.py`:
+```python
+# --- factory.py ------------------------------------------------------------
+
+class TestSenseVoiceFactory:
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "iic/SenseVoiceSmall",
+            "FunAudioLLM/SenseVoiceSmall",
+            "iic/SenseVoice-extra",
+            "IIC/SENSEVOICESMALL",  # case-insensitive
+        ],
+    )
+    def test_sensevoice_models_detected(self, model_name: str) -> None:
+        from server.core.stt.backends.factory import detect_backend_type, is_sensevoice_model
+
+        assert detect_backend_type(model_name) == "sensevoice"
+        assert is_sensevoice_model(model_name) is True
+
+    def test_non_sensevoice_unaffected(self) -> None:
+        from server.core.stt.backends.factory import detect_backend_type
+
+        assert detect_backend_type("Systran/faster-whisper-large-v3") == "whisper"
+        assert detect_backend_type("nvidia/parakeet-tdt-0.6b-v3") == "parakeet"
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_sensevoice_routing.py::TestSenseVoiceFactory -v --tb=short`
+Expected: FAIL — `iic/SenseVoiceSmall` currently resolves to `"whisper"` (default branch); `is_sensevoice_model` does not exist.
+
+- [ ] **Step 3: Add the pattern**
+
+In `factory.py`, after line 26 (`_MLX_PATTERN = …`), add:
+```python
+# SenseVoice (FunAudioLLM) via FunASR — any "<org>/sensevoice…" repo id.
+_SENSEVOICE_PATTERN = re.compile(r"^[^/]+/sensevoice", re.IGNORECASE)
+```
+
+- [ ] **Step 4: Add the detection branch**
+
+In `detect_backend_type`, immediately before `if _looks_like_whispercpp(name):` (line 60), add:
+```python
+    if _SENSEVOICE_PATTERN.match(name):
+        return "sensevoice"
+```
+
+- [ ] **Step 5: Add the `is_sensevoice_model` helper**
+
+After the `is_vibevoice_asr_model` function (line 88-89), add:
+```python
+def is_sensevoice_model(model_name: str) -> bool:
+    """Return True if *model_name* selects the SenseVoice (FunASR) backend."""
+    return detect_backend_type(model_name) == "sensevoice"
+```
+
+- [ ] **Step 6: Add the instantiation branch**
+
+In `create_backend`, immediately after the `vibevoice_asr` block (after line 136), add:
+```python
+    if backend_type == "sensevoice":
+        from server.core.stt.backends.sensevoice_backend import SenseVoiceBackend
+
+        return SenseVoiceBackend()
+```
+
+- [ ] **Step 7: Run the test and confirm it passes**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_sensevoice_routing.py::TestSenseVoiceFactory -v --tb=short`
+Expected: 5 passed. (The `create_backend` import target is created in Task 3; detection tests pass now.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/backend/core/stt/backends/factory.py server/backend/tests/test_sensevoice_routing.py
+git commit -m "feat(stt): route iic/SenseVoice* model ids to a sensevoice backend"
+```
+
+---
+
+## Task 3: `SenseVoiceBackend` implementation
+
+**Files:**
+- Create: `server/backend/core/stt/backends/sensevoice_backend.py`
+- Test: `server/backend/tests/test_sensevoice_backend.py`
+
+### 3a — Lifecycle (load / unload / is_loaded / metadata)
+
+- [ ] **Step 1: Write the failing test (lifecycle + metadata)**
+
+Create `server/backend/tests/test_sensevoice_backend.py`:
+```python
+"""Unit tests for SenseVoiceBackend (funasr stubbed — no model download)."""
+
+from __future__ import annotations
+
+import re
+import sys
+import types
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+class _FakeAutoModel:
+    """Minimal stub for ``funasr.AutoModel``."""
+
+    def __init__(self, result: list[dict[str, Any]] | None = None):
+        # Default: one merged-text result, no sentence_info, no timestamps.
+        self._result = result if result is not None else [{"key": "x", "text": "<|en|><|NEUTRAL|><|Speech|>Hello world."}]
+        self.generate = MagicMock(side_effect=lambda **kw: self._result)
+
+
+def _make_funasr_stub(model: _FakeAutoModel | None = None) -> dict[str, Any]:
+    """sys.modules patch dict stubbing funasr + its postprocess submodule."""
+    fake = model or _FakeAutoModel()
+
+    funasr_mod = types.ModuleType("funasr")
+    funasr_mod.AutoModel = MagicMock(return_value=fake)  # type: ignore[attr-defined]
+
+    utils_mod = types.ModuleType("funasr.utils")
+    postproc_mod = types.ModuleType("funasr.utils.postprocess_utils")
+    # Strip every <|...|> rich-transcription token, like the real helper does.
+    postproc_mod.rich_transcription_postprocess = (  # type: ignore[attr-defined]
+        lambda s: re.sub(r"<\|[^|]*\|>", "", s).strip()
+    )
+    return {
+        "funasr": funasr_mod,
+        "funasr.utils": utils_mod,
+        "funasr.utils.postprocess_utils": postproc_mod,
+    }
+
+
+class TestLifecycle:
+    def test_not_loaded_initially(self) -> None:
+        from server.core.stt.backends.sensevoice_backend import SenseVoiceBackend
+
+        assert SenseVoiceBackend().is_loaded() is False
+
+    def test_load_sets_loaded_and_cuda_device(self) -> None:
+        from server.core.stt.backends.sensevoice_backend import SenseVoiceBackend
+
+        stubs = _make_funasr_stub()
+        with patch.dict(sys.modules, stubs):
+            backend = SenseVoiceBackend()
+            backend.load("iic/SenseVoiceSmall", device="cuda", gpu_device_index=0)
+            assert backend.is_loaded()
+            call_kwargs = stubs["funasr"].AutoModel.call_args.kwargs
+            assert call_kwargs["model"] == "iic/SenseVoiceSmall"
+            assert call_kwargs["device"] == "cuda:0"
+            assert call_kwargs["vad_model"] == "fsmn-vad"
+            assert call_kwargs["hub"] == "hf"
+
+    def test_unload_clears_model(self) -> None:
+        from server.core.stt.backends.sensevoice_backend import SenseVoiceBackend
+
+        stubs = _make_funasr_stub()
+        with patch.dict(sys.modules, stubs):
+            backend = SenseVoiceBackend()
+            backend.load("iic/SenseVoiceSmall", device="cpu")
+        with patch("server.core.stt.backends.sensevoice_backend.clear_gpu_cache"):
+            backend.unload()
+        assert backend.is_loaded() is False
+
+    def test_metadata(self) -> None:
+        from server.core.stt.backends.sensevoice_backend import SenseVoiceBackend
+
+        backend = SenseVoiceBackend()
+        assert backend.backend_name == "sensevoice"
+        assert backend.supports_translation() is False
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_sensevoice_backend.py::TestLifecycle -v --tb=short`
+Expected: FAIL — module `sensevoice_backend` does not exist.
+
+- [ ] **Step 3: Create the backend (full file)**
+
+Create `server/backend/core/stt/backends/sensevoice_backend.py`:
+```python
+"""SenseVoice (FunAudioLLM) STT backend.
+
+Adapted from FunAudioLLM/SenseVoice (https://github.com/FunAudioLLM/SenseVoice)
+and modelscope/FunASR (https://github.com/modelscope/FunASR) — wraps the
+``funasr.AutoModel`` pipeline (SenseVoiceSmall + fsmn-vad) behind the project's
+STTBackend interface.
+
+Phase 1 scope: transcriber-only, CUDA/Linux. SenseVoice is non-autoregressive
+and produces NO word-level timestamps; segments carry empty ``words`` lists and,
+when funasr returns no per-sentence info, a single segment spanning the clip.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import soundfile as sf
+from server.core.audio_utils import clear_gpu_cache
+from server.core.stt.backends.base import (
+    BackendSegment,
+    BackendTranscriptionInfo,
+    STTBackend,
+)
+
+SAMPLE_RATE = 16000
+
+# SenseVoiceSmall's first-class language codes (the only values its API accepts).
+_SENSEVOICE_LANGUAGES = frozenset({"zh", "en", "yue", "ja", "ko"})
+_LANG_TOKEN_RE = re.compile(r"<\|(zh|en|yue|ja|ko)\|>", re.IGNORECASE)
+
+logger = logging.getLogger(__name__)
+
+
+def _compose_device(device: str, gpu_device_index: int) -> str:
+    """Map the engine's ("cuda", index) convention to funasr's "cuda:N" string."""
+    if device == "cuda":
+        return f"cuda:{int(gpu_device_index)}"
+    return device
+
+
+def _extract_language(raw_text: str) -> str | None:
+    """Return the SenseVoice language code embedded in *raw_text*, if any."""
+    match = _LANG_TOKEN_RE.search(raw_text or "")
+    return match.group(1).lower() if match else None
+
+
+def _write_temp_wav(audio: np.ndarray, sample_rate: int) -> str:
+    """Write float32 mono audio to a temp 16-bit WAV and return its path."""
+    fd, path = tempfile.mkstemp(suffix=".wav", prefix="sensevoice_")
+    os.close(fd)
+    sf.write(path, audio, sample_rate, subtype="PCM_16")
+    return path
+
+
+class SenseVoiceBackend(STTBackend):
+    """FunASR-backed SenseVoice transcription backend (Phase 1, CUDA/Linux)."""
+
+    def __init__(self) -> None:
+        self._model: Any | None = None
+        self._model_name: str | None = None
+        self._device: str | None = None
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def load(self, model_name: str, device: str, **kwargs: Any) -> None:
+        from funasr import AutoModel
+
+        gpu_device_index = kwargs.get("gpu_device_index", 0)
+        funasr_device = _compose_device(device, gpu_device_index)
+
+        logger.info(f"Loading SenseVoice model: {model_name} on {funasr_device}")
+        # hub="hf": pull weights from HuggingFace, not the CN-hosted ModelScope.
+        # disable_update=True: skip the ModelScope version ping (offline-friendly).
+        self._model = AutoModel(
+            model=model_name,
+            vad_model="fsmn-vad",
+            vad_kwargs={"max_single_segment_time": 30000},
+            device=funasr_device,
+            hub="hf",
+            disable_update=True,
+        )
+        self._model_name = model_name
+        self._device = funasr_device
+        logger.info("SenseVoice model loaded")
+
+    def unload(self) -> None:
+        self._model = None
+        self._model_name = None
+        self._device = None
+        clear_gpu_cache()
+
+    def is_loaded(self) -> bool:
+        return self._model is not None
+
+    def warmup(self) -> None:
+        if self._model is None:
+            return
+        try:
+            warmup_path = Path(__file__).parent.parent / "warmup_audio.wav"
+            if warmup_path.exists():
+                self._model.generate(
+                    input=str(warmup_path), cache={}, language="en", use_itn=True
+                )
+            logger.debug("SenseVoice warmup complete")
+        except Exception as e:  # noqa: BLE001 — warmup is best-effort
+            logger.warning(f"SenseVoice warmup failed (non-critical): {e}")
+
+    # -- transcription ------------------------------------------------------
+
+    def transcribe(
+        self,
+        audio: np.ndarray,
+        *,
+        audio_sample_rate: int = SAMPLE_RATE,
+        language: str | None = None,
+        task: str = "transcribe",
+        beam_size: int = 5,
+        initial_prompt: str | None = None,
+        suppress_tokens: list[int] | None = None,
+        vad_filter: bool = True,
+        word_timestamps: bool = True,
+        translation_target_language: str | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> tuple[list[BackendSegment], BackendTranscriptionInfo]:
+        # SenseVoice has no translate task and no word timestamps — ignore the
+        # Whisper-shaped knobs the engine passes through.
+        del task, beam_size, initial_prompt, suppress_tokens
+        del vad_filter, word_timestamps, translation_target_language, progress_callback
+
+        if self._model is None:
+            raise RuntimeError("SenseVoice model is not loaded")
+
+        lang = self._resolve_language(language)
+        wav_path = _write_temp_wav(audio, audio_sample_rate)
+        try:
+            result = self._model.generate(
+                input=wav_path,
+                cache={},
+                language=lang,
+                use_itn=True,
+                batch_size_s=300,
+                merge_vad=True,
+                merge_length_s=15,
+            )
+        finally:
+            try:
+                os.remove(wav_path)
+            except OSError:
+                pass
+
+        duration_s = float(len(audio)) / float(audio_sample_rate) if audio_sample_rate else 0.0
+        return self._parse_result(result, duration_s, forced_language=lang)
+
+    def supports_translation(self) -> bool:
+        return False
+
+    @property
+    def backend_name(self) -> str:
+        return "sensevoice"
+
+    # -- helpers ------------------------------------------------------------
+
+    def _resolve_language(self, language: str | None) -> str:
+        if not language:
+            return "auto"
+        code = language.strip().lower()
+        if code in _SENSEVOICE_LANGUAGES:
+            return code
+        logger.warning(
+            f"SenseVoice does not support language '{language}'; falling back to auto-detect"
+        )
+        return "auto"
+
+    def _parse_result(
+        self,
+        result: list[dict[str, Any]],
+        duration_s: float,
+        *,
+        forced_language: str,
+    ) -> tuple[list[BackendSegment], BackendTranscriptionInfo]:
+        from funasr.utils.postprocess_utils import rich_transcription_postprocess
+
+        if not result:
+            return [], BackendTranscriptionInfo(language=None, language_probability=0.0)
+
+        first = result[0]
+        raw_text = str(first.get("text", ""))
+        detected = _extract_language(raw_text)
+        if detected is None and forced_language != "auto":
+            detected = forced_language
+        info = BackendTranscriptionInfo(language=detected, language_probability=0.0)
+
+        # Preferred shape: per-sentence segments (VAD-chunk boundaries in ms).
+        sentence_info = first.get("sentence_info")
+        if isinstance(sentence_info, list) and sentence_info:
+            segments: list[BackendSegment] = []
+            for sentence in sentence_info:
+                text = rich_transcription_postprocess(str(sentence.get("text", "")))
+                start = float(sentence.get("start", 0.0)) / 1000.0
+                end = float(sentence.get("end", 0.0)) / 1000.0
+                segments.append(BackendSegment(text=text, start=start, end=end, words=[]))
+            return segments, info
+
+        # Fallback: one segment spanning the whole clip (no timestamps available).
+        text = rich_transcription_postprocess(raw_text)
+        return [BackendSegment(text=text, start=0.0, end=duration_s, words=[])], info
+```
+
+- [ ] **Step 4: Run the lifecycle tests and confirm they pass**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_sensevoice_backend.py::TestLifecycle -v --tb=short`
+Expected: 4 passed.
+
+### 3b — Transcribe & output parsing
+
+- [ ] **Step 5: Write the failing transcribe tests**
+
+Append to `server/backend/tests/test_sensevoice_backend.py`:
+```python
+class TestTranscribe:
+    def _loaded(self, model: _FakeAutoModel) -> Any:
+        from server.core.stt.backends.sensevoice_backend import SenseVoiceBackend
+
+        stubs = _make_funasr_stub(model)
+        with patch.dict(sys.modules, stubs):
+            backend = SenseVoiceBackend()
+            backend.load("iic/SenseVoiceSmall", device="cpu")
+        return backend, stubs
+
+    def test_raises_if_not_loaded(self) -> None:
+        from server.core.stt.backends.sensevoice_backend import SenseVoiceBackend
+
+        with pytest.raises(RuntimeError, match="not loaded"):
+            SenseVoiceBackend().transcribe(np.zeros(16000, dtype=np.float32))
+
+    def test_merged_text_single_segment_strips_tokens(self) -> None:
+        fake = _FakeAutoModel([{"text": "<|en|><|HAPPY|><|Speech|>Hello world."}])
+        backend, stubs = self._loaded(fake)
+        audio = np.zeros(32000, dtype=np.float32)  # 2.0 s @ 16 kHz
+        with patch.dict(sys.modules, stubs):
+            segments, info = backend.transcribe(audio, audio_sample_rate=16000)
+        assert len(segments) == 1
+        assert segments[0].text == "Hello world."
+        assert segments[0].start == 0.0
+        assert segments[0].end == pytest.approx(2.0)
+        assert segments[0].words == []
+        assert info.language == "en"
+
+    def test_sentence_info_yields_per_sentence_segments(self) -> None:
+        fake = _FakeAutoModel([
+            {
+                "text": "<|zh|>whatever",
+                "sentence_info": [
+                    {"text": "<|en|>First.", "start": 0, "end": 1000},
+                    {"text": "<|en|>Second.", "start": 1000, "end": 2500},
+                ],
+            }
+        ])
+        backend, stubs = self._loaded(fake)
+        with patch.dict(sys.modules, stubs):
+            segments, _ = backend.transcribe(np.zeros(40000, dtype=np.float32))
+        assert [s.text for s in segments] == ["First.", "Second."]
+        assert segments[0].start == 0.0 and segments[0].end == pytest.approx(1.0)
+        assert segments[1].start == pytest.approx(1.0) and segments[1].end == pytest.approx(2.5)
+
+    def test_empty_result_is_safe(self) -> None:
+        backend, stubs = self._loaded(_FakeAutoModel([]))
+        with patch.dict(sys.modules, stubs):
+            segments, info = backend.transcribe(np.zeros(16000, dtype=np.float32))
+        assert segments == []
+        assert info.language is None
+
+    def test_unsupported_language_falls_back_to_auto(self) -> None:
+        fake = _FakeAutoModel()
+        backend, stubs = self._loaded(fake)
+        with patch.dict(sys.modules, stubs):
+            backend.transcribe(np.zeros(16000, dtype=np.float32), language="el")
+        # funasr.generate was called with language="auto" (Greek is unsupported).
+        assert fake.generate.call_args.kwargs["language"] == "auto"
+```
+
+- [ ] **Step 6: Run them — confirm pass (no impl change needed if 3a is correct)**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_sensevoice_backend.py -v --tb=short`
+Expected: all `TestLifecycle` + `TestTranscribe` pass. If `test_unsupported_language_falls_back_to_auto` fails, verify `_resolve_language` clamps non-member codes to `"auto"`.
+
+- [ ] **Step 7: Run the routing test that imports the backend (Task 2 Step 7 dependency)**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_sensevoice_routing.py tests/test_sensevoice_backend.py -v --tb=short`
+Expected: all green. The `create_backend("iic/SenseVoiceSmall")` import target now exists.
+
+- [ ] **Step 8: Lint the new module**
+
+Run: `cd server/backend && ../../build/.venv/bin/ruff check core/stt/backends/sensevoice_backend.py tests/test_sensevoice_backend.py`
+Expected: `All checks passed!` (fix any reported issue, e.g. unused import).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add server/backend/core/stt/backends/sensevoice_backend.py server/backend/tests/test_sensevoice_backend.py
+git commit -m "feat(stt): add SenseVoiceBackend (funasr AutoModel wrapper, transcriber-only)"
+```
+
+---
+
+## Task 4: Install gate in bootstrap (`bootstrap_runtime.py`)
+
+**Files:**
+- Modify: `server/docker/bootstrap_runtime.py` — patterns (~line 110), `is_sensevoice_model_name` (~145), `is_whisper_model_name` (153-158), `check_funasr_import` (after 1300), selection vars (~1751), install block (after 1928), features dict (2139-2144), cache-reuse list (1040)
+- Test: `server/backend/tests/test_sensevoice_routing.py`
+
+> **Why this is needed:** today `is_whisper_model_name` returns `True` for *any* non-NeMo/non-VibeVoice id, so `iic/SenseVoiceSmall` would be misclassified as "whisper selected" and never trigger a funasr install. The pure model-name helpers are unit-tested; the install orchestration is verified by the Task 11 smoke test.
+
+- [ ] **Step 1: Write the failing helper test**
+
+Append to `server/backend/tests/test_sensevoice_routing.py`:
+```python
+# --- bootstrap model-name helpers -----------------------------------------
+
+class TestBootstrapSelection:
+    def _bootstrap(self):
+        import importlib.util
+        from pathlib import Path
+
+        path = Path(__file__).resolve().parents[2] / "docker" / "bootstrap_runtime.py"
+        spec = importlib.util.spec_from_file_location("bootstrap_runtime_under_test", path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+
+    def test_sensevoice_recognised_and_not_whisper(self) -> None:
+        bootstrap = self._bootstrap()
+        assert bootstrap.is_sensevoice_model_name("iic/SenseVoiceSmall") is True
+        # Must NOT be misclassified as a whisper model (else funasr never installs).
+        assert bootstrap.is_whisper_model_name("iic/SenseVoiceSmall") is False
+        # Real whisper ids still classify as whisper.
+        assert bootstrap.is_whisper_model_name("Systran/faster-whisper-large-v3") is True
+        assert bootstrap.is_sensevoice_model_name("nvidia/parakeet-tdt-0.6b-v3") is False
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_sensevoice_routing.py::TestBootstrapSelection -v --tb=short`
+Expected: FAIL — `is_sensevoice_model_name` does not exist; `is_whisper_model_name("iic/SenseVoiceSmall")` returns `True`.
+
+- [ ] **Step 3: Add the pattern + helper, and exclude from whisper**
+
+In `server/docker/bootstrap_runtime.py`, near the other `_*_MODEL_PATTERN` definitions (search for `_VIBEVOICE_ASR_MODEL_PATTERN =`), add:
+```python
+_SENSEVOICE_MODEL_PATTERN = re.compile(r"^[^/]+/sensevoice", re.IGNORECASE)
+```
+After `is_nemo_model_name` (line 150), add:
+```python
+def is_sensevoice_model_name(model_name: str | None) -> bool:
+    """Return True when *model_name* selects the SenseVoice (FunASR) backend."""
+    name = normalize_selected_model_name(model_name)
+    return bool(_SENSEVOICE_MODEL_PATTERN.match(name))
+```
+Then change `is_whisper_model_name` (lines 153-158) to exclude SenseVoice:
+```python
+def is_whisper_model_name(model_name: str | None) -> bool:
+    """Return True when *model_name* belongs to the faster-whisper family."""
+    name = normalize_selected_model_name(model_name)
+    if not name:
+        return False
+    return (
+        not is_nemo_model_name(name)
+        and not is_vibevoice_asr_model_name(name)
+        and not is_sensevoice_model_name(name)
+    )
+```
+
+- [ ] **Step 4: Run the helper test and confirm it passes**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_sensevoice_routing.py::TestBootstrapSelection -v --tb=short`
+Expected: 1 passed.
+
+- [ ] **Step 5: Add the `check_funasr_import` probe**
+
+In `bootstrap_runtime.py`, immediately after `check_nemo_asr_import` (ends line 1300), add a sibling that probes `funasr`:
+```python
+def check_funasr_import(
+    venv_python: Path,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    checker = """
+import importlib.util
+import json
+
+try:
+    spec = importlib.util.find_spec("funasr")
+    if spec is None:
+        print(json.dumps({"available": False, "reason": "import_failed", "error": "funasr: not found"}))
+    else:
+        print(json.dumps({"available": True, "reason": "ready"}))
+except Exception as exc:
+    print(json.dumps({"available": False, "reason": "import_failed", "error": f"{type(exc).__name__}: {exc}"}))
+"""
+    try:
+        result = subprocess.run(
+            [str(venv_python), "-c", checker],
+            text=True,
+            capture_output=True,
+            timeout=max(30, min(timeout_seconds, 300)),
+            check=False,
+        )
+    except Exception as exc:
+        return {"available": False, "reason": "import_failed", "error": f"{type(exc).__name__}: {exc}"}
+
+    output = (result.stdout or "").strip().splitlines()
+    if not output:
+        return {"available": False, "reason": "import_failed"}
+    try:
+        payload = json.loads(output[-1])
+    except json.JSONDecodeError:
+        return {"available": False, "reason": "import_failed"}
+
+    result_payload = {
+        "available": bool(payload.get("available", False)),
+        "reason": str(payload.get("reason", "import_failed") or "import_failed"),
+    }
+    error = payload.get("error")
+    if error:
+        result_payload["error"] = str(error)
+    return result_payload
+```
+
+- [ ] **Step 6: Add the selection var + install block**
+
+After the line `vibevoice_selected = is_vibevoice_asr_model_name(...)` (~1753), add:
+```python
+    sensevoice_selected = is_sensevoice_model_name(main_model) or is_sensevoice_model_name(live_model)
+```
+After the VibeVoice feature-check block ends and **before** the `"features": {` status dict is written (i.e. just before line ~2139), add the SenseVoice block (mirrors NeMo at 1856-1928):
+```python
+    # ── SenseVoice (optional, FunASR pipeline) ──────────────────────────────
+    sensevoice_start = time.perf_counter()
+    install_funasr = parse_bool_env("INSTALL_FUNASR", False)
+    sensevoice_status: dict[str, Any]
+
+    if not sensevoice_selected and not install_funasr:
+        sensevoice_status = {"available": False, "reason": "not_selected"}
+        log("SenseVoice not selected by configured models, skipping feature check")
+    elif _reuse_feature_cache and not install_funasr:
+        sensevoice_status = previous_status_payload["features"]["sensevoice"]
+        log(f"SenseVoice feature check: reusing cached result (available={sensevoice_status.get('available')})")
+    else:
+        existing_sensevoice_status = check_funasr_import(
+            venv_python=venv_python,
+            timeout_seconds=timeout_seconds,
+        )
+        if existing_sensevoice_status.get("available"):
+            sensevoice_status = existing_sensevoice_status
+            log("FunASR already available, skipping optional install")
+        elif install_funasr:
+            log("Installing FunASR for SenseVoice support...")
+            try:
+                run_command(
+                    ["uv", "pip", "install", "--python", str(venv_python), "funasr>=1.3.12"],
+                    timeout_seconds=timeout_seconds,
+                    env=build_uv_sync_env(venv_dir=venv_dir, cache_dir=cache_dir),
+                )
+                sensevoice_status = check_funasr_import(
+                    venv_python=venv_python,
+                    timeout_seconds=timeout_seconds,
+                )
+                if sensevoice_status.get("available"):
+                    log("FunASR installed")
+                else:
+                    failure_error = str(sensevoice_status.get("error", "")).strip()
+                    log(
+                        "FunASR installation completed but import check failed "
+                        f"({sensevoice_status.get('reason', 'import_failed')}"
+                        + (f": {failure_error}" if failure_error else "")
+                        + ")"
+                    )
+            except Exception as exc:
+                sensevoice_status = {"available": False, "reason": "install_failed", "error": str(exc)}
+                log(f"FunASR installation failed: {exc}")
+        else:
+            sensevoice_status = {"available": False, "reason": "selected_but_not_requested"}
+            log("SenseVoice model selected but INSTALL_FUNASR is not enabled, skipping optional install")
+    log_timing("SenseVoice feature check complete", sensevoice_start)
+    if sensevoice_selected and not sensevoice_status.get("available"):
+        emit_event(
+            "warn-sensevoice",
+            "warning",
+            f"SenseVoice unavailable — {sensevoice_status.get('reason', 'unavailable')}",
+            persistent=True,
+        )
+```
+
+- [ ] **Step 7: Register it in the features dict + cache-reuse list**
+
+In the status payload `"features"` dict (lines 2139-2144), add the key:
+```python
+                "vibevoice_asr": vibevoice_asr_status,
+                "sensevoice": sensevoice_status,
+```
+In the cache-reuse loop (line 1040), extend the tuple:
+```python
+    for key in ("whisper", "nemo", "vibevoice_asr", "sensevoice"):
+```
+
+- [ ] **Step 8: Syntax-check the edited bootstrap**
+
+Run: `cd server && ../build/.venv/bin/python -c "import ast; ast.parse(open('docker/bootstrap_runtime.py').read()); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 9: Re-run all routing tests**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_sensevoice_routing.py -v --tb=short`
+Expected: all classes pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add server/docker/bootstrap_runtime.py server/backend/tests/test_sensevoice_routing.py
+git commit -m "feat(server): gate FunASR/SenseVoice install behind INSTALL_FUNASR (bootstrap)"
+```
+
+---
+
+## Task 5: Optional-dependency extra (`pyproject.toml`)
+
+**Files:**
+- Modify: `server/backend/pyproject.toml:63-77` (`[project.optional-dependencies]`)
+
+- [ ] **Step 1: Add the `sensevoice` extra**
+
+In `server/backend/pyproject.toml`, after the `vibevoice_asr = [...]` block (line 73), add:
+```toml
+sensevoice = [
+    "funasr>=1.3.12",
+]
+```
+
+- [ ] **Step 2: Validate the TOML parses**
+
+Run: `cd server/backend && ../../build/.venv/bin/python -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); print(d['project']['optional-dependencies']['sensevoice'])"`
+Expected: `['funasr>=1.3.12']`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/backend/pyproject.toml
+git commit -m "build(deps): add optional 'sensevoice' extra (funasr)"
+```
+
+---
+
+## Task 6: Feature status in `model_manager.py`
+
+**Files:**
+- Modify: `server/backend/core/model_manager.py` — init fields (~224), init call (~244), method (after 343), getter (after 533)
+- Test: `server/backend/tests/test_sensevoice_routing.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/backend/tests/test_sensevoice_routing.py`:
+```python
+# --- model_manager feature status -----------------------------------------
+
+class TestSenseVoiceFeatureStatus:
+    def test_reads_sensevoice_from_bootstrap_status(self, tmp_path, monkeypatch) -> None:
+        import json
+
+        status = {"features": {"sensevoice": {"available": True, "reason": "ready"}}}
+        status_file = tmp_path / "bootstrap-status.json"
+        status_file.write_text(json.dumps(status), encoding="utf-8")
+        monkeypatch.setenv("BOOTSTRAP_STATUS_FILE", str(status_file))
+
+        from server.core.model_manager import ModelManager
+
+        mgr = object.__new__(ModelManager)
+        mgr._sensevoice_feature_available = False
+        mgr._sensevoice_feature_reason = "not_requested"
+        mgr._initialize_sensevoice_feature_status()
+
+        assert mgr.get_sensevoice_feature_status() == {"available": True, "reason": "ready"}
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_sensevoice_routing.py::TestSenseVoiceFeatureStatus -v --tb=short`
+Expected: FAIL — methods/fields do not exist.
+
+- [ ] **Step 3: Add init fields**
+
+In `model_manager.py`, after line 225 (`self._vibevoice_asr_feature_reason = "not_requested"`), add:
+```python
+        self._sensevoice_feature_available: bool = False
+        self._sensevoice_feature_reason: str = "not_requested"
+```
+
+- [ ] **Step 4: Call the initializer**
+
+After line 244 (`self._initialize_vibevoice_asr_feature_status()`), add:
+```python
+        self._initialize_sensevoice_feature_status()
+```
+
+- [ ] **Step 5: Add the initializer method**
+
+After `_initialize_nemo_feature_status` (ends line 342), add a sibling (identical shape, `sensevoice` key):
+```python
+    def _initialize_sensevoice_feature_status(self) -> None:
+        """Initialize SenseVoice (FunASR) feature availability from bootstrap state."""
+        status_file = os.environ.get("BOOTSTRAP_STATUS_FILE", "/runtime/bootstrap-status.json")
+        try:
+            import json
+            from pathlib import Path
+
+            path = Path(status_file)
+            if path.exists():
+                payload = json.loads(path.read_text(encoding="utf-8"))
+                sensevoice = payload.get("features", {}).get("sensevoice", {})
+                available = bool(sensevoice.get("available", False))
+                reason = str(sensevoice.get("reason", "not_requested") or "not_requested")
+                self._sensevoice_feature_available = available
+                self._sensevoice_feature_reason = reason
+                logger.info(
+                    "Loaded SenseVoice feature status from bootstrap: "
+                    f"available={available}, reason={reason}"
+                )
+                return
+        except Exception as e:
+            logger.debug(f"Could not load SenseVoice feature status from bootstrap: {e}")
+
+        self._sensevoice_feature_available = False
+        self._sensevoice_feature_reason = "not_requested"
+```
+
+- [ ] **Step 6: Add the getter**
+
+After `get_vibevoice_asr_feature_status` (ends line 533), add:
+```python
+    def get_sensevoice_feature_status(self) -> dict[str, Any]:
+        """Return SenseVoice (FunASR) feature availability for the dashboard."""
+        return {
+            "available": self._sensevoice_feature_available,
+            "reason": self._sensevoice_feature_reason,
+        }
+```
+
+- [ ] **Step 7: Run the test and confirm it passes**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_sensevoice_routing.py::TestSenseVoiceFeatureStatus -v --tb=short`
+Expected: 1 passed.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/backend/core/model_manager.py server/backend/tests/test_sensevoice_routing.py
+git commit -m "feat(server): expose SenseVoice feature status from ModelManager"
+```
+
+---
+
+## Task 7: Document the model in `config.yaml`
+
+**Files:**
+- Modify: `server/config.yaml:51-56` (main_transcriber comments)
+
+- [ ] **Step 1: Extend the model comment block**
+
+In `server/config.yaml`, in the `main_transcriber:` comment block (after the VibeVoice-ASR examples line, ~line 54), add:
+```yaml
+    # SenseVoice example: "iic/SenseVoiceSmall" (zh/en/yue/ja/ko only, fast NAR; requires INSTALL_FUNASR=true)
+```
+And update the backend-autodetect comment (line 55) to:
+```yaml
+    # Backend is auto-detected from the model name (nvidia/* → NeMo, */VibeVoice-ASR* → VibeVoice-ASR, */SenseVoice* → SenseVoice, else → Whisper).
+```
+
+- [ ] **Step 2: Validate YAML parses**
+
+Run: `cd server && ../build/.venv/bin/python -c "import yaml; yaml.safe_load(open('config.yaml')); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/config.yaml
+git commit -m "docs(config): document iic/SenseVoiceSmall + INSTALL_FUNASR"
+```
+
+---
+
+## Task 8: Dashboard capabilities (`modelCapabilities.ts`)
+
+**Files:**
+- Modify: `dashboard/src/services/modelCapabilities.ts` (patterns ~14, language set, `isSenseVoiceModel`, `isWhisperModel`, `filterLanguagesForModel`, `supportsTranslation`)
+- Test: `dashboard/src/services/modelCapabilities.test.ts`
+
+> Run frontend commands under **Node 22**: `cd dashboard && nvm use` first (see project memory — Vitest needs Node 22).
+
+- [ ] **Step 1: Write the failing Vitest cases**
+
+Append to `dashboard/src/services/modelCapabilities.test.ts` (match the file's existing `import { … } from './modelCapabilities'` style — add the new symbols to that import):
+```typescript
+describe('SenseVoice capabilities', () => {
+  it('detects SenseVoice model ids', () => {
+    expect(isSenseVoiceModel('iic/SenseVoiceSmall')).toBe(true);
+    expect(isSenseVoiceModel('FunAudioLLM/SenseVoiceSmall')).toBe(true);
+    expect(isSenseVoiceModel('Systran/faster-whisper-large-v3')).toBe(false);
+  });
+
+  it('is not treated as a Whisper model', () => {
+    expect(isWhisperModel('iic/SenseVoiceSmall')).toBe(false);
+  });
+
+  it('does not support translation', () => {
+    expect(supportsTranslation('iic/SenseVoiceSmall')).toBe(false);
+  });
+
+  it('restricts languages to the 5 SenseVoice languages + Auto Detect', () => {
+    const all = ['Auto Detect', 'English', 'Chinese', 'Greek', 'Japanese', 'Korean', 'Cantonese'];
+    const filtered = filterLanguagesForModel(all, 'iic/SenseVoiceSmall');
+    expect(filtered).toEqual(['Auto Detect', 'English', 'Chinese', 'Japanese', 'Korean', 'Cantonese']);
+    expect(filtered).not.toContain('Greek');
+  });
+});
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `cd dashboard && npx vitest run src/services/modelCapabilities.test.ts`
+Expected: FAIL — `isSenseVoiceModel` is not exported; SenseVoice currently behaves like Whisper (all languages, translation true).
+
+- [ ] **Step 3: Add the pattern + language set**
+
+In `dashboard/src/services/modelCapabilities.ts`, after line 14 (`const MLX_PATTERN = …`), add:
+```typescript
+const SENSEVOICE_PATTERN = /^[^/]+\/sensevoice/i;
+```
+After the `NEMO_LANGUAGES` set (line 46), add:
+```typescript
+/**
+ * The 5 first-class languages SenseVoiceSmall actually supports
+ * (despite the model's "50+ languages" marketing). No Greek.
+ */
+export const SENSEVOICE_LANGUAGES: ReadonlySet<string> = new Set([
+  'English',
+  'Chinese',
+  'Japanese',
+  'Korean',
+  'Cantonese',
+]);
+```
+
+- [ ] **Step 4: Add `isSenseVoiceModel` + exclude from `isWhisperModel`**
+
+After `isVibeVoiceASRModel` (line 148), add:
+```typescript
+/**
+ * Returns true if the model is a SenseVoice (FunASR) backend variant.
+ */
+export function isSenseVoiceModel(modelName: string | null | undefined): boolean {
+  const name = (modelName ?? '').trim();
+  return SENSEVOICE_PATTERN.test(name);
+}
+```
+Update `isWhisperModel` (lines 133-140) to add the exclusion:
+```typescript
+export function isWhisperModel(modelName: string | null | undefined): boolean {
+  return (
+    !isNemoModel(modelName) &&
+    !isVibeVoiceASRModel(modelName) &&
+    !isWhisperCppModel(modelName) &&
+    !isMLXModel(modelName) &&
+    !isSenseVoiceModel(modelName)
+  );
+}
+```
+
+- [ ] **Step 5: Filter languages + reject translation**
+
+In `filterLanguagesForModel`, before the `if (isVibeVoiceASRModel(modelName))` branch (line 218), add:
+```typescript
+  if (isSenseVoiceModel(modelName)) {
+    // SenseVoiceSmall: zh/en/yue/ja/ko only, plus Auto Detect.
+    return languages.filter(
+      (l) => l === 'Auto Detect' || SENSEVOICE_LANGUAGES.has(l),
+    );
+  }
+```
+In `supportsTranslation`, after the `if (!name) return true;` line (line 246), add:
+```typescript
+  if (isSenseVoiceModel(name)) return false;
+```
+
+- [ ] **Step 6: Run the tests and confirm they pass**
+
+Run: `cd dashboard && npx vitest run src/services/modelCapabilities.test.ts`
+Expected: all pass (including the new `SenseVoice capabilities` block).
+
+- [ ] **Step 7: Typecheck**
+
+Run: `cd dashboard && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add dashboard/src/services/modelCapabilities.ts dashboard/src/services/modelCapabilities.test.ts
+git commit -m "feat(dashboard): SenseVoice capabilities — 5 languages, no translation"
+```
+
+---
+
+## Task 9: Dashboard model registry (`modelRegistry.ts`)
+
+**Files:**
+- Modify: `dashboard/src/services/modelRegistry.ts` (`ModelFamily` type ~20, import ~10, registry entry after the NeMo block ~70)
+
+- [ ] **Step 1: Add the `'sensevoice'` family + import**
+
+In `dashboard/src/services/modelRegistry.ts`, add `'sensevoice'` to the `ModelFamily` union (line 20 region):
+```typescript
+export type ModelFamily =
+  | 'whisper'
+  | 'nemo'
+  | 'sensevoice'
+  | 'vibevoice'
+  | 'whispercpp'
+  | 'mlx'
+  | 'diarization'
+  | 'custom'
+  | 'none';
+```
+Add `isSenseVoiceModel` to the import from `./modelCapabilities` (lines 9-17) so later UI code can use it consistently:
+```typescript
+  isMLXParakeetModel,
+  isSenseVoiceModel,
+```
+
+- [ ] **Step 2: Add the registry entry**
+
+In `MODEL_REGISTRY`, immediately after the NeMo block (after the `nvidia/canary-1b-v2` entry, ~line 72), add:
+```typescript
+  // ── SenseVoice (FunASR) ──────────────────────────────────────────────────
+  {
+    id: 'iic/SenseVoiceSmall',
+    displayName: 'SenseVoice Small',
+    family: 'sensevoice',
+    description:
+      'Alibaba FunAudioLLM non-autoregressive ASR. Very fast, CPU-capable. 5 languages (zh/en/yue/ja/ko) — no Greek, no translation. Linux/NVIDIA, requires INSTALL_FUNASR=true.',
+    parameterCount: '234M',
+    huggingfaceUrl: 'https://huggingface.co/FunAudioLLM/SenseVoiceSmall',
+    capabilities: { translation: false, liveMode: true, diarization: false, languageCount: 5 },
+    roles: ['main'],
+    requiresRuntime: 'cuda',
+  },
+```
+
+- [ ] **Step 3: Typecheck (this surfaces any exhaustive `ModelFamily` switch that needs a `sensevoice` label)**
+
+Run: `cd dashboard && npx tsc --noEmit`
+Expected: no errors. If `tsc` flags a non-exhaustive `switch (family)` in `ModelManagerView.tsx` or `modelRegistry.ts` (family→label/heading map), add a `sensevoice: 'SenseVoice'` case at the reported location, then re-run.
+
+- [ ] **Step 4: Run registry tests**
+
+Run: `cd dashboard && npx vitest run src/services/modelRegistry.test.ts`
+Expected: pass. If a test asserts the registry length or family coverage, update it to include the SenseVoice entry.
+
+- [ ] **Step 5: Build to confirm no UI-contract / CSS impact**
+
+Run: `cd dashboard && npm run build`
+Expected: build succeeds. (These edits touch service/registry logic, not CSS classes, so `ui:contract` is not triggered. If you edited `ModelManagerView.tsx` and added a new `className`, run `npm run ui:contract:check` per the ui-contract skill.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/src/services/modelRegistry.ts dashboard/src/services/modelRegistry.test.ts
+git commit -m "feat(dashboard): register iic/SenseVoiceSmall in the model registry"
+```
+
+---
+
+## Task 10: Full backend + frontend test sweep
+
+- [ ] **Step 1: Backend suite (build venv)**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/ -q --tb=short`
+Expected: all SenseVoice tests pass; no regressions beyond the 2 known pre-existing failures (db migration version, swr_linear resample — see project memory).
+
+- [ ] **Step 2: Backend lint**
+
+Run: `cd server/backend && ../../build/.venv/bin/ruff check core/ tests/test_sensevoice_backend.py tests/test_sensevoice_routing.py`
+Expected: `All checks passed!`
+
+- [ ] **Step 3: Frontend tests + typecheck (Node 22)**
+
+Run: `cd dashboard && nvm use && npx vitest run src/services/ && npx tsc --noEmit`
+Expected: green.
+
+- [ ] **Step 4: Commit (only if any test fixups were needed)**
+
+```bash
+git add -A && git commit -m "test: stabilize suite after SenseVoice integration"
+```
+
+---
+
+## Task 11: Real-hardware smoke test (Linux / NVIDIA) — MANUAL
+
+> This is the **only** step that exercises the real funasr API + GPU. It verifies the assumptions the unit tests mock: that `iic/SenseVoiceSmall` resolves on HuggingFace, that `AutoModel(...).generate(input=<wav>)` returns the shape `_parse_result` expects, and that VRAM/throughput are acceptable. The Phase-1 backend was written defensively (handles both `sentence_info` and merged-text shapes) precisely so this step reconciles reality without code churn.
+
+- [ ] **Step 1: Configure the model + enable install**
+
+Edit your local `~/.config/TranscriptionSuite/config.yaml` (or the dev `server/config.yaml`):
+```yaml
+main_transcriber:
+    model: "iic/SenseVoiceSmall"
+    device: "cuda"
+    gpu_device_index: 0
+```
+Export the install gate before starting the server/bootstrap:
+```bash
+export INSTALL_FUNASR=true
+```
+
+- [ ] **Step 2: Start the server and watch bootstrap**
+
+Start the server as you normally do for dev. Confirm in the bootstrap log:
+- `Installing FunASR for SenseVoice support...` then `FunASR installed`
+- No `SenseVoice unavailable` warning event.
+- `/runtime/bootstrap-status.json` contains `features.sensevoice.available == true`.
+
+If `uv pip install funasr>=1.3.12` fails to resolve against the existing torch, note the conflict and pin a compatible funasr version (Phase-1 risk checkpoint) before continuing.
+
+- [ ] **Step 3: Transcribe a short multilingual clip**
+
+Transcribe a ~30–60s English (and, if available, Mandarin/Japanese) audio file via the dashboard or the `/api/transcribe/audio` endpoint. Confirm:
+- Returned text is correct and **free of `<|…|>` tokens** (post-processing works).
+- `info.language` is populated (e.g. `"en"`).
+- Segments render; note whether you got **per-sentence** segments (funasr produced `sentence_info`) or **one** segment (merged-text fallback). Either is acceptable for Phase 1 — just record which.
+
+- [ ] **Step 4: Transcribe a >30s clip (VAD chunking)**
+
+Transcribe a 2–5 minute file. Confirm it does NOT error at the 30s SenseVoice cap (i.e. `fsmn-vad` chunking is active) and the full transcript returns.
+
+- [ ] **Step 5: Verify durability + record VRAM**
+
+Confirm the completed transcription is persisted (per the project's data-loss invariant) before delivery, and note peak VRAM (`nvidia-smi`) so we can document the footprint.
+
+- [ ] **Step 6: Capture the real `generate()` shape for the record**
+
+In a Python shell in the build venv, run a 5–10s clip directly and paste the raw `res[0].keys()` into the PR description:
+```bash
+cd server/backend && ../../build/.venv/bin/python - <<'PY'
+from funasr import AutoModel
+m = AutoModel(model="iic/SenseVoiceSmall", vad_model="fsmn-vad", device="cuda:0", hub="hf", disable_update=True)
+res = m.generate(input="warmup_audio_or_short.wav", cache={}, language="auto", use_itn=True)
+print(type(res), len(res))
+print(sorted(res[0].keys()))
+print(repr(res[0].get("text"))[:200])
+print("sentence_info?" , "sentence_info" in res[0])
+PY
+```
+If the real keys differ from what `_parse_result` handles, adjust `_parse_result` (and a matching unit test) — this is the one place reality may diverge from the mocks.
+
+---
+
+## Task 12: Documentation
+
+**Files:**
+- Modify: `docs/project-context.md`, `README_DEV.md`
+
+- [ ] **Step 1: Note the new backend**
+
+Add a short subsection to `README_DEV.md` (backend/model list) and a rule/line to `docs/project-context.md`:
+> SenseVoice (`iic/SenseVoiceSmall`) — FunASR PyTorch backend, Linux/NVIDIA only (Phase 1), transcriber-only, `INSTALL_FUNASR=true`. Languages: zh/en/yue/ja/ko (no Greek). No translation, no word timestamps (diarization falls back to segment-level). Backend: `server/backend/core/stt/backends/sensevoice_backend.py`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/project-context.md README_DEV.md
+git commit -m "docs: document SenseVoice Phase 1 (Linux/NVIDIA, transcriber-only)"
+```
+
+---
+
+## Task 13: Open the PR
+
+- [ ] **Step 1: Push + PR**
+
+Run:
+```bash
+git push -u origin feature/sensevoice-asr-phase1
+gh pr create --title "feat(stt): SenseVoice (FunASR) backend — Phase 1 (Linux/NVIDIA, transcriber-only)" --body "$(cat <<'EOF'
+## Summary
+Adds Alibaba FunAudioLLM **SenseVoice** (`iic/SenseVoiceSmall`) as an STT backend via the `funasr` PyTorch pipeline. Phase 1: Linux/NVIDIA, transcriber-only (no new diarization code). Closes the SenseVoice request in #129 (and the duplicate #144) for Phase 1 scope.
+
+## What's included
+- `SenseVoiceBackend` (funasr AutoModel + fsmn-vad), reached via factory routing for `*/sensevoice*` ids
+- Capability flags: no translation; 5 languages (zh/en/yue/ja/ko — **no Greek**)
+- `INSTALL_FUNASR` bootstrap gate + feature status surfaced to the dashboard
+- Dashboard registry + capability wiring
+- Unit tests (funasr mocked); smoke-tested on real Linux/NVIDIA hardware
+
+## Out of scope (later phases)
+FunASR CAM++ diarization, word timestamps, emotion/event tags, sherpa-onnx / SenseVoice.cpp, Windows/macOS/Apple-Silicon, ModelScope download.
+
+## Test plan
+- [ ] `pytest tests/` green (backend)
+- [ ] `vitest run src/services/` + `tsc --noEmit` green (dashboard)
+- [ ] Smoke test: short + >30s clips transcribe on CUDA; tokens stripped; durability verified; VRAM recorded
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (against the Phase-1 scope agreed in conversation):
+- New transcriber backend → Task 3 ✅
+- Factory routing → Task 2 ✅
+- Capability flags (no translation, 5 langs) → Task 1 (backend) + Task 8 (dashboard) ✅
+- Install gating like INSTALL_NEMO → Task 4 + Task 5 ✅
+- Feature status → dashboard surfacing → Task 6 (+ bootstrap features dict Task 4) ✅
+- Config documentation → Task 7 ✅
+- Model selectable in UI → Task 9 ✅
+- ModelScope→HF download avoidance → backend `hub="hf"` (Task 3) ✅
+- Live mode → works automatically via shared backend; explicitly validated in smoke test (Task 11), no code change needed ✅
+- Diarization left on the existing pyannote two-pass (degrades to segment-level for no-word backends — already handled by `build_speaker_segments_nowords`) — **no Phase-1 code**, documented Task 12 ✅
+- Greek-unsupported reality → encoded in language filter (Task 8) + docs (Task 12) ✅
+
+**2. Placeholder scan:** No `TBD`/`TODO`/"handle edge cases"; every code step shows complete code; commands have expected output. Task 11 is explicitly MANUAL (real hardware) — not a placeholder, a required human verification with exact commands.
+
+**3. Type consistency:** `SenseVoiceBackend` implements every abstract member of `STTBackend` from `base.py` (`load`, `unload`, `is_loaded`, `warmup`, `transcribe`, `supports_translation`, `backend_name`) with matching signatures. `detect_backend_type` returns `"sensevoice"`; `create_backend` imports `SenseVoiceBackend` from the file Task 3 creates. Bootstrap key, model_manager key, and features-dict key are all the literal string `"sensevoice"` consistently. Dashboard `isSenseVoiceModel` / `SENSEVOICE_LANGUAGES` / `SENSEVOICE_PATTERN` names are used identically across `modelCapabilities.ts` and `modelRegistry.ts`.
+
+**Known reality-divergence risk (called out, not hidden):** the exact `funasr.generate()` return shape (`sentence_info` vs merged `text`) is reconciled in Task 11 Step 6; `_parse_result` already handles both, so divergence costs at most a small parser tweak + one test.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-24-sensevoice-phase1-linux-nvidia.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — execute tasks in this session with checkpoints for review.
+
+Which approach?

--- a/server/backend/api/main.py
+++ b/server/backend/api/main.py
@@ -644,8 +644,22 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
                 logger.warning(warning_message, exc_info=True)
                 _log_time(timing_label)
             else:
-                logger.error("Model preload failed")
-                raise
+                # A non-dependency model-load failure (bad model id, corrupt
+                # cache, OOM, ...) must not brick the whole server: the dashboard,
+                # audio notebook, search, and transcription history all work
+                # without a loaded transcription model. Degrade gracefully like
+                # the dependency path above — log loudly and continue. The
+                # dashboard reports the server as "not ready" (Record stays
+                # disabled with a reason) so the user can fix the model selection
+                # and restart, instead of facing a crash-looping container.
+                logger.error(
+                    "Model preload failed for model=%s — continuing startup "
+                    "without a loaded transcription model; fix the model "
+                    "selection in the dashboard and restart.",
+                    selected_main_model,
+                    exc_info=True,
+                )
+                _log_time("model preload failed (continuing without model)")
         else:
             _log_time("model preload complete")
 

--- a/server/backend/core/model_manager.py
+++ b/server/backend/core/model_manager.py
@@ -440,8 +440,14 @@ class ModelManager:
         except Exception as e:
             logger.debug(f"Could not load SenseVoice feature status from bootstrap: {e}")
 
+        install_requested = os.environ.get("INSTALL_FUNASR", "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
         self._sensevoice_feature_available = False
-        self._sensevoice_feature_reason = "not_requested"
+        self._sensevoice_feature_reason = "requested" if install_requested else "not_requested"
 
     def _initialize_whispercpp_feature_status(self) -> None:
         """Initialize whisper.cpp sidecar feature availability.

--- a/server/backend/core/model_manager.py
+++ b/server/backend/core/model_manager.py
@@ -224,6 +224,8 @@ class ModelManager:
         self._vibevoice_asr_feature_available: bool = False
         self._vibevoice_asr_feature_reason: str = "not_requested"
         self._vibevoice_asr_feature_error: str | None = None
+        self._sensevoice_feature_available: bool = False
+        self._sensevoice_feature_reason: str = "not_requested"
 
         # Job tracker for ensuring only one transcription runs at a time
         self.job_tracker = TranscriptionJobTracker()
@@ -247,6 +249,7 @@ class ModelManager:
         self._initialize_whisper_feature_status()
         self._initialize_nemo_feature_status()
         self._initialize_vibevoice_asr_feature_status()
+        self._initialize_sensevoice_feature_status()
         self._initialize_whispercpp_feature_status()
 
         # Fix 3: Start background NeMo import if NeMo models will be used
@@ -414,6 +417,32 @@ class ModelManager:
         self._vibevoice_asr_feature_reason = "requested" if install_requested else "not_requested"
         self._vibevoice_asr_feature_error = None
 
+    def _initialize_sensevoice_feature_status(self) -> None:
+        """Initialize SenseVoice (FunASR) feature availability from bootstrap state/env."""
+        status_file = os.environ.get("BOOTSTRAP_STATUS_FILE", "/runtime/bootstrap-status.json")
+        try:
+            import json
+            from pathlib import Path
+
+            path = Path(status_file)
+            if path.exists():
+                payload = json.loads(path.read_text(encoding="utf-8"))
+                sensevoice = payload.get("features", {}).get("sensevoice", {})
+                available = bool(sensevoice.get("available", False))
+                reason = str(sensevoice.get("reason", "not_requested") or "not_requested")
+                self._sensevoice_feature_available = available
+                self._sensevoice_feature_reason = reason
+                logger.info(
+                    "Loaded SenseVoice feature status from bootstrap: "
+                    f"available={available}, reason={reason}"
+                )
+                return
+        except Exception as e:
+            logger.debug(f"Could not load SenseVoice feature status from bootstrap: {e}")
+
+        self._sensevoice_feature_available = False
+        self._sensevoice_feature_reason = "not_requested"
+
     def _initialize_whispercpp_feature_status(self) -> None:
         """Initialize whisper.cpp sidecar feature availability.
 
@@ -540,6 +569,13 @@ class ModelManager:
         if self._vibevoice_asr_feature_error:
             status["error"] = self._vibevoice_asr_feature_error
         return status
+
+    def get_sensevoice_feature_status(self) -> dict[str, Any]:
+        """Return SenseVoice (FunASR) feature availability for API clients."""
+        return {
+            "available": self._sensevoice_feature_available,
+            "reason": self._sensevoice_feature_reason,
+        }
 
     def _get_mlx_feature_status(self) -> dict[str, Any]:
         """Check if MLX (Apple Silicon Metal) STT is available via mlx-audio."""
@@ -990,6 +1026,7 @@ class ModelManager:
                 "vibevoice_asr": self.get_vibevoice_asr_feature_status(),
                 "whispercpp": self.get_whispercpp_feature_status(),
                 "mlx": self._get_mlx_feature_status(),
+                "sensevoice": self.get_sensevoice_feature_status(),
             },
         }
         return status

--- a/server/backend/core/stt/backends/factory.py
+++ b/server/backend/core/stt/backends/factory.py
@@ -24,6 +24,9 @@ _MLX_CANARY_PATTERN = re.compile(r"^[^/]+/canary[^/]*-mlx", re.IGNORECASE)
 # MLX VibeVoice must be checked before the generic VibeVoice pattern.
 _MLX_VIBEVOICE_PATTERN = re.compile(r"^mlx-community/vibevoice-asr", re.IGNORECASE)
 _MLX_PATTERN = re.compile(r"^mlx-community/", re.IGNORECASE)
+# SenseVoice (FunAudioLLM) via FunASR — any "<org>/sensevoice…" repo id.
+# No MLX SenseVoice variant exists; matched before the mlx-community patterns by design.
+_SENSEVOICE_PATTERN = re.compile(r"^[^/]+/sensevoice", re.IGNORECASE)
 
 
 def _looks_like_whispercpp(name: str) -> bool:
@@ -57,6 +60,8 @@ def detect_backend_type(model_name: str) -> str:
         return "mlx_vibevoice"
     if _VIBEVOICE_ASR_PATTERN.match(name):
         return "vibevoice_asr"
+    if _SENSEVOICE_PATTERN.match(name):
+        return "sensevoice"
     if _looks_like_whispercpp(name):
         return "whispercpp"
     if _MLX_PARAKEET_PATTERN.match(name):
@@ -86,6 +91,11 @@ def is_nemo_model(model_name: str) -> bool:
 def is_vibevoice_asr_model(model_name: str) -> bool:
     """Return True if *model_name* selects a VibeVoice-ASR backend variant."""
     return detect_backend_type(model_name) == "vibevoice_asr"
+
+
+def is_sensevoice_model(model_name: str) -> bool:
+    """Return True if *model_name* selects the SenseVoice (FunASR) backend."""
+    return detect_backend_type(model_name) == "sensevoice"
 
 
 def is_whispercpp_model(model_name: str) -> bool:
@@ -134,6 +144,11 @@ def create_backend(model_name: str) -> STTBackend:
         from server.core.stt.backends.vibevoice_asr_backend import VibeVoiceASRBackend
 
         return VibeVoiceASRBackend()
+
+    if backend_type == "sensevoice":
+        from server.core.stt.backends.sensevoice_backend import SenseVoiceBackend
+
+        return SenseVoiceBackend()
 
     if backend_type == "whispercpp":
         from server.core.stt.backends.whispercpp_backend import WhisperCppBackend

--- a/server/backend/core/stt/backends/sensevoice_backend.py
+++ b/server/backend/core/stt/backends/sensevoice_backend.py
@@ -37,6 +37,17 @@ SAMPLE_RATE = 16000
 _SENSEVOICE_LANGUAGES = frozenset({"zh", "en", "yue", "ja", "ko"})
 _LANG_TOKEN_RE = re.compile(r"<\|(zh|en|yue|ja|ko)\|>", re.IGNORECASE)
 
+# FunASR's ``model=`` argument is a *hub repo id*, and the hub determines the
+# namespace. The canonical id ``iic/SenseVoiceSmall`` lives on ModelScope; on
+# HuggingFace (``hub="hf"``) the same weights are published under the FunAudioLLM
+# org, and the bare ``iic/…`` id 404s (FunASR then silently retries it as an
+# architecture key and dies with a misleading "not registered"). Map the
+# well-known ModelScope ids to their HF equivalents so users can keep configuring
+# the recognisable ``iic/SenseVoiceSmall``; unknown ids pass through unchanged.
+_MODELSCOPE_TO_HF_REPO = {
+    "iic/SenseVoiceSmall": "FunAudioLLM/SenseVoiceSmall",
+}
+
 logger = logging.getLogger(__name__)
 
 
@@ -45,6 +56,11 @@ def _compose_device(device: str, gpu_device_index: int) -> str:
     if device == "cuda":
         return f"cuda:{int(gpu_device_index)}"
     return device
+
+
+def _resolve_hf_repo_id(model_name: str) -> str:
+    """Translate a ModelScope model id to its HuggingFace repo id for ``hub="hf"``."""
+    return _MODELSCOPE_TO_HF_REPO.get(model_name, model_name)
 
 
 def _extract_language(raw_text: str | None) -> str | None:
@@ -96,12 +112,15 @@ class SenseVoiceBackend(STTBackend):
 
         gpu_device_index = kwargs.get("gpu_device_index", 0)
         funasr_device = _compose_device(device, gpu_device_index)
+        hf_repo_id = _resolve_hf_repo_id(model_name)
 
-        logger.info(f"Loading SenseVoice model: {model_name} on {funasr_device}")
+        logger.info(f"Loading SenseVoice model: {model_name} (hf:{hf_repo_id}) on {funasr_device}")
         # hub="hf": pull weights from HuggingFace, not the CN-hosted ModelScope.
+        # The repo id must be the HF namespace (FunAudioLLM/…), not the ModelScope
+        # "iic/…" id, which 404s on HF — see _resolve_hf_repo_id.
         # disable_update=True: skip the ModelScope version ping (offline-friendly).
         self._model = AutoModel(
-            model=model_name,
+            model=hf_repo_id,
             vad_model="fsmn-vad",
             vad_kwargs={"max_single_segment_time": 30000},
             device=funasr_device,

--- a/server/backend/core/stt/backends/sensevoice_backend.py
+++ b/server/backend/core/stt/backends/sensevoice_backend.py
@@ -1,0 +1,235 @@
+"""SenseVoice (FunAudioLLM) STT backend.
+
+Adapted from FunAudioLLM/SenseVoice (https://github.com/FunAudioLLM/SenseVoice)
+and modelscope/FunASR (https://github.com/modelscope/FunASR) — wraps the
+``funasr.AutoModel`` pipeline (SenseVoiceSmall + fsmn-vad) behind the project's
+STTBackend interface.
+
+Phase 1 scope: transcriber-only, CUDA/Linux. SenseVoice is non-autoregressive
+and produces NO word-level timestamps; segments carry empty ``words`` lists and,
+when funasr returns no per-sentence info, a single segment spanning the clip.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import re
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import soundfile as sf
+from server.core.audio_utils import clear_gpu_cache
+from server.core.stt.backends.base import (
+    BackendDependencyError,
+    BackendSegment,
+    BackendTranscriptionInfo,
+    STTBackend,
+)
+
+SAMPLE_RATE = 16000
+
+# SenseVoiceSmall's first-class language codes (the only values its API accepts).
+_SENSEVOICE_LANGUAGES = frozenset({"zh", "en", "yue", "ja", "ko"})
+_LANG_TOKEN_RE = re.compile(r"<\|(zh|en|yue|ja|ko)\|>", re.IGNORECASE)
+
+logger = logging.getLogger(__name__)
+
+
+def _compose_device(device: str, gpu_device_index: int) -> str:
+    """Map the engine's ("cuda", index) convention to funasr's "cuda:N" string."""
+    if device == "cuda":
+        return f"cuda:{int(gpu_device_index)}"
+    return device
+
+
+def _extract_language(raw_text: str | None) -> str | None:
+    """Return the SenseVoice language code embedded in *raw_text*, if any."""
+    match = _LANG_TOKEN_RE.search(raw_text or "")
+    return match.group(1).lower() if match else None
+
+
+def _write_temp_wav(audio: np.ndarray, sample_rate: int) -> str:
+    """Write float32 mono audio to a temp 16-bit WAV and return its path."""
+    fd, path = tempfile.mkstemp(suffix=".wav", prefix="sensevoice_")
+    try:
+        os.close(fd)
+        sf.write(path, audio, sample_rate, subtype="PCM_16")
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.remove(path)
+        raise
+    return path
+
+
+def _import_funasr_automodel() -> Any:
+    """Lazy-import ``funasr.AutoModel`` with a clear, actionable error message."""
+    try:
+        from funasr import AutoModel
+
+        return AutoModel
+    except ImportError as exc:
+        raise BackendDependencyError(
+            "FunASR is required for SenseVoice models but is not installed. "
+            "Set INSTALL_FUNASR=true in your Docker environment to enable it.",
+            backend_type="funasr",
+            remedy="Set INSTALL_FUNASR=true in your Docker environment and restart.",
+        ) from exc
+
+
+class SenseVoiceBackend(STTBackend):
+    """FunASR-backed SenseVoice transcription backend (Phase 1, CUDA/Linux)."""
+
+    def __init__(self) -> None:
+        self._model: Any | None = None
+        self._model_name: str | None = None
+        self._device: str | None = None
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def load(self, model_name: str, device: str, **kwargs: Any) -> None:
+        AutoModel = _import_funasr_automodel()
+
+        gpu_device_index = kwargs.get("gpu_device_index", 0)
+        funasr_device = _compose_device(device, gpu_device_index)
+
+        logger.info(f"Loading SenseVoice model: {model_name} on {funasr_device}")
+        # hub="hf": pull weights from HuggingFace, not the CN-hosted ModelScope.
+        # disable_update=True: skip the ModelScope version ping (offline-friendly).
+        self._model = AutoModel(
+            model=model_name,
+            vad_model="fsmn-vad",
+            vad_kwargs={"max_single_segment_time": 30000},
+            device=funasr_device,
+            hub="hf",
+            disable_update=True,
+        )
+        self._model_name = model_name
+        self._device = funasr_device
+        logger.info("SenseVoice model loaded")
+
+    def unload(self) -> None:
+        self._model = None
+        self._model_name = None
+        self._device = None
+        clear_gpu_cache()
+
+    def is_loaded(self) -> bool:
+        return self._model is not None
+
+    def warmup(self) -> None:
+        if self._model is None:
+            return
+        try:
+            warmup_path = Path(__file__).parent.parent / "warmup_audio.wav"
+            if warmup_path.exists():
+                self._model.generate(input=str(warmup_path), cache={}, language="en", use_itn=True)
+                logger.debug("SenseVoice warmup complete")
+            else:
+                logger.debug("SenseVoice warmup skipped (no warmup_audio.wav)")
+        except Exception as e:  # noqa: BLE001 — warmup is best-effort
+            logger.warning(f"SenseVoice warmup failed (non-critical): {e}")
+
+    # -- transcription ------------------------------------------------------
+
+    def transcribe(
+        self,
+        audio: np.ndarray,
+        *,
+        audio_sample_rate: int = SAMPLE_RATE,
+        language: str | None = None,
+        task: str = "transcribe",
+        beam_size: int = 5,
+        initial_prompt: str | None = None,
+        suppress_tokens: list[int] | None = None,
+        vad_filter: bool = True,
+        word_timestamps: bool = True,
+        translation_target_language: str | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> tuple[list[BackendSegment], BackendTranscriptionInfo]:
+        # SenseVoice has no translate task and no word timestamps — ignore the
+        # Whisper-shaped knobs the engine passes through.
+        del task, beam_size, initial_prompt, suppress_tokens
+        del vad_filter, word_timestamps, translation_target_language, progress_callback
+
+        if self._model is None:
+            raise RuntimeError("SenseVoice model is not loaded")
+
+        lang = self._resolve_language(language)
+        wav_path = _write_temp_wav(audio, audio_sample_rate)
+        try:
+            result = self._model.generate(
+                input=wav_path,
+                cache={},
+                language=lang,
+                use_itn=True,
+                batch_size_s=300,
+                merge_vad=True,
+                merge_length_s=15,
+            )
+        finally:
+            try:
+                os.remove(wav_path)
+            except OSError:
+                pass
+
+        duration_s = float(len(audio)) / float(audio_sample_rate) if audio_sample_rate else 0.0
+        return self._parse_result(result, duration_s, forced_language=lang)
+
+    def supports_translation(self) -> bool:
+        return False
+
+    @property
+    def backend_name(self) -> str:
+        return "sensevoice"
+
+    # -- helpers ------------------------------------------------------------
+
+    def _resolve_language(self, language: str | None) -> str:
+        if not language:
+            return "auto"
+        code = language.strip().lower()
+        if code in _SENSEVOICE_LANGUAGES:
+            return code
+        logger.warning(
+            f"SenseVoice does not support language '{language}'; falling back to auto-detect"
+        )
+        return "auto"
+
+    def _parse_result(
+        self,
+        result: list[dict[str, Any]],
+        duration_s: float,
+        *,
+        forced_language: str,
+    ) -> tuple[list[BackendSegment], BackendTranscriptionInfo]:
+        from funasr.utils.postprocess_utils import rich_transcription_postprocess
+
+        if not result:
+            return [], BackendTranscriptionInfo(language=None, language_probability=0.0)
+
+        first = result[0]
+        raw_text = str(first.get("text", ""))
+        detected = _extract_language(raw_text)
+        if detected is None and forced_language != "auto":
+            detected = forced_language
+        info = BackendTranscriptionInfo(language=detected, language_probability=0.0)
+
+        # Preferred shape: per-sentence segments (VAD-chunk boundaries in ms).
+        sentence_info = first.get("sentence_info")
+        if isinstance(sentence_info, list) and sentence_info:
+            segments: list[BackendSegment] = []
+            for sentence in sentence_info:
+                text = rich_transcription_postprocess(str(sentence.get("text", "")))
+                start = float(sentence.get("start", 0.0)) / 1000.0
+                end = float(sentence.get("end", 0.0)) / 1000.0
+                segments.append(BackendSegment(text=text, start=start, end=end, words=[]))
+            return segments, info
+
+        # Fallback: one segment spanning the whole clip (no timestamps available).
+        text = rich_transcription_postprocess(raw_text)
+        return [BackendSegment(text=text, start=0.0, end=duration_s, words=[])], info

--- a/server/backend/core/stt/capabilities.py
+++ b/server/backend/core/stt/capabilities.py
@@ -11,6 +11,8 @@ _CANARY_PATTERN = re.compile(r"^nvidia/canary", re.IGNORECASE)
 _VIBEVOICE_ASR_PATTERN = re.compile(r"^[^/]+/vibevoice-asr(?:-[^/]+)?$", re.IGNORECASE)
 _MLX_PARAKEET_PATTERN = re.compile(r"^mlx-community/parakeet", re.IGNORECASE)
 _MLX_CANARY_PATTERN = re.compile(r"^[^/]+/canary[^/]*-mlx", re.IGNORECASE)
+# SenseVoice (FunAudioLLM) — any "<org>/sensevoice…" repo id.
+_SENSEVOICE_PATTERN = re.compile(r"^[^/]+/sensevoice", re.IGNORECASE)
 
 
 def normalize_model_name(model_name: str | None) -> str:
@@ -63,6 +65,10 @@ def supports_english_translation(model_name: str | None) -> bool:
 
     # VibeVoice-ASR is ASR + diarization only (no translation support in v1 integration).
     if _VIBEVOICE_ASR_PATTERN.match(name):
+        return False
+
+    # SenseVoice (FunASR) is ASR-only in Phase 1 — no translate task.
+    if _SENSEVOICE_PATTERN.match(name):
         return False
 
     # Whisper turbo is not intended for translation.

--- a/server/backend/pyproject.toml
+++ b/server/backend/pyproject.toml
@@ -72,6 +72,9 @@ nemo = [
 vibevoice_asr = [
     "vibevoice @ git+https://github.com/microsoft/VibeVoice.git@1807b858d4f7dffdd286249a01616c243e488c9e",
 ]
+sensevoice = [
+    "funasr>=1.3.12",
+]
 mlx = [
     "parakeet-mlx>=0.2.0",
     "canary-mlx>=0.1.0",

--- a/server/backend/tests/test_install_flag_passthrough.py
+++ b/server/backend/tests/test_install_flag_passthrough.py
@@ -1,0 +1,65 @@
+"""Guard the .env -> compose -> container contract for optional-install flags.
+
+Regression test for the SenseVoice Phase 1 bug where ``INSTALL_FUNASR`` was wired
+through the bootstrap reader, the dashboard writer, and ``.env`` -- but the
+``docker-compose.yml`` ``environment:`` block never forwarded it into the
+container. The variable was therefore dropped at the compose boundary,
+``bootstrap_runtime.py`` read its ``False`` default, FunASR was never installed,
+and the SenseVoice model failed to load (Record button greyed out) despite the
+flag being set everywhere a human would look.
+
+The invariant: every ``INSTALL_*`` flag the runtime bootstrap consumes via
+``parse_bool_env(...)`` MUST be forwarded by the base compose file, otherwise the
+flag is silently inert. A pure-text contract test (no Docker needed) is the
+cheapest place to catch a future flag that forgets the compose line.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_COMPOSE_FILE = _REPO_ROOT / "server/docker/docker-compose.yml"
+_BOOTSTRAP_FILE = _REPO_ROOT / "server/docker/bootstrap_runtime.py"
+
+# Flags consumed by the bootstrap but intentionally NOT plumbed through the base
+# compose environment (none today). Keep empty; document any exception here.
+_KNOWN_COMPOSE_OMISSIONS: frozenset[str] = frozenset()
+
+
+def _flags_consumed_by_bootstrap() -> set[str]:
+    text = _BOOTSTRAP_FILE.read_text(encoding="utf-8")
+    return set(re.findall(r'parse_bool_env\(\s*"(INSTALL_\w+)"', text))
+
+
+def _flags_forwarded_by_compose() -> set[str]:
+    text = _COMPOSE_FILE.read_text(encoding="utf-8")
+    # Matches an environment entry like:  - INSTALL_FUNASR=${INSTALL_FUNASR:-false}
+    return set(re.findall(r"-\s*(INSTALL_\w+)=\$\{", text))
+
+
+def test_repo_files_exist() -> None:
+    assert _COMPOSE_FILE.is_file(), f"missing {_COMPOSE_FILE}"
+    assert _BOOTSTRAP_FILE.is_file(), f"missing {_BOOTSTRAP_FILE}"
+
+
+def test_every_bootstrap_install_flag_is_forwarded_by_compose() -> None:
+    consumed = _flags_consumed_by_bootstrap()
+    forwarded = _flags_forwarded_by_compose()
+    # Sanity: we actually parsed something, so the regexes did not silently rot.
+    assert "INSTALL_WHISPER" in consumed
+    assert "INSTALL_WHISPER" in forwarded
+
+    missing = consumed - forwarded - _KNOWN_COMPOSE_OMISSIONS
+    assert not missing, (
+        "These INSTALL_* flags are read by bootstrap_runtime.py but are not "
+        f"forwarded by {_COMPOSE_FILE.name}'s environment block, so they are "
+        f"silently inert inside the container: {sorted(missing)}"
+    )
+
+
+def test_install_funasr_is_wired_end_to_end() -> None:
+    # Explicit guard for the exact flag whose missing compose line shipped the bug.
+    assert "INSTALL_FUNASR" in _flags_consumed_by_bootstrap()
+    assert "INSTALL_FUNASR" in _flags_forwarded_by_compose()

--- a/server/backend/tests/test_model_manager_init.py
+++ b/server/backend/tests/test_model_manager_init.py
@@ -37,6 +37,7 @@ def _make_bootstrap_status(
     whisper: dict | None = None,
     nemo: dict | None = None,
     vibevoice_asr: dict | None = None,
+    sensevoice: dict | None = None,
 ) -> Path:
     """Write a bootstrap-status.json and return its path."""
     features: dict[str, Any] = {}
@@ -48,6 +49,8 @@ def _make_bootstrap_status(
         features["nemo"] = nemo
     if vibevoice_asr is not None:
         features["vibevoice_asr"] = vibevoice_asr
+    if sensevoice is not None:
+        features["sensevoice"] = sensevoice
 
     status_file = tmp_path / "bootstrap-status.json"
     status_file.write_text(json.dumps({"features": features}), encoding="utf-8")
@@ -158,6 +161,30 @@ class TestFeatureStatusFromBootstrap:
         assert status["available"] is False
         assert status["error"] == "No module named 'nemo'"
 
+    def test_sensevoice_available_from_bootstrap(self, tmp_path: Path):
+        sf = _make_bootstrap_status(tmp_path, sensevoice={"available": True, "reason": "ready"})
+
+        mgr = _build_manager(tmp_path, status_file=sf)
+
+        # Asserts both the __init__ chain AND the get_status() wiring (FIX 1).
+        status = mgr.get_status()
+        assert status["features"]["sensevoice"] == {
+            "available": True,
+            "reason": "ready",
+        }
+
+    def test_sensevoice_unavailable_from_bootstrap(self, tmp_path: Path):
+        sf = _make_bootstrap_status(
+            tmp_path, sensevoice={"available": False, "reason": "not_selected"}
+        )
+
+        mgr = _build_manager(tmp_path, status_file=sf)
+
+        assert mgr.get_sensevoice_feature_status() == {
+            "available": False,
+            "reason": "not_selected",
+        }
+
 
 # ── Feature status fallback (no bootstrap file) ──────────────────────────
 
@@ -222,6 +249,16 @@ class TestFeatureStatusFallback:
         status = mgr.get_vibevoice_asr_feature_status()
         assert status["available"] is False
         assert status["reason"] == "requested"
+
+    def test_sensevoice_fallback_not_requested(self, tmp_path: Path):
+        # No bootstrap file → _build_manager points BOOTSTRAP_STATUS_FILE at a
+        # nonexistent path, so the initializer must fall back to not_requested.
+        mgr = _build_manager(tmp_path)
+
+        assert mgr.get_sensevoice_feature_status() == {
+            "available": False,
+            "reason": "not_requested",
+        }
 
 
 # ── _classify_diarization_error ───────────────────────────────────────────

--- a/server/backend/tests/test_model_manager_init.py
+++ b/server/backend/tests/test_model_manager_init.py
@@ -260,6 +260,15 @@ class TestFeatureStatusFallback:
             "reason": "not_requested",
         }
 
+    def test_sensevoice_fallback_requested(self, tmp_path: Path):
+        # No bootstrap file, but INSTALL_FUNASR=true in env → reason 'requested'.
+        mgr = _build_manager(tmp_path, env_overrides={"INSTALL_FUNASR": "true"})
+
+        assert mgr.get_sensevoice_feature_status() == {
+            "available": False,
+            "reason": "requested",
+        }
+
 
 # ── _classify_diarization_error ───────────────────────────────────────────
 

--- a/server/backend/tests/test_sensevoice_backend.py
+++ b/server/backend/tests/test_sensevoice_backend.py
@@ -61,10 +61,23 @@ class TestLifecycle:
             backend.load("iic/SenseVoiceSmall", device="cuda", gpu_device_index=0)
             assert backend.is_loaded()
             call_kwargs = stubs["funasr"].AutoModel.call_args.kwargs
-            assert call_kwargs["model"] == "iic/SenseVoiceSmall"
+            # hub="hf" downloads from HuggingFace, where the repo is the
+            # FunAudioLLM-namespaced id (the ModelScope "iic/..." id 404s on HF).
+            assert call_kwargs["model"] == "FunAudioLLM/SenseVoiceSmall"
             assert call_kwargs["device"] == "cuda:0"
             assert call_kwargs["vad_model"] == "fsmn-vad"
             assert call_kwargs["hub"] == "hf"
+            # The canonical, user-facing id is preserved on the backend.
+            assert backend._model_name == "iic/SenseVoiceSmall"
+
+    def test_modelscope_id_maps_to_hf_repo(self) -> None:
+        from server.core.stt.backends.sensevoice_backend import _resolve_hf_repo_id
+
+        # Known ModelScope id -> HuggingFace repo id (the bug: hub=hf + iic/... 404s).
+        assert _resolve_hf_repo_id("iic/SenseVoiceSmall") == "FunAudioLLM/SenseVoiceSmall"
+        # Unknown / already-HF ids pass through unchanged.
+        assert _resolve_hf_repo_id("FunAudioLLM/SenseVoiceSmall") == "FunAudioLLM/SenseVoiceSmall"
+        assert _resolve_hf_repo_id("some-org/sensevoice-custom") == "some-org/sensevoice-custom"
 
     def test_unload_clears_model(self) -> None:
         from server.core.stt.backends.sensevoice_backend import SenseVoiceBackend

--- a/server/backend/tests/test_sensevoice_backend.py
+++ b/server/backend/tests/test_sensevoice_backend.py
@@ -1,0 +1,204 @@
+"""Unit tests for SenseVoiceBackend (funasr stubbed — no model download)."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import types
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+class _FakeAutoModel:
+    """Minimal stub for ``funasr.AutoModel``."""
+
+    def __init__(self, result: list[dict[str, Any]] | None = None):
+        # Default: one merged-text result, no sentence_info, no timestamps.
+        self._result = (
+            result
+            if result is not None
+            else [{"key": "x", "text": "<|en|><|NEUTRAL|><|Speech|>Hello world."}]
+        )
+        self.generate = MagicMock(side_effect=lambda **kw: self._result)
+
+
+def _make_funasr_stub(model: _FakeAutoModel | None = None) -> dict[str, Any]:
+    """sys.modules patch dict stubbing funasr + its postprocess submodule."""
+    fake = model or _FakeAutoModel()
+
+    funasr_mod = types.ModuleType("funasr")
+    funasr_mod.AutoModel = MagicMock(return_value=fake)  # type: ignore[attr-defined]
+
+    utils_mod = types.ModuleType("funasr.utils")
+    postproc_mod = types.ModuleType("funasr.utils.postprocess_utils")
+    # Strip every <|...|> rich-transcription token, like the real helper does.
+    postproc_mod.rich_transcription_postprocess = (  # type: ignore[attr-defined]
+        lambda s: re.sub(r"<\|[^|]*\|>", "", s).strip()
+    )
+    return {
+        "funasr": funasr_mod,
+        "funasr.utils": utils_mod,
+        "funasr.utils.postprocess_utils": postproc_mod,
+    }
+
+
+class TestLifecycle:
+    def test_not_loaded_initially(self) -> None:
+        from server.core.stt.backends.sensevoice_backend import SenseVoiceBackend
+
+        assert SenseVoiceBackend().is_loaded() is False
+
+    def test_load_sets_loaded_and_cuda_device(self) -> None:
+        from server.core.stt.backends.sensevoice_backend import SenseVoiceBackend
+
+        stubs = _make_funasr_stub()
+        with patch.dict(sys.modules, stubs):
+            backend = SenseVoiceBackend()
+            backend.load("iic/SenseVoiceSmall", device="cuda", gpu_device_index=0)
+            assert backend.is_loaded()
+            call_kwargs = stubs["funasr"].AutoModel.call_args.kwargs
+            assert call_kwargs["model"] == "iic/SenseVoiceSmall"
+            assert call_kwargs["device"] == "cuda:0"
+            assert call_kwargs["vad_model"] == "fsmn-vad"
+            assert call_kwargs["hub"] == "hf"
+
+    def test_unload_clears_model(self) -> None:
+        from server.core.stt.backends.sensevoice_backend import SenseVoiceBackend
+
+        stubs = _make_funasr_stub()
+        with patch.dict(sys.modules, stubs):
+            backend = SenseVoiceBackend()
+            backend.load("iic/SenseVoiceSmall", device="cpu")
+        with patch("server.core.stt.backends.sensevoice_backend.clear_gpu_cache"):
+            backend.unload()
+        assert backend.is_loaded() is False
+
+    def test_metadata(self) -> None:
+        from server.core.stt.backends.sensevoice_backend import SenseVoiceBackend
+
+        backend = SenseVoiceBackend()
+        assert backend.backend_name == "sensevoice"
+        assert backend.supports_translation() is False
+
+    def test_load_cpu_device_passes_through(self) -> None:
+        from server.core.stt.backends.sensevoice_backend import SenseVoiceBackend
+
+        stubs = _make_funasr_stub()
+        with patch.dict(sys.modules, stubs):
+            backend = SenseVoiceBackend()
+            backend.load("iic/SenseVoiceSmall", device="cpu")
+            call_kwargs = stubs["funasr"].AutoModel.call_args.kwargs
+            assert call_kwargs["device"] == "cpu"
+
+    def test_load_without_funasr_raises_dependency_error(self) -> None:
+        from server.core.stt.backends.base import BackendDependencyError
+        from server.core.stt.backends.sensevoice_backend import SenseVoiceBackend
+
+        # sys.modules["funasr"] = None makes `import funasr` raise ImportError.
+        with patch.dict(sys.modules, {"funasr": None}):
+            with pytest.raises(BackendDependencyError, match="FunASR"):
+                SenseVoiceBackend().load("iic/SenseVoiceSmall", device="cpu")
+
+    def test_warmup_noop_when_not_loaded(self) -> None:
+        from server.core.stt.backends.sensevoice_backend import SenseVoiceBackend
+
+        # No model loaded — must return without error and without calling generate.
+        SenseVoiceBackend().warmup()
+
+
+class TestTranscribe:
+    def _loaded(self, model: _FakeAutoModel) -> Any:
+        from server.core.stt.backends.sensevoice_backend import SenseVoiceBackend
+
+        stubs = _make_funasr_stub(model)
+        with patch.dict(sys.modules, stubs):
+            backend = SenseVoiceBackend()
+            backend.load("iic/SenseVoiceSmall", device="cpu")
+        return backend, stubs
+
+    def test_raises_if_not_loaded(self) -> None:
+        from server.core.stt.backends.sensevoice_backend import SenseVoiceBackend
+
+        with pytest.raises(RuntimeError, match="not loaded"):
+            SenseVoiceBackend().transcribe(np.zeros(16000, dtype=np.float32))
+
+    def test_merged_text_single_segment_strips_tokens(self) -> None:
+        fake = _FakeAutoModel([{"text": "<|en|><|HAPPY|><|Speech|>Hello world."}])
+        backend, stubs = self._loaded(fake)
+        audio = np.zeros(32000, dtype=np.float32)  # 2.0 s @ 16 kHz
+        with patch.dict(sys.modules, stubs):
+            segments, info = backend.transcribe(audio, audio_sample_rate=16000)
+        assert len(segments) == 1
+        assert segments[0].text == "Hello world."
+        assert segments[0].start == 0.0
+        assert segments[0].end == pytest.approx(2.0)
+        assert segments[0].words == []
+        assert info.language == "en"
+
+    def test_sentence_info_yields_per_sentence_segments(self) -> None:
+        fake = _FakeAutoModel(
+            [
+                {
+                    "text": "<|zh|>whatever",
+                    "sentence_info": [
+                        {"text": "<|en|>First.", "start": 0, "end": 1000},
+                        {"text": "<|en|>Second.", "start": 1000, "end": 2500},
+                    ],
+                }
+            ]
+        )
+        backend, stubs = self._loaded(fake)
+        with patch.dict(sys.modules, stubs):
+            segments, _ = backend.transcribe(np.zeros(40000, dtype=np.float32))
+        assert [s.text for s in segments] == ["First.", "Second."]
+        assert segments[0].start == 0.0 and segments[0].end == pytest.approx(1.0)
+        assert segments[1].start == pytest.approx(1.0) and segments[1].end == pytest.approx(2.5)
+
+    def test_empty_result_is_safe(self) -> None:
+        backend, stubs = self._loaded(_FakeAutoModel([]))
+        with patch.dict(sys.modules, stubs):
+            segments, info = backend.transcribe(np.zeros(16000, dtype=np.float32))
+        assert segments == []
+        assert info.language is None
+
+    def test_unsupported_language_falls_back_to_auto(self) -> None:
+        fake = _FakeAutoModel()
+        backend, stubs = self._loaded(fake)
+        with patch.dict(sys.modules, stubs):
+            backend.transcribe(np.zeros(16000, dtype=np.float32), language="el")
+        # funasr.generate was called with language="auto" (Greek is unsupported).
+        assert fake.generate.call_args.kwargs["language"] == "auto"
+
+    def test_forced_language_used_when_no_token_in_text(self) -> None:
+        # No <|xx|> token in text, but a supported language was explicitly requested.
+        fake = _FakeAutoModel([{"text": "Hello with no token."}])
+        backend, stubs = self._loaded(fake)
+        with patch.dict(sys.modules, stubs):
+            segments, info = backend.transcribe(np.zeros(16000, dtype=np.float32), language="ja")
+        assert info.language == "ja"
+        assert segments[0].text == "Hello with no token."
+
+    def test_temp_wav_removed_on_generate_error(self) -> None:
+        import server.core.stt.backends.sensevoice_backend as mod
+
+        fake = _FakeAutoModel()
+        backend, stubs = self._loaded(fake)
+        fake.generate.side_effect = RuntimeError("decode failed")
+
+        created: list[str] = []
+        orig_write = mod._write_temp_wav
+
+        def spy(audio, sr):
+            path = orig_write(audio, sr)
+            created.append(path)
+            return path
+
+        with patch.dict(sys.modules, stubs), patch.object(mod, "_write_temp_wav", spy):
+            with pytest.raises(RuntimeError, match="decode failed"):
+                backend.transcribe(np.zeros(16000, dtype=np.float32))
+        # The finally-block must have removed the temp file despite the error.
+        assert created and not os.path.exists(created[0])

--- a/server/backend/tests/test_sensevoice_routing.py
+++ b/server/backend/tests/test_sensevoice_routing.py
@@ -1,0 +1,32 @@
+"""Routing + capability tests for the SenseVoice (FunASR) backend."""
+
+from __future__ import annotations
+
+import pytest
+
+# --- capabilities.py -------------------------------------------------------
+
+
+class TestSenseVoiceCapabilities:
+    def test_sensevoice_has_no_translation(self) -> None:
+        from server.core.stt.capabilities import supports_english_translation
+
+        assert supports_english_translation("iic/SenseVoiceSmall") is False
+        assert supports_english_translation("FunAudioLLM/SenseVoiceSmall") is False
+        # Regression guard: the new pattern must not affect non-SenseVoice ids.
+        assert supports_english_translation("Systran/faster-whisper-large-v3") is True
+
+    def test_sensevoice_supports_auto_detect(self) -> None:
+        from server.core.stt.capabilities import supports_auto_detect
+
+        assert supports_auto_detect("iic/SenseVoiceSmall") is True
+
+    def test_sensevoice_translate_request_rejected(self) -> None:
+        from server.core.stt.capabilities import validate_translation_request
+
+        with pytest.raises(ValueError, match="does not support translation"):
+            validate_translation_request(
+                model_name="iic/SenseVoiceSmall",
+                task="translate",
+                translation_target_language="en",
+            )

--- a/server/backend/tests/test_sensevoice_routing.py
+++ b/server/backend/tests/test_sensevoice_routing.py
@@ -83,3 +83,25 @@ class TestBootstrapSelection:
         # Real whisper ids still classify as whisper.
         assert bootstrap.is_whisper_model_name("Systran/faster-whisper-large-v3") is True
         assert bootstrap.is_sensevoice_model_name("nvidia/parakeet-tdt-0.6b-v3") is False
+
+
+# --- model_manager feature status -----------------------------------------
+
+
+class TestSenseVoiceFeatureStatus:
+    def test_reads_sensevoice_from_bootstrap_status(self, tmp_path, monkeypatch) -> None:
+        import json
+
+        status = {"features": {"sensevoice": {"available": True, "reason": "ready"}}}
+        status_file = tmp_path / "bootstrap-status.json"
+        status_file.write_text(json.dumps(status), encoding="utf-8")
+        monkeypatch.setenv("BOOTSTRAP_STATUS_FILE", str(status_file))
+
+        from server.core.model_manager import ModelManager
+
+        mgr = object.__new__(ModelManager)
+        mgr._sensevoice_feature_available = False
+        mgr._sensevoice_feature_reason = "not_requested"
+        mgr._initialize_sensevoice_feature_status()
+
+        assert mgr.get_sensevoice_feature_status() == {"available": True, "reason": "ready"}

--- a/server/backend/tests/test_sensevoice_routing.py
+++ b/server/backend/tests/test_sensevoice_routing.py
@@ -30,3 +30,31 @@ class TestSenseVoiceCapabilities:
                 task="translate",
                 translation_target_language="en",
             )
+
+
+# --- factory.py ------------------------------------------------------------
+
+
+class TestSenseVoiceFactory:
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "iic/SenseVoiceSmall",
+            "FunAudioLLM/SenseVoiceSmall",
+            "iic/SenseVoice-extra",
+            "IIC/SENSEVOICESMALL",  # case-insensitive
+        ],
+    )
+    def test_sensevoice_models_detected(self, model_name: str) -> None:
+        from server.core.stt.backends.factory import detect_backend_type, is_sensevoice_model
+
+        assert detect_backend_type(model_name) == "sensevoice"
+        assert is_sensevoice_model(model_name) is True
+
+    def test_non_sensevoice_unaffected(self) -> None:
+        from server.core.stt.backends.factory import detect_backend_type, is_sensevoice_model
+
+        assert detect_backend_type("Systran/faster-whisper-large-v3") == "whisper"
+        assert detect_backend_type("nvidia/parakeet-tdt-0.6b-v3") == "parakeet"
+        # Bilateral coverage: the public helper agrees on the negative case too.
+        assert is_sensevoice_model("Systran/faster-whisper-large-v3") is False

--- a/server/backend/tests/test_sensevoice_routing.py
+++ b/server/backend/tests/test_sensevoice_routing.py
@@ -58,3 +58,28 @@ class TestSenseVoiceFactory:
         assert detect_backend_type("nvidia/parakeet-tdt-0.6b-v3") == "parakeet"
         # Bilateral coverage: the public helper agrees on the negative case too.
         assert is_sensevoice_model("Systran/faster-whisper-large-v3") is False
+
+
+# --- bootstrap model-name helpers -----------------------------------------
+
+
+class TestBootstrapSelection:
+    def _bootstrap(self):
+        import importlib.util
+        from pathlib import Path
+
+        path = Path(__file__).resolve().parents[2] / "docker" / "bootstrap_runtime.py"
+        spec = importlib.util.spec_from_file_location("bootstrap_runtime_under_test", path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+
+    def test_sensevoice_recognised_and_not_whisper(self) -> None:
+        bootstrap = self._bootstrap()
+        assert bootstrap.is_sensevoice_model_name("iic/SenseVoiceSmall") is True
+        # Must NOT be misclassified as a whisper model (else funasr never installs).
+        assert bootstrap.is_whisper_model_name("iic/SenseVoiceSmall") is False
+        # Real whisper ids still classify as whisper.
+        assert bootstrap.is_whisper_model_name("Systran/faster-whisper-large-v3") is True
+        assert bootstrap.is_sensevoice_model_name("nvidia/parakeet-tdt-0.6b-v3") is False

--- a/server/config.yaml
+++ b/server/config.yaml
@@ -52,7 +52,8 @@ main_transcriber:
     # Whisper examples: "Systran/faster-whisper-large-v3", "Systran/faster-whisper-medium"
     # Parakeet examples: "nvidia/parakeet-tdt-0.6b-v3" (25 European languages, requires INSTALL_NEMO=true)
     # VibeVoice-ASR examples: "microsoft/VibeVoice-ASR", "scerz/VibeVoice-ASR-4bit" (experimental, file/notebook only)
-    # Backend is auto-detected from the model name (nvidia/* → NeMo, */VibeVoice-ASR* → VibeVoice-ASR, else → Whisper).
+    # SenseVoice example: "iic/SenseVoiceSmall" (zh/en/yue/ja/ko only, fast NAR; requires INSTALL_FUNASR=true)
+    # Backend is auto-detected from the model name (nvidia/* → NeMo, */VibeVoice-ASR* → VibeVoice-ASR, */SenseVoice* → SenseVoice, else → Whisper).
     model: "nvidia/parakeet-tdt-0.6b-v3"
 
     # Compute type for the model. "default" is recommended.

--- a/server/docker/bootstrap_runtime.py
+++ b/server/docker/bootstrap_runtime.py
@@ -56,6 +56,7 @@ _VIBEVOICE_ASR_MODEL_PATTERN = re.compile(r"^[^/]+/vibevoice-asr(?:-[^/]+)?$", r
 _VIBEVOICE_ASR_4BIT_MODEL_PATTERN = re.compile(
     r"^[^/]+/vibevoice-asr(?:-[^/]+)?-4bit$", re.IGNORECASE
 )
+_SENSEVOICE_MODEL_PATTERN = re.compile(r"^[^/]+/sensevoice", re.IGNORECASE)
 _VIBEVOICE_ASR_QUANT_RUNTIME_PACKAGE_SPECS: tuple[str, ...] = (
     "accelerate>=0.26.0",
     "bitsandbytes>=0.43.1",
@@ -150,12 +151,22 @@ def is_nemo_model_name(model_name: str | None) -> bool:
     return name.startswith("nvidia/parakeet") or name.startswith("nvidia/canary")
 
 
+def is_sensevoice_model_name(model_name: str | None) -> bool:
+    """Return True when *model_name* selects the SenseVoice (FunASR) backend."""
+    name = normalize_selected_model_name(model_name)
+    return bool(_SENSEVOICE_MODEL_PATTERN.match(name))
+
+
 def is_whisper_model_name(model_name: str | None) -> bool:
     """Return True when *model_name* belongs to the faster-whisper family."""
     name = normalize_selected_model_name(model_name)
     if not name:
         return False
-    return not is_nemo_model_name(name) and not is_vibevoice_asr_model_name(name)
+    return (
+        not is_nemo_model_name(name)
+        and not is_vibevoice_asr_model_name(name)
+        and not is_sensevoice_model_name(name)
+    )
 
 
 _NVIDIA_PROC_VERSION = Path("/proc/driver/nvidia/version")
@@ -1037,7 +1048,7 @@ def should_reuse_cached_feature_status(
     features = previous_status_payload.get("features")
     if not isinstance(features, dict):
         return False
-    for key in ("whisper", "nemo", "vibevoice_asr"):
+    for key in ("whisper", "nemo", "vibevoice_asr", "sensevoice"):
         entry = features.get(key)
         if not isinstance(entry, dict):
             return False
@@ -1267,6 +1278,56 @@ except Exception as exc:
     )
 """
 
+    try:
+        result = subprocess.run(
+            [str(venv_python), "-c", checker],
+            text=True,
+            capture_output=True,
+            timeout=max(30, min(timeout_seconds, 300)),
+            check=False,
+        )
+    except Exception as exc:
+        return {
+            "available": False,
+            "reason": "import_failed",
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+
+    output = (result.stdout or "").strip().splitlines()
+    if not output:
+        return {"available": False, "reason": "import_failed"}
+    try:
+        payload = json.loads(output[-1])
+    except json.JSONDecodeError:
+        return {"available": False, "reason": "import_failed"}
+
+    result_payload = {
+        "available": bool(payload.get("available", False)),
+        "reason": str(payload.get("reason", "import_failed") or "import_failed"),
+    }
+    error = payload.get("error")
+    if error:
+        result_payload["error"] = str(error)
+    return result_payload
+
+
+def check_funasr_import(
+    venv_python: Path,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    checker = """
+import importlib.util
+import json
+
+try:
+    spec = importlib.util.find_spec("funasr")
+    if spec is None:
+        print(json.dumps({"available": False, "reason": "import_failed", "error": "funasr: not found"}))
+    else:
+        print(json.dumps({"available": True, "reason": "ready"}))
+except Exception as exc:
+    print(json.dumps({"available": False, "reason": "import_failed", "error": f"{type(exc).__name__}: {exc}"}))
+"""
     try:
         result = subprocess.run(
             [str(venv_python), "-c", checker],
@@ -1753,6 +1814,9 @@ def main() -> int:
     vibevoice_selected = is_vibevoice_asr_model_name(main_model) or is_vibevoice_asr_model_name(
         live_model
     )
+    sensevoice_selected = is_sensevoice_model_name(main_model) or is_sensevoice_model_name(
+        live_model
+    )
 
     # ── Reuse cached feature status when deps are unchanged ───────────────
     _reuse_feature_cache = should_reuse_cached_feature_status(
@@ -2122,6 +2186,72 @@ def main() -> int:
             persistent=True,
         )
 
+    # \u2500\u2500 SenseVoice (optional, FunASR pipeline) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+    sensevoice_start = time.perf_counter()
+    install_funasr = parse_bool_env("INSTALL_FUNASR", False)
+    sensevoice_status: dict[str, Any]
+
+    if not sensevoice_selected and not install_funasr:
+        sensevoice_status = {"available": False, "reason": "not_selected"}
+        log("SenseVoice not selected by configured models, skipping feature check")
+    elif _reuse_feature_cache and not install_funasr:
+        sensevoice_status = previous_status_payload["features"]["sensevoice"]
+        log(
+            "SenseVoice feature check: reusing cached result "
+            f"(available={sensevoice_status.get('available')})"
+        )
+    else:
+        existing_sensevoice_status = check_funasr_import(
+            venv_python=venv_python,
+            timeout_seconds=timeout_seconds,
+        )
+        if existing_sensevoice_status.get("available"):
+            sensevoice_status = existing_sensevoice_status
+            log("FunASR already available, skipping optional install")
+        elif install_funasr:
+            log("Installing FunASR for SenseVoice support...")
+            try:
+                run_command(
+                    ["uv", "pip", "install", "--python", str(venv_python), "funasr>=1.3.12"],
+                    timeout_seconds=timeout_seconds,
+                    env=build_uv_sync_env(venv_dir=venv_dir, cache_dir=cache_dir),
+                )
+                sensevoice_status = check_funasr_import(
+                    venv_python=venv_python,
+                    timeout_seconds=timeout_seconds,
+                )
+                if sensevoice_status.get("available"):
+                    log("FunASR installed")
+                else:
+                    failure_error = str(sensevoice_status.get("error", "")).strip()
+                    log(
+                        "FunASR installation completed but import check failed "
+                        f"({sensevoice_status.get('reason', 'import_failed')}"
+                        + (f": {failure_error}" if failure_error else "")
+                        + ")"
+                    )
+            except Exception as exc:
+                sensevoice_status = {
+                    "available": False,
+                    "reason": "install_failed",
+                    "error": str(exc),
+                }
+                log(f"FunASR installation failed: {exc}")
+        else:
+            sensevoice_status = {"available": False, "reason": "selected_but_not_requested"}
+            log(
+                "SenseVoice model selected but INSTALL_FUNASR is not enabled, "
+                "skipping optional install"
+            )
+    log_timing("SenseVoice feature check complete", sensevoice_start)
+    if sensevoice_selected and not sensevoice_status.get("available"):
+        emit_event(
+            "warn-sensevoice",
+            "warning",
+            f"SenseVoice unavailable \u2014 {sensevoice_status.get('reason', 'unavailable')}",
+            persistent=True,
+        )
+
     status_write_start = time.perf_counter()
     write_status_file(
         status_file,
@@ -2141,6 +2271,7 @@ def main() -> int:
                 "whisper": whisper_status,
                 "nemo": nemo_status,
                 "vibevoice_asr": vibevoice_asr_status,
+                "sensevoice": sensevoice_status,
             },
         },
     )

--- a/server/docker/bootstrap_runtime.py
+++ b/server/docker/bootstrap_runtime.py
@@ -2194,12 +2194,18 @@ def main() -> int:
     if not sensevoice_selected and not install_funasr:
         sensevoice_status = {"available": False, "reason": "not_selected"}
         log("SenseVoice not selected by configured models, skipping feature check")
-    elif _reuse_feature_cache and not install_funasr:
+    elif (
+        _reuse_feature_cache
+        and not install_funasr
+        and previous_status_payload.get("features", {}).get("sensevoice", {}).get("available")
+    ):
+        # Only trust a *positive* cached result. A cached "unavailable" (e.g. a
+        # stale "not_selected" from before this model was configured) must not be
+        # parroted back when SenseVoice is now selected — fall through to a fresh
+        # import check so we report the accurate reason and pick up a funasr that
+        # was installed out of band.
         sensevoice_status = previous_status_payload["features"]["sensevoice"]
-        log(
-            "SenseVoice feature check: reusing cached result "
-            f"(available={sensevoice_status.get('available')})"
-        )
+        log("SenseVoice feature check: reusing cached result (available=True)")
     else:
         existing_sensevoice_status = check_funasr_import(
             venv_python=venv_python,

--- a/server/docker/docker-compose.yml
+++ b/server/docker/docker-compose.yml
@@ -104,6 +104,8 @@ services:
       # VibeVoice-ASR backend support (optional, experimental in-process backend)
       - INSTALL_VIBEVOICE_ASR=${INSTALL_VIBEVOICE_ASR:-false}
       - VIBEVOICE_ASR_PACKAGE_SPEC=${VIBEVOICE_ASR_PACKAGE_SPEC:-git+https://github.com/microsoft/VibeVoice.git@1807b858d4f7dffdd286249a01616c243e488c9e}
+      # SenseVoice (FunASR) backend support (optional family install, additive only)
+      - INSTALL_FUNASR=${INSTALL_FUNASR:-false}
       # whisper.cpp sidecar URL (populated by docker-compose.vulkan.yml overlay)
       - WHISPERCPP_SERVER_URL=${WHISPERCPP_SERVER_URL:-}
       # PyTorch CUDA memory allocator — reduce fragmentation on long transcriptions


### PR DESCRIPTION
## Summary

Adds Alibaba **FunAudioLLM SenseVoice** (`iic/SenseVoiceSmall`) as a new STT backend via the `funasr` PyTorch pipeline. **Phase 1 scope: Linux/NVIDIA, transcriber-only** — no new diarization code (existing pyannote two-pass remains). Selectable like any other model and gated behind a new optional `INSTALL_FUNASR` install flag (mirrors `INSTALL_NEMO`).

Addresses #129 (and its duplicate #144) for the Phase 1 scope.

## What's included (full vertical slice)

**Backend**
- `SenseVoiceBackend` (`server/backend/core/stt/backends/sensevoice_backend.py`) — wraps `funasr.AutoModel` (SenseVoiceSmall + `fsmn-vad`), pulls weights from HuggingFace (`hub="hf"`). Strips `<|…|>` rich-transcription tokens; handles both `sentence_info` (per-sentence segments) and merged-text shapes. Raises `BackendDependencyError` (→ HTTP 503 + remedy) when `funasr` isn't installed, matching the Parakeet pattern.
- Factory routing: `^<org>/sensevoice` → `detect_backend_type` returns `"sensevoice"`. Excluded from the whisper-default fallback in `factory.py`, `capabilities.py`, `bootstrap_runtime.py`, and the dashboard `isWhisperModel` — symmetrically, all four.
- Capabilities: no translation; 5 languages **zh / en / yue / ja / ko — no Greek**; no word-level timestamps.
- Bootstrap: `INSTALL_FUNASR` gate + `check_funasr_import` + `features.sensevoice` status. Optional extra `sensevoice = ["funasr>=1.3.12"]`.
- `ModelManager.get_sensevoice_feature_status()` surfaced in `GET /api/status` → `features.sensevoice` (with a dev-mode `INSTALL_FUNASR` env fallback, matching whisper/vibevoice).

**Dashboard (fully integrated)**
- Capabilities (`modelCapabilities.ts`): `isSenseVoiceModel`, `SENSEVOICE_LANGUAGES`, language filter, no-translation.
- Registry (`modelRegistry.ts`): `iic/SenseVoiceSmall`, family `'sensevoice'`, CUDA runtime, transcriber-only (`roles: ['main']`, `liveMode: false`).
- **Install-flow gating** (`modelSelection.ts` + electron plumbing): selecting SenseVoice now correctly detects a missing FunASR dependency, shows it labeled `SenseVoice (FunASR)` in the "Additional Dependencies Required" prompt, considers it satisfied when `INSTALL_FUNASR=true` or bootstrap reports it available, and on **Install** writes `INSTALL_FUNASR=true` to the compose `.env`.
- **Model Manager panel**: amber SenseVoice section (Docker-only; hidden in Metal mode). UI-contract baseline updated (spec_version `1.0.59 → 1.0.60`).

**Docs**: `docs/README_DEV.md` (§8.6) + `docs/project-context.md` + `server/config.yaml`.

## Scope note

The original Phase-1 plan scoped the dashboard to just the registry entry + capabilities. Holistic review caught that this left SenseVoice missing from the Model Manager panel and misidentified as `whisper` by the install-helper. The dashboard **install-flow gating** and **Model Manager panel** work (commits `77c5be5a`, `56c6a1fd`) were added to complete the integration so the feature is coherent end-to-end.

## Out of scope (later phases)

FunASR's own CAM++ diarization, word-level timestamps, emotion/audio-event tags, sherpa-onnx / SenseVoice.cpp runtimes, Windows / macOS / Apple-Silicon, ModelScope (CN) download path. SenseVoice **cannot transcribe Greek** — it's a specialist (zh/en/yue/ja/ko), not a Whisper replacement.

## Test plan

Automated (all green in CI environment):
- [x] Backend `pytest tests/` — 2058 passed, 4 skipped, 0 failed (incl. new SenseVoice backend/routing/model-manager tests); `ruff` clean
- [x] Frontend `vitest run` — 1459 passed (96 files); `tsc --noEmit` clean; `npm run build` + `ui:contract:check` green

Manual hardware smoke test — **REQUIRED before merge, not runnable in CI** (needs a real Linux/NVIDIA GPU + `funasr` install):
- [ ] Set `main_transcriber.model: iic/SenseVoiceSmall`, `INSTALL_FUNASR=true`; confirm bootstrap logs `FunASR installed` and `features.sensevoice.available == true`
- [ ] Transcribe a short EN (and CN/JA if available) clip: text correct, **free of `<|…|>` tokens**, `info.language` populated; record whether per-sentence or single-segment output
- [ ] Transcribe a 2–5 min clip: confirms `fsmn-vad` chunking (no 30s cap error)
- [ ] Verify durability (result persisted before delivery) and record peak VRAM
- [ ] Capture the real `generate()` return shape (`res[0].keys()`) — reconcile `_parse_result` if it diverges from the mocks