### PR TITLE
fix(dashboard, server): recover large (>1MB) transcription results in packaged builds (GH #202)

### DIFF
--- a/_bmad-output/implementation-artifacts/investigations/gh-202-investigation.md
+++ b/_bmad-output/implementation-artifacts/investigations/gh-202-investigation.md
@@ -1,0 +1,241 @@
+# Investigation: GH #202 — "Result too large to stream — fetch failed" on a 3-hour transcription
+
+## Hand-off Brief
+
+1. **What happened.** A user recorded a ~3-hour lecture on Apple Silicon (v1.3.7, macOS/MLX). On stop, the server transcribed the full recording, and because the result payload exceeded the 1 MB WebSocket inline limit, it sent a lightweight `result_ready` **reference** and told the client to fetch the full result over HTTP. The client's recovery fetch uses a **bare relative URL** (`fetch('/api/transcribe/result/{job_id}')`) that resolves against the packaged renderer's `file://` origin instead of the backend base URL (`http://localhost:9786`). The request never reached the server, so the client showed **"Result too large to stream — fetch failed"**.
+2. **Where the case stands.** Root cause **confirmed** (adversarially verified — 0 of 3 refutation attempts succeeded). The transcript is **not lost** — it was persisted to the DB before the reference was sent and is protected from cleanup. A **second latent defect** was found: even after fixing the URL, the ownership check would `403` on the localhost-bypass path. Both must be fixed together. No code has been changed yet.
+3. **What's needed next.** Implement the two-part fix (route both recovery fetches through `apiClient`'s base URL **and** reconcile the `localhost-user` ownership mismatch), add regression tests, and reply to the reporter with the manual DB-recovery steps so they can retrieve their lecture now.
+
+## Case Info
+
+| Field             | Value                                                                                                  |
+| ----------------- | ------------------------------------------------------------------------------------------------------ |
+| Ticket            | #202                                                                                                   |
+| Date opened       | 2026-07-11 (GH); investigation 2026-07-11                                                               |
+| Status            | Root cause confirmed — fix not yet implemented                                                         |
+| Labels            | `bug`, `apple-silicon-mlx` (the MLX label is **incidental** — see §7)                                   |
+| System (report)   | Apple Silicon Mac, macOS (darwin), TranscriptionSuite v1.3.7 (Metal/MLX), Docker daemon NOT running     |
+| Evidence sources  | Attached `client-debug.log` + `mlx-server.log`; dashboard/server source at main HEAD `2253166d`; git log |
+| Severity          | **High** (user cannot retrieve a completed 3 h transcript in-app) — but **NOT data loss** (recoverable)  |
+| Reproducibility   | Deterministic for any **packaged** build whose result payload exceeds **1 MB** (≈ >30–45 min of speech)  |
+
+## Problem Statement
+
+The reporter recorded a ~3-hour lecture. After stopping, the **Main Transcription** panel displayed:
+
+> Result too large to stream --fetch failed
+
+That exact string is the client's own error text (`dashboard/src/hooks/useTranscription.ts:259` and `:264`), emitted when the HTTP recovery fetch for a large result returns non-200 or throws.
+
+---
+
+## 1. Timeline (reconstructed from the two logs, UTC)
+
+| Time (UTC)        | Source                     | Event |
+| ----------------- | -------------------------- | ----- |
+| 11:12:44          | client-debug.log           | App start; **packaged** build — stack traces show `file:///Applications/TranscriptionSuite.app/…/app.asar/…` (client-debug.log:52) |
+| 11:13:02          | client-debug.log           | Main WS connects to `ws://localhost:9786/ws`, `session_started` |
+| 11:13:09 → 14:24  | client-debug.log           | **Live Mode** runs ~3 h 11 m (`SocketLive` `sentence`/`state` stream) |
+| 14:24:22          | client-debug.log           | `=> stop` |
+| 14:24:31          | client-debug.log           | `<= session_stopped` — server begins the **longform (Main) transcription** of the full recording |
+| 14:24:36 → 14:29:26 | client-debug.log          | `<= processing_progress` every 5 s (~5 min of longform processing) |
+| 14:29:31.548Z     | mlx-server.log:2040        | `Transcription completed … 1606 segments` |
+| 14:29:31.894Z     | mlx-server.log:2042        | `Ended transcription job 39378f14…` (result persisted to DB) |
+| 14:29:31.895Z     | client-debug.log:388       | `<= result_ready` — server sent the **reference** (payload > 1 MB) |
+| 14:29:31.904Z     | client-debug.log:389       | Client `Disconnect requested`; the relative recovery fetch is issued and **fails at the `file://` layer** |
+| 14:29–14:31+      | mlx-server.log:2068–2069   | Same renderer's **apiClient** calls (`/api/notebook/calendar`, `/api/transcribe/languages`) reach the server 200 OK — proving the server was alive and reachable |
+
+**Decisive observation:** `mlx-server.log` contains **zero** `GET /api/transcribe/result/...` lines (only `/api/status` ×416, `/api/admin/status` ×424, `/api/transcribe/languages`, `/api/notebook/calendar`). The recovery request was never emitted as an HTTP request to the backend, while other renderer→backend HTTP calls in the same window succeeded.
+
+---
+
+## 2. Root Cause (primary)
+
+**The large-result recovery fetch uses a root-relative URL that bypasses the configured API base URL, so in a packaged build it resolves to the renderer's `file://` origin and never reaches the backend.**
+
+Server side — the "too large → send a reference" path (correct, durability-safe):
+
+```python
+# server/backend/api/routes/websocket.py:391-425
+_save_result(job_id=..., result_text=..., result_json=json.dumps(result_payload, ...), ...)  # PERSIST BEFORE DELIVER
+...
+_result_size = len(json.dumps(result_payload))
+if _result_size > 1_000_000 and self._current_job_id:
+    await self.send_message("result_ready", {"job_id": self._current_job_id})   # reference, NOT inline
+    _sent_as_reference = True
+else:
+    await self.send_message("final", result_payload)                             # inline
+# mark_delivered is intentionally skipped for the reference path
+```
+
+Client side — the broken recovery fetch:
+
+```ts
+// dashboard/src/hooks/useTranscription.ts:245 (result_ready handler)
+fetch(`/api/transcribe/result/${job_id}`, { headers: authHeader })   // ← RELATIVE
+  ...
+  .catch(() => setError('Result too large to stream — fetch failed'));  // :264
+```
+
+Every other client HTTP call goes through `apiClient`, which prepends the base URL:
+
+```ts
+// dashboard/src/api/client.ts:225  (baseUrl default 'http://localhost:9786', :100)
+const res = await fetch(`${this.baseUrl}${path}`, { ... });
+```
+
+**Mechanism.** In a packaged build the renderer is loaded from disk, not a web server:
+
+- `dashboard/electron/main.ts:121` — `const isDev = !app.isPackaged`
+- `dashboard/electron/main.ts:861` — production branch: `mainWindow.loadFile('.../dist/index.html')` → origin is `file://`
+- `dashboard/vite.config.ts:157-158` — `base: './'` ("Use relative paths so Electron can load from file:// protocol")
+- No custom protocol/proxy is registered (grep for `protocol.handle`/`registerSchemesAsPrivileged`/`webRequest`/`<base>` → 0 matches)
+
+So `fetch('/api/transcribe/result/{id}')` resolves to `file:///api/transcribe/result/{id}`. Chromium rejects a `fetch()` of a `file://` URL (default `webSecurity` is on — `main.ts:799-804` does not disable it), the promise rejects into `.catch()`, and the user sees the error. **The WebSocket works** in the same session only because `getWsUrl()` builds an **absolute** `ws://localhost:9786/ws` from `apiClient.getBaseUrl()` (`dashboard/src/services/websocket.ts:176-181`) — the exact asymmetry that isolates the defect.
+
+The same relative-URL defect exists at a **second call site** — the onClose disconnect-poll fallback (`useTranscription.ts:370`). In this incident only the `result_ready` handler fired (it nulls `jobIdRef` at `:271` before disconnect, so the poll loop is skipped), but both paths are broken identically.
+
+---
+
+## 3. Secondary defect — ownership `403` on the localhost-bypass path (would block the fix)
+
+Fixing the URL alone is **not sufficient**. The WebSocket authenticated via the **localhost bypass**, which hardcodes the job's owner:
+
+```python
+# server/backend/api/routes/utils.py:198-204  (WS auth, localhost + non-TLS)
+if allow_localhost_bypass and not TLS_MODE and is_local_auth_bypass_host(client_host):
+    return WebSocketAuthResult(client_name="localhost-user", is_admin=True, is_localhost_bypass=True, stored_token=None)
+```
+
+So the persisted job's `client_name = "localhost-user"`. But the HTTP result endpoint derives the caller identity from the **token only** — there is no localhost bypass:
+
+```python
+# server/backend/api/routes/utils.py:292-302
+def get_client_name(request: Request) -> str:
+    stored_token = validate_auth_token(get_request_auth_token(request))
+    if stored_token:
+        return stored_token.client_name
+    return "Unknown Client"
+```
+
+And the endpoint enforces ownership:
+
+```python
+# server/backend/api/routes/transcription.py:1408-1410
+client_name = get_client_name(request)
+if job.get("client_name") is not None and job["client_name"] != client_name:
+    raise HTTPException(status_code=403, detail="Access denied")
+```
+
+`get_client_name()` cannot return `"localhost-user"` (the bypass sets `stored_token=None` and creates no such token), so `job["client_name"] ("localhost-user") != client_name` → **403 Access denied**. The same `client_name` mismatch also means `GET /api/transcribe/recent` (`transcription.py:1759`, queries `get_recent_undelivered(client_name, …)`) would **not** surface the job. Both the direct fetch and the recovery-notification list would remain broken for localhost-bypass users until this identity inconsistency is reconciled.
+
+---
+
+## 4. Data safety & recoverability (severity)
+
+**This is a delivery/retrieval bug, not data loss.** The result is persisted to the DB **before** any delivery attempt:
+
+- `server/backend/api/routes/websocket.py:391-399` — `_save_result(...)` writes `result_text` (full transcript) and `result_json` (full payload incl. words) with `status='completed'`, *before* the size check.
+- The reference path deliberately **skips** `mark_delivered`, so the row is `status='completed', delivered=0`.
+- The row is **protected**: orphan recovery only touches `status='processing'` (`job_repository.py:334-360`); cleanup only deletes `status='completed' AND delivered=1` (`job_repository.py:363-392`). A `completed/delivered=0` row is neither purged nor its audio deleted.
+
+**But no working in-app surface can retrieve it**, because every retrieval path is broken by §2 (and §3):
+
+| Retrieval surface | Location | Broken by |
+| ----------------- | -------- | --------- |
+| `result_ready` fetch | `useTranscription.ts:245` | relative URL (§2) + `403` (§3) |
+| onClose poll loop | `useTranscription.ts:370` | relative URL (§2) + `403` (§3) |
+| Recovery notification list | `SessionView.tsx:1059` (`/api/transcribe/recent`) | relative URL + `client_name` mismatch (§3) |
+| Recovery "View" / "Dismiss" | `SessionView.tsx:1255`, `:1281` | relative URL (§2) + `403` (§3) |
+| Notebook / Recordings view | uses `apiClient` (absolute) — would work | but the **longform WS flow never creates a notebook `recordings` row** (`save_longform_to_database` is only called from `notebook.py:1140`, never from `websocket.py`) |
+| Retry | `transcription.py:1462-1469` | only accepts `status='failed'`; this job is `completed` → 409 |
+
+**Immediate recovery for the reporter (no code change):** read the row directly from SQLite at `<data_dir>/database/notebook.db` (`database.py:40,60-67`):
+
+```sql
+SELECT result_text, result_json
+FROM transcription_jobs
+WHERE status='completed' AND delivered=0
+ORDER BY completed_at DESC LIMIT 5;
+```
+
+`result_text` alone contains the full plain transcript.
+
+---
+
+## 5. Why "Main Transcription" and why 3 hours specifically
+
+The user ran **Live Mode**, but the error is on the **Main Transcription** because on stop the server runs a full longform pass over the entire recording and returns it via the main WS (`processing_progress` → `result_ready`). Only results **over 1 MB** take the reference path (`websocket.py:415-417`); the payload is the full `result.to_dict()` with per-word/segment timestamps (`websocket.py:_build_longform_result_payload`). A ~3 h transcript (~27k words) comfortably exceeds 1 MB, so it hits the broken path; shorter recordings stay under the threshold and use the working inline `final` path — which is why this was never seen before.
+
+---
+
+## 6. Contributing factors
+
+- **Never absolute.** The fetches were born relative and stayed relative (see §8). A later "13 code-review patches" commit added auth headers to both sites but left the URLs relative.
+- **Dev masks it.** Dev loads the renderer from `http://localhost:3000` (`main.ts:844`), where a root-relative `/api` at least forms an `http://` URL; and there is **no Vite dev proxy** (0 matches for `proxy` in `vite.config.ts`), so the failure mode differs from prod.
+- **Rarely exercised.** The >1 MB path requires a multi-hour transcript — essentially never produced in routine dev/QA.
+- **Two independent latent bugs stacked** (relative URL + ownership mismatch), so a single-pass fix of the visible symptom would still leave the feature broken.
+
+---
+
+## 7. Is this Apple-Silicon/MLX specific? No.
+
+The `apple-silicon-mlx` label is **incidental** (it's simply the reporter's platform). The failing code is entirely in the **shared** renderer bundle and the **shared** FastAPI backend:
+
+- The MLX server runs the *same* app: `mlxServerManager.ts:189` spawns `uvicorn server.api.main:app` — identical routers, port model (9786), and auth as Docker.
+- The renderer origin is `file://` on **all** platforms in packaged builds (`main.ts:861`).
+- No MLX-vs-Docker CSP/header differences exist (0 matches for CSP customization in `dashboard/electron/`).
+
+**A Docker packaged client (Windows/Linux/Intel-Mac) producing a >1 MB result would fail identically.** Recommend relabeling as a general packaged-build bug.
+
+---
+
+## 8. Git origin & fix location
+
+Both fetches were introduced **relative** and never made absolute (all ancestors of HEAD `2253166d`):
+
+| Call site | Introduced by | Notes |
+| --------- | ------------- | ----- |
+| onClose poll (`:370`) | `9d07247f` "feat: Wave 1 transcription durability — never lose a completed result" (2026-03-30) | first form already relative |
+| `result_ready` (`:245`) | `654e19d3` "feat: Wave 3 transcription recovery — orphan jobs, graceful drain, large results" (2026-03-30) | first form relative, no auth |
+| (both) | `08333f91` "fix: Apply 13 code review patches…" | added `Authorization` headers, **kept URLs relative** |
+
+Only these two sites reference `transcribe/result` in the entire dashboard.
+
+---
+
+## 9. Recommended fix (two parts — both required)
+
+**Part A — route the recovery fetches through the configured base URL.** `apiClient` is already imported (`useTranscription.ts:12`) and used for `getAuthToken()` at both sites. Prefer a dedicated method for consistency with the rest of `client.ts`:
+
+```ts
+// dashboard/src/api/client.ts — new method (reuses ${this.baseUrl}${path} + auth pattern)
+async getTranscriptionResult(jobId: string): Promise<Response> {
+  const token = this.getAuthToken();
+  return fetch(`${this.baseUrl}/api/transcribe/result/${jobId}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+}
+```
+
+Replace the raw `fetch(...)` at `useTranscription.ts:245` and `:370` (and the three relative fetches in `SessionView.tsx:1059/1255/1281`) with base-URL-prefixed calls.
+
+**Part B — reconcile localhost-bypass identity so the owner can read their own job.** Options (pick one, add a test):
+- Give `get_client_name()` the same localhost + non-TLS bypass as the WS auth (return `"localhost-user"` for local, token-less requests), **or**
+- In the ownership check (`transcription.py:1408-1410`) and `get_recent_undelivered`, treat a localhost, non-TLS request as owner of `"localhost-user"` jobs.
+  Ensure `GET /recent` returns localhost-bypass jobs for the same caller.
+
+**Optional hardening.** Consider streaming/chunking large results, or raising the 1 MB inline threshold, so the recovery path is exercised less; but the recovery path must be correct regardless.
+
+---
+
+## 10. Regression tests to add
+
+- **Frontend:** assert the `result_ready` handler and onClose poll issue an **absolute** URL (`http://localhost:9786/api/transcribe/result/…`), e.g. by asserting `fetch` was called with a URL starting with `apiClient.getBaseUrl()`. Guards against reintroducing a relative URL.
+- **Backend (route test, direct-call pattern per CLAUDE.md):** a job owned by `"localhost-user"` must be retrievable via `GET /result/{job_id}` and appear in `GET /recent` for a localhost, non-TLS caller (currently 403 / absent). Extends `tests/test_p0_durability.py` which already covers `result_ready` reference + not-marked-delivered.
+
+---
+
+## 11. Verification method (how this RCA was confirmed)
+
+A structured RCA workflow ran **5 parallel investigators** (renderer origin, recoverability, alternative hypotheses, git archaeology, MLX-label validity) followed by **3 adversarial refutation agents** each instructed to *break* the root cause via (a) the logs, (b) URL resolution, (c) an alternative cause. **All 3 returned `refuted: false`** (refutedCount = 0). Alternatives ruled out with evidence: auth 401/403 (would still produce a server log line — none exists), CSP (`index.html:8` whitelists `http://localhost:*`), WS-close race (fetch has no `AbortController` tied to the socket), URL-encoding, and the 1 MB threshold (correct trigger, not a fault). The one alternative that survived as a *real* issue is the §3 ownership `403`, retained as a secondary defect rather than the primary cause.

