### PR TITLE
fix(server, dashboard): make the "Auto-add recordings to Audio Notebook" toggle work (GH #199)

### DIFF
--- a/dashboard/components/__tests__/SessionView.canary-language.test.tsx
+++ b/dashboard/components/__tests__/SessionView.canary-language.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -353,7 +353,9 @@ describe('SessionView — Canary language guards (gh-102)', () => {
     fireEvent.click(startButton);
 
     expect(mockToastError).not.toHaveBeenCalled();
-    expect(mockTranscription.start).toHaveBeenCalledTimes(1);
+    // start() is dispatched from an async chain (it reads `notebook.autoAdd`
+    // first (GH-199), so it lands a microtask after the click.
+    await waitFor(() => expect(mockTranscription.start).toHaveBeenCalledTimes(1));
     const startArgs = mockTranscription.start.mock.calls[0][0] as { language?: string };
     expect(startArgs.language).toBe('es');
   });
@@ -467,7 +469,9 @@ describe('SessionView — Canary language guards (gh-102)', () => {
     });
 
     expect(mockToastError).not.toHaveBeenCalled();
-    expect(mockTranscription.start).toHaveBeenCalledTimes(1);
+    // start() is dispatched from an async chain (it reads `notebook.autoAdd`
+    // first (GH-199), so it lands a microtask after the click.
+    await waitFor(() => expect(mockTranscription.start).toHaveBeenCalledTimes(1));
     const startArgs = mockTranscription.start.mock.calls[0][0] as { language?: string };
     expect(startArgs.language).toBe('es');
   });

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -799,6 +799,10 @@ export const SessionView: React.FC<SessionViewProps> = ({
           await window.electronAPI?.audio?.enableSystemAudioLoopback?.();
         }
       }
+      // GH-199: read at start so the server knows whether to promote this
+      // recording into the Audio Notebook when it finishes.
+      const autoAddToNotebook = (await getConfig<boolean>('notebook.autoAdd')) ?? false;
+
       transcription.start({
         language: resolvedLang,
         deviceId: isSystemAudio ? undefined : micDeviceIds[micDevice],
@@ -806,6 +810,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
         translationTarget: mainTranslateTarget,
         systemAudio: isSystemAudio,
         monitorDeviceLabel: monitorLabel,
+        autoAddToNotebook,
       });
       // Apply persisted capture gain after capture starts
       if (isSystemAudio) {

--- a/dashboard/src/hooks/useTranscription.ts
+++ b/dashboard/src/hooks/useTranscription.ts
@@ -40,6 +40,8 @@ export interface TranscriptionState {
     translationTarget?: string;
     systemAudio?: boolean;
     monitorDeviceLabel?: string;
+    /** Save the finished recording to the Audio Notebook (GH-199). */
+    autoAddToNotebook?: boolean;
   }) => void;
   /** Stop recording and wait for the final result */
   stop: () => void;
@@ -119,6 +121,8 @@ export function useTranscription(): TranscriptionState {
     monitorDeviceLabel?: string;
     /** Active recording-profile id (FR18). Snapshotted server-side at job start. */
     profileId?: number | null;
+    /** Save the finished recording to the Audio Notebook (GH-199). */
+    autoAddToNotebook?: boolean;
   }>({});
 
   // Cleanup on unmount — skip disconnect if actively recording/processing
@@ -161,6 +165,8 @@ export function useTranscription(): TranscriptionState {
               translation_target_language: startOptsRef.current.translationTarget ?? 'en',
               // Story 1.3 — server snapshots the profile at job start when present.
               profile_id: startOptsRef.current.profileId ?? null,
+              // GH-199: server promotes the finished recording into the Notebook.
+              auto_add_to_notebook: startOptsRef.current.autoAddToNotebook ?? false,
             },
           });
           break;
@@ -320,7 +326,9 @@ export function useTranscription(): TranscriptionState {
       translate?: boolean;
       translationTarget?: string;
       systemAudio?: boolean;
+      monitorDeviceLabel?: string;
       profileId?: number | null;
+      autoAddToNotebook?: boolean;
     }) => {
       // Reset previous state
       setResult(null);

--- a/docs/README_DEV.md
+++ b/docs/README_DEV.md
@@ -2966,7 +2966,7 @@ on Linux). Settings are managed through the **Settings** modal in the UI.
 | `audio.gracePeriod` | `0.5` | Seconds of silence before finalising a recording chunk |
 | `diarization.constrainSpeakers` | `false` | Constrain speaker count for diarization |
 | `diarization.numSpeakers` | `2` | Number of speakers when constrained |
