### PR TITLE
feat(dashboard): redesign Server tab around a verified runtime/model/diarization compatibility matrix

### DIFF
--- a/dashboard/components/__tests__/ServerView.test.tsx
+++ b/dashboard/components/__tests__/ServerView.test.tsx
@@ -74,12 +74,15 @@ vi.mock('../../src/hooks/useAdminStatus', () => ({
   useAdminStatus: () => mockAdminStatus,
 }));
 
-vi.mock('../../src/stores/activityStore', () => ({
-  useActivityStore: (selector: (s: Record<string, unknown>) => unknown) => {
-    const state = { items: [], addActivity: vi.fn(), updateActivity: vi.fn() };
-    return typeof selector === 'function' ? selector(state) : state;
-  },
-}));
+vi.mock('../../src/stores/activityStore', () => {
+  // zustand-style store mock: callable as a hook AND exposing getState()
+  // (handleRuntimeProfileChange calls useActivityStore.getState() directly).
+  const state = { items: [], addActivity: vi.fn(), updateActivity: vi.fn() };
+  const useActivityStore = (selector?: (s: Record<string, unknown>) => unknown) =>
+    typeof selector === 'function' ? selector(state) : state;
+  useActivityStore.getState = () => state;
+  return { useActivityStore };
+});
 
 // apiClient
 vi.mock('../../src/api/client', () => ({
@@ -104,18 +107,23 @@ vi.mock('../../src/config/store', () => ({
   DEFAULT_SERVER_PORT: 7239,
 }));
 
-// modelCapabilities — must export the full surface ServerView imports
-// (isWhisperModel, isWhisperCppModel, isMLXModel, isNemoModel, isSenseVoiceModel);
-// a missing export throws "No <name> export is defined on the mock" the moment
-// ServerView accesses it during render. The test world treats every model as
-// plain Whisper. `isSenseVoiceModel` is name-based so the merged-diarization
-// tests can drive the SenseVoice-only greying / migration by selecting a main
-// model whose id contains "sensevoice".
+// modelCapabilities — must export the full surface ServerView AND
+// instanceMatrix import (a missing export throws "No <name> export is defined
+// on the mock" the moment it is accessed during render). The test world treats
+// every model as plain Whisper; `isSenseVoiceModel`, `isWhisperCppModel` and
+// `isMLXModel` are name-based so the selector tests can drive family-specific
+// greying / resets by choosing an appropriately named main model.
 vi.mock('../../src/services/modelCapabilities', () => ({
   isWhisperModel: () => true,
-  isWhisperCppModel: () => false,
-  isMLXModel: () => false,
+  isWhisperCppModel: (m: string) =>
+    typeof m === 'string' && /(?:^|\/)ggml-.*\.bin$|\.gguf$/i.test(m),
+  isMLXModel: (m: string) => typeof m === 'string' && m.toLowerCase().startsWith('mlx-community/'),
   isNemoModel: () => false,
+  isParakeetModel: () => false,
+  isCanaryModel: () => false,
+  isMLXParakeetModel: () => false,
+  isMLXCanaryModel: () => false,
+  isVibeVoiceASRModel: () => false,
   isSenseVoiceModel: (m: string) => typeof m === 'string' && m.toLowerCase().includes('sensevoice'),
 }));
 
@@ -136,6 +144,7 @@ vi.mock('../../src/services/modelSelection', () => ({
   MODEL_DISABLED_OPTION: 'Disabled',
   DISABLED_MODEL_SENTINEL: '__disabled__',
   WHISPER_MEDIUM: 'openai/whisper-medium',
+  LIVE_RECOMMENDED_MODEL: 'openai/whisper-medium',
   MAIN_MODEL_PRESETS: ['openai/whisper-large-v3-turbo', 'iic/SenseVoiceSmall'],
   LIVE_MODEL_PRESETS: ['openai/whisper-medium'],
   VULKAN_RECOMMENDED_MODEL: 'ggml-large-v3-turbo.bin',
@@ -285,9 +294,14 @@ describe('[P2] ServerView', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('Pyannote diarization on Mac Metal (gate removed, Issue #112)', () => {
+  // Persisted electron-store values (must never change) …
   const SORTFORMER = 'Sortformer (Metal; ≤ 4 speakers)';
   const PYANNOTE = 'pyannote/speaker-diarization-community-1';
   const CUSTOM = 'Custom (HuggingFace repo)';
+  // … and the short labels the diarization selector tiles display for them.
+  const SORTFORMER_TILE = 'Sortformer';
+  const PYANNOTE_TILE = 'PyAnnote';
+  const CUSTOM_TILE = 'Custom';
 
   function setupElectronAPI(configMap: Record<string, unknown>) {
     const setSpy = vi.fn().mockResolvedValue(undefined);
@@ -337,9 +351,11 @@ describe('Pyannote diarization on Mac Metal (gate removed, Issue #112)', () => {
 
     render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
 
-    // Pyannote stays selected (appears in the ListboxButton and/or an option).
+    // Pyannote stays selected (its tile is pressed).
     await waitFor(() => {
-      expect(screen.queryAllByText(PYANNOTE).length).toBeGreaterThanOrEqual(1);
+      expect(
+        screen.getByRole('button', { name: new RegExp(PYANNOTE_TILE, 'i'), pressed: true }),
+      ).toBeDefined();
     });
     // The old auto-migration to Sortformer must NOT fire on Metal anymore.
     // (ServerView persists the merged control under server.diarizationModelSelection.)
@@ -358,12 +374,14 @@ describe('Pyannote diarization on Mac Metal (gate removed, Issue #112)', () => {
 
     render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
 
-    // Sortformer is the default selection; pyannote is now a selectable option.
+    // Sortformer is the stored selection; pyannote is a selectable tile.
     await waitFor(() => {
-      expect(screen.queryAllByText(SORTFORMER).length).toBeGreaterThanOrEqual(1);
+      expect(
+        screen.getByRole('button', { name: new RegExp(SORTFORMER_TILE, 'i'), pressed: true }),
+      ).toBeDefined();
     });
-    expect(screen.queryAllByText(PYANNOTE).length).toBeGreaterThanOrEqual(1);
-    expect(screen.queryAllByText(CUSTOM).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryAllByText(PYANNOTE_TILE).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryAllByText(CUSTOM_TILE).length).toBeGreaterThanOrEqual(1);
     // The "not supported on Apple Silicon" inline reason is gone.
     expect(screen.queryByText(/pyannote\.audio MPS path/i)).toBeNull();
   });
@@ -378,15 +396,19 @@ describe('Pyannote diarization on Mac Metal (gate removed, Issue #112)', () => {
     render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
 
     await waitFor(() => {
-      expect(screen.queryAllByText(PYANNOTE).length).toBeGreaterThanOrEqual(1);
+      expect(
+        screen.getByRole('button', { name: new RegExp(PYANNOTE_TILE, 'i'), pressed: true }),
+      ).toBeDefined();
     });
     const sortformerSet = setSpy.mock.calls.some(
       ([k, v]) => k === 'server.diarizationModelSelection' && v === SORTFORMER,
     );
     expect(sortformerSet).toBe(false);
     expect(screen.queryByText(/pyannote\.audio MPS path/i)).toBeNull();
-    expect(screen.queryAllByText(SORTFORMER).length).toBeGreaterThanOrEqual(1);
-    expect(screen.queryAllByText(CUSTOM).length).toBeGreaterThanOrEqual(1);
+    // Sortformer stays visible on non-Metal, greyed with its reason badge.
+    expect(screen.queryAllByText(SORTFORMER_TILE).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText('Requires Metal')).not.toBeNull();
+    expect(screen.queryAllByText(CUSTOM_TILE).length).toBeGreaterThanOrEqual(1);
   });
 
   it('on Mac Metal with Custom + pyannote-prefixed value, shows NO unsupported warning', async () => {
@@ -400,7 +422,7 @@ describe('Pyannote diarization on Mac Metal (gate removed, Issue #112)', () => {
 
     // The custom-repo input renders; the old amber "not supported" warning is gone.
     await waitFor(() => {
-      expect(screen.queryAllByText(CUSTOM).length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByDisplayValue('pyannote/some-fork')).toBeDefined();
     });
     expect(
       screen.queryByText(/Custom pyannote repos are not supported on Apple Silicon/i),
@@ -409,21 +431,26 @@ describe('Pyannote diarization on Mac Metal (gate removed, Issue #112)', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Merged Diarization dropdown — CAM++ + engine collapsed into ONE control.
+// Merged Diarization control — CAM++ + engine collapsed into ONE selector.
 //
-// The Server tab renders a SINGLE "Diarization Model" dropdown listing CAM++
-// alongside Sortformer, pyannote and Custom. Selecting CAM++ sends
+// The Server tab renders a single Diarization selector (tile grid) listing
+// CAM++ alongside Sortformer, PyAnnote and Custom. Selecting CAM++ sends
 // SENSEVOICE_DIARIZATION_ENGINE=funasr with an EMPTY DIARIZATION_MODEL; every
 // other pick sends the pyannote engine. The merged value keeps the original
 // server.diarizationModelSelection key (shared with the Model Manager tab and the
-// Metal boot auto-start). The retired server.sensevoiceDiarizationEngine key acts
-// as a one-shot migration marker and is cleared once the fold is applied.
+// Metal boot auto-start), storing the SAME literal strings as the pre-tile
+// dropdown. The retired server.sensevoiceDiarizationEngine key acts as a
+// one-shot migration marker and is cleared once the fold is applied.
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('Merged Diarization dropdown (CAM++ + engine)', () => {
+describe('Merged Diarization control (CAM++ + engine)', () => {
+  // Persisted electron-store values (must never change) …
   const CAMPP = 'CAM++ (fast, built-in)';
   const SORTFORMER = 'Sortformer (Metal; ≤ 4 speakers)';
   const PYANNOTE = 'pyannote/speaker-diarization-community-1';
+  // … and the short labels their tiles display.
+  const CAMPP_TILE = 'CAM++';
+  const SORTFORMER_TILE = 'Sortformer';
   const SENSEVOICE_MAIN = 'iic/SenseVoiceSmall';
   const WHISPER_MAIN = 'openai/whisper-large-v3-turbo';
 
@@ -466,16 +493,16 @@ describe('Merged Diarization dropdown (CAM++ + engine)', () => {
     mockAdminStatus.status = { models: {} };
   });
 
-  it('greys the CAM++ option (SenseVoice only) when the main transcriber is not SenseVoice', async () => {
+  it('greys the CAM++ tile (SenseVoice only) when the main transcriber is not SenseVoice', async () => {
     setupMergedAPI({ 'server.runtimeProfile': 'cpu', 'server.mainModelSelection': WHISPER_MAIN });
     render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
     await waitFor(() => {
       expect(screen.queryByText('SenseVoice only')).not.toBeNull();
     });
-    expect(screen.queryAllByText(CAMPP).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryAllByText(CAMPP_TILE).length).toBeGreaterThanOrEqual(1);
   });
 
-  it('enables the CAM++ option (no SenseVoice-only badge) when the main transcriber is SenseVoice', async () => {
+  it('enables the CAM++ tile (no SenseVoice-only badge) when the main transcriber is SenseVoice', async () => {
     setupMergedAPI({
       'server.runtimeProfile': 'cpu',
       'server.mainModelSelection': SENSEVOICE_MAIN,
@@ -486,16 +513,16 @@ describe('Merged Diarization dropdown (CAM++ + engine)', () => {
     await waitFor(() => {
       expect(screen.queryByText('SenseVoice only')).toBeNull();
     });
-    expect(screen.queryAllByText(CAMPP).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryAllByText(CAMPP_TILE).length).toBeGreaterThanOrEqual(1);
   });
 
-  it('greys the Sortformer option (Requires Metal) on a non-Metal runtime', async () => {
+  it('greys the Sortformer tile (Requires Metal) on a non-Metal runtime', async () => {
     setupMergedAPI({ 'server.runtimeProfile': 'cpu', 'server.mainModelSelection': WHISPER_MAIN });
     render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
     await waitFor(() => {
       expect(screen.queryByText('Requires Metal')).not.toBeNull();
     });
-    expect(screen.queryAllByText(SORTFORMER).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryAllByText(SORTFORMER_TILE).length).toBeGreaterThanOrEqual(1);
   });
 
   it('does NOT grey Sortformer on the Metal runtime', async () => {
@@ -505,7 +532,7 @@ describe('Merged Diarization dropdown (CAM++ + engine)', () => {
     );
     render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
     await waitFor(() => {
-      expect(screen.queryAllByText(SORTFORMER).length).toBeGreaterThanOrEqual(1);
+      expect(screen.queryAllByText(SORTFORMER_TILE).length).toBeGreaterThanOrEqual(1);
     });
     expect(screen.queryByText('Requires Metal')).toBeNull();
   });
@@ -563,7 +590,7 @@ describe('Merged Diarization dropdown (CAM++ + engine)', () => {
     // The retired key is cleared so the migration can never re-fire and clobber a
     // later user choice.
     expect(setSpy).toHaveBeenCalledWith('server.sensevoiceDiarizationEngine', '');
-    expect(screen.queryAllByText(CAMPP).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryAllByText(CAMPP_TILE).length).toBeGreaterThanOrEqual(1);
   });
 
   it('migrates legacy {pyannote model, CAM++ engine} + Whisper main to the pyannote option', async () => {
@@ -614,6 +641,132 @@ describe('Merged Diarization dropdown (CAM++ + engine)', () => {
       expect(setSpy).toHaveBeenCalledWith('server.diarizationModelSelection', CAMPP);
     });
     expect(setSpy).not.toHaveBeenCalledWith('server.diarizationModelSelection', PYANNOTE);
-    expect(screen.queryAllByText(CAMPP).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryAllByText(CAMPP_TILE).length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Server tab matrix redesign — card layout + deferred runtime downloads.
+//
+// The tab is five numbered cards: Docker Image → Instance Settings (runtime +
+// model + live + diarization selectors) → Remote Connection (auth token +
+// Tailscale hostname) → Persistent Volumes → Clean Up. Selecting a runtime
+// must never start downloads: in particular, picking Metal only persists the
+// profile — the native MLX server (whose startup pre-downloads models) starts
+// exclusively from the explicit Start button.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Server tab matrix redesign', () => {
+  function setupRedesignAPI(configMap: Record<string, unknown>, arch = 'x64') {
+    const setSpy = vi.fn().mockResolvedValue(undefined);
+    const mlxStart = vi.fn().mockResolvedValue(undefined);
+    const mlxStop = vi.fn().mockResolvedValue(undefined);
+    (window as any).electronAPI = {
+      config: {
+        get: vi.fn().mockImplementation(async (key: string) => configMap[key]),
+        set: setSpy,
+      },
+      docker: {
+        readComposeEnvValue: vi.fn().mockResolvedValue('false'),
+        checkModelCache: vi.fn().mockResolvedValue({}),
+      },
+      app: {
+        getArch: vi.fn().mockReturnValue(arch),
+        getConfigDir: vi.fn().mockResolvedValue('/mock/config'),
+      },
+      mlx: {
+        getStatus: vi.fn().mockResolvedValue('stopped'),
+        onStatusChanged: vi.fn().mockReturnValue(vi.fn()),
+        start: mlxStart,
+        stop: mlxStop,
+      },
+      tailscale: {
+        getHostname: vi.fn().mockResolvedValue('my-server.tail1234.ts.net'),
+      },
+      server: {
+        checkFirewallPort: vi.fn().mockResolvedValue(null),
+        checkGpu: vi.fn().mockResolvedValue({ gpu: false, toolkit: false, vulkan: false }),
+      },
+    };
+    return { setSpy, mlxStart, mlxStop };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDocker.available = true;
+    mockDocker.images = [];
+    mockDocker.container = { exists: false, running: false, status: 'unknown', health: undefined };
+    mockDocker.operationError = null;
+    mockDocker.operating = false;
+    mockDocker.composeAvailable = true;
+    mockAdminStatus.status = { models: {} };
+  });
+
+  it('renders the five renumbered cards and drops the old standalone model cards', async () => {
+    setupRedesignAPI({ 'server.runtimeProfile': 'cpu' });
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    expect(screen.getByText('1. Docker Image')).toBeDefined();
+    expect(screen.getByText('2. Instance Settings')).toBeDefined();
+    expect(screen.getByText('3. Remote Connection')).toBeDefined();
+    expect(screen.getByText('4. Persistent Volumes')).toBeDefined();
+    expect(screen.getByText('5. Clean Up')).toBeDefined();
+    expect(screen.queryByText(/ASR Models Configuration/)).toBeNull();
+    expect(screen.queryByText(/Diarization Models Configuration/)).toBeNull();
+  });
+
+  it('shows the Tailscale hostname inside the Remote Connection card', async () => {
+    setupRedesignAPI({ 'server.runtimeProfile': 'cpu' });
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByText('my-server.tail1234.ts.net')).toBeDefined();
+    });
+    expect(screen.getByText('Tailscale Hostname')).toBeDefined();
+  });
+
+  it('selecting the Metal runtime does NOT start the MLX server (deferred downloads)', async () => {
+    const { setSpy, mlxStart } = setupRedesignAPI({ 'server.runtimeProfile': 'cpu' }, 'arm64');
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    fireEvent.click(screen.getByRole('button', { name: /GPU \(Metal\)/i }));
+    await waitFor(() => {
+      expect(setSpy).toHaveBeenCalledWith('server.runtimeProfile', 'metal');
+    });
+    expect(mlxStart).not.toHaveBeenCalled();
+  });
+
+  it('leaving the Metal runtime still stops a running MLX server', async () => {
+    const { setSpy, mlxStop } = setupRedesignAPI({ 'server.runtimeProfile': 'metal' }, 'arm64');
+    ((window as any).electronAPI.mlx.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue(
+      'running',
+    );
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    fireEvent.click(screen.getByRole('button', { name: /CPU Only/i }));
+    await waitFor(() => {
+      expect(setSpy).toHaveBeenCalledWith('server.runtimeProfile', 'cpu');
+    });
+    await waitFor(() => {
+      expect(mlxStop).toHaveBeenCalled();
+    });
+  });
+
+  it('switching runtimes resets a main model the new runtime cannot run', async () => {
+    // A GGML main persisted under a Vulkan profile must not survive a switch
+    // to CUDA — the redesign resets it to the runtime default (previously the
+    // stale GGML pick leaked into a CUDA start).
+    const { setSpy } = setupRedesignAPI({
+      'server.runtimeProfile': 'vulkan',
+      'server.mainModelSelection': 'ggml-large-v3-turbo.bin',
+    });
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(setSpy).toHaveBeenCalledWith('server.mainModelSelection', 'ggml-large-v3-turbo.bin');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /GPU \(CUDA\)/i }));
+    await waitFor(() => {
+      // Runtime default for gpu in the mocked world = MAIN_RECOMMENDED_MODEL.
+      expect(setSpy).toHaveBeenCalledWith(
+        'server.mainModelSelection',
+        'openai/whisper-large-v3-turbo',
+      );
+    });
   });
 });

--- a/dashboard/components/ui/SelectorGroup.tsx
+++ b/dashboard/components/ui/SelectorGroup.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+interface SelectorGroupProps {
+  icon: React.ReactNode;
+  title: string;
+  /** Short helper sentence rendered under the title. */
+  hint?: string;
+  /** Optional right-aligned element (badge, status light, button). */
+  action?: React.ReactNode;
+  /** Tailwind grid-cols classes for the tile grid. */
+  columnsClass?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Labelled section inside the Instance Settings card: a colored icon heading
+ * followed by a responsive grid of SelectorTiles (plus any auxiliary rows).
+ */
+export const SelectorGroup: React.FC<SelectorGroupProps> = ({
+  icon,
+  title,
+  hint,
+  action,
+  columnsClass = 'grid-cols-2 sm:grid-cols-3 lg:grid-cols-5',
+  children,
+}) => {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2">
+          {icon}
+          <div>
+            <h4 className="text-sm font-semibold text-white/90">{title}</h4>
+            {hint && <p className="text-xs text-slate-400">{hint}</p>}
+          </div>
+        </div>
+        {action}
+      </div>
+      <div className={`grid gap-2 ${columnsClass}`}>{children}</div>
+    </div>
+  );
+};

--- a/dashboard/components/ui/SelectorTile.tsx
+++ b/dashboard/components/ui/SelectorTile.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { Lock } from 'lucide-react';
+
+export type TileAccent =
+  | 'cyan'
+  | 'magenta'
+  | 'green'
+  | 'yellow'
+  | 'amber'
+  | 'blue'
+  | 'purple'
+  | 'orange'
+  | 'red'
+  | 'slate';
+
+interface AccentClasses {
+  selected: string;
+  icon: string;
+}
+
+// Static class strings per accent so the Tailwind JIT scanner picks them up.
+const ACCENT_CLASSES: Record<TileAccent, AccentClasses> = {
+  cyan: {
+    selected: 'border-accent-cyan/60 bg-accent-cyan/10 shadow-[0_0_12px_rgba(34,211,238,0.2)]',
+    icon: 'text-accent-cyan',
+  },
+  magenta: {
+    selected:
+      'border-accent-magenta/60 bg-accent-magenta/10 shadow-[0_0_12px_rgba(232,121,249,0.2)]',
+    icon: 'text-accent-magenta',
+  },
+  green: {
+    selected: 'border-green-400/60 bg-green-400/10 shadow-[0_0_12px_rgba(74,222,128,0.2)]',
+    icon: 'text-green-400',
+  },
+  yellow: {
+    selected: 'border-yellow-400/60 bg-yellow-400/10 shadow-[0_0_12px_rgba(250,204,21,0.2)]',
+    icon: 'text-yellow-400',
+  },
+  amber: {
+    selected: 'border-amber-400/60 bg-amber-400/10 shadow-[0_0_12px_rgba(251,191,36,0.2)]',
+    icon: 'text-amber-400',
+  },
+  blue: {
+    selected: 'border-blue-400/60 bg-blue-400/10 shadow-[0_0_12px_rgba(96,165,250,0.2)]',
+    icon: 'text-blue-400',
+  },
+  purple: {
+    selected: 'border-purple-400/60 bg-purple-400/10 shadow-[0_0_12px_rgba(192,132,252,0.2)]',
+    icon: 'text-purple-400',
+  },
+  orange: {
+    selected: 'border-orange-400/60 bg-orange-400/10 shadow-[0_0_12px_rgba(251,146,60,0.2)]',
+    icon: 'text-orange-400',
+  },
+  red: {
+    selected: 'border-red-400/60 bg-red-400/10 shadow-[0_0_12px_rgba(248,113,113,0.2)]',
+    icon: 'text-red-400',
+  },
+  slate: {
+    selected: 'border-slate-300/60 bg-slate-300/10 shadow-[0_0_12px_rgba(203,213,225,0.2)]',
+    icon: 'text-slate-200',
+  },
+};
+
+interface SelectorTileProps {
+  icon: React.ReactNode;
+  label: string;
+  sublabel?: string;
+  selected: boolean;
+  onSelect: () => void;
+  accent?: TileAccent;
+  disabled?: boolean;
+  /** Reason badge shown when the tile is disabled (e.g. "Requires Metal"). */
+  badge?: string;
+  /** Small note shown under the label (e.g. "Slow on CPU"). */
+  hint?: string;
+  /** Selected but not user-changeable (e.g. VibeVoice built-in diarization). */
+  locked?: boolean;
+  /** Optional mini capability glyph row rendered at the bottom of the tile. */
+  glyphs?: React.ReactNode;
+}
+
+/**
+ * A colorful icon tile used by the Instance Settings selector groups.
+ * Disabled tiles stay visible (dimmed, with a reason badge) so the whole
+ * compatibility matrix remains readable at a glance.
+ */
+export const SelectorTile: React.FC<SelectorTileProps> = ({
+  icon,
+  label,
+  sublabel,
+  selected,
+  onSelect,
+  accent = 'cyan',
+  disabled = false,
+  badge,
+  hint,
+  locked = false,
+  glyphs,
+}) => {
+  const accentClasses = ACCENT_CLASSES[accent];
+  const stateClasses = disabled
+    ? 'cursor-not-allowed border-white/5 bg-white/[0.02] opacity-45'
+    : selected
+      ? `${accentClasses.selected} ${locked ? 'cursor-default' : 'cursor-pointer'}`
+      : 'cursor-pointer border-white/10 bg-white/5 hover:border-white/25 hover:bg-white/10';
+
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      disabled={disabled}
+      onClick={() => {
+        if (!disabled && !locked) onSelect();
+      }}
+      title={disabled && badge ? badge : hint}
+      className={`relative flex min-h-20 flex-col items-start gap-1 rounded-xl border p-3 text-left transition-all duration-200 ${stateClasses}`}
+    >
+      <span className="flex w-full items-center gap-2">
+        <span className={selected && !disabled ? accentClasses.icon : 'text-slate-300'}>
+          {icon}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-sm font-medium text-white/90">{label}</span>
+          {sublabel && (
+            <span className="block truncate text-[10px] text-slate-400">{sublabel}</span>
+          )}
+        </span>
+        {locked && <Lock size={12} className="shrink-0 text-slate-400" />}
+      </span>
+      {badge && disabled && (
+        <span className="rounded bg-white/10 px-1.5 py-0.5 text-[10px] text-slate-300">
+          {badge}
+        </span>
+      )}
+      {hint && !disabled && <span className="text-[10px] text-slate-400">{hint}</span>}
+      {glyphs && <span className="mt-auto flex items-center gap-1.5">{glyphs}</span>}
+    </button>
+  );
+};

--- a/dashboard/components/views/ServerView.tsx
+++ b/dashboard/components/views/ServerView.tsx
@@ -2,10 +2,10 @@ import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import { Dialog, DialogPanel, DialogTitle } from '@headlessui/react';
 import { toast } from 'sonner';
 import {
-  Box,
   Cpu,
   HardDrive,
   Download,
+  Globe,
   Loader2,
   RefreshCw,
   CheckCircle2,
@@ -17,26 +17,27 @@ import {
   Copy,
   Check,
   FolderOpen,
-  Eye,
-  EyeOff,
-  Users,
   Laptop,
   Radio,
+  SlidersHorizontal,
   Zap,
   MinusCircle,
 } from 'lucide-react';
 import { GlassCard } from '../ui/GlassCard';
 import { Button } from '../ui/Button';
 import { StatusLight } from '../ui/StatusLight';
-import { CustomSelect } from '../ui/CustomSelect';
 import { ImageTagChips } from '../ui/ImageTagChips';
 import { AppleSwitch } from '../ui/AppleSwitch';
+import { SelectorGroup } from '../ui/SelectorGroup';
+import { SelectorTile } from '../ui/SelectorTile';
 import { NvidiaIcon } from '../ui/icons/NvidiaIcon';
 import { AmdIcon } from '../ui/icons/AmdIcon';
 import { IntelIcon } from '../ui/icons/IntelIcon';
 import { AppleIcon } from '../ui/icons/AppleIcon';
 import { GpuHealthCard } from './GpuHealthCard';
 import { GpuDiagnosticModal, type GpuDiagnosticResultProp } from './GpuDiagnosticModal';
+import { InstanceSettingsSelectors } from './server/InstanceSettingsSelectors';
+import { RemoteConnectionCard } from './server/RemoteConnectionCard';
 
 import { useActivityStore } from '../../src/stores/activityStore';
 import { useAdminStatus } from '../../src/hooks/useAdminStatus';
@@ -49,14 +50,12 @@ import {
   isWhisperModel,
   isWhisperCppModel,
   isMLXModel,
-  isNemoModel,
   isSenseVoiceModel,
 } from '../../src/services/modelCapabilities';
-import { MODEL_REGISTRY, getModelsByFamily } from '../../src/services/modelRegistry';
+import { getModelsByFamily } from '../../src/services/modelRegistry';
 import {
   MODEL_DEFAULT_LOADING_PLACEHOLDER,
   MAIN_MODEL_CUSTOM_OPTION,
-  MAIN_RECOMMENDED_MODEL,
   LIVE_MODEL_SAME_AS_MAIN_OPTION,
   LIVE_MODEL_CUSTOM_OPTION,
   MODEL_DISABLED_OPTION,
@@ -69,12 +68,17 @@ import {
   resolveLiveModelSelectionValue,
   toBackendModelEnvValue,
 } from '../../src/services/modelSelection';
-import { getModelById } from '../../src/services/modelRegistry';
-import type { OptionMeta } from '../ui/CustomSelect';
-import { DEFAULT_SERVER_PORT } from '../../src/config/store';
+import {
+  DIARIZATION_CAMPP_OPTION,
+  DIARIZATION_DEFAULT_MODEL,
+  DIARIZATION_MODEL_CUSTOM_OPTION,
+  DIARIZATION_SORTFORMER_OPTION,
+  MLX_DEFAULT_MODEL,
+  defaultMainModelFor,
+  familyChoiceForModel,
+  isFamilyChoiceEnabledFor,
+} from '../../src/services/instanceMatrix';
 import { isRuntimeProfile, type RuntimeProfile } from '../../src/types/runtime';
-
-const MLX_DEFAULT_MODEL = 'mlx-community/parakeet-tdt-0.6b-v3';
 
 interface ServerViewProps {
   onStartServer: (
@@ -92,16 +96,11 @@ interface ServerViewProps {
   startupFlowPending: boolean;
 }
 
-const DIARIZATION_SORTFORMER_OPTION = 'Sortformer (Metal; ≤ 4 speakers)';
-const DIARIZATION_DEFAULT_MODEL = 'pyannote/speaker-diarization-community-1';
-const DIARIZATION_MODEL_CUSTOM_OPTION = 'Custom (HuggingFace repo)';
-// CAM++ is SenseVoice's built-in single-pass diarizer, merged into the single
-// Diarization Model dropdown. It is a UI label (not a model id): selecting it
-// sends SENSEVOICE_DIARIZATION_ENGINE=funasr and an EMPTY DIARIZATION_MODEL, so
-// the server keeps its config.yaml pyannote default as the fallback diarizer if
-// cam++ fails to load. Its literal string doubles as the legacy
-// `server.sensevoiceDiarizationEngine` value the one-shot migration recognises.
-const DIARIZATION_CAMPP_OPTION = 'CAM++ (fast, built-in)';
+// The diarization option strings (CAM++, Sortformer, pyannote, Custom) are
+// persisted verbatim in electron-store and now live in instanceMatrix.ts.
+// CAM++ sends SENSEVOICE_DIARIZATION_ENGINE=funasr with an EMPTY
+// DIARIZATION_MODEL, so the server keeps its config.yaml pyannote default as
+// the fallback diarizer if cam++ fails to load.
 // CAM++'s HuggingFace repo (cache dir models--funasr--campplus). Used only for
 // the download badge / cache check, since CAM++ sends an empty DIARIZATION_MODEL.
 const CAMPP_HF_REPO = 'funasr/campplus';
@@ -134,9 +133,6 @@ const DIARIZATION_MODEL_SELECTION_OPTIONS = new Set([
   DIARIZATION_DEFAULT_MODEL,
   DIARIZATION_MODEL_CUSTOM_OPTION,
 ]);
-
-// IDs of models that require the Metal/MLX runtime.
-const MLX_MODEL_IDS = new Set(MODEL_REGISTRY.filter((m) => m.family === 'mlx').map((m) => m.id));
 
 const UI_SENTINEL_VALUES = new Set([
   MODEL_DEFAULT_LOADING_PLACEHOLDER,
@@ -333,55 +329,11 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
     setTimeout(() => setCopiedPath((c) => (c === label ? null : c)), 2000);
   }, []);
 
-  // Derive model option lists filtered by the active runtime profile.
-  // Metal mode:     only MLX models (non-MLX need Docker/ctranslate2).
-  // Non-Metal mode: only non-MLX models (MLX needs Apple Silicon Metal).
+  // Runtime profile shorthands. Valid model families, live options and
+  // diarization engines per runtime are encoded in instanceMatrix.ts and
+  // rendered by InstanceSettingsSelectors.
   const isMetal = runtimeProfile === 'metal';
   const isVulkan = runtimeProfile === 'vulkan' || runtimeProfile === 'vulkan-wsl2';
-  const mainModelOptions = useMemo(() => {
-    // Vulkan: the Main Transcriber owns the whisper.cpp sidecar's model, so the
-    // dropdown is restricted to GGML models. WHISPERCPP_MODEL is derived from
-    // this pick at start (no separate sidecar selector). Custom is omitted —
-    // only registry GGML files exist on disk for the sidecar to load.
-    if (isVulkan) {
-      return [...GGML_MODELS.map((m) => m.id), MODEL_DISABLED_OPTION];
-    }
-    const presets = MAIN_MODEL_PRESETS.filter((id) =>
-      isMetal ? MLX_MODEL_IDS.has(id) : !MLX_MODEL_IDS.has(id),
-    );
-    return [...presets, MODEL_DISABLED_OPTION, MAIN_MODEL_CUSTOM_OPTION];
-  }, [isMetal, isVulkan]);
-  const liveModelOptions = useMemo(() => {
-    return [
-      LIVE_MODEL_SAME_AS_MAIN_OPTION,
-      ...LIVE_MODEL_PRESETS,
-      MODEL_DISABLED_OPTION,
-      LIVE_MODEL_CUSTOM_OPTION,
-    ];
-  }, []);
-  // Diarization options. Pyannote is offered on Mac Metal too: pyannote.audio 4.x
-  // runs on Apple Silicon GPU (MPS) for *inference* — validated on M2 hardware,
-  // including >4 speakers (beyond Sortformer's 4-cap). The upstream MPS issues
-  // (#1886/#1337/#1091) concern training, not inference. Sortformer stays the
-  // no-token Metal-native default; pyannote is opt-in and needs a HuggingFace token.
-  const diarizationOptions = useMemo(
-    () => [
-      DIARIZATION_CAMPP_OPTION,
-      DIARIZATION_SORTFORMER_OPTION,
-      DIARIZATION_DEFAULT_MODEL,
-      DIARIZATION_MODEL_CUSTOM_OPTION,
-    ],
-    [],
-  );
-
-  // Auth token display in Instance Settings
-  const [showAuthToken, setShowAuthToken] = useState(false);
-  const [authTokenCopied, setAuthTokenCopied] = useState(false);
-  const [authToken, setAuthToken] = useState('');
-
-  // Tailscale hostname auto-detection
-  const [tailscaleHostname, setTailscaleHostname] = useState<string | null>(null);
-  const [tailscaleHostnameCopied, setTailscaleHostnameCopied] = useState(false);
 
   // Clean-all modal state
   const [isCleanAllDialogOpen, setIsCleanAllDialogOpen] = useState(false);
@@ -392,13 +344,10 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
   // Vulkan sidecar image prompt state
   const [sidecarNeeded, setSidecarNeeded] = useState<boolean | null>(null); // null = not checked
 
-  // Firewall warning state (remote mode)
-  const [firewallWarning, setFirewallWarning] = useState<string | null>(null);
-
   // Server mode badge (local vs remote)
   const [serverMode, setServerMode] = useState<'local' | 'remote' | null>(null);
 
-  // Load persisted runtime profile, auth token, and Tailscale hostname on mount
+  // Load persisted runtime profile and legacy-GPU toggle on mount
   useEffect(() => {
     const api = (window as any).electronAPI;
     if (api?.config) {
@@ -431,27 +380,12 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
           }
         })
         .catch(() => {});
-      api.config
-        .get('connection.authToken')
-        .then((val: unknown) => {
-          if (typeof val === 'string') setAuthToken(val);
-        })
-        .catch(() => {});
     }
     // Issue #83 — load the legacy-GPU toggle through the dedicated IPC.
     if (api?.server?.getUseLegacyGpu) {
       api.server
         .getUseLegacyGpu()
         .then((val: boolean) => setUseLegacyGpu(Boolean(val)))
-        .catch(() => {});
-    }
-    // Detect local Tailscale hostname
-    if (api?.tailscale?.getHostname) {
-      api.tailscale
-        .getHostname()
-        .then((hostname: string | null) => {
-          if (hostname) setTailscaleHostname(hostname);
-        })
         .catch(() => {});
     }
   }, [adminStatus]);
@@ -656,7 +590,11 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
     };
   }, []);
 
-  // Persist runtime profile changes, check sidecar availability for Vulkan, and start/stop MLX for Metal
+  // Persist runtime profile changes, reset selections the new runtime cannot
+  // run, and check sidecar availability for Vulkan. Selecting a runtime never
+  // downloads anything: even Metal only persists the profile — the native MLX
+  // server (whose startup pre-downloads models) starts from the Inference
+  // Server card's Start button.
   const handleRuntimeProfileChange = useCallback(
     async (profile: RuntimeProfile) => {
       setRuntimeProfile(profile);
@@ -664,32 +602,47 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
       if (api?.config) {
         api.config.set('server.runtimeProfile', profile);
       }
-      // Leaving Metal: reset any MLX-only model selections back to non-MLX defaults.
-      if (profile !== 'metal') {
-        if (MLX_MODEL_IDS.has(mainModelSelection)) {
-          setMainModelSelection(MAIN_RECOMMENDED_MODEL);
-          api?.config?.set('server.mainModelSelection', MAIN_RECOMMENDED_MODEL);
-        }
-        if (MLX_MODEL_IDS.has(liveModelSelection)) {
+      // Reset a main model the new runtime cannot run to the runtime's
+      // recommended default. Subsumes the old special cases (MLX ids off
+      // Metal, NeMo on CPU — GH-125) and also covers GGML mains left over
+      // from a Vulkan profile, which used to survive the switch.
+      const resolvedMain = resolveMainModelSelectionValue(mainModelSelection, mainCustomModel, '');
+      const mainFamily = familyChoiceForModel(resolvedMain);
+      let mainAfterReset = resolvedMain;
+      if (mainFamily && !isFamilyChoiceEnabledFor(mainFamily, profile)) {
+        const nextDefault = defaultMainModelFor(profile);
+        mainAfterReset = nextDefault;
+        setMainModelSelection(nextDefault);
+        setMainCustomModel('');
+        api?.config?.set('server.mainModelSelection', nextDefault);
+        api?.config?.set('server.mainCustomModel', '');
+      }
+      // Live picks are whisper/whispercpp-only; GGML live models are invalid
+      // off Vulkan and MLX ids are never valid. Fall back to Same-as-main —
+      // the live-compatibility effect below refines that if the main model
+      // cannot serve Live Mode either.
+      if (
+        liveModelSelection !== LIVE_MODEL_SAME_AS_MAIN_OPTION &&
+        liveModelSelection !== MODEL_DISABLED_OPTION
+      ) {
+        const resolvedLive = resolveLiveModelSelectionValue(
+          liveModelSelection,
+          liveCustomModel,
+          mainAfterReset,
+          '',
+        );
+        const liveFamily = familyChoiceForModel(resolvedLive);
+        const liveInvalid =
+          liveFamily !== null &&
+          liveFamily !== 'whisper' &&
+          !(liveFamily === 'whispercpp' && isFamilyChoiceEnabledFor('whispercpp', profile));
+        if (liveInvalid) {
           setLiveModelSelection(LIVE_MODEL_SAME_AS_MAIN_OPTION);
           api?.config?.set('server.liveModelSelection', LIVE_MODEL_SAME_AS_MAIN_OPTION);
         }
       }
-      // Switching to CPU: NeMo models (Parakeet/Canary) need a GPU to be
-      // practical and pull in the heavy `nemo` extra (GH-125). Reset a NeMo
-      // selection to a CPU-friendly faster-whisper default so CPU hosts skip the
-      // CUDA wheels and the NeMo install entirely.
-      if (profile === 'cpu') {
-        if (isNemoModel(mainModelSelection)) {
-          setMainModelSelection(WHISPER_MEDIUM);
-          api?.config?.set('server.mainModelSelection', WHISPER_MEDIUM);
-        }
-        if (isNemoModel(liveModelSelection)) {
-          setLiveModelSelection(LIVE_MODEL_SAME_AS_MAIN_OPTION);
-          api?.config?.set('server.liveModelSelection', LIVE_MODEL_SAME_AS_MAIN_OPTION);
-        }
-      }
-      // Handle Vulkan sidecar image check
+      // Handle Vulkan sidecar image check (read-only — the actual pull is an
+      // explicit button in the sidecar banner).
       if (profile === 'vulkan') {
         docker
           .hasSidecarImage()
@@ -714,67 +667,27 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
         );
       }
 
-      // Handle MLX native server start/stop for Metal
+      // Leaving Metal — stop the native server if it is running or errored.
+      // (Entering Metal deliberately does NOT start it; see the Start button.)
       if (!api?.mlx) return;
       if (profile !== 'metal') {
-        // Leaving Metal — stop the native server if it is running or errored.
         const current = await api.mlx.getStatus().catch(() => 'stopped');
         if (current === 'running' || current === 'starting' || current === 'error') {
           await api.mlx.stop().catch(() => {});
         }
-      } else {
-        // Entering Metal — start the native server if it is not already up.
-        const current = await api.mlx.getStatus().catch(() => 'stopped');
-        if (current === 'stopped' || current === 'error') {
-          try {
-            const port = (await api.config?.get('server.port').catch(() => 9786)) ?? 9786;
-            const hfToken = (await api.config?.get('server.hfToken').catch(() => '')) ?? '';
-            const storedModel =
-              (await api.config?.get('server.mainModelSelection').catch(() => '')) ?? '';
-            const storedCustomModel =
-              (await api.config?.get('server.mainCustomModel').catch(() => '')) ?? '';
-            const storedLiveModel =
-              (await api.config?.get('server.liveModelSelection').catch(() => '')) ?? '';
-            const storedLiveCustom =
-              (await api.config?.get('server.liveCustomModel').catch(() => '')) ?? '';
-            const storedDiarizationModel =
-              (await api.config?.get('server.diarizationModelSelection').catch(() => '')) ?? '';
-            const storedDiarizationCustom_auto =
-              (await api.config?.get('server.diarizationCustomModel').catch(() => '')) ?? '';
-            const resolvedDiarization =
-              storedDiarizationModel === DIARIZATION_MODEL_CUSTOM_OPTION
-                ? storedDiarizationCustom_auto.trim()
-                : storedDiarizationModel === DIARIZATION_SORTFORMER_OPTION ||
-                    storedDiarizationModel === DIARIZATION_CAMPP_OPTION ||
-                    storedDiarizationModel === 'Auto (best available)' ||
-                    !storedDiarizationModel
-                  ? ''
-                  : storedDiarizationModel;
-            const resolvedMain =
-              resolveMainModelSelectionValue(storedModel, storedCustomModel, '') ||
-              MLX_DEFAULT_MODEL;
-            const resolvedLive = resolveLiveModelSelectionValue(
-              storedLiveModel,
-              storedLiveCustom,
-              resolvedMain,
-              '',
-            );
-            const normalizedLive = normalizeLiveModelToWhisper(resolvedLive);
-            await api.mlx.start({
-              port: Number(port),
-              hfToken: hfToken || undefined,
-              mainTranscriberModel: sanitizeModelName(resolvedMain) || MLX_DEFAULT_MODEL,
-              liveTranscriberModel: sanitizeModelName(normalizedLive) || undefined,
-              diarizationModel: resolvedDiarization || undefined,
-            });
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            toast.error(`Failed to start Metal server: ${msg}`);
-          }
-        }
       }
     },
-    [mainModelSelection, liveModelSelection, docker.hasSidecarImage, docker.cancelSidecarPull],
+    [
+      mainModelSelection,
+      mainCustomModel,
+      liveModelSelection,
+      liveCustomModel,
+      isAppleSilicon,
+      metalSupported,
+      mlxFeature,
+      docker.hasSidecarImage,
+      docker.cancelSidecarPull,
+    ],
   );
   const containerStatus = docker.container;
   const isRunning = containerStatus.running;
@@ -808,41 +721,6 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
   const statusLabel = containerStatus.exists
     ? containerStatus.status.charAt(0).toUpperCase() + containerStatus.status.slice(1)
     : 'Not Found';
-
-  // Check firewall when container becomes healthy in remote mode
-  useEffect(() => {
-    if (!isRunningAndHealthy) {
-      setFirewallWarning(null);
-      return;
-    }
-    const api = (window as any).electronAPI;
-    if (!api?.server?.checkFirewallPort || !api?.config?.get) return;
-
-    // Only check if server was started in remote/TLS mode
-    api.config
-      .get('connection.useRemote')
-      .then(async (useRemote: unknown) => {
-        // Also check the compose env to see if TLS was enabled (server-side indicator)
-        const tlsFromCompose = await api.docker
-          ?.readComposeEnvValue?.('TLS_ENABLED')
-          .catch(() => null);
-        const isRemote = useRemote === true || tlsFromCompose === 'true';
-        if (!isRemote) return;
-
-        try {
-          const port = ((await api.config.get('connection.port')) as number) ?? DEFAULT_SERVER_PORT;
-          const result = await api.server.checkFirewallPort(port);
-          if (result.firewallSuspect && result.hint) {
-            setFirewallWarning(result.hint);
-          } else {
-            setFirewallWarning(null);
-          }
-        } catch {
-          // Best effort
-        }
-      })
-      .catch(() => {});
-  }, [isRunningAndHealthy]);
 
   // Track server mode (local vs remote) from compose env
   useEffect(() => {
@@ -990,16 +868,6 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
   // DIARIZATION_MODEL, so surface CAM++'s own HuggingFace repo instead.
   const diarizationStatusModelId =
     diarizationModelSelection === DIARIZATION_CAMPP_OPTION ? CAMPP_HF_REPO : activeDiarizationModel;
-
-  // Per-option greying for the merged Diarization Model dropdown. CAM++ requires
-  // a SenseVoice main transcriber; Sortformer requires the Metal runtime.
-  const diarizationOptionMeta = useMemo<Record<string, OptionMeta>>(() => {
-    const meta: Record<string, OptionMeta> = {};
-    if (!isSenseVoiceMain)
-      meta[DIARIZATION_CAMPP_OPTION] = { disabled: true, badge: 'SenseVoice only' };
-    if (!isMetal) meta[DIARIZATION_SORTFORMER_OPTION] = { disabled: true, badge: 'Requires Metal' };
-    return meta;
-  }, [isSenseVoiceMain, isMetal]);
 
   // MLX native-process start/stop handlers (depend on activeTranscriber declared above)
   const handleMLXStart = useCallback(async () => {
@@ -1271,25 +1139,6 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
       if (modelCacheCheckRef.current) clearTimeout(modelCacheCheckRef.current);
     };
   }, [activeTranscriber, normalizedLiveModel, diarizationStatusModelId, isRunning]);
-
-  // Compute per-option metadata for the Main Transcriber dropdown.
-  // Models requiring a different runtime are dimmed with a badge.
-  const mainModelOptionMeta = useMemo<Record<string, OptionMeta>>(() => {
-    const meta: Record<string, OptionMeta> = {};
-    for (const option of MAIN_MODEL_PRESETS) {
-      const info = getModelById(option);
-      if (!info?.requiresRuntime) continue;
-      if (runtimeProfile === 'vulkan' && info.requiresRuntime === 'cuda') {
-        meta[option] = { dim: true, badge: 'Requires CUDA' };
-      } else if (
-        (runtimeProfile === 'gpu' || runtimeProfile === 'cpu') &&
-        info.requiresRuntime === 'vulkan'
-      ) {
-        meta[option] = { dim: true, badge: 'Requires Vulkan' };
-      }
-    }
-    return meta;
-  }, [runtimeProfile]);
 
   // ─── Image tag selection (merged remote + local) ─────────────────────────
 
@@ -2228,129 +2077,133 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
             <div
               className={`absolute top-0 -left-4.25 z-10 flex h-8 w-8 items-center justify-center rounded-full border-4 border-slate-900 transition-colors duration-300 ${isRunning || mlxStatus === 'running' ? `bg-accent-cyan text-slate-900 ${isRunningAndHealthy || mlxStatus === 'running' ? 'shadow-[0_0_15px_rgba(34,211,238,0.5)]' : ''}` : containerStatus.exists ? 'bg-accent-orange text-slate-900 shadow-[0_0_15px_rgba(251,146,60,0.5)]' : 'bg-slate-800 text-slate-300'}`}
             >
-              <Box size={16} />
+              <SlidersHorizontal size={16} />
             </div>
             <GlassCard
               title="2. Instance Settings"
               className={`transition-all duration-500 ease-in-out ${isRunningAndHealthy || mlxStatus === 'running' ? ACTIVE_CARD_ACCENT_CLASS : ''}`}
             >
               <div className="space-y-6">
-                {/* Runtime Profile Selector */}
-                <div className="flex items-center gap-4 border-b border-white/5 pb-4">
-                  <label className="text-xs font-medium tracking-wider whitespace-nowrap text-slate-500 uppercase">
-                    Runtime
-                  </label>
-                  {/* GH-101 follow-up: re-run GPU detection without restarting
-                      Electron. Hidden until initial detection completes
-                      (gpuInfo !== null) so it never appears in the loading flicker. */}
-                  {gpuInfo !== null && (
-                    <button
-                      type="button"
-                      onClick={handleRedetectGpu}
-                      disabled={gpuRedetecting || isRunning}
-                      title="Re-run GPU detection (use after toggling Docker Desktop's WSL2/Hyper-V backend)"
-                      className={`text-xs whitespace-nowrap underline ${
-                        gpuRedetecting || isRunning
-                          ? 'cursor-not-allowed text-slate-600'
-                          : 'cursor-pointer text-slate-500 hover:text-slate-200'
-                      }`}
-                    >
-                      {gpuRedetecting ? 'Detecting...' : 'Re-detect'}
-                    </button>
-                  )}
-                  <div className="flex gap-2">
-                    <button
-                      onClick={() => handleRuntimeProfileChange('gpu')}
-                      disabled={isRunning}
-                      className={`flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-all ${
-                        runtimeProfile === 'gpu'
-                          ? 'bg-accent-cyan/15 border-accent-cyan/40 text-accent-cyan shadow-[0_0_10px_rgba(34,211,238,0.15)]'
-                          : 'border-white/10 bg-white/5 text-slate-400 hover:bg-white/10 hover:text-slate-200'
-                      } ${isRunning ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}
-                    >
-                      <NvidiaIcon size={14} />
-                      GPU (CUDA)
-                    </button>
-                    <button
-                      onClick={() => handleRuntimeProfileChange('vulkan')}
-                      disabled={isRunning}
-                      className={`flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-all ${
-                        runtimeProfile === 'vulkan'
-                          ? 'bg-accent-rose/15 border-accent-rose/40 text-accent-rose shadow-[0_0_10px_rgba(244,63,94,0.15)]'
-                          : 'border-white/10 bg-white/5 text-slate-400 hover:bg-white/10 hover:text-slate-200'
-                      } ${isRunning ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}
-                    >
-                      <span className="flex h-5 w-10 flex-col items-center justify-center -space-y-1">
-                        <AmdIcon size={30} />
-                        <IntelIcon size={30} />
-                      </span>
-                      GPU (Vulkan Linux)
-                    </button>
-                    <button
-                      onClick={() => handleRuntimeProfileChange('metal')}
-                      disabled={isRunning}
-                      className={`flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-all ${
-                        runtimeProfile === 'metal'
-                          ? 'border-violet-500/40 bg-violet-500/15 text-violet-400 shadow-[0_0_10px_rgba(167,139,250,0.15)]'
-                          : 'border-white/10 bg-white/5 text-slate-400 hover:bg-white/10 hover:text-slate-200'
-                      } ${isRunning ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}
-                    >
-                      <AppleIcon size={14} />
-                      GPU (Metal)
-                    </button>
-                    <button
-                      onClick={() => handleRuntimeProfileChange('cpu')}
-                      disabled={isRunning}
-                      className={`flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-all ${
-                        runtimeProfile === 'cpu'
-                          ? 'bg-accent-orange/15 border-accent-orange/40 text-accent-orange shadow-[0_0_10px_rgba(255,145,0,0.15)]'
-                          : 'border-white/10 bg-white/5 text-slate-400 hover:bg-white/10 hover:text-slate-200'
-                      } ${isRunning ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}
-                    >
-                      <Cpu size={14} />
-                      CPU Only
-                    </button>
-                    {/* Experimental Vulkan-WSL2 button (GH-101 follow-up) —
-                        only rendered when the dashboard's main-process probe
-                        confirms Docker Desktop is running on the WSL2 backend
-                        AND a tiny container could see /dev/dxg. Sits in-line
-                        with the four-button row to keep selection state
-                        visible at a glance when the profile is active. */}
-                    {gpuInfo?.wslSupport?.gpuPassthroughDetected && hostPlatform === 'win32' && (
-                      <button
-                        onClick={() => handleRuntimeProfileChange('vulkan-wsl2')}
-                        disabled={isRunning}
-                        className={`flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-all ${
-                          runtimeProfile === 'vulkan-wsl2'
-                            ? 'bg-accent-rose/15 border-accent-rose/40 text-accent-rose shadow-[0_0_10px_rgba(244,63,94,0.15)]'
-                            : 'border-white/10 bg-white/5 text-slate-400 hover:bg-white/10 hover:text-slate-200'
-                        } ${isRunning ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}
-                      >
+                {/* Runtime selector — tiles gated per host platform. hostPlatform
+                    stays 'unknown' in jsdom/test mounts, which keeps every tile
+                    enabled there (gating only engages on a known platform). */}
+                <div className="border-b border-white/5 pb-4">
+                  <SelectorGroup
+                    icon={<Zap size={16} className="text-accent-cyan" />}
+                    title="Runtime"
+                    hint="Which hardware runs the inference server"
+                    action={
+                      /* GH-101 follow-up: re-run GPU detection without restarting
+                         Electron. Hidden until initial detection completes
+                         (gpuInfo !== null) so it never appears in the loading flicker. */
+                      gpuInfo !== null ? (
+                        <button
+                          type="button"
+                          onClick={handleRedetectGpu}
+                          disabled={gpuRedetecting || isRunning}
+                          title="Re-run GPU detection (use after toggling Docker Desktop's WSL2/Hyper-V backend)"
+                          className={`text-xs whitespace-nowrap underline ${
+                            gpuRedetecting || isRunning
+                              ? 'cursor-not-allowed text-slate-600'
+                              : 'cursor-pointer text-slate-500 hover:text-slate-200'
+                          }`}
+                        >
+                          {gpuRedetecting ? 'Detecting...' : 'Re-detect'}
+                        </button>
+                      ) : undefined
+                    }
+                  >
+                    <SelectorTile
+                      icon={<NvidiaIcon size={16} />}
+                      label="GPU (CUDA)"
+                      sublabel="NVIDIA"
+                      accent="green"
+                      selected={runtimeProfile === 'gpu'}
+                      disabled={isRunning || hostPlatform === 'darwin'}
+                      badge={hostPlatform === 'darwin' ? 'Requires NVIDIA' : undefined}
+                      onSelect={() => handleRuntimeProfileChange('gpu')}
+                    />
+                    <SelectorTile
+                      icon={
                         <span className="flex h-5 w-10 flex-col items-center justify-center -space-y-1">
                           <AmdIcon size={30} />
                           <IntelIcon size={30} />
                         </span>
-                        GPU (Vulkan Windows)
-                        <span className="bg-accent-orange/20 text-accent-orange ml-1 rounded px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase">
-                          Exp
-                        </span>
-                      </button>
+                      }
+                      label="GPU (Vulkan Linux)"
+                      sublabel="AMD / Intel"
+                      accent="red"
+                      selected={runtimeProfile === 'vulkan'}
+                      disabled={isRunning || hostPlatform === 'win32' || hostPlatform === 'darwin'}
+                      badge={
+                        hostPlatform === 'win32' || hostPlatform === 'darwin'
+                          ? 'Linux only'
+                          : undefined
+                      }
+                      hint="Experimental"
+                      onSelect={() => handleRuntimeProfileChange('vulkan')}
+                    />
+                    {/* Experimental Vulkan-WSL2 tile (GH-101 follow-up) — only
+                        rendered when the main-process probe confirms Docker
+                        Desktop runs on the WSL2 backend AND a tiny container
+                        could see /dev/dxg. */}
+                    {gpuInfo?.wslSupport?.gpuPassthroughDetected && hostPlatform === 'win32' && (
+                      <SelectorTile
+                        icon={
+                          <span className="flex h-5 w-10 flex-col items-center justify-center -space-y-1">
+                            <AmdIcon size={30} />
+                            <IntelIcon size={30} />
+                          </span>
+                        }
+                        label="GPU (Vulkan Windows)"
+                        sublabel="AMD / Intel · WSL2"
+                        accent="red"
+                        selected={runtimeProfile === 'vulkan-wsl2'}
+                        disabled={isRunning}
+                        hint="Experimental"
+                        onSelect={() => handleRuntimeProfileChange('vulkan-wsl2')}
+                      />
                     )}
-                  </div>
+                    <SelectorTile
+                      icon={<AppleIcon size={16} />}
+                      label="GPU (Metal)"
+                      sublabel="Apple Silicon"
+                      accent="purple"
+                      selected={runtimeProfile === 'metal'}
+                      disabled={
+                        isRunning || (hostPlatform !== 'unknown' && hostPlatform !== 'darwin')
+                      }
+                      badge={
+                        hostPlatform !== 'unknown' && hostPlatform !== 'darwin'
+                          ? 'Requires Apple Silicon'
+                          : undefined
+                      }
+                      onSelect={() => handleRuntimeProfileChange('metal')}
+                    />
+                    <SelectorTile
+                      icon={<Cpu size={16} />}
+                      label="CPU Only"
+                      sublabel="Universal"
+                      accent="orange"
+                      selected={runtimeProfile === 'cpu'}
+                      disabled={isRunning}
+                      onSelect={() => handleRuntimeProfileChange('cpu')}
+                    />
+                  </SelectorGroup>
                   {runtimeProfile === 'vulkan' && !isRunning && (
-                    <span className="text-xs text-slate-500 italic">
-                      AMD/Intel GPU via whisper.cpp — no diarization or live mode
-                    </span>
+                    <p className="mt-2 text-xs text-slate-500 italic">
+                      AMD/Intel GPU via whisper.cpp — no diarization; live mode via GGML models
+                    </p>
                   )}
                   {runtimeProfile === 'vulkan-wsl2' && !isRunning && (
-                    <span className="text-accent-orange text-xs italic">
+                    <p className="text-accent-orange mt-2 text-xs italic">
                       Experimental: AMD/Intel GPU via WSL2 + Mesa dzn — see README §2.5.2
-                    </span>
+                    </p>
                   )}
                   {runtimeProfile === 'cpu' && !isRunning && (
-                    <span className="text-xs text-slate-500 italic">
+                    <p className="mt-2 text-xs text-slate-500 italic">
                       Slower transcription, no NVIDIA GPU required
-                    </span>
+                    </p>
                   )}
                 </div>
 
@@ -2464,286 +2317,58 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                   </div>
                 )}
 
-                {/* Auth Token (read-only) */}
-                {authToken && (
-                  <div className="border-t border-white/5 pt-4">
-                    <label className="mb-1.5 block text-xs font-medium tracking-wider text-slate-500 uppercase">
-                      Auth Token
-                    </label>
-                    <div className="relative">
-                      <input
-                        type={showAuthToken ? 'text' : 'password'}
-                        value={authToken}
-                        readOnly
-                        className="w-full rounded-lg border border-white/10 bg-black/20 px-3 py-2 pr-20 font-mono text-sm text-white focus:outline-none"
-                      />
-                      <div className="absolute top-2 right-2 flex items-center gap-1">
-                        <button
-                          onClick={() => {
-                            writeToClipboard(authToken).catch(() => {});
-                            setAuthTokenCopied(true);
-                            setTimeout(() => setAuthTokenCopied(false), 2000);
-                          }}
-                          className="p-1 text-slate-500 transition-colors hover:text-white"
-                          title="Copy token"
-                        >
-                          {authTokenCopied ? (
-                            <Check size={14} className="text-green-400" />
-                          ) : (
-                            <Copy size={14} />
-                          )}
-                        </button>
-                        <button
-                          onClick={() => setShowAuthToken(!showAuthToken)}
-                          className="p-1 text-slate-500 transition-colors hover:text-white"
-                        >
-                          {showAuthToken ? <EyeOff size={14} /> : <Eye size={14} />}
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                )}
-
-                {/* Tailscale Hostname (for remote mode configuration) */}
-                {tailscaleHostname && (
-                  <div className="border-t border-white/5 pt-4">
-                    <label className="mb-1.5 block text-xs font-medium tracking-wider text-slate-500 uppercase">
-                      Tailscale Hostname
-                    </label>
-                    <div className="flex items-center gap-2 rounded-lg border border-white/10 bg-black/20 px-3 py-2">
-                      <span className="flex-1 truncate font-mono text-sm text-slate-300">
-                        {tailscaleHostname}
-                      </span>
-                      <button
-                        onClick={() => {
-                          writeToClipboard(tailscaleHostname).catch(() => {});
-                          setTailscaleHostnameCopied(true);
-                          setTimeout(() => setTailscaleHostnameCopied(false), 2000);
-                        }}
-                        className="shrink-0 p-1 text-slate-500 transition-colors hover:text-white"
-                        title="Copy Tailscale hostname"
-                      >
-                        {tailscaleHostnameCopied ? (
-                          <Check size={14} className="text-green-400" />
-                        ) : (
-                          <Copy size={14} />
-                        )}
-                      </button>
-                    </div>
-                    <p className="mt-1.5 text-xs text-slate-500">
-                      Use this hostname when configuring remote clients to connect via Tailscale.
-                    </p>
-                  </div>
-                )}
-
-                {/* Firewall warning (remote mode) */}
-                {firewallWarning && isRunningAndHealthy && (
-                  <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5">
-                    <AlertTriangle size={16} className="mt-0.5 shrink-0 text-amber-400" />
-                    <div className="text-xs text-amber-200">
-                      <p className="font-medium">Firewall may block remote connections</p>
-                      <p className="mt-0.5 text-amber-300/80">{firewallWarning}</p>
-                    </div>
-                  </div>
-                )}
-              </div>
-            </GlassCard>
-          </div>
-
-          {/* 3. ASR Models Card */}
-          <div className="relative shrink-0 border-l-2 border-white/10 pb-8 pl-8 last:border-0 last:pb-0">
-            <div className="absolute top-0 -left-4.25 z-10 flex h-8 w-8 items-center justify-center rounded-full border-4 border-slate-900 bg-slate-800 text-slate-300">
-              <Cpu size={14} />
-            </div>
-            <GlassCard title="3. ASR Models Configuration">
-              <div className="space-y-4">
-                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between">
-                      <label className="text-sm font-medium text-slate-300">Main Transcriber</label>
-                      {isRunning &&
-                        activeTranscriber &&
-                        activeTranscriber !== MODEL_DEFAULT_LOADING_PLACEHOLDER &&
-                        activeTranscriber !== DISABLED_MODEL_SENTINEL && (
-                          <div className="flex items-center gap-1.5">
-                            <span
-                              className={`inline-block h-2 w-2 rounded-full ${modelCacheStatus[activeTranscriber]?.exists ? 'bg-green-500 shadow-[0_0_6px_rgba(34,197,94,0.5)]' : 'bg-slate-500'}`}
-                            />
-                            <span
-                              className={`font-mono text-[10px] ${modelCacheStatus[activeTranscriber]?.exists ? 'text-green-400' : 'text-slate-500'}`}
-                            >
-                              {modelCacheStatus[activeTranscriber]?.exists
-                                ? 'Downloaded'
-                                : 'Missing'}
-                            </span>
-                          </div>
-                        )}
-                    </div>
-                    <CustomSelect
-                      value={mainModelSelection}
-                      onChange={setMainModelSelection}
-                      options={mainModelOptions}
-                      optionMeta={mainModelOptionMeta}
-                      accentColor="magenta"
-                      className="focus:ring-accent-magenta h-10 w-full rounded-lg border border-white/10 bg-white/5 px-3 text-sm text-white transition-shadow outline-none focus:ring-1"
-                      disabled={isRunning}
-                    />
-                    {isVulkan && (
-                      <p className="text-xs text-slate-500 italic">
-                        This GGML model runs on the AMD/Intel GPU via the whisper.cpp sidecar.
-                        Switching models requires a server restart.
-                      </p>
-                    )}
-                    {MLX_MODEL_IDS.has(mainModelSelection) && (
-                      <p className="flex items-center gap-1 text-xs text-violet-400">
-                        <Zap size={10} />
-                        Metal / MLX accelerated
-                      </p>
-                    )}
-                    {mainModelSelection === MAIN_MODEL_CUSTOM_OPTION && (
-                      <input
-                        type="text"
-                        value={mainCustomModel}
-                        onChange={(e) => setMainCustomModel(e.target.value)}
-                        placeholder="owner/model-name"
-                        disabled={isRunning}
-                        className={`focus:ring-accent-magenta h-10 w-full rounded-lg border border-white/10 bg-white/5 px-3 text-sm text-white placeholder-slate-500 transition-shadow outline-none focus:ring-1${isRunning ? 'cursor-not-allowed opacity-50' : ''}`}
-                      />
-                    )}
-                  </div>
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between">
-                      <label className="text-sm font-medium text-slate-300">Live Mode Model</label>
-                      {isRunning &&
-                        activeLiveModel &&
-                        activeLiveModel !== MODEL_DEFAULT_LOADING_PLACEHOLDER &&
-                        activeLiveModel !== DISABLED_MODEL_SENTINEL &&
-                        (() => {
-                          const liveKey =
-                            liveModelSelection === LIVE_MODEL_SAME_AS_MAIN_OPTION
-                              ? activeTranscriber
-                              : activeLiveModel;
-                          const liveExists = modelCacheStatus[liveKey ?? '']?.exists;
-                          return (
-                            <div className="flex items-center gap-1.5">
-                              <span
-                                className={`inline-block h-2 w-2 rounded-full ${liveExists ? 'bg-green-500 shadow-[0_0_6px_rgba(34,197,94,0.5)]' : 'bg-slate-500'}`}
-                              />
-                              <span
-                                className={`font-mono text-[10px] ${liveExists ? 'text-green-400' : 'text-slate-500'}`}
-                              >
-                                {liveExists ? 'Downloaded' : 'Missing'}
-                              </span>
-                            </div>
-                          );
-                        })()}
-                    </div>
-                    <CustomSelect
-                      value={liveModelSelection}
-                      onChange={setLiveModelSelection}
-                      options={liveModelOptions}
-                      className="focus:ring-accent-cyan h-10 w-full rounded-lg border border-white/10 bg-white/5 px-3 text-sm text-white transition-shadow outline-none focus:ring-1"
-                      disabled={isRunning}
-                    />
-                    {liveModelSelection === LIVE_MODEL_CUSTOM_OPTION && (
-                      <input
-                        type="text"
-                        value={liveCustomModel}
-                        onChange={(e) => setLiveCustomModel(e.target.value)}
-                        placeholder="owner/model-name"
-                        disabled={isRunning}
-                        className={`focus:ring-accent-cyan h-10 w-full rounded-lg border border-white/10 bg-white/5 px-3 text-sm text-white placeholder-slate-500 transition-shadow outline-none focus:ring-1${isRunning ? 'cursor-not-allowed opacity-50' : ''}`}
-                      />
-                    )}
-                    {!liveModelWhisperOnlyCompatible && (
-                      <p className="text-accent-orange text-xs">{liveModeModelConstraintMessage}</p>
-                    )}
-                  </div>
-                </div>
-                <div className="flex gap-2 border-t border-white/5 pt-2">
-                  <Button
-                    variant={adminStatus?.models_loaded === false ? 'secondary' : 'danger'}
-                    className="h-9 px-4 whitespace-nowrap"
-                    onClick={
-                      adminStatus?.models_loaded === false ? handleLoadModels : handleUnloadModels
-                    }
-                    disabled={modelsLoading || !isRunning}
-                  >
-                    {modelsLoading ? (
-                      <>
-                        <Loader2 size={14} className="mr-2 animate-spin" /> Loading...
-                      </>
-                    ) : adminStatus?.models_loaded === false ? (
-                      'Load Models'
-                    ) : (
-                      'Unload Models'
-                    )}
-                  </Button>
-                  {adminStatus?.models_loaded !== undefined && (
-                    <span
-                      className={`ml-auto self-center font-mono text-xs ${adminStatus.models_loaded ? 'text-green-400' : 'text-slate-500'}`}
-                    >
-                      {adminStatus.models_loaded ? 'Models Loaded' : 'Models Not Loaded'}
-                    </span>
-                  )}
-                </div>
-              </div>
-            </GlassCard>
-          </div>
-
-          {/* 4. Diarization Models Card */}
-          <div className="relative shrink-0 border-l-2 border-white/10 pb-8 pl-8 last:border-0 last:pb-0">
-            <div className="absolute top-0 -left-4.25 z-10 flex h-8 w-8 items-center justify-center rounded-full border-4 border-slate-900 bg-slate-800 text-slate-300">
-              <Users size={14} />
-            </div>
-            <GlassCard title="4. Diarization Models Configuration">
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <label className="text-sm font-medium text-slate-300">Diarization Model</label>
-                  {isRunning && diarizationStatusModelId && (
-                    <div className="flex items-center gap-1.5">
-                      <span
-                        className={`inline-block h-2 w-2 rounded-full ${modelCacheStatus[diarizationStatusModelId]?.exists ? 'bg-green-500 shadow-[0_0_6px_rgba(34,197,94,0.5)]' : 'bg-slate-500'}`}
-                      />
-                      <span
-                        className={`font-mono text-[10px] ${modelCacheStatus[diarizationStatusModelId]?.exists ? 'text-green-400' : 'text-slate-500'}`}
-                      >
-                        {modelCacheStatus[diarizationStatusModelId]?.exists
-                          ? 'Downloaded'
-                          : 'Missing'}
-                      </span>
-                    </div>
-                  )}
-                </div>
-                <CustomSelect
-                  value={diarizationModelSelection}
-                  onChange={setDiarizationModelSelection}
-                  options={diarizationOptions}
-                  optionMeta={diarizationOptionMeta}
-                  className="focus:ring-accent-cyan h-10 w-full rounded-lg border border-white/10 bg-white/5 px-3 text-sm text-white transition-shadow outline-none focus:ring-1"
-                  disabled={isRunning}
+                {/* Model / live / diarization selectors — all valid combinations
+                    come from src/services/instanceMatrix.ts */}
+                <InstanceSettingsSelectors
+                  runtimeProfile={runtimeProfile}
+                  isRunning={isRunning}
+                  mainModelSelection={mainModelSelection}
+                  onMainModelSelectionChange={setMainModelSelection}
+                  mainCustomModel={mainCustomModel}
+                  onMainCustomModelChange={setMainCustomModel}
+                  liveModelSelection={liveModelSelection}
+                  onLiveModelSelectionChange={setLiveModelSelection}
+                  liveCustomModel={liveCustomModel}
+                  onLiveCustomModelChange={setLiveCustomModel}
+                  diarizationModelSelection={diarizationModelSelection}
+                  onDiarizationModelSelectionChange={setDiarizationModelSelection}
+                  diarizationCustomModel={diarizationCustomModel}
+                  onDiarizationCustomModelChange={setDiarizationCustomModel}
+                  activeTranscriber={activeTranscriber}
+                  activeLiveModel={activeLiveModel}
+                  diarizationStatusModelId={diarizationStatusModelId}
+                  modelCacheStatus={modelCacheStatus}
+                  liveModelWhisperOnlyCompatible={liveModelWhisperOnlyCompatible}
+                  liveModeModelConstraintMessage={liveModeModelConstraintMessage}
+                  modelsLoaded={adminStatus?.models_loaded}
+                  modelsLoading={modelsLoading}
+                  onLoadModels={handleLoadModels}
+                  onUnloadModels={handleUnloadModels}
                 />
-                {diarizationModelSelection === DIARIZATION_MODEL_CUSTOM_OPTION && (
-                  <input
-                    type="text"
-                    value={diarizationCustomModel}
-                    onChange={(e) => setDiarizationCustomModel(e.target.value)}
-                    placeholder="owner/model-name"
-                    disabled={isRunning}
-                    className={`focus:ring-accent-cyan h-10 w-full rounded-lg border border-white/10 bg-white/5 px-3 text-sm text-white placeholder-slate-500 transition-shadow outline-none focus:ring-1${isRunning ? 'cursor-not-allowed opacity-50' : ''}`}
-                  />
-                )}
               </div>
             </GlassCard>
           </div>
 
-          {/* 5. Volumes Card */}
+          {/* 3. Remote Connection Card */}
+          <div className="relative shrink-0 border-l-2 border-white/10 pb-8 pl-8 last:border-0 last:pb-0">
+            <div
+              className={`absolute top-0 -left-4.25 z-10 flex h-8 w-8 items-center justify-center rounded-full border-4 border-slate-900 transition-colors duration-300 ${isRunningAndHealthy && serverMode === 'remote' ? 'bg-accent-magenta text-slate-900 shadow-[0_0_15px_rgba(232,121,249,0.5)]' : 'bg-slate-800 text-slate-300'}`}
+            >
+              <Globe size={14} />
+            </div>
+            <RemoteConnectionCard
+              title="3. Remote Connection"
+              isRunningAndHealthy={isRunningAndHealthy}
+            />
+          </div>
+
+          {/* 4. Volumes Card */}
           <div className="relative shrink-0 border-l-2 border-white/10 pb-2 pl-8 last:border-0 last:pb-0">
             <div className="absolute top-0 -left-4.25 z-10 flex h-8 w-8 items-center justify-center rounded-full border-4 border-slate-900 bg-slate-800 text-slate-300">
               <HardDrive size={14} />
             </div>
             <GlassCard
-              title="5. Persistent Volumes"
+              title="4. Persistent Volumes"
               action={
                 !isMetal ? (
                   <Button
@@ -2863,12 +2488,12 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
             </GlassCard>
           </div>
 
-          {/* 6. Clean Up */}
+          {/* 5. Clean Up */}
           <div className="relative shrink-0 border-l-2 border-white/10 pb-2 pl-8 last:border-0 last:pb-0">
             <div className="absolute top-0 -left-4.25 z-10 flex h-8 w-8 items-center justify-center rounded-full border-4 border-slate-900 bg-slate-800 text-slate-300">
               <AlertTriangle size={14} />
             </div>
-            <GlassCard title="6. Clean Up">
+            <GlassCard title="5. Clean Up">
               <div className="rounded-xl border border-red-500/25 bg-red-500/5 p-4">
                 <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                   <div className="space-y-1">

--- a/dashboard/components/views/server/InstanceSettingsSelectors.tsx
+++ b/dashboard/components/views/server/InstanceSettingsSelectors.tsx
@@ -1,0 +1,469 @@
+import React, { useMemo } from 'react';
+import {
+  AudioLines,
+  Bird,
+  Boxes,
+  Ear,
+  Feather,
+  KeyRound,
+  Languages,
+  Link2,
+  Loader2,
+  Mic,
+  MicOff,
+  PenLine,
+  Radio,
+  Sparkles,
+  Speech,
+  Users,
+  Zap,
+} from 'lucide-react';
+
+import { AppleIcon } from '../../ui/icons/AppleIcon';
+import { Button } from '../../ui/Button';
+import { CustomSelect } from '../../ui/CustomSelect';
+import { SelectorGroup } from '../../ui/SelectorGroup';
+import { SelectorTile } from '../../ui/SelectorTile';
+import type { TileAccent } from '../../ui/SelectorTile';
+import {
+  DIARIZATION_MODEL_CUSTOM_OPTION,
+  type FamilyChoiceId,
+  defaultModelForFamilyChoice,
+  diarizationTilesFor,
+  familyChoiceForModel,
+  familyChoicesFor,
+  liveModelsFor,
+  liveTilesFor,
+  type LiveTileId,
+  modelsForFamilyChoice,
+} from '../../../src/services/instanceMatrix';
+import {
+  DISABLED_MODEL_SENTINEL,
+  LIVE_MODEL_CUSTOM_OPTION,
+  LIVE_MODEL_SAME_AS_MAIN_OPTION,
+  LIVE_RECOMMENDED_MODEL,
+  MAIN_MODEL_CUSTOM_OPTION,
+  MODEL_DEFAULT_LOADING_PLACEHOLDER,
+  MODEL_DISABLED_OPTION,
+  VULKAN_RECOMMENDED_MODEL,
+} from '../../../src/services/modelSelection';
+import { isWhisperCppModel } from '../../../src/services/modelCapabilities';
+import type { RuntimeProfile } from '../../../src/types/runtime';
+
+interface ModelCacheStatus {
+  exists: boolean;
+  size?: string;
+}
+
+interface InstanceSettingsSelectorsProps {
+  runtimeProfile: RuntimeProfile;
+  isRunning: boolean;
+  mainModelSelection: string;
+  onMainModelSelectionChange: (value: string) => void;
+  mainCustomModel: string;
+  onMainCustomModelChange: (value: string) => void;
+  liveModelSelection: string;
+  onLiveModelSelectionChange: (value: string) => void;
+  liveCustomModel: string;
+  onLiveCustomModelChange: (value: string) => void;
+  diarizationModelSelection: string;
+  onDiarizationModelSelectionChange: (value: string) => void;
+  diarizationCustomModel: string;
+  onDiarizationCustomModelChange: (value: string) => void;
+  activeTranscriber: string;
+  activeLiveModel: string;
+  diarizationStatusModelId: string;
+  modelCacheStatus: Record<string, ModelCacheStatus>;
+  liveModelWhisperOnlyCompatible: boolean;
+  liveModeModelConstraintMessage: string;
+  modelsLoaded: boolean | undefined;
+  modelsLoading: boolean;
+  onLoadModels: () => void;
+  onUnloadModels: () => void;
+}
+
+const FAMILY_ICONS: Record<FamilyChoiceId, React.ReactNode> = {
+  whisper: <AudioLines size={16} />,
+  parakeet: <Bird size={16} />,
+  canary: <Feather size={16} />,
+  sensevoice: <Ear size={16} />,
+  vibevoice: <Speech size={16} />,
+  whispercpp: <Boxes size={16} />,
+  'mlx-whisper': <AudioLines size={16} />,
+  'mlx-parakeet': <Bird size={16} />,
+  'mlx-canary': <Feather size={16} />,
+  'mlx-vibevoice': <Speech size={16} />,
+};
+
+const LIVE_TILE_ICONS: Record<LiveTileId, React.ReactNode> = {
+  'same-as-main': <Link2 size={16} />,
+  whisper: <AudioLines size={16} />,
+  whispercpp: <Boxes size={16} />,
+  disabled: <MicOff size={16} />,
+};
+
+const LIVE_TILE_ACCENTS: Record<LiveTileId, TileAccent> = {
+  'same-as-main': 'cyan',
+  whisper: 'slate',
+  whispercpp: 'purple',
+  disabled: 'slate',
+};
+
+const DIARIZATION_TILE_ICONS: Record<string, React.ReactNode> = {
+  pyannote: <Users size={16} />,
+  campp: <Zap size={16} />,
+  sortformer: <AppleIcon size={16} />,
+  builtin: <Sparkles size={16} />,
+  custom: <PenLine size={16} />,
+};
+
+const DIARIZATION_TILE_ACCENTS: Record<string, TileAccent> = {
+  pyannote: 'magenta',
+  campp: 'amber',
+  sortformer: 'slate',
+  builtin: 'blue',
+  custom: 'cyan',
+};
+
+function CacheBadge({ status }: { status: ModelCacheStatus | undefined }) {
+  const exists = status?.exists ?? false;
+  return (
+    <div className="flex items-center gap-1.5">
+      <span
+        className={`inline-block h-2 w-2 rounded-full ${exists ? 'bg-green-500 shadow-[0_0_6px_rgba(34,197,94,0.5)]' : 'bg-slate-500'}`}
+      />
+      <span className={`font-mono text-[10px] ${exists ? 'text-green-400' : 'text-slate-500'}`}>
+        {exists ? 'Downloaded' : 'Missing'}
+      </span>
+    </div>
+  );
+}
+
+function isRealModelValue(value: string): boolean {
+  return Boolean(
+    value && value !== MODEL_DEFAULT_LOADING_PLACEHOLDER && value !== DISABLED_MODEL_SENTINEL,
+  );
+}
+
+/**
+ * The three model selector groups of the Instance Settings card: main
+ * transcriber (family tiles + per-family model dropdown), Live Mode and
+ * diarization engine. All valid/invalid combinations come from
+ * src/services/instanceMatrix.ts — this component only renders them.
+ */
+export function InstanceSettingsSelectors({
+  runtimeProfile,
+  isRunning,
+  mainModelSelection,
+  onMainModelSelectionChange,
+  mainCustomModel,
+  onMainCustomModelChange,
+  liveModelSelection,
+  onLiveModelSelectionChange,
+  liveCustomModel,
+  onLiveCustomModelChange,
+  diarizationModelSelection,
+  onDiarizationModelSelectionChange,
+  diarizationCustomModel,
+  onDiarizationCustomModelChange,
+  activeTranscriber,
+  activeLiveModel,
+  diarizationStatusModelId,
+  modelCacheStatus,
+  liveModelWhisperOnlyCompatible,
+  liveModeModelConstraintMessage,
+  modelsLoaded,
+  modelsLoading,
+  onLoadModels,
+  onUnloadModels,
+}: InstanceSettingsSelectorsProps) {
+  const familyChoices = useMemo(() => familyChoicesFor(runtimeProfile), [runtimeProfile]);
+
+  // The family tile that should light up: derived from the dropdown value
+  // (or the custom text when the Custom option is active).
+  const selectedFamily = useMemo(() => {
+    if (mainModelSelection === MAIN_MODEL_CUSTOM_OPTION) {
+      return familyChoiceForModel(mainCustomModel) ?? 'whisper';
+    }
+    return familyChoiceForModel(mainModelSelection);
+  }, [mainModelSelection, mainCustomModel]);
+
+  const mainDropdownOptions = useMemo(() => {
+    if (!selectedFamily) return [MODEL_DISABLED_OPTION, MAIN_MODEL_CUSTOM_OPTION];
+    const ids = modelsForFamilyChoice(selectedFamily).map((m) => m.id);
+    // Vulkan GGML: Custom is omitted — only registry GGML files exist on disk
+    // for the sidecar to load (matches the pre-redesign dropdown).
+    if (selectedFamily === 'whispercpp') {
+      return [...ids, MODEL_DISABLED_OPTION];
+    }
+    return [...ids, MODEL_DISABLED_OPTION, MAIN_MODEL_CUSTOM_OPTION];
+  }, [selectedFamily]);
+
+  const liveTiles = useMemo(
+    () => liveTilesFor(runtimeProfile, activeTranscriber),
+    [runtimeProfile, activeTranscriber],
+  );
+
+  const activeLiveTile: LiveTileId = useMemo(() => {
+    if (liveModelSelection === LIVE_MODEL_SAME_AS_MAIN_OPTION) return 'same-as-main';
+    if (liveModelSelection === MODEL_DISABLED_OPTION) return 'disabled';
+    if (isWhisperCppModel(liveModelSelection)) return 'whispercpp';
+    return 'whisper';
+  }, [liveModelSelection]);
+
+  const liveDropdownOptions = useMemo(() => {
+    if (activeLiveTile === 'same-as-main' || activeLiveTile === 'disabled') return [];
+    const ids = liveModelsFor(activeLiveTile === 'whispercpp' ? 'vulkan' : 'gpu').map((m) => m.id);
+    if (activeLiveTile === 'whispercpp') return ids;
+    return [...ids, LIVE_MODEL_CUSTOM_OPTION];
+  }, [activeLiveTile]);
+
+  const diarizationTiles = useMemo(
+    () => diarizationTilesFor(runtimeProfile, activeTranscriber),
+    [runtimeProfile, activeTranscriber],
+  );
+
+  const handleLiveTileSelect = (id: LiveTileId) => {
+    if (id === 'same-as-main') onLiveModelSelectionChange(LIVE_MODEL_SAME_AS_MAIN_OPTION);
+    else if (id === 'disabled') onLiveModelSelectionChange(MODEL_DISABLED_OPTION);
+    else if (id === 'whispercpp') onLiveModelSelectionChange(VULKAN_RECOMMENDED_MODEL);
+    else onLiveModelSelectionChange(LIVE_RECOMMENDED_MODEL);
+  };
+
+  const liveBadgeKey =
+    liveModelSelection === LIVE_MODEL_SAME_AS_MAIN_OPTION ? activeTranscriber : activeLiveModel;
+
+  return (
+    <div className="space-y-6">
+      {/* Main transcriber */}
+      <SelectorGroup
+        icon={<Mic size={16} className="text-accent-magenta" />}
+        title="Main Transcriber"
+        hint="Which model transcribes your recordings"
+        action={
+          isRunning && isRealModelValue(activeTranscriber) ? (
+            <CacheBadge status={modelCacheStatus[activeTranscriber]} />
+          ) : undefined
+        }
+      >
+        {familyChoices.map((choice) => (
+          <SelectorTile
+            key={choice.id}
+            icon={FAMILY_ICONS[choice.id]}
+            label={choice.label}
+            sublabel={choice.sublabel}
+            accent={choice.accent as TileAccent}
+            selected={selectedFamily === choice.id}
+            disabled={!choice.enabled || isRunning}
+            badge={choice.reason}
+            hint={choice.hint}
+            onSelect={() => {
+              onMainModelSelectionChange(defaultModelForFamilyChoice(choice.id));
+              onMainCustomModelChange('');
+            }}
+            glyphs={
+              <>
+                <span
+                  className="flex items-center gap-0.5 text-[10px] text-slate-400"
+                  title={`${choice.capabilities.languages} languages`}
+                >
+                  <Languages size={10} />
+                  {choice.capabilities.languages}
+                </span>
+                {choice.capabilities.translation !== 'none' && (
+                  <span
+                    className="text-[10px] text-slate-400"
+                    title={
+                      choice.capabilities.translation === 'multilingual'
+                        ? 'Translates between languages'
+                        : 'Translates to English'
+                    }
+                  >
+                    {choice.capabilities.translation === 'multilingual' ? 'A⇄B' : '→EN'}
+                  </span>
+                )}
+                {choice.capabilities.live && (
+                  <Radio size={10} className="text-slate-400" aria-label="Live Mode capable" />
+                )}
+                {choice.capabilities.diarization !== 'none' && (
+                  <Users size={10} className="text-slate-400" aria-label="Diarization capable" />
+                )}
+                {choice.capabilities.requiresToken && (
+                  <KeyRound
+                    size={10}
+                    className="text-slate-500"
+                    aria-label="Diarization needs a HuggingFace token"
+                  />
+                )}
+              </>
+            }
+          />
+        ))}
+      </SelectorGroup>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <label className="text-xs font-medium tracking-wider text-slate-500 uppercase">
+            Model Variant
+          </label>
+          <CustomSelect
+            value={mainModelSelection}
+            onChange={onMainModelSelectionChange}
+            options={mainDropdownOptions}
+            accentColor="magenta"
+            className="focus:ring-accent-magenta h-10 w-full rounded-lg border border-white/10 bg-white/5 px-3 text-sm text-white transition-shadow outline-none focus:ring-1"
+            disabled={isRunning}
+          />
+          {mainModelSelection === MAIN_MODEL_CUSTOM_OPTION && (
+            <input
+              type="text"
+              value={mainCustomModel}
+              onChange={(e) => onMainCustomModelChange(e.target.value)}
+              placeholder="owner/model-name"
+              disabled={isRunning}
+              className={`focus:ring-accent-magenta h-10 w-full rounded-lg border border-white/10 bg-white/5 px-3 text-sm text-white placeholder-slate-500 transition-shadow outline-none focus:ring-1${isRunning ? 'cursor-not-allowed opacity-50' : ''}`}
+            />
+          )}
+          {selectedFamily === 'whispercpp' && (
+            <p className="text-xs text-slate-500 italic">
+              This GGML model runs on the AMD/Intel GPU via the whisper.cpp sidecar. Switching
+              models requires a server restart.
+            </p>
+          )}
+          {selectedFamily?.startsWith('mlx') && (
+            <p className="flex items-center gap-1 text-xs text-violet-400">
+              <Zap size={10} />
+              Metal / MLX accelerated
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Live Mode model */}
+      <SelectorGroup
+        icon={<Radio size={16} className="text-accent-cyan" />}
+        title="Live Mode Model"
+        hint="Realtime transcription runs on faster-whisper or whisper.cpp"
+        columnsClass="grid-cols-2 sm:grid-cols-4"
+        action={
+          isRunning && isRealModelValue(activeLiveModel) ? (
+            <CacheBadge status={modelCacheStatus[liveBadgeKey ?? '']} />
+          ) : undefined
+        }
+      >
+        {liveTiles.map((tile) => (
+          <SelectorTile
+            key={tile.id}
+            icon={LIVE_TILE_ICONS[tile.id]}
+            label={tile.label}
+            accent={LIVE_TILE_ACCENTS[tile.id]}
+            selected={activeLiveTile === tile.id}
+            disabled={!tile.enabled || isRunning}
+            badge={tile.reason}
+            hint={tile.hint}
+            onSelect={() => handleLiveTileSelect(tile.id)}
+          />
+        ))}
+      </SelectorGroup>
+      {liveDropdownOptions.length > 0 && (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <CustomSelect
+              value={liveModelSelection}
+              onChange={onLiveModelSelectionChange}
+              options={liveDropdownOptions}
+              className="focus:ring-accent-cyan h-10 w-full rounded-lg border border-white/10 bg-white/5 px-3 text-sm text-white transition-shadow outline-none focus:ring-1"
+              disabled={isRunning}
+            />
+            {liveModelSelection === LIVE_MODEL_CUSTOM_OPTION && (
+              <input
+                type="text"
+                value={liveCustomModel}
+                onChange={(e) => onLiveCustomModelChange(e.target.value)}
+                placeholder="owner/model-name"
+                disabled={isRunning}
+                className={`focus:ring-accent-cyan h-10 w-full rounded-lg border border-white/10 bg-white/5 px-3 text-sm text-white placeholder-slate-500 transition-shadow outline-none focus:ring-1${isRunning ? 'cursor-not-allowed opacity-50' : ''}`}
+              />
+            )}
+          </div>
+        </div>
+      )}
+      {!liveModelWhisperOnlyCompatible && (
+        <p className="text-accent-orange text-xs">{liveModeModelConstraintMessage}</p>
+      )}
+
+      {/* Diarization engine */}
+      <SelectorGroup
+        icon={<Users size={16} className="text-accent-magenta" />}
+        title="Diarization"
+        hint="How speakers get identified"
+        columnsClass="grid-cols-2 sm:grid-cols-4"
+        action={
+          isRunning && diarizationStatusModelId ? (
+            <CacheBadge status={modelCacheStatus[diarizationStatusModelId]} />
+          ) : undefined
+        }
+      >
+        {diarizationTiles.map((tile) => (
+          <SelectorTile
+            key={tile.id}
+            icon={DIARIZATION_TILE_ICONS[tile.id]}
+            label={tile.label}
+            accent={DIARIZATION_TILE_ACCENTS[tile.id]}
+            selected={tile.id === 'builtin' || diarizationModelSelection === tile.storedValue}
+            locked={tile.id === 'builtin'}
+            disabled={!tile.enabled || isRunning}
+            badge={tile.reason}
+            hint={tile.hint}
+            onSelect={() => onDiarizationModelSelectionChange(tile.storedValue)}
+          />
+        ))}
+      </SelectorGroup>
+      {diarizationTiles.length === 0 && (
+        <p className="text-xs text-slate-500 italic">
+          Diarization is not available for whisper.cpp (GGML) models.
+        </p>
+      )}
+      {diarizationTiles.length > 0 &&
+        diarizationModelSelection === DIARIZATION_MODEL_CUSTOM_OPTION && (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <input
+              type="text"
+              value={diarizationCustomModel}
+              onChange={(e) => onDiarizationCustomModelChange(e.target.value)}
+              placeholder="owner/model-name"
+              disabled={isRunning}
+              className={`focus:ring-accent-cyan h-10 w-full rounded-lg border border-white/10 bg-white/5 px-3 text-sm text-white placeholder-slate-500 transition-shadow outline-none focus:ring-1${isRunning ? 'cursor-not-allowed opacity-50' : ''}`}
+            />
+          </div>
+        )}
+
+      {/* Load / unload models */}
+      <div className="flex gap-2 border-t border-white/5 pt-2">
+        <Button
+          variant={modelsLoaded === false ? 'secondary' : 'danger'}
+          className="h-9 px-4 whitespace-nowrap"
+          onClick={modelsLoaded === false ? onLoadModels : onUnloadModels}
+          disabled={modelsLoading || !isRunning}
+        >
+          {modelsLoading ? (
+            <>
+              <Loader2 size={14} className="mr-2 animate-spin" /> Loading...
+            </>
+          ) : modelsLoaded === false ? (
+            'Load Models'
+          ) : (
+            'Unload Models'
+          )}
+        </Button>
+        {modelsLoaded !== undefined && (
+          <span
+            className={`ml-auto self-center font-mono text-xs ${modelsLoaded ? 'text-green-400' : 'text-slate-500'}`}
+          >
+            {modelsLoaded ? 'Models Loaded' : 'Models Not Loaded'}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/components/views/server/RemoteConnectionCard.tsx
+++ b/dashboard/components/views/server/RemoteConnectionCard.tsx
@@ -1,0 +1,173 @@
+import React, { useEffect, useState } from 'react';
+import { AlertTriangle, Check, Copy, Eye, EyeOff } from 'lucide-react';
+
+import { GlassCard } from '../../ui/GlassCard';
+import { writeToClipboard } from '../../../src/hooks/useClipboard';
+import { DEFAULT_SERVER_PORT } from '../../../src/config/store';
+
+interface RemoteConnectionCardProps {
+  title: string;
+  /** Firewall check only makes sense once the server is up and healthy. */
+  isRunningAndHealthy: boolean;
+}
+
+/**
+ * Remote Connection card: the credentials a remote client needs — the
+ * server auth token and the machine's Tailscale hostname — plus a firewall
+ * warning when the remote port looks blocked. Self-contained: loads its own
+ * data through the electronAPI bridge.
+ */
+export function RemoteConnectionCard({ title, isRunningAndHealthy }: RemoteConnectionCardProps) {
+  const [authToken, setAuthToken] = useState('');
+  const [showAuthToken, setShowAuthToken] = useState(false);
+  const [authTokenCopied, setAuthTokenCopied] = useState(false);
+  const [tailscaleHostname, setTailscaleHostname] = useState<string | null>(null);
+  const [tailscaleHostnameCopied, setTailscaleHostnameCopied] = useState(false);
+  const [firewallWarning, setFirewallWarning] = useState<string | null>(null);
+
+  // Re-fetch when the server comes up: the auth token is generated during the
+  // first server start, so a mount-only load would miss it until a remount.
+  useEffect(() => {
+    const api = (window as any).electronAPI;
+    api?.config
+      ?.get('connection.authToken')
+      .then((val: unknown) => {
+        if (typeof val === 'string') setAuthToken(val);
+      })
+      .catch(() => {});
+    if (api?.tailscale?.getHostname) {
+      api.tailscale
+        .getHostname()
+        .then((hostname: string | null) => {
+          if (hostname) setTailscaleHostname(hostname);
+        })
+        .catch(() => {});
+    }
+  }, [isRunningAndHealthy]);
+
+  // Check the firewall when the container becomes healthy in remote mode.
+  useEffect(() => {
+    if (!isRunningAndHealthy) {
+      setFirewallWarning(null);
+      return;
+    }
+    const api = (window as any).electronAPI;
+    if (!api?.server?.checkFirewallPort || !api?.config?.get) return;
+
+    api.config
+      .get('connection.useRemote')
+      .then(async (useRemote: unknown) => {
+        const tlsFromCompose = await api.docker
+          ?.readComposeEnvValue?.('TLS_ENABLED')
+          .catch(() => null);
+        const isRemote = useRemote === true || tlsFromCompose === 'true';
+        if (!isRemote) return;
+
+        try {
+          const port = ((await api.config.get('connection.port')) as number) ?? DEFAULT_SERVER_PORT;
+          const result = await api.server.checkFirewallPort(port);
+          if (result.firewallSuspect && result.hint) {
+            setFirewallWarning(result.hint);
+          } else {
+            setFirewallWarning(null);
+          }
+        } catch {
+          // Best effort
+        }
+      })
+      .catch(() => {});
+  }, [isRunningAndHealthy]);
+
+  return (
+    <GlassCard title={title}>
+      <div className="space-y-4">
+        {authToken ? (
+          <div>
+            <label className="mb-1.5 block text-xs font-medium tracking-wider text-slate-500 uppercase">
+              Auth Token
+            </label>
+            <div className="relative">
+              <input
+                type={showAuthToken ? 'text' : 'password'}
+                value={authToken}
+                readOnly
+                className="w-full rounded-lg border border-white/10 bg-black/20 px-3 py-2 pr-20 font-mono text-sm text-white focus:outline-none"
+              />
+              <div className="absolute top-2 right-2 flex items-center gap-1">
+                <button
+                  onClick={() => {
+                    writeToClipboard(authToken).catch(() => {});
+                    setAuthTokenCopied(true);
+                    setTimeout(() => setAuthTokenCopied(false), 2000);
+                  }}
+                  className="p-1 text-slate-500 transition-colors hover:text-white"
+                  title="Copy token"
+                >
+                  {authTokenCopied ? (
+                    <Check size={14} className="text-green-400" />
+                  ) : (
+                    <Copy size={14} />
+                  )}
+                </button>
+                <button
+                  onClick={() => setShowAuthToken(!showAuthToken)}
+                  className="p-1 text-slate-500 transition-colors hover:text-white"
+                >
+                  {showAuthToken ? <EyeOff size={14} /> : <Eye size={14} />}
+                </button>
+              </div>
+            </div>
+            <p className="mt-1.5 text-xs text-slate-500">
+              Remote clients authenticate with this token.
+            </p>
+          </div>
+        ) : (
+          <p className="text-xs text-slate-500 italic">
+            The auth token appears here after the server generates one (first start).
+          </p>
+        )}
+
+        {tailscaleHostname && (
+          <div>
+            <label className="mb-1.5 block text-xs font-medium tracking-wider text-slate-500 uppercase">
+              Tailscale Hostname
+            </label>
+            <div className="flex items-center gap-2 rounded-lg border border-white/10 bg-black/20 px-3 py-2">
+              <span className="flex-1 truncate font-mono text-sm text-slate-300">
+                {tailscaleHostname}
+              </span>
+              <button
+                onClick={() => {
+                  writeToClipboard(tailscaleHostname).catch(() => {});
+                  setTailscaleHostnameCopied(true);
+                  setTimeout(() => setTailscaleHostnameCopied(false), 2000);
+                }}
+                className="shrink-0 p-1 text-slate-500 transition-colors hover:text-white"
+                title="Copy Tailscale hostname"
+              >
+                {tailscaleHostnameCopied ? (
+                  <Check size={14} className="text-green-400" />
+                ) : (
+                  <Copy size={14} />
+                )}
+              </button>
+            </div>
+            <p className="mt-1.5 text-xs text-slate-500">
+              Use this hostname when configuring remote clients to connect via Tailscale.
+            </p>
+          </div>
+        )}
+
+        {firewallWarning && isRunningAndHealthy && (
+          <div className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2.5">
+            <AlertTriangle size={16} className="mt-0.5 shrink-0 text-amber-400" />
+            <div className="text-xs text-amber-200">
+              <p className="font-medium">Firewall may block remote connections</p>
+              <p className="mt-0.5 text-amber-300/80">{firewallWarning}</p>
+            </div>
+          </div>
+        )}
+      </div>
+    </GlassCard>
+  );
+}

--- a/dashboard/electron/main.ts
+++ b/dashboard/electron/main.ts
@@ -514,6 +514,11 @@ const store = new Store({
     'updates.lastNotified': { appLatest: '', serverLatest: '' },
     'updates.bannerSnoozedUntil': 0,
     'server.runtimeProfile': 'cpu',
+    // Metal boot auto-start gate: true only after the user explicitly started
+    // the native MLX server (mlx:start) and until they stop it (mlx:stop).
+    // Keeps model downloads from beginning before the first explicit start —
+    // selecting the Metal runtime alone must not launch the server.
+    'server.mlxDesiredRunning': false,
     'server.gpuAutoDetectDone': false,
     // Issue #83 — opt-in legacy-GPU image variant (Pascal/Maxwell support).
     // Default false keeps behaviour unchanged for existing users. When true,
@@ -2306,9 +2311,14 @@ app.whenReady().then(async () => {
   // Crash-resilient container cleanup: sentinel survives SIGBUS/SIGKILL
   spawnContainerSentinel();
 
-  // Auto-start the native MLX server if the Metal runtime profile is selected.
+  // Auto-start the native MLX server only when the Metal profile is selected
+  // AND the user had explicitly started the server (mlx:start sets the flag,
+  // mlx:stop clears it). Merely selecting the Metal runtime must not start
+  // the server — its startup pre-downloads models, and downloads may only
+  // begin after an explicit start.
   const runtimeProfile = store.get('server.runtimeProfile') as string;
-  if (runtimeProfile === 'metal') {
+  const mlxDesiredRunning = store.get('server.mlxDesiredRunning') === true;
+  if (runtimeProfile === 'metal' && mlxDesiredRunning) {
     const port = (store.get('server.port') as number) ?? 9786;
     const hfToken = (store.get('server.hfToken') as string) || undefined;
     const mainTranscriberModel =
@@ -2416,10 +2426,12 @@ app.whenReady().then(async () => {
 
 ipcMain.handle('mlx:start', async (_event, opts: MLXStartOptions) => {
   await mlxServerManager.start(opts);
+  store.set('server.mlxDesiredRunning', true);
 });
 
 ipcMain.handle('mlx:stop', async () => {
   await mlxServerManager.stop();
+  store.set('server.mlxDesiredRunning', false);
 });
 
 ipcMain.handle('mlx:getStatus', () => {

--- a/dashboard/src/services/instanceMatrix.test.ts
+++ b/dashboard/src/services/instanceMatrix.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DIARIZATION_BUILTIN_LABEL,
+  DIARIZATION_CAMPP_OPTION,
+  DIARIZATION_DEFAULT_MODEL,
+  DIARIZATION_MODEL_CUSTOM_OPTION,
+  DIARIZATION_SORTFORMER_OPTION,
+  FAMILY_CHOICE_IDS,
+  type FamilyChoiceId,
+  defaultMainModelFor,
+  diarizationTilesFor,
+  familyChoiceForModel,
+  familyChoicesFor,
+  liveTilesFor,
+  modelsForFamilyChoice,
+} from './instanceMatrix';
+import { MODEL_REGISTRY } from './modelRegistry';
+import { MAIN_RECOMMENDED_MODEL, VULKAN_RECOMMENDED_MODEL, WHISPER_MEDIUM } from './modelSelection';
+import type { RuntimeProfile } from '../types/runtime';
+
+const RUNTIMES: RuntimeProfile[] = ['gpu', 'cpu', 'vulkan', 'vulkan-wsl2', 'metal'];
+
+/**
+ * The verified compatibility matrix (design spec 2026-07-11, section 3).
+ * true = selectable as main transcriber on that runtime profile.
+ */
+const EXPECTED_FAMILY_MATRIX: Record<FamilyChoiceId, Record<RuntimeProfile, boolean>> = {
+  whisper: { gpu: true, cpu: true, vulkan: false, 'vulkan-wsl2': false, metal: false },
+  parakeet: { gpu: true, cpu: false, vulkan: false, 'vulkan-wsl2': false, metal: false },
+  canary: { gpu: true, cpu: false, vulkan: false, 'vulkan-wsl2': false, metal: false },
+  sensevoice: { gpu: true, cpu: true, vulkan: false, 'vulkan-wsl2': false, metal: false },
+  vibevoice: { gpu: true, cpu: true, vulkan: false, 'vulkan-wsl2': false, metal: false },
+  whispercpp: { gpu: false, cpu: false, vulkan: true, 'vulkan-wsl2': true, metal: false },
+  'mlx-whisper': { gpu: false, cpu: false, vulkan: false, 'vulkan-wsl2': false, metal: true },
+  'mlx-parakeet': { gpu: false, cpu: false, vulkan: false, 'vulkan-wsl2': false, metal: true },
+  'mlx-canary': { gpu: false, cpu: false, vulkan: false, 'vulkan-wsl2': false, metal: true },
+  'mlx-vibevoice': { gpu: false, cpu: false, vulkan: false, 'vulkan-wsl2': false, metal: true },
+};
+
+const REPRESENTATIVE_MODEL: Record<FamilyChoiceId, string> = {
+  whisper: 'Systran/faster-whisper-large-v3',
+  parakeet: 'nvidia/parakeet-tdt-0.6b-v3',
+  canary: 'nvidia/canary-1b-v2',
+  sensevoice: 'iic/SenseVoiceSmall',
+  vibevoice: 'microsoft/VibeVoice-ASR',
+  whispercpp: 'ggml-large-v3-turbo-q8_0.bin',
+  'mlx-whisper': 'mlx-community/whisper-large-v3-turbo-asr-fp16',
+  'mlx-parakeet': 'mlx-community/parakeet-tdt-0.6b-v3',
+  'mlx-canary': 'eelcor/canary-1b-v2-mlx',
+  'mlx-vibevoice': 'mlx-community/VibeVoice-ASR-4bit',
+};
+
+describe('instanceMatrix: familyChoicesFor', () => {
+  it.each(RUNTIMES)('%s exposes every family choice exactly once', (runtime) => {
+    const ids = familyChoicesFor(runtime).map((c) => c.id);
+    expect([...ids].sort()).toEqual([...FAMILY_CHOICE_IDS].sort());
+  });
+
+  for (const runtime of RUNTIMES) {
+    for (const id of FAMILY_CHOICE_IDS) {
+      const expected = EXPECTED_FAMILY_MATRIX[id][runtime];
+      it(`${runtime} × ${id} → ${expected ? 'enabled' : 'disabled'}`, () => {
+        const choice = familyChoicesFor(runtime).find((c) => c.id === id);
+        expect(choice).toBeDefined();
+        expect(choice!.enabled).toBe(expected);
+        if (!expected) {
+          expect(choice!.reason).toBeTruthy();
+        }
+      });
+    }
+  }
+
+  it('NeMo families on cpu carry an NVIDIA reason (mirrors applyCpuModelDefaults)', () => {
+    const choices = familyChoicesFor('cpu');
+    for (const id of ['parakeet', 'canary'] as const) {
+      expect(choices.find((c) => c.id === id)?.reason).toMatch(/NVIDIA/i);
+    }
+  });
+
+  it('sensevoice/vibevoice on cpu warn about speed but stay selectable', () => {
+    const choices = familyChoicesFor('cpu');
+    for (const id of ['sensevoice', 'vibevoice'] as const) {
+      const choice = choices.find((c) => c.id === id)!;
+      expect(choice.enabled).toBe(true);
+      expect(choice.hint).toMatch(/cpu/i);
+    }
+  });
+});
+
+describe('instanceMatrix: familyChoiceForModel', () => {
+  it.each(Object.entries(REPRESENTATIVE_MODEL))('classifies %s exemplar', (id, model) => {
+    expect(familyChoiceForModel(model)).toBe(id);
+  });
+
+  it('classifies every main-role registry model into an existing choice', () => {
+    for (const model of MODEL_REGISTRY.filter((m) => m.roles.includes('main'))) {
+      const choice = familyChoiceForModel(model.id);
+      expect(choice, model.id).not.toBeNull();
+      expect(FAMILY_CHOICE_IDS).toContain(choice!);
+    }
+  });
+
+  it('returns null for empty and sentinel values', () => {
+    expect(familyChoiceForModel('')).toBeNull();
+    expect(familyChoiceForModel(null)).toBeNull();
+    expect(familyChoiceForModel(undefined)).toBeNull();
+    expect(familyChoiceForModel('__none__')).toBeNull();
+  });
+
+  it('keeps MLX VibeVoice out of the CUDA VibeVoice family (registry ordering bug guard)', () => {
+    expect(familyChoiceForModel('mlx-community/VibeVoice-ASR-bf16')).toBe('mlx-vibevoice');
+  });
+});
+
+describe('instanceMatrix: modelsForFamilyChoice consistency with MODEL_REGISTRY', () => {
+  it.each(FAMILY_CHOICE_IDS)('%s has at least one registry model', (id) => {
+    expect(modelsForFamilyChoice(id).length).toBeGreaterThan(0);
+  });
+
+  it('partitions the main-role registry without overlap or loss', () => {
+    const mains = MODEL_REGISTRY.filter((m) => m.roles.includes('main'));
+    const seen = new Map<string, FamilyChoiceId>();
+    for (const id of FAMILY_CHOICE_IDS) {
+      for (const model of modelsForFamilyChoice(id)) {
+        expect(seen.has(model.id), `${model.id} in two families`).toBe(false);
+        seen.set(model.id, id);
+      }
+    }
+    expect(seen.size).toBe(mains.length);
+  });
+
+  it('registry requiresRuntime agrees with the family matrix', () => {
+    for (const id of FAMILY_CHOICE_IDS) {
+      for (const model of modelsForFamilyChoice(id)) {
+        if (model.requiresRuntime === 'vulkan') {
+          expect(EXPECTED_FAMILY_MATRIX[id].vulkan, model.id).toBe(true);
+        }
+        if (model.requiresRuntime === 'cuda') {
+          expect(EXPECTED_FAMILY_MATRIX[id].gpu, model.id).toBe(true);
+          expect(EXPECTED_FAMILY_MATRIX[id].metal, model.id).toBe(false);
+        }
+      }
+    }
+  });
+
+  it('only whisper and whispercpp registry models carry the live role (backend live.py gate)', () => {
+    for (const model of MODEL_REGISTRY.filter((m) => m.roles.includes('live'))) {
+      expect(['whisper', 'whispercpp']).toContain(familyChoiceForModel(model.id));
+    }
+  });
+});
+
+describe('instanceMatrix: liveTilesFor (full cross-product)', () => {
+  const LIVE_CAPABLE_MAINS: FamilyChoiceId[] = ['whisper', 'whispercpp'];
+  for (const runtime of RUNTIMES) {
+    for (const mainId of FAMILY_CHOICE_IDS) {
+      if (!EXPECTED_FAMILY_MATRIX[mainId][runtime]) continue; // impossible combo
+      const mainModel = REPRESENTATIVE_MODEL[mainId];
+      it(`${runtime} + main=${mainId}`, () => {
+        const tiles = liveTilesFor(runtime, mainModel);
+        const byId = new Map(tiles.map((t) => [t.id, t]));
+        expect(byId.get('same-as-main')!.enabled).toBe(LIVE_CAPABLE_MAINS.includes(mainId));
+        expect(byId.get('disabled')!.enabled).toBe(true);
+        // faster-whisper live decoding works everywhere (CPU fallback on
+        // vulkan/metal — server/backend/pyproject.toml mlx extra ships it).
+        const whisper = byId.get('whisper')!;
+        expect(whisper.enabled).toBe(true);
+        if (runtime === 'metal' || runtime === 'vulkan' || runtime === 'vulkan-wsl2') {
+          expect(whisper.hint).toMatch(/cpu/i);
+        }
+        const ggml = byId.get('whispercpp')!;
+        expect(ggml.enabled).toBe(runtime === 'vulkan' || runtime === 'vulkan-wsl2');
+      });
+    }
+  }
+
+  it('same-as-main explains why it is unavailable for non-live mains', () => {
+    const tiles = liveTilesFor('gpu', REPRESENTATIVE_MODEL.parakeet);
+    const same = tiles.find((t) => t.id === 'same-as-main')!;
+    expect(same.enabled).toBe(false);
+    expect(same.reason).toBeTruthy();
+  });
+});
+
+describe('instanceMatrix: diarizationTilesFor (full cross-product)', () => {
+  for (const runtime of RUNTIMES) {
+    for (const mainId of FAMILY_CHOICE_IDS) {
+      if (!EXPECTED_FAMILY_MATRIX[mainId][runtime]) continue;
+      const mainModel = REPRESENTATIVE_MODEL[mainId];
+      it(`${runtime} + main=${mainId}`, () => {
+        const tiles = diarizationTilesFor(runtime, mainModel);
+        const byId = new Map(tiles.map((t) => [t.id, t]));
+
+        if (mainId === 'whispercpp') {
+          // whisper.cpp mains cannot diarize at all.
+          expect(tiles).toHaveLength(0);
+          return;
+        }
+        if (mainId === 'vibevoice' || mainId === 'mlx-vibevoice') {
+          // VibeVoice diarizes natively; the engine choice is locked.
+          expect(tiles).toHaveLength(1);
+          expect(tiles[0].id).toBe('builtin');
+          expect(tiles[0].enabled).toBe(true);
+          expect(tiles[0].isDefault).toBe(true);
+          return;
+        }
+
+        expect(byId.get('builtin')).toBeUndefined();
+        const pyannote = byId.get('pyannote')!;
+        expect(pyannote.enabled).toBe(true);
+        expect(pyannote.storedValue).toBe(DIARIZATION_DEFAULT_MODEL);
+
+        const campp = byId.get('campp')!;
+        expect(campp.enabled).toBe(mainId === 'sensevoice');
+        expect(campp.storedValue).toBe(DIARIZATION_CAMPP_OPTION);
+        if (mainId !== 'sensevoice') expect(campp.reason).toBe('SenseVoice only');
+
+        const sortformer = byId.get('sortformer')!;
+        expect(sortformer.enabled).toBe(runtime === 'metal');
+        expect(sortformer.storedValue).toBe(DIARIZATION_SORTFORMER_OPTION);
+        if (runtime !== 'metal') expect(sortformer.reason).toBe('Requires Metal');
+
+        expect(byId.get('custom')!.enabled).toBe(true);
+        expect(byId.get('custom')!.storedValue).toBe(DIARIZATION_MODEL_CUSTOM_OPTION);
+
+        // Exactly one default, and it matches the engine hierarchy.
+        const defaults = tiles.filter((t) => t.isDefault);
+        expect(defaults).toHaveLength(1);
+        if (mainId === 'sensevoice') expect(defaults[0].id).toBe('campp');
+        else if (runtime === 'metal') expect(defaults[0].id).toBe('sortformer');
+        else expect(defaults[0].id).toBe('pyannote');
+      });
+    }
+  }
+
+  it('keeps the persisted option strings stable (electron-store compat)', () => {
+    expect(DIARIZATION_CAMPP_OPTION).toBe('CAM++ (fast, built-in)');
+    expect(DIARIZATION_SORTFORMER_OPTION).toBe('Sortformer (Metal; ≤ 4 speakers)');
+    expect(DIARIZATION_DEFAULT_MODEL).toBe('pyannote/speaker-diarization-community-1');
+    expect(DIARIZATION_MODEL_CUSTOM_OPTION).toBe('Custom (HuggingFace repo)');
+    expect(DIARIZATION_BUILTIN_LABEL).toBeTruthy();
+  });
+
+  it('custom mains fall back to whisper-like diarization rules', () => {
+    const tiles = diarizationTilesFor('gpu', 'someone/finetuned-whisper');
+    expect(tiles.find((t) => t.id === 'pyannote')!.enabled).toBe(true);
+    expect(tiles.find((t) => t.id === 'campp')!.enabled).toBe(false);
+  });
+
+  it('disabled main keeps the server-wide pyannote default available', () => {
+    const tiles = diarizationTilesFor('gpu', '__none__');
+    expect(tiles.find((t) => t.id === 'pyannote')!.enabled).toBe(true);
+  });
+});
+
+describe('instanceMatrix: defaultMainModelFor', () => {
+  it('matches per-runtime recommended defaults', () => {
+    expect(defaultMainModelFor('gpu')).toBe(MAIN_RECOMMENDED_MODEL);
+    expect(defaultMainModelFor('cpu')).toBe(WHISPER_MEDIUM);
+    expect(defaultMainModelFor('vulkan')).toBe(VULKAN_RECOMMENDED_MODEL);
+    expect(defaultMainModelFor('vulkan-wsl2')).toBe(VULKAN_RECOMMENDED_MODEL);
+    expect(defaultMainModelFor('metal')).toBe('mlx-community/parakeet-tdt-0.6b-v3');
+  });
+
+  it('every default is enabled on its own runtime', () => {
+    for (const runtime of RUNTIMES) {
+      const model = defaultMainModelFor(runtime);
+      const choice = familyChoiceForModel(model)!;
+      expect(EXPECTED_FAMILY_MATRIX[choice][runtime], `${runtime} → ${model}`).toBe(true);
+    }
+  });
+});

--- a/dashboard/src/services/instanceMatrix.ts
+++ b/dashboard/src/services/instanceMatrix.ts
@@ -1,0 +1,477 @@
+/**
+ * Single source of truth for the Instance Settings compatibility matrix:
+ * which model families, live-mode options and diarization engines are valid
+ * for each runtime profile. The Server tab selectors render from this module
+ * and instanceMatrix.test.ts verifies the full cross-product against the
+ * design spec (docs/superpowers/specs/2026-07-11-server-tab-matrix-redesign-design.md).
+ *
+ * Backend gates mirrored here:
+ * - live.py: only whisper / whispercpp backends may serve Live Mode
+ * - dockerManager applyCpuModelDefaults: NeMo mains are substituted on cpu
+ * - config.py resolve_sensevoice_diarization_engine: CAM++ is SenseVoice-only
+ * - diarization_engine.py create_diarization_engine: Sortformer needs mlx-audio (Metal)
+ * - base.py use_integrated_diarization_for: VibeVoice always diarizes natively
+ */
+import type { RuntimeProfile } from '../types/runtime';
+import {
+  isCanaryModel,
+  isMLXCanaryModel,
+  isMLXModel,
+  isMLXParakeetModel,
+  isParakeetModel,
+  isSenseVoiceModel,
+  isVibeVoiceASRModel,
+  isWhisperCppModel,
+} from './modelCapabilities';
+import { MODEL_REGISTRY, type ModelInfo } from './modelRegistry';
+import {
+  DISABLED_MODEL_SENTINEL,
+  MAIN_RECOMMENDED_MODEL,
+  MODEL_DEFAULT_LOADING_PLACEHOLDER,
+  MODEL_DISABLED_OPTION,
+  VULKAN_RECOMMENDED_MODEL,
+  WHISPER_MEDIUM,
+} from './modelSelection';
+
+// Persisted option strings — stored verbatim in electron-store
+// (server.diarizationModelSelection); values must never change.
+export const DIARIZATION_SORTFORMER_OPTION = 'Sortformer (Metal; ≤ 4 speakers)';
+export const DIARIZATION_DEFAULT_MODEL = 'pyannote/speaker-diarization-community-1';
+export const DIARIZATION_MODEL_CUSTOM_OPTION = 'Custom (HuggingFace repo)';
+export const DIARIZATION_CAMPP_OPTION = 'CAM++ (fast, built-in)';
+export const DIARIZATION_BUILTIN_LABEL = 'Built-in';
+
+export const MLX_DEFAULT_MODEL = 'mlx-community/parakeet-tdt-0.6b-v3';
+
+export const FAMILY_CHOICE_IDS = [
+  'whisper',
+  'parakeet',
+  'canary',
+  'sensevoice',
+  'vibevoice',
+  'whispercpp',
+  'mlx-whisper',
+  'mlx-parakeet',
+  'mlx-canary',
+  'mlx-vibevoice',
+] as const;
+export type FamilyChoiceId = (typeof FAMILY_CHOICE_IDS)[number];
+
+export type FamilyAccent = 'slate' | 'green' | 'yellow' | 'amber' | 'blue' | 'purple' | 'orange';
+
+export interface FamilyCapabilities {
+  /** Rough language count shown on the tile. */
+  languages: string;
+  translation: 'none' | 'english' | 'multilingual';
+  live: boolean;
+  diarization: 'pyannote' | 'campp' | 'sortformer' | 'builtin' | 'none';
+  /** Whether the default diarization engine needs a HuggingFace token. */
+  requiresToken: boolean;
+}
+
+export interface FamilyChoice {
+  id: FamilyChoiceId;
+  label: string;
+  sublabel: string;
+  accent: FamilyAccent;
+  enabled: boolean;
+  reason?: string;
+  hint?: string;
+  capabilities: FamilyCapabilities;
+}
+
+interface FamilyMeta {
+  label: string;
+  sublabel: string;
+  accent: FamilyAccent;
+  capabilities: FamilyCapabilities;
+}
+
+const FAMILY_META: Record<FamilyChoiceId, FamilyMeta> = {
+  whisper: {
+    label: 'Whisper',
+    sublabel: 'faster-whisper / WhisperX',
+    accent: 'slate',
+    capabilities: {
+      languages: '90+',
+      translation: 'english',
+      live: true,
+      diarization: 'pyannote',
+      requiresToken: true,
+    },
+  },
+  parakeet: {
+    label: 'Parakeet v3',
+    sublabel: 'NVIDIA NeMo',
+    accent: 'green',
+    capabilities: {
+      languages: '25',
+      translation: 'none',
+      live: false,
+      diarization: 'pyannote',
+      requiresToken: true,
+    },
+  },
+  canary: {
+    label: 'Canary v2',
+    sublabel: 'NVIDIA NeMo',
+    accent: 'yellow',
+    capabilities: {
+      languages: '25',
+      translation: 'multilingual',
+      live: false,
+      diarization: 'pyannote',
+      requiresToken: true,
+    },
+  },
+  sensevoice: {
+    label: 'SenseVoice',
+    sublabel: 'FunASR',
+    accent: 'amber',
+    capabilities: {
+      languages: '5',
+      translation: 'none',
+      live: false,
+      diarization: 'campp',
+      requiresToken: false,
+    },
+  },
+  vibevoice: {
+    label: 'VibeVoice',
+    sublabel: 'Microsoft ASR',
+    accent: 'blue',
+    capabilities: {
+      languages: '51',
+      translation: 'none',
+      live: false,
+      diarization: 'builtin',
+      requiresToken: false,
+    },
+  },
+  whispercpp: {
+    label: 'Whisper.cpp',
+    sublabel: 'GGML via Vulkan',
+    accent: 'purple',
+    capabilities: {
+      languages: '90+',
+      translation: 'english',
+      live: true,
+      diarization: 'none',
+      requiresToken: false,
+    },
+  },
+  'mlx-whisper': {
+    label: 'MLX Whisper',
+    sublabel: 'Apple Silicon',
+    accent: 'orange',
+    capabilities: {
+      languages: '90+',
+      translation: 'english',
+      live: false,
+      diarization: 'sortformer',
+      requiresToken: false,
+    },
+  },
+  'mlx-parakeet': {
+    label: 'MLX Parakeet',
+    sublabel: 'Apple Silicon',
+    accent: 'green',
+    capabilities: {
+      languages: '25',
+      translation: 'none',
+      live: false,
+      diarization: 'sortformer',
+      requiresToken: false,
+    },
+  },
+  'mlx-canary': {
+    label: 'MLX Canary',
+    sublabel: 'Apple Silicon',
+    accent: 'yellow',
+    capabilities: {
+      languages: '25',
+      translation: 'none',
+      live: false,
+      diarization: 'sortformer',
+      requiresToken: false,
+    },
+  },
+  'mlx-vibevoice': {
+    label: 'MLX VibeVoice',
+    sublabel: 'Apple Silicon',
+    accent: 'blue',
+    capabilities: {
+      languages: '51',
+      translation: 'none',
+      live: false,
+      diarization: 'builtin',
+      requiresToken: false,
+    },
+  },
+};
+
+const REASON_REQUIRES_CUDA = 'Requires CUDA';
+const REASON_REQUIRES_VULKAN = 'Requires Vulkan';
+const REASON_REQUIRES_APPLE_SILICON = 'Requires Apple Silicon';
+const REASON_REQUIRES_DOCKER = 'Requires Docker';
+const REASON_REQUIRES_NVIDIA = 'Requires NVIDIA GPU';
+const HINT_SLOW_ON_CPU = 'Slow on CPU';
+const HINT_RUNS_ON_CPU = 'Runs on CPU';
+
+const MLX_FAMILIES: readonly FamilyChoiceId[] = [
+  'mlx-whisper',
+  'mlx-parakeet',
+  'mlx-canary',
+  'mlx-vibevoice',
+];
+
+function isVulkanProfile(runtime: RuntimeProfile): boolean {
+  return runtime === 'vulkan' || runtime === 'vulkan-wsl2';
+}
+
+/**
+ * Availability + disabled-reason for one family on one runtime.
+ * This is the single place the family × runtime truth table lives.
+ */
+function familyAvailability(
+  id: FamilyChoiceId,
+  runtime: RuntimeProfile,
+): { enabled: boolean; reason?: string; hint?: string } {
+  if (MLX_FAMILIES.includes(id)) {
+    return runtime === 'metal'
+      ? { enabled: true }
+      : { enabled: false, reason: REASON_REQUIRES_APPLE_SILICON };
+  }
+  if (id === 'whispercpp') {
+    return isVulkanProfile(runtime)
+      ? { enabled: true }
+      : { enabled: false, reason: REASON_REQUIRES_VULKAN };
+  }
+  // CUDA-stack families (run in the Docker torch image).
+  if (runtime === 'metal') return { enabled: false, reason: REASON_REQUIRES_DOCKER };
+  if (isVulkanProfile(runtime)) return { enabled: false, reason: REASON_REQUIRES_CUDA };
+  if (runtime === 'cpu') {
+    if (id === 'parakeet' || id === 'canary') {
+      // dockerManager substitutes NeMo mains with faster-whisper on cpu;
+      // surface that as an explicit disable instead of a silent swap.
+      return { enabled: false, reason: REASON_REQUIRES_NVIDIA };
+    }
+    if (id === 'sensevoice' || id === 'vibevoice') {
+      return { enabled: true, hint: HINT_SLOW_ON_CPU };
+    }
+  }
+  return { enabled: true };
+}
+
+export function familyChoicesFor(runtime: RuntimeProfile): FamilyChoice[] {
+  return FAMILY_CHOICE_IDS.map((id) => {
+    const meta = FAMILY_META[id];
+    const availability = familyAvailability(id, runtime);
+    return { id, ...meta, ...availability };
+  });
+}
+
+export function isFamilyChoiceEnabledFor(id: FamilyChoiceId, runtime: RuntimeProfile): boolean {
+  return familyAvailability(id, runtime).enabled;
+}
+
+/**
+ * Classify a concrete model id (including custom HF repos) into a family
+ * choice. MLX checks run first: mlx-community/VibeVoice-ASR-* also matches
+ * the generic VibeVoice pattern (same ordering as backend factory.py).
+ */
+export function familyChoiceForModel(modelId: string | null | undefined): FamilyChoiceId | null {
+  const name = (modelId ?? '').trim();
+  if (
+    !name ||
+    name === DISABLED_MODEL_SENTINEL ||
+    name === MODEL_DISABLED_OPTION ||
+    name === MODEL_DEFAULT_LOADING_PLACEHOLDER
+  ) {
+    return null;
+  }
+  if (isMLXParakeetModel(name)) return 'mlx-parakeet';
+  if (isMLXCanaryModel(name)) return 'mlx-canary';
+  if (isMLXModel(name)) {
+    return /vibevoice/i.test(name) ? 'mlx-vibevoice' : 'mlx-whisper';
+  }
+  if (isParakeetModel(name)) return 'parakeet';
+  if (isCanaryModel(name)) return 'canary';
+  if (isSenseVoiceModel(name)) return 'sensevoice';
+  if (isVibeVoiceASRModel(name)) return 'vibevoice';
+  if (isWhisperCppModel(name)) return 'whispercpp';
+  return 'whisper';
+}
+
+export function modelsForFamilyChoice(choice: FamilyChoiceId): ModelInfo[] {
+  return MODEL_REGISTRY.filter(
+    (m) => m.roles.includes('main') && familyChoiceForModel(m.id) === choice,
+  );
+}
+
+/**
+ * The model a family tile selects when clicked: the curated recommendation
+ * where one exists, else the family's first registry entry.
+ */
+export function defaultModelForFamilyChoice(choice: FamilyChoiceId): string {
+  if (choice === 'whispercpp') return VULKAN_RECOMMENDED_MODEL;
+  if (choice === 'parakeet') return MAIN_RECOMMENDED_MODEL;
+  if (choice === 'mlx-parakeet') return MLX_DEFAULT_MODEL;
+  return modelsForFamilyChoice(choice)[0]?.id ?? '';
+}
+
+export function defaultMainModelFor(runtime: RuntimeProfile): string {
+  switch (runtime) {
+    case 'metal':
+      return MLX_DEFAULT_MODEL;
+    case 'vulkan':
+    case 'vulkan-wsl2':
+      return VULKAN_RECOMMENDED_MODEL;
+    case 'cpu':
+      // Matches dockerManager applyCpuModelDefaults' substitution target.
+      return WHISPER_MEDIUM;
+    default:
+      return MAIN_RECOMMENDED_MODEL;
+  }
+}
+
+export type LiveTileId = 'same-as-main' | 'whisper' | 'whispercpp' | 'disabled';
+
+export interface LiveTile {
+  id: LiveTileId;
+  label: string;
+  enabled: boolean;
+  reason?: string;
+  hint?: string;
+}
+
+/**
+ * Live Mode options for a runtime + main model. Only whisper-family and
+ * whisper.cpp backends may serve Live Mode (live.py gate); faster-whisper
+ * decodes on CPU where CUDA is absent — the Metal venv ships it for exactly
+ * this purpose.
+ */
+export function liveTilesFor(
+  runtime: RuntimeProfile,
+  mainModelId: string | null | undefined,
+): LiveTile[] {
+  const mainChoice = familyChoiceForModel(mainModelId);
+  const mainIsLiveCapable = mainChoice === 'whisper' || mainChoice === 'whispercpp';
+  const cpuDecode = runtime === 'metal' || isVulkanProfile(runtime);
+  return [
+    {
+      id: 'same-as-main',
+      label: 'Same as main',
+      enabled: mainIsLiveCapable,
+      reason: mainIsLiveCapable ? undefined : 'Main model has no Live Mode',
+    },
+    {
+      id: 'whisper',
+      label: 'Faster-Whisper',
+      enabled: true,
+      hint: cpuDecode ? HINT_RUNS_ON_CPU : undefined,
+    },
+    {
+      id: 'whispercpp',
+      label: 'Whisper.cpp',
+      enabled: isVulkanProfile(runtime),
+      reason: isVulkanProfile(runtime) ? undefined : REASON_REQUIRES_VULKAN,
+    },
+    {
+      id: 'disabled',
+      label: 'Disabled',
+      enabled: true,
+    },
+  ];
+}
+
+export function liveModelsFor(runtime: RuntimeProfile): ModelInfo[] {
+  const family: FamilyChoiceId = isVulkanProfile(runtime) ? 'whispercpp' : 'whisper';
+  return MODEL_REGISTRY.filter(
+    (m) => m.roles.includes('live') && familyChoiceForModel(m.id) === family,
+  );
+}
+
+export type DiarizationTileId = 'pyannote' | 'campp' | 'sortformer' | 'builtin' | 'custom';
+
+export interface DiarizationTile {
+  id: DiarizationTileId;
+  label: string;
+  /** Value persisted to server.diarizationModelSelection. */
+  storedValue: string;
+  enabled: boolean;
+  isDefault: boolean;
+  reason?: string;
+  hint?: string;
+}
+
+/**
+ * Diarization engine options for a runtime + main model.
+ * whisper.cpp mains → empty list (no diarization path exists);
+ * VibeVoice mains → single locked "Built-in" tile (the backend always uses
+ * its native diarization regardless of configuration).
+ */
+export function diarizationTilesFor(
+  runtime: RuntimeProfile,
+  mainModelId: string | null | undefined,
+): DiarizationTile[] {
+  const mainChoice = familyChoiceForModel(mainModelId);
+  if (mainChoice === 'whispercpp') return [];
+  if (mainChoice === 'vibevoice' || mainChoice === 'mlx-vibevoice') {
+    return [
+      {
+        id: 'builtin',
+        label: DIARIZATION_BUILTIN_LABEL,
+        storedValue: '',
+        enabled: true,
+        isDefault: true,
+        hint: 'VibeVoice identifies speakers natively',
+      },
+    ];
+  }
+
+  const isSenseVoiceMain = mainChoice === 'sensevoice';
+  const isMetal = runtime === 'metal';
+  const defaultId: DiarizationTileId = isSenseVoiceMain
+    ? 'campp'
+    : isMetal
+      ? 'sortformer'
+      : 'pyannote';
+
+  return [
+    {
+      id: 'campp',
+      label: 'CAM++',
+      storedValue: DIARIZATION_CAMPP_OPTION,
+      enabled: isSenseVoiceMain,
+      isDefault: defaultId === 'campp',
+      reason: isSenseVoiceMain ? undefined : 'SenseVoice only',
+      hint: isSenseVoiceMain ? 'No token needed' : undefined,
+    },
+    {
+      id: 'sortformer',
+      label: 'Sortformer',
+      storedValue: DIARIZATION_SORTFORMER_OPTION,
+      enabled: isMetal,
+      isDefault: defaultId === 'sortformer',
+      reason: isMetal ? undefined : 'Requires Metal',
+      hint: isMetal ? 'No token · up to 4 speakers' : undefined,
+    },
+    {
+      id: 'pyannote',
+      label: 'PyAnnote',
+      storedValue: DIARIZATION_DEFAULT_MODEL,
+      enabled: true,
+      isDefault: defaultId === 'pyannote',
+      hint: 'HuggingFace token required',
+    },
+    {
+      id: 'custom',
+      label: 'Custom',
+      storedValue: DIARIZATION_MODEL_CUSTOM_OPTION,
+      enabled: true,
+      isDefault: false,
+      hint: 'HuggingFace repo',
+    },
+  ];
+}

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.0.60",
-  "contract_sha256": "205affbf70519656686f02f6a9db7e0567b2406d9ce18238bb2d02e28ddb968e",
-  "updated_at": "2026-06-28T08:24:20.759Z"
+  "spec_version": "1.1.0",
+  "contract_sha256": "16caf2da9ede97dc76a0117064c86c02834e48ce2a695308347140c7ee72df5c",
+  "updated_at": "2026-07-11T18:11:59.700Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,10 +1,10 @@
 meta:
-  spec_version: 1.0.60
+  spec_version: 1.1.0
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
   generated_from:
-    repo_path: /home/Bill/Code_Projects/Python_Projects/TranscriptionSuite/dashboard
+    repo_path: /home/Bill/Code_Projects/Python_Projects/TranscriptionSuite/.claude/worktrees/server-tab-matrix-redesign/dashboard
     source_files:
       - App.tsx
       - components/__tests__/AddNoteModal.canary-language.test.tsx
@@ -68,6 +68,8 @@ meta:
       - components/ui/LogTerminal.tsx
       - components/ui/PersistentInfoBanner.tsx
       - components/ui/QueuePausedBanner.tsx
+      - components/ui/SelectorGroup.tsx
+      - components/ui/SelectorTile.tsx
       - components/ui/ShortcutCapture.tsx
       - components/ui/StatusLight.test.tsx
       - components/ui/StatusLight.tsx
@@ -88,6 +90,8 @@ meta:
       - components/views/ModelManagerTab.tsx
       - components/views/ModelManagerView.tsx
       - components/views/NotebookView.tsx
+      - components/views/server/InstanceSettingsSelectors.tsx
+      - components/views/server/RemoteConnectionCard.tsx
       - components/views/ServerConfigEditor.tsx
       - components/views/ServerView.tsx
       - components/views/SessionImportTab.tsx
@@ -98,7 +102,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-06-28T08:24:10.018Z
+    generated_at: 2026-07-11T18:11:50.540Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -190,22 +194,27 @@ foundation:
         - rgba(0, 0, 0, 0.7)
         - rgba(0,0,0,0.3)
         - rgba(0,0,0,0.4)
-        - rgba(167,139,250,0.15)
+        - rgba(192,132,252,0.2)
+        - rgba(203,213,225,0.2)
         - rgba(217, 70, 239, 0.5)
         - rgba(217,70,239,0.5)
         - rgba(22,31,50,0.9)
         - rgba(22,31,50,0.95)
+        - rgba(232,121,249,0.2)
+        - rgba(232,121,249,0.5)
         - rgba(239,22,238,0.5)
         - rgba(239,68,68,0.35)
         - rgba(239,68,68,0.6)
-        - rgba(244,63,94,0.15)
+        - rgba(248,113,113,0.2)
+        - rgba(250,204,21,0.2)
         - rgba(251, 146, 60, 0.3)
+        - rgba(251,146,60,0.2)
         - rgba(251,146,60,0.3)
         - rgba(251,146,60,0.5)
+        - rgba(251,191,36,0.2)
         - rgba(255, 255, 255, 0.1)
         - rgba(255, 255, 255, 0.2)
         - rgba(255, 255, 255, 0.4)
-        - rgba(255,145,0,0.15)
         - rgba(255,255,255,0.3)
         - rgba(34, 211, 238, 0.4)
         - rgba(34, 211, 238, 0.6)
@@ -217,6 +226,8 @@ foundation:
         - rgba(34,211,238,0.4)
         - rgba(34,211,238,0.5)
         - rgba(34,211,238,0.6)
+        - rgba(74,222,128,0.2)
+        - rgba(96,165,250,0.2)
         - rgba(96,165,250,0.6)
       accent_scale: *a1
       glass_scale: *a2
@@ -267,8 +278,20 @@ foundation:
       classes:
         - shadow
         - shadow-[0_0_10px_#22d3ee]
+        - shadow-[0_0_12px_rgba(192,132,252,0.2)]
+        - shadow-[0_0_12px_rgba(203,213,225,0.2)]
+        - shadow-[0_0_12px_rgba(232,121,249,0.2)]
+        - shadow-[0_0_12px_rgba(248,113,113,0.2)]
+        - shadow-[0_0_12px_rgba(250,204,21,0.2)]
+        - shadow-[0_0_12px_rgba(251,146,60,0.2)]
+        - shadow-[0_0_12px_rgba(251,191,36,0.2)]
+        - shadow-[0_0_12px_rgba(34,211,238,0.2)]
+        - shadow-[0_0_12px_rgba(74,222,128,0.2)]
+        - shadow-[0_0_12px_rgba(96,165,250,0.2)]
+        - shadow-[0_0_15px_rgba(251,146,60,0.5)]
         - shadow-[0_0_15px_rgba(34,211,238,0.2)]
-        - shadow-[0_0_15px_rgba(34,211,238,0.2)]!
+        - shadow-[0_0_15px_rgba(34,211,238,0.5)]
+        - shadow-[0_0_18px_rgba(239,68,68,0.35)]
         - shadow-[0_0_20px_rgba(255,255,255,0.3)]
         - shadow-[0_0_5px_rgba(217,70,239,0.5)]
         - shadow-[0_0_5px_rgba(239,22,238,0.5)]
@@ -358,8 +381,20 @@ foundation:
         - min-w-[5rem]
         - p-[3px]
         - shadow-[0_0_10px_#22d3ee]
+        - shadow-[0_0_12px_rgba(192,132,252,0.2)]
+        - shadow-[0_0_12px_rgba(203,213,225,0.2)]
+        - shadow-[0_0_12px_rgba(232,121,249,0.2)]
+        - shadow-[0_0_12px_rgba(248,113,113,0.2)]
+        - shadow-[0_0_12px_rgba(250,204,21,0.2)]
+        - shadow-[0_0_12px_rgba(251,146,60,0.2)]
+        - shadow-[0_0_12px_rgba(251,191,36,0.2)]
+        - shadow-[0_0_12px_rgba(34,211,238,0.2)]
+        - shadow-[0_0_12px_rgba(74,222,128,0.2)]
+        - shadow-[0_0_12px_rgba(96,165,250,0.2)]
+        - shadow-[0_0_15px_rgba(251,146,60,0.5)]
         - shadow-[0_0_15px_rgba(34,211,238,0.2)]
-        - shadow-[0_0_15px_rgba(34,211,238,0.2)]!
+        - shadow-[0_0_15px_rgba(34,211,238,0.5)]
+        - shadow-[0_0_18px_rgba(239,68,68,0.35)]
         - shadow-[0_0_20px_rgba(255,255,255,0.3)]
         - shadow-[0_0_5px_rgba(217,70,239,0.5)]
         - shadow-[0_0_5px_rgba(239,22,238,0.5)]
@@ -488,6 +523,7 @@ utility_allowlist:
     - bg-accent-orange
     - bg-accent-orange/10
     - bg-accent-orange/20
+    - bg-accent-rose/5
     - bg-accent-violet/15
     - bg-amber-400/10
     - bg-amber-400/20
@@ -503,6 +539,7 @@ utility_allowlist:
     - bg-black/50
     - bg-black/60
     - bg-black/70
+    - bg-black/75
     - bg-blue-400
     - bg-blue-400/10
     - bg-blue-400/20
@@ -519,6 +556,7 @@ utility_allowlist:
     - bg-glass-100/50
     - bg-glass-200
     - bg-glass-surface
+    - bg-green-400/10
     - bg-green-500
     - bg-green-500/10
     - bg-linear-to-b
@@ -527,15 +565,19 @@ utility_allowlist:
     - bg-linear-to-t
     - bg-neutral-700
     - bg-neutral-900
+    - bg-orange-400/10
     - bg-orange-500
     - bg-orange-500/10
+    - bg-purple-400/10
     - bg-purple-500
     - bg-purple-500/10
     - bg-red-400/10
     - bg-red-500
     - bg-red-500/10
     - bg-red-500/20
+    - bg-red-500/25
     - bg-red-500/5
+    - bg-slate-300/10
     - bg-slate-400/10
     - bg-slate-500
     - bg-slate-500/10
@@ -559,24 +601,30 @@ utility_allowlist:
     - border
     - border-2
     - border-4
+    - border-accent-amber/30
     - border-accent-cyan/10
     - border-accent-cyan/20
     - border-accent-cyan/30
     - border-accent-cyan/40
-    - border-accent-cyan/40!
+    - border-accent-cyan/60
     - border-accent-magenta/20
     - border-accent-magenta/5
+    - border-accent-magenta/60
     - border-accent-orange/20
+    - border-accent-orange/25
+    - border-accent-rose/20
     - border-amber-400/20
     - border-amber-400/25
     - border-amber-400/30
     - border-amber-400/40
+    - border-amber-400/60
     - border-amber-500/20
     - border-amber-500/30
     - border-amber-500/40
     - border-b
     - border-b-2
     - border-blue-400/30
+    - border-blue-400/60
     - border-blue-500/20
     - border-cyan-400/30
     - border-dashed
@@ -584,6 +632,7 @@ utility_allowlist:
     - border-emerald-400/40
     - border-glass-100
     - border-glass-border
+    - border-green-400/60
     - border-green-500/20
     - border-green-500/30
     - border-l
@@ -597,10 +646,16 @@ utility_allowlist:
     - border-l-red-500
     - border-l-slate-300
     - border-l-slate-500
+    - border-orange-400/60
     - border-orange-500/20
+    - border-purple-400/60
     - border-r
     - border-red-400/20
+    - border-red-400/40
+    - border-red-400/60
     - border-red-500/20
+    - border-red-500/25
+    - border-slate-300/60
     - border-slate-400/30
     - border-slate-500/40
     - border-slate-900
@@ -611,6 +666,7 @@ utility_allowlist:
     - border-white/5
     - border-yellow-400/20
     - border-yellow-400/30
+    - border-yellow-400/60
     - bottom-0
     - bottom-1
     - bottom-4
@@ -660,6 +716,7 @@ utility_allowlist:
     - from-slate-900/10
     - from-white/10
     - from-white/5
+    - gap-0.5
     - gap-1
     - gap-1.5
     - gap-2
@@ -671,6 +728,7 @@ utility_allowlist:
     - gap-8
     - gap-px
     - gap-x-3
+    - gap-y-1
     - grid
     - grid-cols-1
     - grid-cols-2
@@ -725,6 +783,7 @@ utility_allowlist:
     - hover:bg-red-500/10
     - hover:bg-red-500/20
     - hover:bg-red-500/30
+    - hover:bg-red-500/35
     - hover:bg-white/10
     - hover:bg-white/15
     - hover:bg-white/20
@@ -734,6 +793,7 @@ utility_allowlist:
     - hover:border-accent-cyan/50
     - hover:border-white/10
     - hover:border-white/20
+    - hover:border-white/25
     - hover:opacity-85
     - hover:scale-105
     - hover:shadow-accent-cyan/40
@@ -776,6 +836,7 @@ utility_allowlist:
     - left-8
     - lg:flex
     - lg:grid-cols-2
+    - lg:grid-cols-5
     - lg:p-10
     - line-clamp-2
     - m-0
@@ -807,10 +868,14 @@ utility_allowlist:
     - mb-4
     - mb-6
     - mb-8
+    - md:flex-row
     - md:grid-cols-2
     - md:grid-cols-4
+    - md:items-center
     - md:items-end
+    - md:justify-between
     - min-h-0
+    - min-h-20
     - min-h-32
     - min-h-full
     - min-height
@@ -824,6 +889,7 @@ utility_allowlist:
     - ml-0.5
     - ml-1
     - ml-2
+    - ml-3
     - ml-auto
     - ml-model
     - mr-1
@@ -848,6 +914,7 @@ utility_allowlist:
     - opacity-10
     - opacity-30
     - opacity-40
+    - opacity-45
     - opacity-50
     - opacity-60
     - opacity-70
@@ -873,6 +940,7 @@ utility_allowlist:
     - pb-0
     - pb-1
     - pb-10
+    - pb-2
     - pb-4
     - pb-8
     - pl-0
@@ -890,6 +958,7 @@ utility_allowlist:
     - pr-20
     - pr-3
     - pr-4
+    - pr-5
     - pr-6
     - pr-8
     - pt-0
@@ -926,7 +995,6 @@ utility_allowlist:
     - right-2
     - right-3
     - right-4
-    - right-align
     - ring-0
     - ring-1
     - ring-accent-cyan/20
@@ -970,6 +1038,8 @@ utility_allowlist:
     - slide-in-from-top-2
     - slide-in-from-top-4
     - sm:block
+    - sm:grid-cols-3
+    - sm:grid-cols-4
     - snap-mandatory
     - snap-start
     - snap-x
@@ -994,6 +1064,7 @@ utility_allowlist:
     - text-accent-cyan/80
     - text-accent-magenta
     - text-accent-orange
+    - text-accent-rose
     - text-accent-violet
     - text-accent-violet/80
     - text-amber-100
@@ -1026,7 +1097,9 @@ utility_allowlist:
     - text-orange-400
     - text-orange-500
     - text-purple-400
+    - text-red-100
     - text-red-200
+    - text-red-200/90
     - text-red-300
     - text-red-400
     - text-red-400/80
@@ -1040,6 +1113,7 @@ utility_allowlist:
     - text-slate-700
     - text-slate-900
     - text-sm
+    - text-violet-400
     - text-white
     - text-white/60
     - text-white/90
@@ -1125,6 +1199,7 @@ utility_allowlist:
     - bg-[#0f172a]
     - bg-[rgba(22,31,50,0.9)]
     - bg-[rgba(22,31,50,0.95)]
+    - bg-white/[0.02]
     - ease-[cubic-bezier(0.22,1,0.36,1)]
     - ease-[cubic-bezier(0.25,0.1,0.25,1)]
     - ease-[cubic-bezier(0.32,0.72,0,1)]
@@ -1142,8 +1217,20 @@ utility_allowlist:
     - min-w-[5rem]
     - p-[3px]
     - shadow-[0_0_10px_#22d3ee]
+    - shadow-[0_0_12px_rgba(192,132,252,0.2)]
+    - shadow-[0_0_12px_rgba(203,213,225,0.2)]
+    - shadow-[0_0_12px_rgba(232,121,249,0.2)]
+    - shadow-[0_0_12px_rgba(248,113,113,0.2)]
+    - shadow-[0_0_12px_rgba(250,204,21,0.2)]
+    - shadow-[0_0_12px_rgba(251,146,60,0.2)]
+    - shadow-[0_0_12px_rgba(251,191,36,0.2)]
+    - shadow-[0_0_12px_rgba(34,211,238,0.2)]
+    - shadow-[0_0_12px_rgba(74,222,128,0.2)]
+    - shadow-[0_0_12px_rgba(96,165,250,0.2)]
+    - shadow-[0_0_15px_rgba(251,146,60,0.5)]
     - shadow-[0_0_15px_rgba(34,211,238,0.2)]
-    - shadow-[0_0_15px_rgba(34,211,238,0.2)]!
+    - shadow-[0_0_15px_rgba(34,211,238,0.5)]
+    - shadow-[0_0_18px_rgba(239,68,68,0.35)]
     - shadow-[0_0_20px_rgba(255,255,255,0.3)]
     - shadow-[0_0_5px_rgba(217,70,239,0.5)]
     - shadow-[0_0_5px_rgba(239,22,238,0.5)]
@@ -1582,6 +1669,23 @@ component_contracts:
     state_rules:
       - id: variant-closed-set
         rule: Only declared variant/size combinations are allowed without contract/version update.
+  CacheBadge:
+    file: components/views/server/InstanceSettingsSelectors.tsx
+    required_tokens:
+      - colors
+      - motion
+      - radii
+      - shadows
+    allowed_variants: {}
+    structural_invariants:
+      - id: structure-stable
+        rule: Preserve current structural layout and region hierarchy for this component.
+    behavior_rules:
+      - id: motion-locked
+        rule: Use only approved motion tokens and classes from foundation token registry.
+    state_rules:
+      - id: closed-set-styles
+        rule: Do not introduce unregistered utility, arbitrary, or inline style values.
   CalendarTab:
     file: components/views/NotebookView.tsx
     required_tokens:
@@ -2072,6 +2176,23 @@ component_contracts:
     state_rules:
       - id: import-switch-options
         rule: Speaker diarization and word timestamp option switches remain present in fixed order.
+  InstanceSettingsSelectors:
+    file: components/views/server/InstanceSettingsSelectors.tsx
+    required_tokens:
+      - colors
+      - motion
+      - radii
+      - shadows
+    allowed_variants: {}
+    structural_invariants:
+      - id: structure-stable
+        rule: Preserve current structural layout and region hierarchy for this component.
+    behavior_rules:
+      - id: motion-locked
+        rule: Use only approved motion tokens and classes from foundation token registry.
+    state_rules:
+      - id: closed-set-styles
+        rule: Do not introduce unregistered utility, arbitrary, or inline style values.
   IntelIcon:
     file: components/ui/icons/IntelIcon.tsx
     required_tokens:
@@ -2379,6 +2500,23 @@ component_contracts:
     state_rules:
       - id: closed-set-styles
         rule: Do not introduce unregistered utility, arbitrary, or inline style values.
+  RemoteConnectionCard:
+    file: components/views/server/RemoteConnectionCard.tsx
+    required_tokens:
+      - colors
+      - motion
+      - radii
+      - shadows
+    allowed_variants: {}
+    structural_invariants:
+      - id: structure-stable
+        rule: Preserve current structural layout and region hierarchy for this component.
+    behavior_rules:
+      - id: motion-locked
+        rule: Use only approved motion tokens and classes from foundation token registry.
+    state_rules:
+      - id: closed-set-styles
+        rule: Do not introduce unregistered utility, arbitrary, or inline style values.
   SearchTab:
     file: components/views/NotebookView.tsx
     required_tokens:
@@ -2418,6 +2556,40 @@ component_contracts:
     state_rules:
       - id: heading-divider
         rule: Heading divider line remains part of section title structure.
+  SelectorGroup:
+    file: components/ui/SelectorGroup.tsx
+    required_tokens:
+      - colors
+      - motion
+      - radii
+      - shadows
+    allowed_variants: {}
+    structural_invariants:
+      - id: structure-stable
+        rule: Preserve current structural layout and region hierarchy for this component.
+    behavior_rules:
+      - id: motion-locked
+        rule: Use only approved motion tokens and classes from foundation token registry.
+    state_rules:
+      - id: closed-set-styles
+        rule: Do not introduce unregistered utility, arbitrary, or inline style values.
+  SelectorTile:
+    file: components/ui/SelectorTile.tsx
+    required_tokens:
+      - colors
+      - motion
+      - radii
+      - shadows
+    allowed_variants: {}
+    structural_invariants:
+      - id: structure-stable
+        rule: Preserve current structural layout and region hierarchy for this component.
+    behavior_rules:
+      - id: motion-locked
+        rule: Use only approved motion tokens and classes from foundation token registry.
+    state_rules:
+      - id: closed-set-styles
+        rule: Do not introduce unregistered utility, arbitrary, or inline style values.
   ServerConfigEditor:
     file: components/views/ServerConfigEditor.tsx
     required_tokens:

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,9 +16,9 @@ AI assistant (OpenAI-compatible), and
 both longform and live transcription. Electron
 dashboard + Python backend with
 multi-backend STT (Whisper, NVIDIA NeMo,
-VibeVoice-ASR, whisper.cpp), NVIDIA GPU
-acceleration, AMD/Intel Vulkan support,
-or CPU mode. Dockerized for fast setup.
+VibeVoice-ASR, SenseVoice, whisper.cpp),
+NVIDIA GPU acceleration, AMD/Intel Vulkan
+support, or CPU mode. Dockerized for fast setup.
 </pre>
           </td>
         </tr>
@@ -52,8 +52,9 @@ https://github.com/user-attachments/assets/f63ee730-de9a-4a55-b0ab-e342b30905a4
 
 - [1. Introduction](#1-introduction)
   - [1.1 Features](#11-features)
-  - [1.2 Screenshots](#12-screenshots)
-  - [1.3 Short Tour](#13-short-tour)
+  - [1.2 Compatibility Matrix](#12-compatibility-matrix)
+  - [1.3 Screenshots](#13-screenshots)
+  - [1.4 Short Tour](#14-short-tour)
 - [2. Installation](#2-installation)
   - [2.1 macOS Apple Silicon](#21-macos-apple-silicon)
   - [2.2 macOS Intel](#22-macos-intel)
@@ -84,10 +85,10 @@ https://github.com/user-attachments/assets/f63ee730-de9a-4a55-b0ab-e342b30905a4
 ### 1.1 Features
 
 - **100% Local**: *Everything* runs on your own computer, the app doesn't need internet beyond the initial setup*
-- **Multiple Models available**: On **Docker/Linux/Windows**: *WhisperX* ([`faster-whisper`](https://huggingface.co/Systran/faster-whisper-large-v3) models), NVIDIA NeMo [*Parakeet v3*](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3)/[*Canary v2*](https://huggingface.co/nvidia/canary-1b-v2), [*VibeVoice-ASR*](https://huggingface.co/microsoft/VibeVoice-ASR), and [*whisper.cpp*](https://github.com/ggerganov/whisper.cpp) (GGML models for AMD/Intel GPU via Vulkan — Linux via Docker sidecar; Windows via native `whisper-server.exe` auto-downloaded by the app, see §2.7). On **Apple Silicon (Metal)**: [*MLX Whisper*](https://huggingface.co/mlx-community/whisper-large-v3-turbo-asr-fp16) (tiny → large-v3-turbo), [*MLX Parakeet v3*](https://huggingface.co/mlx-community/parakeet-tdt-0.6b-v3), [*MLX Canary v2*](https://huggingface.co/mlx-community/canary-1b-v2), and [*MLX VibeVoice-ASR*](https://huggingface.co/mlx-community/VibeVoice-ASR-bf16) - all running natively without Docker
-- **Speaker Diarization**: Speaker identification & diarization (subtitling) for Whisper, NeMo, and VibeVoice models; Whisper and NeMo use PyAnnote for diarization while VibeVoice does it by itself (not available for whisper.cpp models). On Apple Silicon, [*Sortformer*](https://huggingface.co/mlx-community/diar_sortformer_4spk-v1-fp32) provides Metal-native diarization for up to 4 speakers - no HuggingFace token required
+- **Multiple Models available**: On **Docker/Linux/Windows**: *WhisperX* ([`faster-whisper`](https://huggingface.co/Systran/faster-whisper-large-v3) models), NVIDIA NeMo [*Parakeet v3*](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3)/[*Canary v2*](https://huggingface.co/nvidia/canary-1b-v2), [*VibeVoice-ASR*](https://huggingface.co/microsoft/VibeVoice-ASR), [*SenseVoice*](https://huggingface.co/FunAudioLLM/SenseVoiceSmall) (FunASR), and [*whisper.cpp*](https://github.com/ggerganov/whisper.cpp) (GGML models for AMD/Intel GPU via Vulkan — Linux via Docker sidecar; Windows via native `whisper-server.exe` auto-downloaded by the app, see §2.7). On **Apple Silicon (Metal)**: [*MLX Whisper*](https://huggingface.co/mlx-community/whisper-large-v3-turbo-asr-fp16) (tiny → large-v3-turbo), [*MLX Parakeet v3*](https://huggingface.co/mlx-community/parakeet-tdt-0.6b-v3), [*MLX Canary v2*](https://huggingface.co/mlx-community/canary-1b-v2), and [*MLX VibeVoice-ASR*](https://huggingface.co/mlx-community/VibeVoice-ASR-bf16) - all running natively without Docker
+- **Speaker Diarization**: Speaker identification & diarization (subtitling) for Whisper, NeMo, SenseVoice, and VibeVoice models; Whisper and NeMo use PyAnnote (HuggingFace token required), SenseVoice ships a built-in CAM++ single-pass diarizer (no token needed, with PyAnnote as an optional override), and VibeVoice does it by itself (not available for whisper.cpp models). On Apple Silicon, [*Sortformer*](https://huggingface.co/mlx-community/diar_sortformer_4spk-v1-fp32) provides Metal-native diarization for up to 4 speakers - no HuggingFace token required
 - **Parallel Processing**: If your VRAM budget allows it, transcribe & diarize a recording at the same time - speeding up processing time significantly
-- **Truly Multilingual**: Whisper supports [90+ languages](https://github.com/openai/whisper/blob/main/whisper/tokenizer.py); NeMo Parakeet/Canary support [25 European languages](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3); VibeVoice supports [51 languages](https://huggingface.co/microsoft/VibeVoice-ASR)
+- **Truly Multilingual**: Whisper supports [90+ languages](https://github.com/openai/whisper/blob/main/whisper/tokenizer.py); NeMo Parakeet/Canary support [25 European languages](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3); VibeVoice supports [51 languages](https://huggingface.co/microsoft/VibeVoice-ASR); SenseVoice supports 5 languages (Chinese, English, Cantonese, Japanese, Korean)
 - **Longform Transcription**: Record as long as you want and have it transcribed in seconds; either using your mic or the system audio
 - **Session File Import**: Import existing audio files from the Session tab; transcription results are saved directly as `.txt` or `.srt` to a folder of your choice - no Notebook entry created
 - **Live Mode**: Real-time sentence-by-sentence transcription for continuous dictation workflows (available for Whisper and whisper.cpp/GGML models; not available for NeMo or VibeVoice models)
@@ -100,7 +101,44 @@ https://github.com/user-attachments/assets/f63ee730-de9a-4a55-b0ab-e342b30905a4
 
 **All transcription processing runs entirely on your own computer - your audio never leaves your machine. Internet is only needed to download model weights on first use (STT models, PyAnnote diarization, and wav2vec2 alignment models); all weights are cached locally in a Docker volume and no further internet access is required after that.*
 
-### 1.2 Screenshots
+### 1.2 Compatibility Matrix
+
+Not every model runs on every machine. The tables below show which **runtime** fits your hardware, and what each **model family** can do on it. The Server tab's Instance Settings selectors enforce the same rules — incompatible choices are greyed out with the reason.
+
+**Where each runtime runs:**
+
+| Runtime | Linux NVIDIA | Linux AMD/Intel | Windows NVIDIA | Windows AMD/Intel | macOS Apple Silicon | macOS Intel |
+|---------|--------------|-----------------|----------------|-------------------|---------------------|-------------|
+| **NVIDIA CUDA** (Docker) | Yes | No | Yes | No | No | No |
+| **CPU** (Docker) | Yes | Yes | Yes | Yes | No | Yes |
+| **Vulkan Linux** (Docker + sidecar, experimental) | Yes | Yes | No | No | No | No |
+| **Vulkan Windows** (WSL2 + native whisper-server) | No | No | Yes | Yes | No | No |
+| **Apple Metal** (native, no Docker) | No | No | No | No | Yes | No |
+
+**Models × runtimes × features:**
+
+| Model family | Runtime(s) | Live Mode | Translation | Diarization |
+|--------------|------------|-----------|-------------|-------------|
+| **Faster-Whisper** (WhisperX) | CUDA, CPU | Yes | To English (not turbo/`.en` variants) | PyAnnote (token) |
+| **Parakeet v3** (NeMo) | CUDA | No | No | PyAnnote (token) |
+| **Canary v2** (NeMo) | CUDA | No | Yes — bidirectional, 25 languages | PyAnnote (token) |
+| **SenseVoice** (FunASR) | CUDA, CPU (slow) | No | No | CAM++ built-in (no token) or PyAnnote |
+| **VibeVoice-ASR** | CUDA, CPU (very slow) | No | No | Built-in |
+| **Whisper.cpp** (GGML) | Vulkan Linux/Windows | Yes | To English (not turbo/`.en` variants) | No |
+| **MLX Whisper** | Metal | Via faster-whisper (CPU) | To English | Sortformer (≤ 4 speakers) or PyAnnote |
+| **MLX Parakeet v3** | Metal | Via faster-whisper (CPU) | No | Sortformer or PyAnnote |
+| **MLX Canary v2** | Metal | Via faster-whisper (CPU) | No (MLX port) | Sortformer or PyAnnote |
+| **MLX VibeVoice-ASR** | Metal | Via faster-whisper (CPU) | No | Built-in |
+
+> **Notes:**
+>
+> - **Live Mode** always runs on faster-whisper or whisper.cpp models. On Apple Silicon the Metal server bundles faster-whisper for exactly this — Live Mode works, but decodes on the CPU rather than the GPU.
+> - **PyAnnote** diarization needs a free HuggingFace token and accepting the [model's terms](https://huggingface.co/pyannote/speaker-diarization-community-1). **CAM++** (SenseVoice), **Sortformer** (Apple Silicon) and VibeVoice's **built-in** diarization need no token.
+> - **Sortformer** handles up to 4 speakers; pick PyAnnote on Apple Silicon for larger groups.
+> - NeMo models (Parakeet/Canary) are unavailable on the CPU runtime — the app substitutes a faster-whisper model instead.
+> - Older NVIDIA cards (GTX 10-series and earlier) use the same CUDA runtime with the legacy image toggle — see [§2.6](#26-setting-up-the-server).
+
+### 1.3 Screenshots
 
 <div align="center">
 
@@ -114,7 +152,7 @@ https://github.com/user-attachments/assets/f63ee730-de9a-4a55-b0ab-e342b30905a4
 
 </div>
 
-### 1.3 Short Tour
+### 1.4 Short Tour
 
 <div align="center">
 
@@ -288,8 +326,8 @@ Setting up the server has two parts: downloading the Docker image, then starting
 > **Windows:** make sure Docker Desktop is **already running** before you start — server setup fails if it isn't started first.
 
 1. **Download the image.** In the left sidebar, open the **Server** tab and click **Fetch Fresh Image**.
-2. **Start the container.** Scroll down and click **Start Local** in the **#2** box.
-3. **Pick models & diarization.** Prompts ask which models to download to begin with, and whether to enable diarization. For diarization you'll need a free HuggingFace token and to accept the [model's terms](https://huggingface.co/pyannote/speaker-diarization-community-1). To create a token, go to your [HuggingFace token settings](https://huggingface.co/settings/tokens), click *Create new token*, and choose **Read** as the access type (Write / Fine-grained aren't needed).
+2. **Pick your runtime, models & diarization.** The **Instance Settings** card (box **#2**) holds the selectors — runtime, main model, Live Mode model, diarization engine. Incompatible combinations are greyed out with the reason (see the [Compatibility Matrix](#12-compatibility-matrix)).
+3. **Start the container.** Click **Start Local** in the **#1** box. Prompts confirm which models to download and whether to enable diarization. A free HuggingFace token is needed only for **PyAnnote** diarization (plus accepting the [model's terms](https://huggingface.co/pyannote/speaker-diarization-community-1)) — SenseVoice's CAM++ and Apple Silicon's Sortformer diarizers need no token. To create a token, go to your [HuggingFace token settings](https://huggingface.co/settings/tokens), click *Create new token*, and choose **Read** as the access type (Write / Fine-grained aren't needed).
 4. **Wait.** The first startup can take a while, even on newer hardware and fast internet — think **10–20 minutes** with reasonable specs, not hours. You'll know it's done when the server status light turns **green**.
 5. **Start the client.** Go to the **Session** tab and click **Start Local** in the **Client Link** box — when it turns green, you're ready to roll!
 
@@ -391,6 +429,8 @@ Either way, you use **GGML models** (not the CUDA models) — see the [model tab
 | `ggml-small.en.bin` | ~465 MB | English | No | Smallest English-only |
 
 #### What works on Vulkan
+
+> **Note:** the full picture across all runtimes and models lives in the [Compatibility Matrix](#12-compatibility-matrix) (§1.2).
 
 | Feature | Vulkan (AMD/Intel) | NVIDIA (CUDA) |
 |---------|-------------------|---------------|
@@ -741,7 +781,7 @@ Transcribe **and translate** an audio or video file to English. Identical to `/t
 
 **Error codes:** Same as `/transcriptions`.
 
-> **Backend note:** Translation requires a Whisper-family model with translation capability. Parakeet/Canary backends that don't support `task="translate"` will return a `400` or `500` from the engine layer.
+> **Backend note:** Translation requires a model with translation capability — a multilingual Whisper model (to English) or Canary v2 (bidirectional). Backends without `task="translate"` support (Parakeet, SenseVoice, VibeVoice, turbo/`.en` Whisper variants) will return a `400` or `500` from the engine layer.
 
 **Example (curl):**
 ```bash

--- a/docs/README_DEV.md
+++ b/docs/README_DEV.md
@@ -358,7 +358,7 @@ TranscriptionSuite uses a **client-server architecture**:
 - **SQLite + FTS5**: Lightweight full-text search without external dependencies
 - **Dual VAD**: Real-time engine uses both Silero (neural) and WebRTC (algorithmic) VAD
 - **Multi-device support**: Multiple clients can connect, but only one transcription runs at a time
-- **Multi-backend STT**: Pluggable backend architecture - Whisper, NeMo Parakeet/Canary, WhisperX, VibeVoice-ASR, whisper.cpp (Vulkan), MLX (Apple Silicon: Whisper, Parakeet, Canary, VibeVoice) - auto-detected from the model name
+- **Multi-backend STT**: Pluggable backend architecture - Whisper, NeMo Parakeet/Canary, WhisperX, VibeVoice-ASR, SenseVoice (FunASR), whisper.cpp (Vulkan), MLX (Apple Silicon: Whisper, Parakeet, Canary, VibeVoice) - auto-detected from the model name
 - **Live Mode**: Continuous sentence-by-sentence transcription with automatic model swapping to manage VRAM; Whisper and whisper.cpp/GGML backends supported
 - **AI Assistant (OpenAI-compatible)**: Supports any OpenAI-compatible endpoint - LM Studio, Ollama, OpenAI, Groq, OpenRouter, and others. Configurable via Settings → AI tab with API key support, model selection, and endpoint URL. Per-conversation model overrides are available in the Notebook AI sidebar. Uses standard `/v1/chat/completions` with full conversation history
 

--- a/docs/superpowers/specs/2026-07-11-server-tab-matrix-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-11-server-tab-matrix-redesign-design.md
@@ -1,0 +1,195 @@
+# Server Tab Matrix Redesign — Design Spec
+
+Date: 2026-07-11
+Branch: `feature/server-tab-matrix-redesign` (worktree off `main` @ 2253166d)
+
+## Goal
+
+Reorganize the Server tab around a verified compatibility matrix of
+architectures × runtimes × models × diarization engines, publish the same
+matrix in the user README, and guarantee that runtime-related downloads start
+only when the user starts the server — never at selector-click time.
+
+## 1. New Server tab structure
+
+The tab stays a vertical timeline of numbered glass cards (a ui-contract
+structural invariant), but goes from six cards to five:
+
+| # | Card | Contents |
+|---|------|----------|
+| 1 | Docker Image / Inference Server (Metal) | unchanged |
+| 2 | **Instance Settings** (merged) | Runtime selector, Main model selector, Live model selector, Diarization selector, legacy-GPU toggle, Vulkan sidecar prompt, configuration summary strip |
+| 3 | **Remote Connection** (new) | Auth token field, Tailscale hostname field, firewall warning |
+| 4 | Persistent Volumes | unchanged (was #5) |
+| 5 | Clean Up | unchanged (was #6) |
+
+Former cards 2 (Instance Settings), 3 (ASR Models Configuration) and
+4 (Diarization Models Configuration) merge into the new card 2. The auth
+token + Tailscale hostname fields (previously inside old card 2) move to the
+new card 3.
+
+## 2. Instance Settings card — four selector groups
+
+Each group renders a heading (colored lucide icon + title + hint) above a
+grid of **selector tiles**. Two new UI primitives:
+
+- `SelectorTile` — button with icon, label, optional sublabel, per-choice
+  accent color when selected, disabled state with a reason badge, and up to
+  three mini capability glyphs (translation / live / diarization) with
+  tooltips.
+- `SelectorGroup` — labelled wrapper providing the grid layout.
+
+Icons are lucide-react SVG components plus the existing custom vendor SVGs
+(`NvidiaIcon`, `AmdIcon`, `IntelIcon`, `AppleIcon`). No emoji anywhere —
+bundled vector components render identically on Linux, Windows and macOS.
+
+### Group: Runtime
+Tiles: NVIDIA CUDA (green), AMD/Intel Vulkan (red, Linux, experimental),
+Windows Vulkan / WSL2 (red, Windows), Apple Metal (silver, Apple Silicon),
+CPU (blue). Availability gating reuses existing host-platform logic.
+The legacy-GPU toggle and Vulkan sidecar prompt remain in this group,
+shown contextually.
+
+### Group: Main model
+Family tiles (colors follow ModelManagerTab's `FAMILY_SECTIONS`):
+Whisper, Parakeet, Canary, SenseVoice, VibeVoice on CUDA profiles;
+Whisper.cpp (GGML) on Vulkan profiles; MLX Whisper / MLX Parakeet /
+MLX Canary / MLX VibeVoice on Metal. Plus small "Custom" and "Disabled"
+tiles. Selecting a family switches the model dropdown (existing
+`CustomSelect`) to that family's registry entries; the Downloaded/Missing
+cache badge is kept. Families invalid for the active runtime are disabled
+with a reason badge ("Requires NVIDIA runtime", "Requires Vulkan runtime",
+"Requires Apple Silicon"). NeMo tiles are disabled on the CPU profile
+(mirrors backend `applyCpuModelDefaults` instead of silently substituting);
+SenseVoice/VibeVoice remain selectable on CPU with a "Slow on CPU" hint.
+
+### Group: Live model
+Tiles: "Same as main" (enabled only when the main family is live-capable),
+"Faster-Whisper" (with model dropdown), "Whisper.cpp" (Vulkan profiles),
+"Disabled". Live capability is whisper/whispercpp-only (backend gate in
+`live.py`). On Metal, "Same as main" is disabled (MLX models cannot do live)
+and faster-whisper runs on CPU — labelled as such
+(`server/backend/pyproject.toml:83-84` confirms this is by design).
+
+### Group: Diarization
+Tiles: PyAnnote (violet; "HF token" chip), CAM++ (orange; "No token ·
+SenseVoice only"), Sortformer (silver; "No token · Metal · ≤ 4 speakers"),
+Built-in (auto-locked for VibeVoice mains), Custom (HF repo input).
+GGML mains show a "not available for whisper.cpp models" info state.
+**Stored electron-store values keep the existing literal strings**
+(`'CAM++ (fast, built-in)'` etc.) — only display labels change — so
+persisted configs and the one-shot migration keep working.
+
+### Summary strip
+A footer row inside card 2 summarizing the chosen combination (runtime +
+main + live + diarization) with capability chips (languages, translation,
+live, diarization, token requirement). This is the in-app matrix rendered
+for the *current* selection.
+
+## 3. Single source of truth: `dashboard/src/services/instanceMatrix.ts`
+
+Pure module encoding the verified matrix; the card renders from it and an
+exhaustive unit test enumerates the full cross-product. Key exports:
+
+- runtime metadata + per-host availability inputs
+- `familiesForRuntime(runtime)` → ordered list with `{enabled, reason?}`
+- `modelsForFamily(family, runtime)` (delegates to modelRegistry)
+- `liveOptionsFor(runtime, mainFamily)`
+- `diarizationOptionsFor(runtime, mainFamily)` with per-option
+  `{enabled, reason?, default?}`
+
+### The verified matrix (derived from code, file:line in recon notes)
+
+Runtime × architecture:
+
+| Runtime profile | Linux NVIDIA | Linux AMD/Intel | Windows NVIDIA | Windows AMD/Intel | macOS AS | macOS Intel |
+|---|---|---|---|---|---|---|
+| `gpu` (CUDA, cu129/cu126-legacy) | Yes | No | Yes | No | No | No |
+| `cpu` | Yes | Yes | Yes | Yes | No | Yes |
+| `vulkan` (experimental) | Yes | Yes | No | No | No | No |
+| `vulkan-wsl2` | No | No | Yes | Yes | No | No |
+| `metal` (native, no Docker) | No | No | No | No | Yes | No |
+
+Model family × runtime (main transcriber):
+
+| Family | gpu | cpu | vulkan(-wsl2) | metal | Live | Translation | Diarization |
+|---|---|---|---|---|---|---|---|
+| Faster-Whisper (WhisperX) | Yes | Yes | No | No | Yes | → English (not turbo/.en) | PyAnnote (token) |
+| Parakeet v3 (NeMo) | Yes | No (auto-substituted) | No | No | No | No | PyAnnote |
+| Canary v2 (NeMo) | Yes | No | No | No | No | 25-lang bidirectional | PyAnnote |
+| SenseVoice (FunASR) | Yes | Yes (slow) | No | No | No | No | CAM++ built-in (no token) or PyAnnote |
+| VibeVoice-ASR | Yes | Yes (very slow) | No | No | No | No | Built-in |
+| Whisper.cpp GGML | No | No | Yes | No | Yes | → English (not turbo/.en) | None |
+| MLX Whisper | No | No | No | Yes | via faster-whisper (CPU) | → English | Sortformer (≤4) or PyAnnote |
+| MLX Parakeet | No | No | No | Yes | same | No | Sortformer or PyAnnote |
+| MLX Canary | No | No | No | Yes | same | No (MLX port) | Sortformer or PyAnnote |
+| MLX VibeVoice | No | No | No | Yes | same | No | Built-in |
+
+Diarization engine gates (backend-verified):
+- PyAnnote: needs HF token + accepted gated-model terms; any main except
+  whispercpp/vibevoice; works on CUDA, CPU and Metal (MPS inference).
+- CAM++ (`funasr`): SenseVoice mains only; resolver falls back to pyannote
+  otherwise (`config.py::resolve_sensevoice_diarization_engine`).
+- Sortformer: Metal only (`mlx-audio`), ≤4 speakers, no token; loses to an
+  explicit pyannote model (`diarization_engine.py:433-438`).
+- Built-in: VibeVoice CUDA + MLX (backend overrides
+  `transcribe_with_diarization` unconditionally).
+
+## 4. Deferred runtime downloads
+
+Verified: the only selection-time download paths are Metal-related.
+
+1. `ServerView.handleRuntimeProfileChange` — remove the MLX **start** side
+   effect when switching to `metal` (keep the **stop** when leaving it).
+   Selecting Metal now only persists the profile; the Start button in card 1
+   spawns the server (whose lifespan performs model downloads).
+2. `main.ts` boot auto-start — gate on a new persisted flag
+   `server.mlxDesiredRunning`, set `true` in the `mlx:start` IPC handler and
+   `false` in `mlx:stop`. Fresh installs and updated installs default to
+   `false`, so no downloads occur before the first explicit start.
+
+All other downloads already comply: image pulls are explicit-button-only,
+`uv`/pip installs + CAM++ prefetch + HF model preloads happen in container
+bootstrap/lifespan at start, GGML/whisper-server.exe downloads happen at
+start (vulkan-wsl2) or via explicit Model Manager buttons.
+
+## 5. README matrix
+
+`docs/README.md` gains a new `### 1.2 Compatibility Matrix` after Features
+(screenshots/tour renumber to 1.3/1.4; ToC updated) with the two tables
+above in house style (plain `|---|` separators, `Yes`/`No` text). Stale
+statements fixed in the same pass: SenseVoice added to the header blurb,
+features bullets and diarization docs; §4's incorrect "Parakeet/Canary
+don't translate" note corrected (Canary does); §2.6 diarization framing
+mentions the no-token CAM++/Sortformer paths; "What works on Vulkan" links
+to the matrix. `docs/README_DEV.md`'s multi-backend line and platform table
+get minimal consistency edits.
+
+## 6. File plan
+
+New files:
+- `dashboard/src/services/instanceMatrix.ts` (+ exhaustive test)
+- `dashboard/components/ui/SelectorTile.tsx`, `SelectorGroup.tsx`
+- `dashboard/components/views/server/InstanceSettingsCard.tsx`
+- `dashboard/components/views/server/RemoteConnectionCard.tsx`
+
+Modified:
+- `dashboard/components/views/ServerView.tsx` (card merge/renumber, state
+  wiring passed down as props; MLX-start side effect removed)
+- `dashboard/electron/main.ts` (`server.mlxDesiredRunning` flag + gate)
+- `dashboard/components/__tests__/ServerView.test.tsx` (labels/structure)
+- `docs/README.md`, `docs/README_DEV.md`
+- ui-contract YAML + baseline (spec_version bump, full update sequence)
+
+Non-goals: changing electron-store keys, start-options IPC contract,
+ModelManagerView behavior, backend code, or the per-job diarization toggle.
+
+## 7. Risks / mitigations
+
+- ServerView tests are visible-text based → update assertions alongside
+  label changes; keep badge semantics ("SenseVoice only", "Requires Metal").
+- Persisted option strings are load-bearing → constants keep their values;
+  only display labels change.
+- ModelManagerView shares the electron-store keys → keys untouched.
+- ui-contract hash will change → run extract/build/update-baseline/check
+  with a manual spec_version bump.

--- a/docs/superpowers/specs/2026-07-11-server-tab-matrix-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-11-server-tab-matrix-redesign-design.md
@@ -18,7 +18,7 @@ structural invariant), but goes from six cards to five:
 | # | Card | Contents |
 |---|------|----------|
 | 1 | Docker Image / Inference Server (Metal) | unchanged |
-| 2 | **Instance Settings** (merged) | Runtime selector, Main model selector, Live model selector, Diarization selector, legacy-GPU toggle, Vulkan sidecar prompt, configuration summary strip |
+| 2 | **Instance Settings** (merged) | Runtime selector, Main model selector, Live model selector, Diarization selector, legacy-GPU toggle, Vulkan sidecar prompt |
 | 3 | **Remote Connection** (new) | Auth token field, Tailscale hostname field, firewall warning |
 | 4 | Persistent Volumes | unchanged (was #5) |
 | 5 | Clean Up | unchanged (was #6) |
@@ -80,11 +80,12 @@ GGML mains show a "not available for whisper.cpp models" info state.
 (`'CAM++ (fast, built-in)'` etc.) — only display labels change — so
 persisted configs and the one-shot migration keep working.
 
-### Summary strip
-A footer row inside card 2 summarizing the chosen combination (runtime +
-main + live + diarization) with capability chips (languages, translation,
-live, diarization, token requirement). This is the in-app matrix rendered
-for the *current* selection.
+### Capability glyphs (implemented in place of a separate summary strip)
+Each family tile carries a mini glyph row — language count, translation
+direction (→EN / A⇄B), live capability, diarization capability, and a key
+icon when the default diarization engine needs a HuggingFace token — with
+tooltips. The tile grid itself therefore renders the full in-app matrix; a
+separate summary footer would have duplicated it.
 
 ## 3. Single source of truth: `dashboard/src/services/instanceMatrix.ts`
 


### PR DESCRIPTION
## Summary

Reorganizes the Server tab around a single, code-verified compatibility matrix of runtimes x model families x live mode x diarization engines, publishes the same matrix in the README, and guarantees that runtime-related downloads only start when the user explicitly starts the server.

### New Server tab layout (5 cards, still the numbered timeline)

1. **Docker Image / Inference Server** - unchanged
2. **Instance Settings** (merged from the old cards 2+3+4) - four colorful tile-selector groups built on new `SelectorTile`/`SelectorGroup` primitives:
   - **Runtime**: NVIDIA CUDA / Vulkan Linux / Vulkan Windows (WSL2) / Apple Metal / CPU, with vendor SVG icons and per-platform gating
   - **Main Transcriber**: ten family tiles (Whisper, Parakeet v3, Canary v2, SenseVoice, VibeVoice, Whisper.cpp, MLX Whisper/Parakeet/Canary/VibeVoice), each with its own accent color and mini capability glyphs (languages, translation direction, live, diarization, HF-token requirement), plus a per-family model dropdown
   - **Live Mode Model**: Same-as-main / Faster-Whisper / Whisper.cpp / Disabled
   - **Diarization**: PyAnnote / CAM++ / Sortformer / Built-in (VibeVoice) / Custom
   - Invalid combinations stay visible but greyed with the reason badge ("Requires Vulkan", "SenseVoice only", "Requires Metal", ...), so the matrix is readable at a glance. All icons are bundled SVG components - no emoji - so they render identically on Linux, Windows and macOS.
3. **Remote Connection** (new) - auth token, Tailscale hostname and the firewall warning, moved out of the old Instance Settings card into a self-contained component
4. **Persistent Volumes** / 5. **Clean Up** - renumbered

### Single source of truth: `instanceMatrix.ts`

All validity rules live in `dashboard/src/services/instanceMatrix.ts`, mirroring the actual backend gates (`live.py` whisper-only live gate, `applyCpuModelDefaults` NeMo-on-CPU substitution, `resolve_sensevoice_diarization_engine` CAM++ scoping, the Sortformer mlx-audio gate, VibeVoice's always-native diarization). A 117-test cross-product suite enumerates every runtime x family x live x diarization combination against a literal transcription of the design-spec table, plus registry-consistency guards.

### Deferred runtime downloads

- Selecting the Metal runtime no longer auto-starts the native MLX server (whose startup pre-downloads models); the Start button in card 1 is now the only trigger
- The Metal boot auto-start in `electron/main.ts` is gated on a new `server.mlxDesiredRunning` flag, set true only by the `mlx:start` IPC and cleared by `mlx:stop`
- All other download paths already complied (explicit pull buttons, container bootstrap at start, HF preload in the server lifespan)

### Fixed along the way

- Switching runtimes now resets any main/live model the new runtime cannot run - generalizes the old MLX-off-Metal and NeMo-on-CPU special cases and closes the hole where a stale GGML main could leak into a CUDA start
- Persisted electron-store option strings ('CAM++ (fast, built-in)', 'Sortformer (Metal; <= 4 speakers)', ...) are unchanged - tiles display short labels but store the original literals, so existing configs and the one-shot diarization migration keep working
- `ServerView.tsx` shrank from 3119 to ~2740 lines with logic extracted to focused modules

### Docs

- `docs/README.md`: new **1.2 Compatibility Matrix** section (runtime x architecture and model x runtime x feature tables, with token/live/translation notes); Screenshots/Short Tour renumbered to 1.3/1.4; SenseVoice added to the header blurb, features, diarization and multilingual bullets; fixed the stale "Parakeet/Canary don't translate" API note (Canary does), the 2.6 diarization-token framing (CAM++/Sortformer need no token), and the wrong Start-button box number
- `docs/README_DEV.md`: SenseVoice added to the multi-backend list
- Design spec committed at `docs/superpowers/specs/2026-07-11-server-tab-matrix-redesign-design.md`

### ui-contract

Contract rebuilt for the new components, `spec_version` bumped to 1.1.0, baseline updated; the `timeline-cards` structural invariant is preserved.

## Test plan

- [x] Full frontend suite green: 1600/1600 tests across 98 files (baseline before this branch: 1478)
- [x] New: 117 instanceMatrix cross-product tests (every runtime x family x live x diarization combination)
- [x] New ServerView tests: deferred Metal start, MLX stop on leaving Metal, card renumbering, runtime-switch model resets, Remote Connection card
- [x] Existing diarization semantics preserved: greying rules, engine wiring to `onStartServer`, one-shot migration, Issue #112 no-auto-migration on Metal
- [x] `npm run typecheck`, `eslint --max-warnings=0`, `ui:contract:check` all green
- [ ] TODO: visual smoke test of the new tab in the running app (Linux, then Windows/macOS)
- [ ] TODO: verify on real Apple Silicon that selecting Metal no longer downloads anything and that boot auto-start only resumes after an explicit Start
- [ ] TODO: verify a Vulkan host still gets the sidecar banner and GGML-only model list

Note for existing Metal users: after this change the server will not auto-start on app boot until they click Start once (the new flag starts false by design).