--- a/dashboard/components/__tests__/SessionView.canary-language.test.tsx
+++ b/dashboard/components/__tests__/SessionView.canary-language.test.tsx
@@ -147,6 +147,11 @@ vi.mock('../../src/api/client', () => ({
     unloadModels: vi.fn().mockResolvedValue(undefined),
     unloadLLMModel: vi.fn().mockResolvedValue(undefined),
     loadModelsStream: vi.fn().mockReturnValue(vi.fn()),
+    // GH-202 recovery notification (mounted via useEffect): return a Response
+    // whose json() yields an empty list so the recovery useEffect resolves.
+    fetchRecentUndelivered: vi.fn().mockResolvedValue({ json: async () => [] }),
+    fetchTranscriptionResult: vi.fn().mockResolvedValue({ status: 404, json: async () => ({}) }),
+    dismissTranscriptionResult: vi.fn().mockResolvedValue({ status: 200 }),
   },
 }));
 

--- a/dashboard/components/__tests__/SessionView.test.tsx
+++ b/dashboard/components/__tests__/SessionView.test.tsx
@@ -125,6 +125,11 @@ vi.mock('../../src/api/client', () => ({
     unloadModels: vi.fn().mockResolvedValue(undefined),
     unloadLLMModel: vi.fn().mockResolvedValue(undefined),
     loadModelsStream: vi.fn().mockReturnValue(vi.fn()),
+    // GH-202 recovery notification (mounted via useEffect): return a Response
+    // whose json() yields an empty list so the recovery useEffect resolves.
+    fetchRecentUndelivered: vi.fn().mockResolvedValue({ json: async () => [] }),
+    fetchTranscriptionResult: vi.fn().mockResolvedValue({ status: 404, json: async () => ({}) }),
+    dismissTranscriptionResult: vi.fn().mockResolvedValue({ status: 200 }),
   },
 }));
 

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -1055,8 +1055,10 @@ export const SessionView: React.FC<SessionViewProps> = ({
     Array<{ job_id: string; completed_at: string; text_preview: string }>
   >([]);
   useEffect(() => {
-    const token = apiClient.getAuthToken();
-    fetch('/api/transcribe/recent', token ? { headers: { Authorization: `Bearer ${token}` } } : {})
+    // Absolute base URL via apiClient — a relative fetch resolves to the
+    // packaged renderer file:// origin and never reaches the backend (GH-202).
+    apiClient
+      .fetchRecentUndelivered()
       .then((r) => r.json())
       .then((data) => {
         if (Array.isArray(data)) setRecoveryJobs(data);
@@ -1251,11 +1253,8 @@ export const SessionView: React.FC<SessionViewProps> = ({
                   <button
                     className="rounded px-2 py-1 text-xs font-semibold text-amber-300 hover:bg-amber-500/20"
                     onClick={() => {
-                      const viewToken = apiClient.getAuthToken();
-                      fetch(
-                        `/api/transcribe/result/${job.job_id}`,
-                        viewToken ? { headers: { Authorization: `Bearer ${viewToken}` } } : {},
-                      )
+                      apiClient
+                        .fetchTranscriptionResult(job.job_id)
                         .then(async (resp) => {
                           if (resp.status === 200) {
                             const data = await resp.json();
@@ -1277,13 +1276,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
                   <button
                     className="rounded px-2 py-1 text-xs font-semibold text-amber-300/60 hover:bg-amber-500/20 hover:text-amber-300"
                     onClick={() => {
-                      const dismissToken = apiClient.getAuthToken();
-                      fetch(`/api/transcribe/result/${job.job_id}/dismiss`, {
-                        method: 'POST',
-                        ...(dismissToken
-                          ? { headers: { Authorization: `Bearer ${dismissToken}` } }
-                          : {}),
-                      }).catch(() => {});
+                      apiClient.dismissTranscriptionResult(job.job_id).catch(() => {});
                       setRecoveryJobs((prev) => prev.filter((j) => j.job_id !== job.job_id));
                     }}
                   >

--- a/dashboard/src/api/client.test.ts
+++ b/dashboard/src/api/client.test.ts
@@ -658,3 +658,69 @@ describe('initApiClient — bootstrap diagnostic for unconfigured gate', () => {
     expect(bootstrapWarnings).toHaveLength(1);
   });
 });
+
+// GH-202: the large-result recovery fetches (result_ready handler, onClose
+// poll, and the SessionView recovery notification) previously used bare
+// RELATIVE URLs. In a packaged Electron build the renderer origin is file://,
+// so a relative '/api/...' resolves to file:///api/... and never reaches the
+// backend. These methods MUST build an absolute URL from the configured base.
+describe('APIClient — transcription-result recovery uses absolute URLs (GH-202)', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn(async () => new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('fetchTranscriptionResult targets the configured base URL, not a relative path', async () => {
+    const client = new APIClient('http://localhost:9786');
+    await client.fetchTranscriptionResult('job-abc');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const url = String(fetchSpy.mock.calls[0][0]);
+    expect(url).toBe('http://localhost:9786/api/transcribe/result/job-abc');
+    expect(url.startsWith('/')).toBe(false);
+  });
+
+  it('honors a remote base URL (would 404 the wrong origin if left relative)', async () => {
+    const client = new APIClient('https://box.example:9786');
+    await client.fetchTranscriptionResult('job-abc');
+
+    expect(String(fetchSpy.mock.calls[0][0])).toBe(
+      'https://box.example:9786/api/transcribe/result/job-abc',
+    );
+  });
+
+  it('fetchRecentUndelivered and dismissTranscriptionResult also use absolute URLs', async () => {
+    const client = new APIClient('http://localhost:9786');
+
+    await client.fetchRecentUndelivered();
+    expect(String(fetchSpy.mock.calls[0][0])).toBe('http://localhost:9786/api/transcribe/recent');
+
+    await client.dismissTranscriptionResult('job-xyz');
+    expect(String(fetchSpy.mock.calls[1][0])).toBe(
+      'http://localhost:9786/api/transcribe/result/job-xyz/dismiss',
+    );
+    expect((fetchSpy.mock.calls[1][1] as RequestInit)?.method).toBe('POST');
+  });
+
+  it('attaches the bearer token when one is set, and omits it otherwise', async () => {
+    const client = new APIClient('http://localhost:9786');
+
+    await client.fetchTranscriptionResult('job-1');
+    expect(
+      (fetchSpy.mock.calls[0][1] as RequestInit).headers as Record<string, string>,
+    ).not.toHaveProperty('Authorization');
+
+    client.setAuthToken('tok123');
+    await client.fetchTranscriptionResult('job-2');
+    expect(
+      ((fetchSpy.mock.calls[1][1] as RequestInit).headers as Record<string, string>).Authorization,
+    ).toBe('Bearer tok123');
+  });
+});

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -300,6 +300,36 @@ export class APIClient {
     return this.get('/api/status');
   }
 
+  // ─── Transcription result recovery (GH-202) ───────────────────────────────
+  // Return the raw Response so callers can branch on status (200 ready,
+  // 202 processing, 410 failed). These MUST build an absolute URL from the
+  // configured base: a bare relative '/api/...' fetch resolves against the
+  // packaged renderer file:// origin and never reaches the backend, so a
+  // large (>1 MB) result served as a `result_ready` reference can never be
+  // retrieved.
+
+  /** GET /api/transcribe/result/{jobId} — fetch a persisted (possibly >1 MB) result. */
+  async fetchTranscriptionResult(jobId: string): Promise<Response> {
+    return fetch(`${this.baseUrl}/api/transcribe/result/${jobId}`, {
+      headers: this.authHeaders(),
+    });
+  }
+
+  /** GET /api/transcribe/recent — recently completed but undelivered results for this caller. */
+  async fetchRecentUndelivered(): Promise<Response> {
+    return fetch(`${this.baseUrl}/api/transcribe/recent`, {
+      headers: this.authHeaders(),
+    });
+  }
+
+  /** POST /api/transcribe/result/{jobId}/dismiss — mark a recovered result dismissed. */
+  async dismissTranscriptionResult(jobId: string): Promise<Response> {
+    return fetch(`${this.baseUrl}/api/transcribe/result/${jobId}/dismiss`, {
+      method: 'POST',
+      headers: this.authHeaders(),
+    });
+  }
+
   /**
    * Combined connectivity check — returns a summary of server state.
    * Uses a single GET /api/status request whose ``ready`` field

--- a/dashboard/src/hooks/useTranscription.test.ts
+++ b/dashboard/src/hooks/useTranscription.test.ts
@@ -2,6 +2,7 @@ import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 
 import { useTranscription } from './useTranscription';
+import { apiClient } from '../api/client';
 
 // ── Mocks ──────────────────────────────────────────────────────────────
 
@@ -79,6 +80,9 @@ vi.mock('../api/client', () => ({
   apiClient: {
     getAuthToken: vi.fn().mockReturnValue('test-token'),
     getBaseUrl: vi.fn().mockReturnValue('http://localhost:9786'),
+    // GH-202: the large-result recovery path must go through apiClient (which
+    // builds an absolute URL), never a bare relative fetch().
+    fetchTranscriptionResult: vi.fn(),
     isBaseUrlConfigured: vi.fn(() => mockGateConfigured),
     onConfigChanged: vi.fn((listener: () => void) => {
       configChangedListeners.add(listener);
@@ -208,6 +212,35 @@ describe('[P1] useTranscription', () => {
         language: 'en',
         duration: 1.5,
       });
+      expect(lastSocket.disconnect).toHaveBeenCalled();
+    });
+
+    // GH-202: a >1 MB result arrives as a `result_ready` reference; the hook
+    // must retrieve it through apiClient (absolute URL), not a relative fetch()
+    // that would resolve to file:// in a packaged build and always fail.
+    it('completes via apiClient on result_ready (large-result recovery)', async () => {
+      (apiClient.fetchTranscriptionResult as Mock).mockResolvedValue({
+        status: 200,
+        json: async () => ({
+          result: { text: 'big transcript', words: [], language: 'en', duration: 42 },
+        }),
+      });
+
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+      act(() => {
+        result.current.stop();
+      });
+
+      await act(async () => {
+        lastSocketCbs.onMessage!({ type: 'result_ready', data: { job_id: 'job-1' } });
+      });
+      // Flush the fetch().then(async → json()) → setState microtask chain.
+      await act(async () => {});
+
+      expect(apiClient.fetchTranscriptionResult).toHaveBeenCalledWith('job-1');
+      expect(result.current.status).toBe('complete');
+      expect(result.current.result?.text).toBe('big transcript');
       expect(lastSocket.disconnect).toHaveBeenCalled();
     });
 

--- a/dashboard/src/hooks/useTranscription.ts
+++ b/dashboard/src/hooks/useTranscription.ts
@@ -238,11 +238,13 @@ export function useTranscription(): TranscriptionState {
           break;
 
         case 'result_ready': {
-          // Result was too large to stream over WebSocket — fetch it via HTTP
+          // Result was too large to stream over WebSocket — fetch it via HTTP.
+          // Must go through apiClient (absolute base URL): a relative fetch
+          // resolves against the packaged renderer file:// origin and never
+          // reaches the backend (GH-202).
           const job_id = msg.data?.job_id as string;
-          const token = apiClient.getAuthToken();
-          const authHeader = token ? { Authorization: `Bearer ${token}` } : {};
-          fetch(`/api/transcribe/result/${job_id}`, { headers: authHeader })
+          apiClient
+            .fetchTranscriptionResult(job_id)
             .then(async (resp) => {
               if (resp.status === 200) {
                 const data = await resp.json();
@@ -365,11 +367,9 @@ export function useTranscription(): TranscriptionState {
             const poll = async () => {
               if (pollCancelledRef.current || jobIdRef.current !== currentJobId) return;
               try {
-                const pollToken = apiClient.getAuthToken();
-                const pollAuthHeader = pollToken ? { Authorization: `Bearer ${pollToken}` } : {};
-                const resp = await fetch(`/api/transcribe/result/${currentJobId}`, {
-                  headers: pollAuthHeader,
-                });
+                // Absolute base URL via apiClient — a relative fetch fails in
+                // the packaged (file://) renderer (GH-202).
+                const resp = await apiClient.fetchTranscriptionResult(currentJobId);
                 if (pollCancelledRef.current || jobIdRef.current !== currentJobId) return;
                 if (resp.status === 200) {
                   const data = await resp.json();

--- a/server/backend/api/routes/utils.py
+++ b/server/backend/api/routes/utils.py
@@ -293,8 +293,21 @@ def get_client_name(request: Request) -> str:
     """
     Extract the client name from the request's authentication token.
 
+    On a local, non-TLS deployment the localhost auth bypass takes precedence
+    over any token — mirroring ``authenticate_websocket_*`` above, which stamp
+    jobs with ``client_name="localhost-user"`` without consulting a token. This
+    keeps HTTP identity consistent with the WebSocket, so the local owner can
+    retrieve a persisted (>1 MB) result via ``GET /result/{job_id}`` and see it
+    in ``GET /recent``. Without the bypass those endpoints would 403 the
+    legitimate owner because the job is owned by ``localhost-user`` while the
+    token (or absence of one) resolves to a different name (GH #202).
+
     Returns the client_name from the token, or a default value if not found.
     """
+    client_host = request.client.host if request.client else None
+    if not TLS_MODE and is_local_auth_bypass_host(client_host):
+        return "localhost-user"
+
     stored_token = validate_auth_token(get_request_auth_token(request))
     if stored_token:
         return stored_token.client_name

--- a/server/backend/tests/test_get_client_name_localhost_bypass.py
+++ b/server/backend/tests/test_get_client_name_localhost_bypass.py
@@ -1,0 +1,91 @@
+"""Tests for ``get_client_name`` localhost-bypass identity (GH #202).
+
+A >1 MB transcription result is persisted by the WebSocket handler, which — on a
+local, non-TLS deployment — stamps the job with ``client_name="localhost-user"``
+via the localhost auth bypass (``authenticate_websocket_*`` in
+``server.api.routes.utils``), *without* consulting any token.
+
+The HTTP recovery endpoint ``GET /api/transcribe/result/{job_id}`` derives the
+caller identity from ``get_client_name`` and 403s when it differs from the job's
+owner.  For the legitimate local owner to retrieve their own result,
+``get_client_name`` must apply the *same* localhost bypass with the *same*
+precedence (bypass before token).  These tests pin that contract.
+"""
+
+import types
+
+from server.api.routes import utils
+
+
+class _FakeClient:
+    def __init__(self, host: str | None) -> None:
+        self.host = host
+
+
+class _FakeRequest:
+    """Minimal Request stand-in exposing ``.client.host``/``.headers``/``.cookies``."""
+
+    def __init__(
+        self,
+        host: str | None,
+        headers: dict | None = None,
+        cookies: dict | None = None,
+    ) -> None:
+        self.client = _FakeClient(host) if host is not None else None
+        self.headers = headers or {}
+        self.cookies = cookies or {}
+
+
+def test_local_non_tls_tokenless_request_resolves_to_localhost_user(monkeypatch):
+    """A token-less loopback request maps to 'localhost-user' (was 'Unknown Client')."""
+    monkeypatch.setattr(utils, "TLS_MODE", False)
+    req = _FakeRequest("127.0.0.1")
+    assert utils.get_client_name(req) == "localhost-user"
+
+
+def test_local_bypass_takes_precedence_over_token(monkeypatch):
+    """Even with a valid token, a local non-TLS request is 'localhost-user'.
+
+    This mirrors the WebSocket bypass (which ignores the token on localhost) so
+    that HTTP identity matches the persisted job owner.
+    """
+    monkeypatch.setattr(utils, "TLS_MODE", False)
+    monkeypatch.setattr(
+        utils,
+        "validate_auth_token",
+        lambda _t: types.SimpleNamespace(client_name="alice", is_admin=False),
+    )
+    req = _FakeRequest("127.0.0.1", headers={"Authorization": "Bearer tok"})
+    assert utils.get_client_name(req) == "localhost-user"
+
+
+def test_tls_mode_disables_localhost_bypass(monkeypatch):
+    """Under TLS the bypass must NOT apply — token identity is preserved."""
+    monkeypatch.setattr(utils, "TLS_MODE", True)
+    monkeypatch.setattr(
+        utils,
+        "validate_auth_token",
+        lambda _t: types.SimpleNamespace(client_name="alice", is_admin=False),
+    )
+    req = _FakeRequest("127.0.0.1", headers={"Authorization": "Bearer tok"})
+    assert utils.get_client_name(req) == "alice"
+
+
+def test_remote_request_with_token_uses_token_name(monkeypatch):
+    """A non-local request with a valid token keeps the token's client name."""
+    monkeypatch.setattr(utils, "TLS_MODE", False)
+    monkeypatch.setattr(
+        utils,
+        "validate_auth_token",
+        lambda _t: types.SimpleNamespace(client_name="alice", is_admin=False),
+    )
+    req = _FakeRequest("8.8.8.8", headers={"Authorization": "Bearer tok"})
+    assert utils.get_client_name(req) == "alice"
+
+
+def test_remote_request_without_token_is_unknown(monkeypatch):
+    """A non-local request with no valid token stays 'Unknown Client'."""
+    monkeypatch.setattr(utils, "TLS_MODE", False)
+    monkeypatch.setattr(utils, "validate_auth_token", lambda _t: None)
+    req = _FakeRequest("8.8.8.8")
+    assert utils.get_client_name(req) == "Unknown Client"


### PR DESCRIPTION
Fixes #202.

## Summary
A ~3-hour lecture on a packaged build failed at delivery with **"Result too large to stream — fetch failed"**. The transcription actually completed and was **persisted to the database** — the client just could not retrieve it. This PR fixes the retrieval path and a latent ownership `403` that would otherwise still block it. No data was lost (see recovery note).

## Root cause
When a result exceeds the 1 MB WebSocket inline limit, the server persists it and sends a lightweight `result_ready` reference so the client fetches it over HTTP (`websocket.py`). The client's recovery fetch used a **bare relative URL** (`/api/transcribe/result/{job_id}`) that bypasses `apiClient`'s configured base URL. In a packaged build the renderer origin is `file://`, so the request resolved to `file:///api/...` and never reached the backend — confirmed by the complete absence of any `GET /result` line in the attached `mlx-server.log`, while `apiClient` (absolute-URL) calls in the same window did reach it.

The bug is **platform-independent**; the `apple-silicon-mlx` label is incidental (the reporter's platform). Full analysis: `_bmad-output/implementation-artifacts/investigations/gh-202-investigation.md`.

## Changes
**Part A — client can retrieve large results (primary fix)**
- `dashboard/src/api/client.ts`: add `fetchTranscriptionResult` / `fetchRecentUndelivered` / `dismissTranscriptionResult`, all building absolute `${baseUrl}` URLs.
- `dashboard/src/hooks/useTranscription.ts`: the `result_ready` handler and the onClose poll now go through `apiClient`.
- `dashboard/components/views/SessionView.tsx`: the recovery-notification list, **View**, and **Dismiss** now go through `apiClient`.

**Part B — the local owner passes the ownership check (latent 403)**
- `server/backend/api/routes/utils.py`: `get_client_name` now applies the localhost auth bypass (bypass-precedence, mirroring `authenticate_websocket_*`), returning `"localhost-user"` for local, non-TLS requests. Without this, `GET /result/{job_id}` and `/recent` would `403` the legitimate owner of a WebSocket-created job even after Part A. TLS/remote requests are unaffected.

## Test plan
- New backend test `test_get_client_name_localhost_bypass.py` (5 cases: local bypass precedence, TLS-off, remote token, remote unknown). Full backend suite: **2105 passed**.
- Frontend: absolute-URL assertions (`client.test.ts`), `result_ready` completes via `apiClient` (`useTranscription.test.ts`), extended `SessionView` mocks. Full frontend suite: **1483 passed**.
- `tsc --noEmit` (both configs), ESLint, `ruff`, and `ui:contract:check` all clean.

## Recovery for the affected user (no upgrade required)
The transcript is safe in the local DB (`transcription_jobs.result_text`, state `completed` / `delivered=0`) and can be read directly now; after this ships it will also surface automatically via the in-app recovery notification. Steps are in the investigation doc.