-| `notebook.autoAdd` | `true` | Auto-add longform transcriptions to Notebook |
+| `notebook.autoAdd` | `false` | Auto-add finished session recordings to the Audio Notebook |
 | `server.hfToken` | `""` | HuggingFace token for PyAnnote diarization models |
 | `server.runtimeProfile` | `gpu` | `"gpu"` or `"cpu"` - controls Docker GPU reservation |
 | `app.autoCopy` | `true` | Copy transcription to clipboard on completion |

--- a/server/backend/api/routes/websocket.py
+++ b/server/backend/api/routes/websocket.py
@@ -12,10 +12,12 @@ Handles:
 
 import asyncio
 import json
+import os
 import shutil
 import struct
 import tempfile
 import uuid
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -79,6 +81,95 @@ def _build_longform_result_payload(result: Any) -> dict[str, Any]:
     return sanitize_for_json(result.to_dict())
 
 
+def _warn_notebook_autoadd_failed(message: str) -> None:
+    """Surface a failed notebook auto-add in the dashboard (GH #199).
+
+    Cannot be a WebSocket message: the client disconnects the moment it receives
+    the `final` result, so anything sent afterwards is dropped. The startup-event
+    channel is independent of the socket, so the warning still lands.
+    """
+    from server.core.startup_events import emit_event
+
+    try:
+        emit_event("warn-notebook-autoadd", "warning", message, status="error")
+    except Exception:
+        logger.warning("emit_event failed for warn-notebook-autoadd", exc_info=True)
+
+
+def _save_session_to_notebook(
+    *,
+    audio_path: Path,
+    duration_seconds: float,
+    result: Any,
+    model_name: str | None,
+) -> int | None:
+    """Promote a finished session recording into the Audio Notebook (GH #199).
+
+    Blocking (MP3 encode + DB write): call via ``asyncio.to_thread``.
+
+    The session already wrote its audio to disk and already has a transcript, so
+    the recording is promoted in place: no re-upload and no second transcription
+    pass. Deliberately mirrors the manual-import route (notebook.py) step for
+    step, including its ffmpeg fallback. ``database.save_longform_recording()``
+    looks like the natural helper here but caps ffmpeg at 60s (a long lecture
+    would silently produce no entry) and returns None when ffmpeg is absent.
+
+    Returns the new recording id, or None when no entry was written.
+    """
+    # Lazy imports: these pull in the audio/ML stack.
+    from server.config import get_config
+    from server.core.audio_utils import convert_to_mp3
+    from server.core.stt.backends.factory import detect_backend_type
+    from server.database.database import save_longform_to_database
+
+    if audio_path is None or not Path(audio_path).exists():
+        logger.warning("Notebook auto-add skipped: session audio is missing")
+        return None
+    if not duration_seconds or duration_seconds <= 0:
+        logger.warning("Notebook auto-add skipped: recording has no duration")
+        return None
+
+    cfg = get_config()
+    data_dir = os.environ.get("DATA_DIR", "/data")
+    audio_dir = Path(cfg.get("audio_notebook", "audio_dir", default=f"{data_dir}/audio"))
+    audio_dir.mkdir(parents=True, exist_ok=True)
+
+    stem = f"session_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+
+    def _free_path(suffix: str) -> Path:
+        candidate = audio_dir / f"{stem}{suffix}"
+        counter = 2
+        while candidate.exists():
+            candidate = audio_dir / f"{stem}-{counter}{suffix}"
+            counter += 1
+        return candidate
+
+    # ffmpeg is not guaranteed (a stock macOS install has none). Storing the
+    # audio verbatim beats dropping a completed recording on the floor.
+    dest_path = _free_path(".mp3")
+    try:
+        convert_to_mp3(str(audio_path), str(dest_path))
+    except Exception as mp3_err:
+        logger.warning("MP3 conversion failed (%s); storing the session audio verbatim.", mp3_err)
+        dest_path = _free_path(Path(audio_path).suffix or ".wav")
+        shutil.copyfile(str(audio_path), str(dest_path))
+
+    # Lift word timestamps out of the segments so the entry carries real
+    # word-level timing rather than a wall of text.
+    word_timestamps: list[dict[str, Any]] | None = None
+    segments = getattr(result, "segments", None) or []
+    if segments and "words" in segments[0]:
+        word_timestamps = [w for seg in segments for w in seg.get("words", [])]
+
+    return save_longform_to_database(
+        audio_path=dest_path,
+        duration_seconds=duration_seconds,
+        transcription_text=getattr(result, "text", "") or "",
+        word_timestamps=word_timestamps,
+        transcription_backend=detect_backend_type(model_name or ""),
+    )
+
+
 class TranscriptionSession:
     """
     Manages a single transcription session.
@@ -115,6 +206,11 @@ class TranscriptionSession:
         # Preview transcription (ephemeral "last N seconds" reminder — never persisted)
         self._preview_in_progress = False
         self._preview_task: asyncio.Task[None] | None = None
+
+        # Auto-add the finished recording to the Audio Notebook (GH #199).
+        # Resolved per-session at `start` from the client toggle OR the
+        # server-wide config key.
+        self.auto_add_to_notebook = False
 
         # Job tracking for transcription
         self._current_job_id: str | None = None
@@ -455,6 +551,31 @@ class TranscriptionSession:
 
             logger.info(f"Transcription complete for {self.client_name}")
 
+            # Auto-add to the Audio Notebook (GH #199). Runs AFTER the result is
+            # persisted and delivered: the notebook entry is a derived artifact,
+            # so a failure here must never cost the user their transcript. Runs
+            # in a thread, since the MP3 encode would otherwise block the event loop.
+            if self.auto_add_to_notebook:
+                try:
+                    recording_id = await asyncio.to_thread(
+                        _save_session_to_notebook,
+                        audio_path=self.temp_file,
+                        duration_seconds=result.duration,
+                        result=result,
+                        model_name=getattr(engine, "model_name", None),
+                    )
+                    if recording_id:
+                        logger.info("Saved session recording to notebook: id=%s", recording_id)
+                    else:
+                        _warn_notebook_autoadd_failed(
+                            "Could not save the recording to the Audio Notebook."
+                        )
+                except Exception as nb_err:
+                    logger.error("Failed to add recording to notebook: %s", nb_err, exc_info=True)
+                    _warn_notebook_autoadd_failed(
+                        f"Could not save the recording to the Audio Notebook: {nb_err}"
+                    )
+
             # Fire outgoing webhook (separate guard so failures don't
             # trigger a "transcription failed" error message to the client)
             try:
@@ -532,6 +653,7 @@ class TranscriptionSession:
         use_vad: bool = False,
         translation_enabled: bool = False,
         translation_target_language: str = "en",
+        auto_add_to_notebook: bool = False,
     ) -> None:
         """
         Start a recording session.
@@ -541,11 +663,13 @@ class TranscriptionSession:
             use_vad: Use VAD for automatic start/stop detection
             translation_enabled: Enable source→target translation
             translation_target_language: Translation target (v1: "en" only)
+            auto_add_to_notebook: Save the finished recording to the Audio Notebook
         """
         self.is_recording = True
         self.language = language
         self.translation_enabled = translation_enabled
         self.translation_target_language = translation_target_language
+        self.auto_add_to_notebook = auto_add_to_notebook
         self.audio_chunks = []
         self._sample_rate_mismatch_reported = False
         self._use_realtime_engine = use_vad and self.capabilities.supports_vad_events
@@ -750,8 +874,29 @@ async def handle_client_message(session: TranscriptionSession, message: dict[str
         use_vad = _msg_data.get("use_vad", False)
         translation_enabled = _msg_data.get("translation_enabled", False)
         translation_target_language = _msg_data.get("translation_target_language", "en")
+
+        # GH #199: "Auto-add recordings to Audio Notebook". Two toggles reach
+        # this: the per-client one in the dashboard's Client tab, and the
+        # server-wide key (rendered in the Server tab). Either one enables it,
+        # so both checkboxes do what they say. Untrusted input: bool only.
+        _raw_auto_add = _msg_data.get("auto_add_to_notebook")
+        _client_auto_add = _raw_auto_add if isinstance(_raw_auto_add, bool) else False
+        _server_auto_add = False
+        try:
+            from server.config import get_config as _get_config
+
+            _server_auto_add = bool(
+                _get_config().get("longform_recording", "auto_add_to_audio_notebook", default=False)
+            )
+        except Exception as _cfg_err:
+            logger.debug("Could not read auto_add_to_audio_notebook: %s", repr(_cfg_err))
+
         await session.start_recording(
-            language, use_vad, translation_enabled, translation_target_language
+            language,
+            use_vad,
+            translation_enabled,
+            translation_target_language,
+            auto_add_to_notebook=_client_auto_add or _server_auto_add,
         )
 
     elif msg_type == "stop":

--- a/server/backend/tests/test_p0_durability.py
+++ b/server/backend/tests/test_p0_durability.py
@@ -53,6 +53,7 @@ def _make_session(
     session._use_realtime_engine = False
     session._current_job_id = job_id
     session._client_disconnected = False
+    session.auto_add_to_notebook = False
     session.capabilities = SimpleNamespace(
         supports_binary_audio=True,
         preferred_sample_rate=sample_rate,

--- a/server/backend/tests/test_websocket_notebook_autoadd.py
+++ b/server/backend/tests/test_websocket_notebook_autoadd.py
@@ -1,0 +1,471 @@
+"""Tests for "Auto-add recordings to Audio Notebook" on the session (WS) path.
+
+GH #199 — the toggle existed in Settings but was a write-only orphan: nothing
+read `notebook.autoAdd` (client) or `longform_recording.auto_add_to_audio_notebook`
+(server), and `save_longform_recording()` — the helper purpose-built to persist a
+session recording into the Notebook — had zero callers. Session transcriptions
+therefore never produced a Notebook entry.
+
+Invariants covered here:
+  1. The flag is resolved from the client `start` payload OR the server config.
+  2. When enabled, a completed session recording is written to the Notebook.
+  3. The Notebook write happens AFTER the result is persisted and delivered, and
+     a Notebook failure NEVER costs the user their transcript (delivery still
+     happens, no `error` is sent, the job is not marked failed).
+
+Run:  ../../build/.venv/bin/pytest tests/test_websocket_notebook_autoadd.py -v --tb=short
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from server.api.routes import websocket as ws_mod
+from server.core import model_manager as mm_mod
+from starlette.websockets import WebSocketState
+
+_BYTES_PER_SECOND = 16000 * 2
+
+
+@dataclass
+class _FakeResult:
+    """Duck-typed TranscriptionResult (avoids the torch/webrtcvad import chain)."""
+
+    text: str = "hello world"
+    segments: list[dict[str, Any]] = field(default_factory=list)
+    words: list[dict[str, Any]] = field(default_factory=list)
+    language: str | None = "en"
+    language_probability: float = 0.9
+    duration: float = 2.0
+    num_speakers: int = 0
+    partial: bool = False
+    partial_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "text": self.text,
+            "segments": self.segments,
+            "words": self.words,
+            "language": self.language,
+            "language_probability": self.language_probability,
+            "duration": self.duration,
+            "num_speakers": self.num_speakers,
+            "total_words": len(self.words),
+            "partial": self.partial,
+            "partial_reason": self.partial_reason,
+            "metadata": {"num_segments": len(self.segments)},
+        }
+
+
+def _make_session(*, auto_add: bool = False, job_id: str | None = "job-001"):
+    """Build a TranscriptionSession without running the heavy __init__."""
+    session = object.__new__(ws_mod.TranscriptionSession)
+    session.websocket = MagicMock()
+    session.websocket.client_state = WebSocketState.CONNECTED
+    session.websocket.send_json = AsyncMock()
+    session.client_name = "test-client"
+    session.is_recording = False
+    session.language = None
+    session.audio_chunks = [b"\x00\x01" * 16000]  # 1s of 16 kHz Int16 mono
+    session.sample_rate = 16000
+    session.temp_file = None
+    session.translation_enabled = False
+    session.translation_target_language = "en"
+    session._preview_in_progress = False
+    session._preview_task = None
+    session._client_disconnected = False
+    session._current_job_id = job_id
+    session.auto_add_to_notebook = auto_add
+    session.send_message = AsyncMock()
+    return session
+
+
+def _patch_transcription(monkeypatch, tmp_path, *, result: _FakeResult | None = None):
+    """Patch everything process_transcription() touches except the notebook hop."""
+    fake_engine = MagicMock()
+    fake_engine.model_name = "large-v3"
+    fake_engine.transcribe_file.return_value = result or _FakeResult()
+
+    fake_manager = MagicMock()
+    fake_manager.ensure_transcription_loaded.return_value = fake_engine
+    monkeypatch.setattr(mm_mod, "get_model_manager", lambda: fake_manager)
+
+    # Durability writes — irrelevant here, keep them silent.
+    monkeypatch.setattr(ws_mod, "_save_result", MagicMock())
+    monkeypatch.setattr(ws_mod, "_mark_delivered", MagicMock())
+    monkeypatch.setattr(ws_mod, "_mark_failed", MagicMock())
+    monkeypatch.setattr(ws_mod, "_set_audio_path", MagicMock())
+
+    # recordings_dir -> tmp so the persistent-audio write succeeds.
+    import server.config as cfg_mod
+
+    fake_cfg = MagicMock()
+    fake_cfg.get.side_effect = lambda *a, **kw: (
+        str(tmp_path) if a[:2] == ("durability", "recordings_dir") else kw.get("default")
+    )
+    monkeypatch.setattr(cfg_mod, "get_config", lambda: fake_cfg)
+
+    # Outgoing webhook — no-op.
+    import server.core.webhook as wh_mod
+
+    monkeypatch.setattr(wh_mod, "dispatch", AsyncMock())
+
+    return fake_engine
+
+
+def _sent(session) -> list[str]:
+    """Message types sent to the client, in order."""
+    return [c.args[0] for c in session.send_message.call_args_list]
+
+
+# ── Flag resolution (client payload OR server config) ──────────────────────
+
+
+def _patch_start_deps(monkeypatch, *, server_default: bool = False):
+    fake_tracker = MagicMock()
+    fake_tracker.try_start_job.return_value = (True, "job-xyz", None)
+    fake_manager = MagicMock()
+    fake_manager.job_tracker = fake_tracker
+    monkeypatch.setattr(mm_mod, "get_model_manager", lambda: fake_manager)
+    monkeypatch.setattr(ws_mod, "_create_job", MagicMock())
+
+    import server.config as cfg_mod
+
+    fake_cfg = MagicMock()
+    fake_cfg.get.side_effect = lambda *a, **kw: (
+        server_default
+        if a[:2] == ("longform_recording", "auto_add_to_audio_notebook")
+        else kw.get("default")
+    )
+    monkeypatch.setattr(cfg_mod, "get_config", lambda: fake_cfg)
+
+
+def _start_kwargs(session) -> dict[str, Any]:
+    _, kwargs = session.start_recording.call_args
+    return kwargs
+
+
+def test_start_payload_enables_auto_add(monkeypatch):
+    """Client toggle ON -> the session records into the Notebook."""
+    _patch_start_deps(monkeypatch, server_default=False)
+    session = _make_session()
+    session.start_recording = AsyncMock()
+
+    asyncio.run(
+        ws_mod.handle_client_message(
+            session, {"type": "start", "data": {"auto_add_to_notebook": True}}
+        )
+    )
+
+    assert _start_kwargs(session)["auto_add_to_notebook"] is True
+
+
+def test_start_payload_absent_defaults_off(monkeypatch):
+    _patch_start_deps(monkeypatch, server_default=False)
+    session = _make_session()
+    session.start_recording = AsyncMock()
+
+    asyncio.run(ws_mod.handle_client_message(session, {"type": "start", "data": {}}))
+
+    assert _start_kwargs(session)["auto_add_to_notebook"] is False
+
+
+def test_server_config_forces_auto_add_on(monkeypatch):
+    """The Server-tab key is a server-wide force-on, even if the client omits/disables it.
+
+    The GH #199 reporter ticked BOTH the Client and the Server checkbox; both
+    must actually do something.
+    """
+    _patch_start_deps(monkeypatch, server_default=True)
+    session = _make_session()
+    session.start_recording = AsyncMock()
+
+    asyncio.run(
+        ws_mod.handle_client_message(
+            session, {"type": "start", "data": {"auto_add_to_notebook": False}}
+        )
+    )
+
+    assert _start_kwargs(session)["auto_add_to_notebook"] is True
+
+
+def test_non_bool_flag_is_not_trusted(monkeypatch):
+    """Untrusted client input: a non-bool must not enable the write."""
+    _patch_start_deps(monkeypatch, server_default=False)
+    session = _make_session()
+    session.start_recording = AsyncMock()
+
+    asyncio.run(
+        ws_mod.handle_client_message(
+            session, {"type": "start", "data": {"auto_add_to_notebook": "sure"}}
+        )
+    )
+
+    assert _start_kwargs(session)["auto_add_to_notebook"] is False
+
+
+# ── The Notebook write itself ──────────────────────────────────────────────
+
+
+def test_completed_session_is_saved_to_notebook(monkeypatch, tmp_path):
+    """The bug: this produced no Notebook entry. Now it must."""
+    _patch_transcription(monkeypatch, tmp_path)
+    saved = MagicMock(return_value=42)
+    monkeypatch.setattr(ws_mod, "_save_session_to_notebook", saved)
+
+    session = _make_session(auto_add=True)
+    asyncio.run(session.process_transcription())
+
+    saved.assert_called_once()
+    kwargs = saved.call_args.kwargs
+    assert kwargs["result"].text == "hello world"
+    assert kwargs["duration_seconds"] == 2.0
+    # The recording's persisted audio is what gets promoted into the notebook.
+    assert kwargs["audio_path"] == tmp_path / "job-001.wav"
+    # The transcript still reaches the user.
+    assert "final" in _sent(session)
+
+
+def test_notebook_write_skipped_when_toggle_off(monkeypatch, tmp_path):
+    _patch_transcription(monkeypatch, tmp_path)
+    saved = MagicMock(return_value=42)
+    monkeypatch.setattr(ws_mod, "_save_session_to_notebook", saved)
+
+    session = _make_session(auto_add=False)
+    asyncio.run(session.process_transcription())
+
+    saved.assert_not_called()
+    assert "final" in _sent(session)
+
+
+def test_notebook_failure_never_costs_the_transcript(monkeypatch, tmp_path):
+    """AVOID DATA LOSS: a Notebook failure must not break result delivery."""
+    _patch_transcription(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        ws_mod,
+        "_save_session_to_notebook",
+        MagicMock(side_effect=RuntimeError("disk full")),
+    )
+    warned = MagicMock()
+    monkeypatch.setattr(ws_mod, "_warn_notebook_autoadd_failed", warned)
+
+    session = _make_session(auto_add=True)
+    asyncio.run(session.process_transcription())
+
+    sent = _sent(session)
+    assert "final" in sent  # transcript delivered anyway
+    assert "error" not in sent  # not reported as a transcription failure
+    ws_mod._mark_failed.assert_not_called()  # job is not failed over a notebook hiccup
+    # ...but the failure is NOT silent — that was the original bug's whole shape.
+    warned.assert_called_once()
+
+
+def test_notebook_write_returning_none_is_surfaced(monkeypatch, tmp_path):
+    """A no-op write must warn too, rather than pretend it saved."""
+    _patch_transcription(monkeypatch, tmp_path)
+    monkeypatch.setattr(ws_mod, "_save_session_to_notebook", MagicMock(return_value=None))
+    warned = MagicMock()
+    monkeypatch.setattr(ws_mod, "_warn_notebook_autoadd_failed", warned)
+
+    session = _make_session(auto_add=True)
+    asyncio.run(session.process_transcription())
+
+    warned.assert_called_once()
+    assert "final" in _sent(session)
+
+
+def test_notebook_warning_reaches_the_dashboard_event_channel(monkeypatch):
+    """The warning must go over the startup-event channel, not the WS socket.
+
+    The client disconnects on `final`, so a WS message would be dropped.
+    """
+    import server.core.startup_events as ev_mod
+
+    emitted = MagicMock()
+    monkeypatch.setattr(ev_mod, "emit_event", emitted)
+
+    ws_mod._warn_notebook_autoadd_failed("disk full")
+
+    emitted.assert_called_once()
+    args, kwargs = emitted.call_args
+    assert args[1] == "warning"
+    assert "disk full" in args[2]
+    assert kwargs["status"] == "error"
+
+
+def test_notebook_write_happens_after_result_is_persisted(monkeypatch, tmp_path):
+    """Persist-before-deliver: the durable job row is written before the notebook hop."""
+    _patch_transcription(monkeypatch, tmp_path)
+    order: list[str] = []
+    monkeypatch.setattr(
+        ws_mod, "_save_result", MagicMock(side_effect=lambda **kw: order.append("save_result"))
+    )
+    monkeypatch.setattr(
+        ws_mod,
+        "_save_session_to_notebook",
+        MagicMock(side_effect=lambda **kw: order.append("notebook") or 7),
+    )
+
+    session = _make_session(auto_add=True)
+    asyncio.run(session.process_transcription())
+
+    assert order == ["save_result", "notebook"]
+
+
+# ── _save_session_to_notebook() ────────────────────────────────────────────
+
+
+def _patch_notebook_write(monkeypatch, tmp_path, *, mp3_raises: bool = False):
+    """Patch the notebook-write dependencies; return (recorded_kwargs, audio_dir)."""
+    import server.config as cfg_mod
+    import server.core.audio_utils as au_mod
+    import server.database.database as db_mod
+
+    audio_dir = tmp_path / "audio"
+    fake_cfg = MagicMock()
+    fake_cfg.get.side_effect = lambda *a, **kw: (
+        str(audio_dir) if a[:2] == ("audio_notebook", "audio_dir") else kw.get("default")
+    )
+    monkeypatch.setattr(cfg_mod, "get_config", lambda: fake_cfg)
+
+    def _fake_mp3(src, dst, *a, **kw):
+        if mp3_raises:
+            raise RuntimeError("ffmpeg is not installed or not in PATH")
+        Path(dst).write_bytes(b"ID3-fake")
+        return dst
+
+    monkeypatch.setattr(au_mod, "convert_to_mp3", _fake_mp3)
+
+    recorded: dict[str, Any] = {}
+
+    def _fake_save(**kwargs):
+        recorded.update(kwargs)
+        return 99
+
+    monkeypatch.setattr(db_mod, "save_longform_to_database", _fake_save)
+    return recorded, audio_dir
+
+
+def _wav(tmp_path) -> Path:
+    src = tmp_path / "job-001.wav"
+    src.write_bytes(b"RIFF-fake-wav")
+    return src
+
+
+def test_save_session_to_notebook_persists_audio_and_words(monkeypatch, tmp_path):
+    recorded, audio_dir = _patch_notebook_write(monkeypatch, tmp_path)
+
+    result = _FakeResult(
+        text="hello world",
+        segments=[
+            {
+                "text": "hello world",
+                "start": 0.0,
+                "end": 1.0,
+                "words": [{"word": "hello", "start": 0.0, "end": 0.5}],
+            }
+        ],
+    )
+
+    rec_id = ws_mod._save_session_to_notebook(
+        audio_path=_wav(tmp_path),
+        duration_seconds=2.0,
+        result=result,
+        model_name="large-v3",
+    )
+
+    assert rec_id == 99
+    assert recorded["transcription_text"] == "hello world"
+    assert recorded["duration_seconds"] == 2.0
+    assert recorded["transcription_backend"] == "whisper"
+    # The notebook gets its own copy in the notebook audio dir (deleting the
+    # entry must not delete the job's retry audio).
+    assert recorded["audio_path"].parent == audio_dir
+    assert recorded["audio_path"].suffix == ".mp3"
+    # Word timestamps are lifted out of the segments so the entry carries real
+    # word-level timing, not just a wall of text.
+    assert recorded["word_timestamps"] == [{"word": "hello", "start": 0.0, "end": 0.5}]
+
+
+def test_notebook_entry_survives_missing_ffmpeg(monkeypatch, tmp_path):
+    """A stock macOS box has no ffmpeg — store the audio verbatim, don't drop the entry."""
+    recorded, audio_dir = _patch_notebook_write(monkeypatch, tmp_path, mp3_raises=True)
+
+    rec_id = ws_mod._save_session_to_notebook(
+        audio_path=_wav(tmp_path),
+        duration_seconds=2.0,
+        result=_FakeResult(),
+        model_name="large-v3",
+    )
+
+    assert rec_id == 99
+    assert recorded["audio_path"].suffix == ".wav"
+    assert recorded["audio_path"].parent == audio_dir
+    assert recorded["audio_path"].read_bytes() == b"RIFF-fake-wav"
+
+
+def test_save_session_to_notebook_returns_none_when_db_fails(monkeypatch, tmp_path):
+    _patch_notebook_write(monkeypatch, tmp_path)
+    import server.database.database as db_mod
+
+    monkeypatch.setattr(db_mod, "save_longform_to_database", lambda **kw: None)
+
+    assert (
+        ws_mod._save_session_to_notebook(
+            audio_path=_wav(tmp_path),
+            duration_seconds=2.0,
+            result=_FakeResult(),
+            model_name="large-v3",
+        )
+        is None
+    )
+
+
+def test_missing_audio_file_is_not_written_to_notebook(monkeypatch, tmp_path):
+    recorded, _ = _patch_notebook_write(monkeypatch, tmp_path)
+
+    assert (
+        ws_mod._save_session_to_notebook(
+            audio_path=tmp_path / "gone.wav",
+            duration_seconds=2.0,
+            result=_FakeResult(),
+            model_name="large-v3",
+        )
+        is None
+    )
+    assert recorded == {}
+
+
+def test_empty_audio_is_not_written_to_notebook(monkeypatch, tmp_path):
+    """Silence in, nothing out — a zero-length recording must not create an entry."""
+    recorded, _ = _patch_notebook_write(monkeypatch, tmp_path)
+
+    assert (
+        ws_mod._save_session_to_notebook(
+            audio_path=_wav(tmp_path),
+            duration_seconds=0.0,
+            result=_FakeResult(),
+            model_name="large-v3",
+        )
+        is None
+    )
+    assert recorded == {}
+
+
+def test_no_audio_chunks_never_reaches_the_notebook(monkeypatch, tmp_path):
+    """The pre-existing 'No audio data received' bail-out short-circuits everything."""
+    _patch_transcription(monkeypatch, tmp_path)
+    saved = MagicMock()
+    monkeypatch.setattr(ws_mod, "_save_session_to_notebook", saved)
+
+    session = _make_session(auto_add=True)
+    session.audio_chunks = []
+
+    asyncio.run(session.process_transcription())
+
+    saved.assert_not_called()
+    assert _sent(session) == ["error"]

--- a/server/config.yaml
+++ b/server/config.yaml
@@ -20,8 +20,11 @@ longform_recording:
     # Translation output target language. Faster-whisper only offers English translation.
     translation_target_language: "en"
 
-    # Automatically add longform recordings to Audio Notebook.
-    # When enabled, recordings are sent to the notebook instead of just the clipboard.
+    # Automatically add finished longform recordings to the Audio Notebook.
+    # Server-wide: applies to every client, on top of the dashboard's own
+    # per-client "Auto-add recordings to Audio Notebook" toggle (either one
+    # enables it). The transcript is still shown and copied as usual; the
+    # notebook entry is added in addition, not instead.
     auto_add_to_audio_notebook: false
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #199.

## The bug

The "Auto-add recordings to Audio Notebook" toggle did nothing. Session transcriptions never produced a Notebook entry, while manual imports worked fine (which is why the Notebook itself looked healthy).

## Root cause

The feature was implemented **client-side** in the old PyQt dashboard (`orchestrator.py:450` branched to the notebook upload endpoint) and was dropped in the React port. Only its toggle came back. That left three orphaned pieces with no wire between them:

| Piece | Location | State |
|---|---|---|
| Client toggle `notebook.autoAdd` | `SettingsModal.tsx` -> electron-store | persisted, read by nobody |
| Server key `auto_add_to_audio_notebook` | `server/config.yaml` | zero read sites in the backend |
| `database.save_longform_recording()` | `database.py:1844` | fully implemented, zero callers |

The Server tab renders config.yaml keys generically, so the server key shows up as a real checkbox too. That is why the reporter ticked both a Client and a Server box and neither did anything.

## The fix

Wire it **server-side** rather than porting the old client-side endpoint switch:

- `_save_session_to_notebook()` in the WS route promotes the finished recording into the Notebook. The session already wrote its audio to disk and already has a transcript, so there is no re-upload and no second transcription pass.
- It runs **after** the result is persisted and delivered, in a thread. A Notebook failure can never cost the user their transcript, and the MP3 encode never blocks the event loop or delays the transcript reaching the user.
- The flag is resolved as `client payload OR server config`, so **both** checkboxes the user can see now do what they say.

### Why not `save_longform_recording()`

It looks like the natural helper (its signature is a key-fit), but it caps ffmpeg at **60 seconds** (a long lecture would silently produce no entry) and returns `None` when ffmpeg is absent (a stock macOS box). This mirrors the proven manual-import route instead, including its ffmpeg fallback that stores the audio verbatim rather than dropping a completed recording.

## Behaviour notes

- **Additive, not exclusive.** The old config comment said recordings go to the Notebook *instead of* the clipboard. Now the transcript still appears and is copied as before; the Notebook entry is added on top.
- Entries from a session are **not diarized** (the WS path has no diarization pass). They do carry real word-level timing.
- A failed write is surfaced via the startup-event channel, because the client disconnects the moment it receives `final` and would drop a WebSocket message.

## Out of scope

- **Live Mode** retains no audio at all (only a list of sentence strings), so "one audio note per live session" is a genuine new feature, not a broken toggle.
- **Preview** stays ephemeral by design and correctly creates no entry.

## Test plan

- 16 new tests (`test_websocket_notebook_autoadd.py`): flag resolution (client / server / both / untrusted input), the notebook write, the ffmpeg-missing fallback, empty and missing audio, and the invariant that a Notebook failure never breaks result delivery.
- Full backend suite: **2121 passed**. Frontend: **1643 passed**. tsc, ruff, eslint, UI contract all clean.
- [x] **Manual hardware check passed:** recorded a session with the toggle on; the entry appears in the Notebook with playable audio.
