### PR TITLE
fix(server, docker, docs): make the corporate-CA remedy for TLS interception actually exist (GH #200)

### DIFF
--- a/dashboard/electron/__tests__/dockerManagerComposeEnvPreservation.test.ts
+++ b/dashboard/electron/__tests__/dockerManagerComposeEnvPreservation.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment node
+
+/**
+ * GH-200 — a hand-added compose env key must survive every server start.
+ *
+ * On a TLS-intercepting network (corporate proxy / antivirus HTTPS scanning) the
+ * only way a packaged-app user can get their root CA into the container is to add
+ * `EXTRA_CA_CERTS_DIR=...` to `<userData>/docker/.env` by hand: there is no UI for
+ * it yet, and the compose files themselves are overwritten from the bundle on every
+ * launch.
+ *
+ * `upsertComposeEnvValues` rewrites that same file on every start. It only strips
+ * the keys it is about to write, so unknown keys survive — and this test pins that,
+ * because a refactor to "rewrite the file from the known key set" would look
+ * perfectly reasonable and would silently re-break exactly the users who are hardest
+ * to support.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+const userDataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ts-compose-env-test-'));
+
+// Simulate a PACKAGED install, which is the population that hits GH-200: resolveComposeDir()
+// copies every file from resources/docker over <userData>/docker on each start. Packaging
+// ships only the compose YAMLs (electron-builder `extraResources`), never a .env — which is
+// precisely why a user-authored .env survives. Shipping a .env would silently kill the only
+// escape hatch these users have, so this fixture mirrors the real resource set.
+const resourcesRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ts-compose-res-test-'));
+fs.mkdirSync(path.join(resourcesRoot, 'docker'), { recursive: true });
+fs.writeFileSync(path.join(resourcesRoot, 'docker', 'docker-compose.yml'), 'services: {}\n');
+(process as NodeJS.Process & { resourcesPath: string }).resourcesPath = resourcesRoot;
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: true,
+    getPath: (_name: string) => userDataRoot,
+    setPath: vi.fn(),
+  },
+}));
+
+vi.mock('electron-store', () => ({
+  default: class MockStore {
+    get() {
+      return undefined;
+    }
+    set() {}
+  },
+}));
+
+const composeEnvPath = path.join(userDataRoot, 'TranscriptionSuite', 'docker', '.env');
+
+function readComposeEnv(): string {
+  return fs.readFileSync(composeEnvPath, 'utf8');
+}
+
+function envValue(text: string, key: string): string | undefined {
+  for (const line of text.split(/\r?\n/)) {
+    const match = new RegExp(`^${key}=(.*)$`).exec(line.trim());
+    if (match) return match[1];
+  }
+  return undefined;
+}
+
+describe('upsertComposeEnvValues — GH-200 CA escape hatch', () => {
+  beforeEach(() => {
+    fs.mkdirSync(path.dirname(composeEnvPath), { recursive: true });
+    fs.rmSync(composeEnvPath, { force: true });
+  });
+
+  it('preserves a hand-added EXTRA_CA_CERTS_DIR across a server start', async () => {
+    const { upsertComposeEnvValues } = await import('../dockerManager.js');
+
+    fs.writeFileSync(
+      composeEnvPath,
+      '# user-added for corporate network (GH-200)\nEXTRA_CA_CERTS_DIR=C:\\Users\\me\\AppData\\Roaming\\TranscriptionSuite\\ca\nTAG=v1.3.7\n',
+      'utf8',
+    );
+
+    // What a normal server start writes.
+    upsertComposeEnvValues({ TAG: 'v1.3.8', PYTORCH_VARIANT: 'cpu' });
+
+    const text = readComposeEnv();
+    expect(envValue(text, 'EXTRA_CA_CERTS_DIR')).toBe(
+      'C:\\Users\\me\\AppData\\Roaming\\TranscriptionSuite\\ca',
+    );
+    expect(envValue(text, 'TAG')).toBe('v1.3.8');
+    expect(envValue(text, 'PYTORCH_VARIANT')).toBe('cpu');
+    expect(text).toContain('# user-added for corporate network (GH-200)');
+  });
+
+  it('still preserves it after repeated starts', async () => {
+    const { upsertComposeEnvValues } = await import('../dockerManager.js');
+
+    fs.writeFileSync(
+      composeEnvPath,
+      'EXTRA_CA_CERTS_DIR=/home/me/.config/TranscriptionSuite/ca\n',
+      'utf8',
+    );
+
+    for (let i = 0; i < 5; i += 1) {
+      upsertComposeEnvValues({ TAG: `v1.3.${i}` });
+    }
+
+    const text = readComposeEnv();
+    expect(envValue(text, 'EXTRA_CA_CERTS_DIR')).toBe('/home/me/.config/TranscriptionSuite/ca');
+    expect(envValue(text, 'TAG')).toBe('v1.3.4');
+    // The key must not accumulate duplicates that compose would resolve ambiguously.
+    expect(text.match(/^EXTRA_CA_CERTS_DIR=/gm)?.length).toBe(1);
+  });
+
+  it('preserves other unrelated user keys too (proxy vars)', async () => {
+    const { upsertComposeEnvValues } = await import('../dockerManager.js');
+
+    fs.writeFileSync(
+      composeEnvPath,
+      'HTTPS_PROXY=http://proxy.corp:8080\nNO_PROXY=localhost,127.0.0.1\n',
+      'utf8',
+    );
+
+    upsertComposeEnvValues({ TAG: 'v1.3.8' });
+
+    const text = readComposeEnv();
+    expect(envValue(text, 'HTTPS_PROXY')).toBe('http://proxy.corp:8080');
+    expect(envValue(text, 'NO_PROXY')).toBe('localhost,127.0.0.1');
+  });
+});

--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -823,7 +823,11 @@ function sanitizeEnvValue(value: string): string {
   return value.replace(/[\r\n]+/g, '').trim();
 }
 
-function upsertComposeEnvValues(values: Record<string, string>): void {
+// Exported for tests: preserving keys we do not own is load-bearing. It is the only
+// way a packaged-app user can set EXTRA_CA_CERTS_DIR to escape a TLS-intercepting
+// network (GH #200), and a refactor that stripped unknown keys would silently
+// re-break them on the next server start.
+export function upsertComposeEnvValues(values: Record<string, string>): void {
   const composeEnvPath = path.join(getComposeDir(), '.env');
   const entries = Object.entries(values);
   if (entries.length === 0) return;

--- a/docs/README.md
+++ b/docs/README.md
@@ -933,7 +933,7 @@ sudo systemctl enable --now nvidia-persistence.service
 **Steps:**
 
 1. **Use the CPU profile.** In **Settings > Server**, select the **CPU** profile before starting. CPU-only hosts no longer download the multi-GB NVIDIA CUDA wheels and default to a lighter faster-whisper model instead of the GPU-only NeMo model.
-2. **`UnknownIssuer` / certificate errors** mean your network (a corporate proxy or antivirus HTTPS scanning) is intercepting HTTPS, so the container can't verify the package index. Set `UV_NATIVE_TLS=true` and add your organization's root CA — see the [deployment guide](deployment-guide.md#tls-interception--corporate-network-unknownissuer).
+2. **`UnknownIssuer` / certificate errors** mean something (antivirus HTTPS scanning, or a corporate proxy) is intercepting HTTPS and re-signing it, so the container can't verify the package index. Turn off your antivirus's HTTPS-scanning setting, or point `EXTRA_CA_CERTS_DIR` at a folder holding the intercepting root CA — see the [deployment guide](deployment-guide.md#tls-interception--corporate-network-unknownissuer).
 3. **`UnicodeEncodeError` on model load** means a HuggingFace token containing a non-ASCII character was provided. Clear the token (most models don't need one); the server now also ignores non-ASCII tokens automatically and downloads anonymously.
 
 ### Advanced Troubleshooting

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -89,36 +89,80 @@ On first container start, the server installs Python dependencies into `/runtime
 
 If first-run `uv sync` fails with `invalid peer certificate: UnknownIssuer`,
 `certificate verify failed`, or `server certificate verification failed.
-CAfile: none` (a git clone), your network is intercepting HTTPS — a corporate
-proxy or antivirus "HTTPS scanning" feature presents a re-signed certificate
-whose root CA is trusted on your host but **not** inside the container. Each
-client ships/uses its own trust store and rejects the re-signed cert. The
-bootstrap detects all of these signatures and prints an actionable hint instead
-of a bare traceback.
+CAfile: none` (a git clone), something is intercepting HTTPS and re-signing it
+with a certificate the container does not trust.
 
-Fix (certificate verification stays ON — never disable it):
+**Why it works in your browser but not here.** The interceptor's root CA is
+installed in your *host's* trust store. Docker does not copy the host trust store
+into containers, so every HTTPS client inside the container rejects the re-signed
+certificate. Nothing is wrong with your Docker install or your image.
 
-1. **Trust the system CA store:** set `UV_NATIVE_TLS=true` (already wired into
-   `docker-compose.yml`). uv then reads the container's CA trust store instead
-   of its bundled roots.
-2. **Add your corporate root CA** so that store actually contains it. Easiest is
-   a small derived image:
-   ```dockerfile
-   FROM ghcr.io/homelab-00/transcriptionsuite-server:latest
-   COPY corp-root-ca.crt /usr/local/share/ca-certificates/corp-root-ca.crt
-   RUN update-ca-certificates
-   ```
-   Point `IMAGE_REPO`/`TAG` at your derived image and run with
-   `UV_NATIVE_TLS=true`. Alternatively, mount the CA and set
-   `SSL_CERT_FILE=/path/to/corp-root-ca.pem` in your own compose override.
+Certificate verification stays ON throughout. Never disable it.
 
-> **Why both steps matter.** `UV_NATIVE_TLS` only covers uv's own HTTPS client.
-> The `git` subprocess uv uses for git-sourced dependencies, and the `requests`
-> client HuggingFace uses to download models, ignore it — they read
-> `GIT_SSL_CAINFO` and `REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE`. When you set
-> `UV_NATIVE_TLS=true` (or `SSL_CERT_FILE`), the bootstrap now propagates the CA
-> bundle to those clients automatically, so once your root CA is in the container
-> store (step 2) **git clones and model downloads trust it too**.
+#### 1. First, rule out your antivirus (most home users stop here)
+
+Consumer security suites ship an HTTPS-scanning feature that is **on by default**
+and does exactly this interception. Turn it off and start the server again:
+
+| Product | Setting to disable |
+|---|---|
+| ESET | Web and email → SSL/TLS → *Enable SSL/TLS protocol filtering* |
+| Kaspersky | Settings → Network → *Do not scan encrypted connections* |
+| Avast / AVG | Protection → Core Shields → *Enable HTTPS scanning* |
+| Bitdefender | Protection → Online Threat Prevention → *Encrypted Web Scan* |
+| Avira | Web Protection → *Scan HTTPS connections* |
+
+Corporate laptops with a managed proxy (Zscaler, Netskope, Fortinet, a company
+CA) cannot do this. Use step 2.
+
+#### 2. Give the container the intercepting root CA
+
+Export the root CA, put it in a folder **of its own**, and point
+`EXTRA_CA_CERTS_DIR` at that folder. The entrypoint installs everything it finds
+there into the container trust store at startup, before any download runs.
+
+Export it on Windows with PowerShell (no admin rights needed):
+
+```powershell
+$dir = "$env:APPDATA\TranscriptionSuite\ca"
+New-Item -ItemType Directory -Force -Path $dir | Out-Null
+Get-ChildItem Cert:\LocalMachine\Root, Cert:\CurrentUser\Root | ForEach-Object {
+  "-----BEGIN CERTIFICATE-----"
+  [Convert]::ToBase64String($_.RawData, [Base64FormattingOptions]::InsertLineBreaks)
+  "-----END CERTIFICATE-----"
+} | Set-Content -Encoding ascii "$dir\host-roots.crt"
+```
+
+Then set `EXTRA_CA_CERTS_DIR=%APPDATA%\TranscriptionSuite\ca` and restart the
+server. (This exports every root your OS already trusts, which necessarily
+includes the interceptor's. If you prefer to trust only that one CA, export it
+alone from `certmgr.msc` → Trusted Root Certification Authorities → right-click
+→ All Tasks → Export → **Base-64 encoded X.509** and drop the file in that
+folder instead.)
+
+On Linux/macOS the equivalent is any directory containing your CA:
+`EXTRA_CA_CERTS_DIR=~/.config/TranscriptionSuite/ca`.
+
+Accepted file extensions are `.crt`, `.pem` and `.cer`; PEM bundles holding many
+certificates are split automatically. Files that are not PEM (a DER export) are
+skipped with a warning rather than corrupting the trust store.
+
+Behind a corporate proxy you likely also need `HTTP_PROXY`, `HTTPS_PROXY` and
+`NO_PROXY`, which are passed through to the container.
+
+> **Why one folder covers everything.** The install path spans three trust
+> stores: uv reads `SSL_CERT_FILE`, the `git` subprocess uv uses for git-sourced
+> dependencies reads `GIT_SSL_CAINFO`, and the `requests` client HuggingFace uses
+> for model downloads reads `REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE` and honors
+> neither of the others. Once a CA is installed, the entrypoint points all of them
+> at the combined bundle (`/etc/ssl/certs/ca-certificates.crt`), which holds the
+> public roots **and** yours — so package installs, git clones and model downloads
+> all trust it, and non-intercepted hosts keep working. Setting `SSL_CERT_FILE` to
+> a bare root CA by hand does *not* do this: it **replaces** the trust store rather
+> than adding to it, and breaks every host your interceptor does not touch.
+
+`UV_NATIVE_TLS=true` remains available but is no longer something you need to
+set: once a CA is installed, uv switches to the system trust store on its own.
 
 CPU-only hosts hit this most often because the default install pulls multi-GB
 CUDA wheels. Selecting the **CPU profile** in the dashboard (or

--- a/server/backend/tests/test_bootstrap_runtime.py
+++ b/server/backend/tests/test_bootstrap_runtime.py
@@ -1740,7 +1740,10 @@ def test_raise_dependency_sync_failure_emits_tls_hint(
     with pytest.raises(RuntimeError) as excinfo:
         module._raise_dependency_sync_failure(RuntimeError(long_cert_error), "rebuild-sync")
 
-    assert any("UV_NATIVE_TLS" in line for line in logs), "TLS hint must be logged in full"
+    # The hint must name a remedy the container can actually perform (GH #200): the
+    # CA mount, and the antivirus HTTPS-scanning setting that is the likelier cause.
+    assert any("EXTRA_CA_CERTS_DIR" in line for line in logs), "TLS hint must be logged in full"
+    assert any("HTTPS scanning" in line for line in logs)
     assert any(kwargs.get("status") == "error" for _, kwargs in events)
     assert "Dependency sync failed for mode=rebuild-sync" in str(excinfo.value)
 

--- a/server/backend/tests/test_install_ca_certs.py
+++ b/server/backend/tests/test_install_ca_certs.py
@@ -1,0 +1,355 @@
+"""Tests for the runtime CA-certificate installer (GH #200).
+
+The installer runs as root from docker-entrypoint.sh and is the only path by
+which an operator's root CA can reach the container trust store. Everything it
+does must survive a hostile mount: junk files, DER blobs, multi-cert bundles,
+and names that try to escape the anchor directory.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_module() -> ModuleType:
+    repo_root = Path(__file__).resolve().parents[3]
+    module_path = repo_root / "server/docker/install_ca_certs.py"
+    spec = importlib.util.spec_from_file_location(
+        "install_ca_certs_test_module",
+        module_path,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def mod() -> ModuleType:
+    return _load_module()
+
+
+def _pem(label: str) -> str:
+    """A syntactically valid single-certificate PEM block."""
+    return f"-----BEGIN CERTIFICATE-----\n{label}\n-----END CERTIFICATE-----\n"
+
+
+class _Runner:
+    """Records update-ca-certificates invocations; optionally fails the first n."""
+
+    def __init__(self, fail_times: int = 0) -> None:
+        self.calls: list[list[str]] = []
+        self.fail_times = fail_times
+
+    def __call__(self, cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        self.calls.append(list(cmd))
+        if len(self.calls) <= self.fail_times:
+            raise subprocess.CalledProcessError(1, cmd, output="", stderr="boom")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+
+# --------------------------------------------------------------------------
+# PEM block extraction
+# --------------------------------------------------------------------------
+
+
+def test_pem_blocks_extracts_single_certificate(mod: ModuleType) -> None:
+    assert mod.pem_blocks(_pem("AAA")) == [_pem("AAA").strip()]
+
+
+def test_pem_blocks_splits_a_multi_certificate_bundle(mod: ModuleType) -> None:
+    """A Windows root-store export is one file with hundreds of certs in it."""
+    bundle = _pem("AAA") + _pem("BBB") + _pem("CCC")
+    blocks = mod.pem_blocks(bundle)
+    assert len(blocks) == 3
+    assert "AAA" in blocks[0] and "BBB" in blocks[1] and "CCC" in blocks[2]
+    assert all(b.startswith("-----BEGIN CERTIFICATE-----") for b in blocks)
+    assert all(b.endswith("-----END CERTIFICATE-----") for b in blocks)
+
+
+def test_pem_blocks_ignores_surrounding_noise(mod: ModuleType) -> None:
+    text = f"Bag Attributes\n  friendlyName: Corp\n{_pem('AAA')}trailing junk\n"
+    assert len(mod.pem_blocks(text)) == 1
+
+
+def test_pem_blocks_rejects_non_pem_content(mod: ModuleType) -> None:
+    assert mod.pem_blocks("\x00\x01binary DER blob") == []
+    assert mod.pem_blocks("") == []
+
+
+def test_pem_blocks_ignores_an_unterminated_block(mod: ModuleType) -> None:
+    assert mod.pem_blocks("-----BEGIN CERTIFICATE-----\nAAA\n") == []
+
+
+# --------------------------------------------------------------------------
+# Staging
+# --------------------------------------------------------------------------
+
+
+def test_stage_returns_nothing_when_source_dir_is_absent(mod: ModuleType, tmp_path: Path) -> None:
+    anchors = tmp_path / "anchors"
+    anchors.mkdir()
+    assert mod.stage_certificates(tmp_path / "missing", anchors) == []
+
+
+def test_stage_returns_nothing_for_an_empty_source_dir(mod: ModuleType, tmp_path: Path) -> None:
+    source = tmp_path / "src"
+    source.mkdir()
+    anchors = tmp_path / "anchors"
+    anchors.mkdir()
+    assert mod.stage_certificates(source, anchors) == []
+
+
+def test_stage_ignores_the_empty_placeholder_dirs_contents(mod: ModuleType, tmp_path: Path) -> None:
+    """compose mounts ./.empty when EXTRA_CA_CERTS_DIR is unset."""
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / ".gitkeep").write_text("", encoding="utf-8")
+    (source / "startup-events.jsonl").write_text("{}\n", encoding="utf-8")
+    anchors = tmp_path / "anchors"
+    anchors.mkdir()
+
+    assert mod.stage_certificates(source, anchors) == []
+    assert list(anchors.iterdir()) == []
+
+
+def test_stage_normalizes_a_pem_extension_to_crt(mod: ModuleType, tmp_path: Path) -> None:
+    """update-ca-certificates ONLY reads *.crt; a .pem would be silently ignored."""
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "corp-root-ca.pem").write_text(_pem("AAA"), encoding="utf-8")
+    anchors = tmp_path / "anchors"
+    anchors.mkdir()
+
+    staged = mod.stage_certificates(source, anchors)
+
+    assert len(staged) == 1
+    assert staged[0].suffix == ".crt"
+    assert staged[0].parent == anchors
+    assert "AAA" in staged[0].read_text(encoding="utf-8")
+
+
+def test_stage_accepts_crt_and_cer_and_pem(mod: ModuleType, tmp_path: Path) -> None:
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "a.crt").write_text(_pem("AAA"), encoding="utf-8")
+    (source / "b.cer").write_text(_pem("BBB"), encoding="utf-8")
+    (source / "c.pem").write_text(_pem("CCC"), encoding="utf-8")
+    anchors = tmp_path / "anchors"
+    anchors.mkdir()
+
+    staged = mod.stage_certificates(source, anchors)
+
+    assert len(staged) == 3
+    assert all(p.suffix == ".crt" for p in staged)
+
+
+def test_stage_is_case_insensitive_about_extensions(mod: ModuleType, tmp_path: Path) -> None:
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "corp.PEM").write_text(_pem("AAA"), encoding="utf-8")
+    anchors = tmp_path / "anchors"
+    anchors.mkdir()
+
+    staged = mod.stage_certificates(source, anchors)
+
+    assert len(staged) == 1
+    assert staged[0].suffix == ".crt"
+
+
+def test_stage_skips_files_without_a_certificate_extension(mod: ModuleType, tmp_path: Path) -> None:
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "notes.txt").write_text(_pem("AAA"), encoding="utf-8")
+    anchors = tmp_path / "anchors"
+    anchors.mkdir()
+
+    assert mod.stage_certificates(source, anchors) == []
+
+
+def test_stage_skips_a_der_or_binary_file(mod: ModuleType, tmp_path: Path) -> None:
+    """A DER export has the right extension but no PEM armor; it would break the bundle."""
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "corp.cer").write_bytes(b"\x30\x82\x03\x00binary DER")
+    anchors = tmp_path / "anchors"
+    anchors.mkdir()
+
+    assert mod.stage_certificates(source, anchors) == []
+    assert list(anchors.iterdir()) == []
+
+
+def test_stage_splits_a_multi_certificate_bundle_into_one_file_each(
+    mod: ModuleType, tmp_path: Path
+) -> None:
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "host-roots.crt").write_text(
+        _pem("AAA") + _pem("BBB") + _pem("CCC"), encoding="utf-8"
+    )
+    anchors = tmp_path / "anchors"
+    anchors.mkdir()
+
+    staged = mod.stage_certificates(source, anchors)
+
+    assert len(staged) == 3
+    assert len({p.name for p in staged}) == 3, "staged names must be unique"
+    bodies = [p.read_text(encoding="utf-8") for p in staged]
+    assert sum("AAA" in b for b in bodies) == 1
+    assert sum("BBB" in b for b in bodies) == 1
+    assert sum("CCC" in b for b in bodies) == 1
+    for body in bodies:
+        assert body.count("BEGIN CERTIFICATE") == 1
+
+
+def test_stage_ignores_subdirectories(mod: ModuleType, tmp_path: Path) -> None:
+    source = tmp_path / "src"
+    (source / "nested.crt").mkdir(parents=True)
+    anchors = tmp_path / "anchors"
+    anchors.mkdir()
+
+    assert mod.stage_certificates(source, anchors) == []
+
+
+def test_stage_confines_output_to_the_anchor_dir(mod: ModuleType, tmp_path: Path) -> None:
+    """A crafted filename must never write outside the anchor directory."""
+    source = tmp_path / "src"
+    source.mkdir()
+    hostile = source / "..%2f..%2fetc%2fpasswd.crt"
+    hostile.write_text(_pem("AAA"), encoding="utf-8")
+    anchors = tmp_path / "anchors"
+    anchors.mkdir()
+
+    staged = mod.stage_certificates(source, anchors)
+
+    assert len(staged) == 1
+    assert staged[0].resolve().parent == anchors.resolve()
+    assert "/" not in staged[0].name
+
+
+def test_stage_does_not_collide_when_two_sources_normalize_to_one_name(
+    mod: ModuleType, tmp_path: Path
+) -> None:
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "corp.crt").write_text(_pem("AAA"), encoding="utf-8")
+    (source / "corp.CRT").write_text(_pem("BBB"), encoding="utf-8")
+    anchors = tmp_path / "anchors"
+    anchors.mkdir()
+
+    staged = mod.stage_certificates(source, anchors)
+
+    assert len(staged) == 2
+    assert len({p.name for p in staged}) == 2
+    bodies = [p.read_text(encoding="utf-8") for p in staged]
+    assert sum("AAA" in b for b in bodies) == 1
+    assert sum("BBB" in b for b in bodies) == 1
+
+
+def test_stage_creates_the_anchor_dir_when_missing(mod: ModuleType, tmp_path: Path) -> None:
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "corp.crt").write_text(_pem("AAA"), encoding="utf-8")
+    anchors = tmp_path / "anchors"
+
+    staged = mod.stage_certificates(source, anchors)
+
+    assert anchors.is_dir()
+    assert len(staged) == 1
+
+
+# --------------------------------------------------------------------------
+# install_ca_certificates: staging + update-ca-certificates + rollback
+# --------------------------------------------------------------------------
+
+
+def test_install_runs_update_ca_certificates_once_when_certs_are_present(
+    mod: ModuleType, tmp_path: Path
+) -> None:
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "corp.crt").write_text(_pem("AAA"), encoding="utf-8")
+    anchors = tmp_path / "anchors"
+    runner = _Runner()
+
+    staged = mod.install_ca_certificates(source, anchors, runner=runner)
+
+    assert len(staged) == 1
+    assert len(runner.calls) == 1
+    assert runner.calls[0][0] == "update-ca-certificates"
+
+
+def test_install_skips_update_ca_certificates_when_no_certs_are_supplied(
+    mod: ModuleType, tmp_path: Path
+) -> None:
+    """The default compose mount is an empty placeholder dir; startup must not pay for it."""
+    source = tmp_path / "src"
+    source.mkdir()
+    anchors = tmp_path / "anchors"
+    runner = _Runner()
+
+    assert mod.install_ca_certificates(source, anchors, runner=runner) == []
+    assert runner.calls == []
+
+
+def test_install_rolls_back_staged_certs_when_update_fails(mod: ModuleType, tmp_path: Path) -> None:
+    """A bad cert must not leave a broken bundle that breaks ALL TLS in the container."""
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "corp.crt").write_text(_pem("AAA"), encoding="utf-8")
+    anchors = tmp_path / "anchors"
+    runner = _Runner(fail_times=1)
+
+    staged = mod.install_ca_certificates(source, anchors, runner=runner)
+
+    assert staged == [], "a failed install must report nothing installed"
+    assert list(anchors.iterdir()) == [], "staged certs must be removed on failure"
+    assert len(runner.calls) == 2, "must re-run update-ca-certificates to restore the bundle"
+
+
+def test_install_preserves_certs_baked_in_at_build_time(mod: ModuleType, tmp_path: Path) -> None:
+    """Rollback must only remove what THIS run staged, not a derived image's own CA."""
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "corp.crt").write_text(_pem("AAA"), encoding="utf-8")
+    anchors = tmp_path / "anchors"
+    anchors.mkdir()
+    baked = anchors / "baked-in.crt"
+    baked.write_text(_pem("BAKED"), encoding="utf-8")
+    runner = _Runner(fail_times=1)
+
+    mod.install_ca_certificates(source, anchors, runner=runner)
+
+    assert baked.exists(), "a build-time CA must survive a failed runtime install"
+
+
+# --------------------------------------------------------------------------
+# main(): never fatal
+# --------------------------------------------------------------------------
+
+
+def test_main_returns_zero_when_no_certs_are_mounted(
+    mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CA_TRUST_SOURCE_DIR", str(tmp_path / "missing"))
+    monkeypatch.setenv("CA_TRUST_ANCHOR_DIR", str(tmp_path / "anchors"))
+    assert mod.main() == 0
+
+
+def test_main_is_non_fatal_when_update_ca_certificates_fails(
+    mod: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A CA problem must degrade to a clear bootstrap TLS error, never brick startup."""
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "corp.crt").write_text(_pem("AAA"), encoding="utf-8")
+    monkeypatch.setenv("CA_TRUST_SOURCE_DIR", str(source))
+    monkeypatch.setenv("CA_TRUST_ANCHOR_DIR", str(tmp_path / "anchors"))
+    monkeypatch.setattr(mod, "_run", _Runner(fail_times=99))
+
+    assert mod.main() == 0

--- a/server/docker/Dockerfile
+++ b/server/docker/Dockerfile
@@ -87,6 +87,9 @@ COPY --chown=appuser:appuser server/backend/ ./server/
 COPY --chown=appuser:appuser server/docker/entrypoint.py ./docker/
 COPY --chown=appuser:appuser server/docker/bootstrap_runtime.py ./docker/
 COPY server/docker/docker-entrypoint.sh ./docker/
+# Root-owned on purpose: it runs as root (before the gosu drop) to write the
+# container trust store, so appuser must not be able to modify it (GH #200).
+COPY server/docker/install_ca_certs.py ./docker/
 RUN chmod 700 ./docker/docker-entrypoint.sh
 
 # Copy default configuration (users can override via mounted /user-config/config.yaml)

--- a/server/docker/bootstrap_runtime.py
+++ b/server/docker/bootstrap_runtime.py
@@ -534,14 +534,20 @@ _TLS_INTERCEPTION_MARKERS: tuple[str, ...] = (
 )
 
 _TLS_INTERCEPTION_HINT = (
-    "TLS certificate verification failed while downloading dependencies. Your "
-    "network appears to intercept HTTPS (corporate proxy or antivirus HTTPS "
-    "scanning), so the certificate is not trusted inside the container. Fix: "
-    "(1) set UV_NATIVE_TLS=true so uv trusts the container CA store, and "
-    "(2) mount your organization's root CA into the container and run "
-    "update-ca-certificates so git (git-sourced deps) and HuggingFace model "
-    "downloads trust it too — UV_NATIVE_TLS alone does not cover them. See "
-    "docs/deployment-guide.md (TLS interception / corporate network)."
+    "TLS certificate verification failed while downloading dependencies. Something on "
+    "your machine or network is intercepting HTTPS and re-signing it with a "
+    "certificate the container does not trust. Docker never copies the host's trust "
+    "store into a container, so this fails even though your browser works. "
+    "Two fixes, easiest first: "
+    "(1) If you run an antivirus/security suite (ESET, Kaspersky, Avast, Bitdefender, "
+    "Avira...), turn OFF its 'HTTPS scanning' / 'SSL protocol filtering' / 'encrypted "
+    "connection scanning' setting and start the server again. That is the whole fix "
+    "for most home users. "
+    "(2) Otherwise (corporate proxy, or you want to keep the scanner on), export the "
+    "intercepting root CA and put it in a folder of its own, then set "
+    "EXTRA_CA_CERTS_DIR to that folder — the container installs it at startup and "
+    "trusts it. Certificate verification stays ON either way. "
+    "Full instructions: https://github.com/homelab-00/TranscriptionSuite/blob/main/docs/deployment-guide.md#tls-interception--corporate-network-unknownissuer"
 )
 
 

--- a/server/docker/docker-compose.yml
+++ b/server/docker/docker-compose.yml
@@ -90,9 +90,17 @@ services:
       - PYTORCH_VARIANT=${PYTORCH_VARIANT:-cu129}
       # GH #125: opt-in for TLS-intercepting networks (corporate proxy / antivirus
       # HTTPS scanning). true makes uv trust the system/container CA store instead
-      # of its bundled roots — mount your corporate root CA so it is honored.
+      # of its bundled roots. Since GH #200 you rarely need this: put your root CA
+      # in EXTRA_CA_CERTS_DIR (see volumes) and the entrypoint sets SSL_CERT_FILE,
+      # which flips uv to the system store by itself.
       # Certificate verification stays ON. See docs/deployment-guide.md.
       - UV_NATIVE_TLS=${UV_NATIVE_TLS:-false}
+      # GH #200: corporate proxies need these to reach the network at all. Compose
+      # only injects variables listed here, so an unlisted host var is silently
+      # dropped — which is exactly why the documented remedy used to do nothing.
+      - HTTP_PROXY=${HTTP_PROXY:-}
+      - HTTPS_PROXY=${HTTPS_PROXY:-}
+      - NO_PROXY=${NO_PROXY:-}
       # ASR model overrides (set by dashboard, empty = use config.yaml defaults)
       - MAIN_TRANSCRIBER_MODEL=${MAIN_TRANSCRIBER_MODEL:-}
       - LIVE_TRANSCRIBER_MODEL=${LIVE_TRANSCRIBER_MODEL:-}
@@ -132,9 +140,19 @@ services:
       #   Windows: USER_CONFIG_DIR=$HOME/Documents/TranscriptionSuite
       #   macOS: USER_CONFIG_DIR=~/Library/Application Support/TranscriptionSuite
       - ${USER_CONFIG_DIR:-./.empty}:/user-config
-      # TLS certificates (bind-mounted from host when TLS_CERT_PATH/TLS_KEY_PATH are set)
+      # TLS certificates the server PRESENTS for remote access (its own HTTPS listener).
+      # This is not a trust anchor — see EXTRA_CA_CERTS_DIR below for that.
       - ${TLS_CERT_PATH:-./.empty}:/certs/cert.crt:ro
       - ${TLS_KEY_PATH:-./.empty}:/certs/cert.key:ro
+      # CA certificates the container TRUSTS (GH #200). Point EXTRA_CA_CERTS_DIR at a
+      # directory holding your root CA(s) when a corporate proxy or antivirus HTTPS
+      # scanner re-signs traffic; the entrypoint installs every *.crt/*.pem/*.cer found
+      # here into the container trust store. Docker does not propagate the host's trust
+      # store into containers, so without this the re-signed cert is always rejected.
+      #   Windows: EXTRA_CA_CERTS_DIR=%APPDATA%\TranscriptionSuite\ca
+      #   Linux/macOS: EXTRA_CA_CERTS_DIR=~/.config/TranscriptionSuite/ca
+      # Unset mounts an empty placeholder, which is a no-op.
+      - ${EXTRA_CA_CERTS_DIR:-./.empty}:/ca-trust:ro
       # Startup events file (bind-mounted for Electron fs.watch access)
       - ${STARTUP_EVENTS_DIR:-./.empty}:/startup-events
     

--- a/server/docker/docker-entrypoint.sh
+++ b/server/docker/docker-entrypoint.sh
@@ -3,8 +3,9 @@
 #
 # This script runs as root to:
 # 1) handle TLS certificate permissions,
-# 2) bootstrap runtime dependencies into /runtime/.venv,
-# 3) drop privileges to appuser and launch the Python server.
+# 2) install operator-supplied CA certificates into the container trust store,
+# 3) bootstrap runtime dependencies into /runtime/.venv,
+# 4) drop privileges to appuser and launch the Python server.
 
 set -e
 
@@ -52,6 +53,31 @@ if [ "${TLS_ENABLED:-false}" = "true" ]; then
     export TLS_KEY_FILE="$KEY_DST"
     
     log "TLS certificates prepared successfully"
+fi
+
+# Install operator-supplied CA certificates (GH #200). Must happen here: this is the
+# only root context in the container, and it must precede bootstrap_runtime.py, which
+# makes the first HTTPS request. On a TLS-intercepting network (corporate proxy or
+# antivirus HTTPS scanning) nothing downstream can succeed without this.
+/usr/bin/python3.13 docker/install_ca_certs.py || true
+
+# Point every HTTPS client at the combined bundle whenever the container carries any
+# locally trusted CA — whether bind-mounted just now, or baked into a derived image at
+# build time. update-ca-certificates writes system roots AND local CAs into this one
+# file, so this adds trust anchors without ever removing the public ones.
+#
+# These four vars exist because the install path spans three trust stores: uv reads
+# SSL_CERT_FILE (and switches itself to native certs when it is set), the git subprocess
+# uv shells out to reads GIT_SSL_CAINFO, and the requests client huggingface_hub uses
+# for model downloads reads REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE — it honors neither of the
+# others. Exporting here covers bootstrap, its child processes, and the server alike.
+if compgen -G "/usr/local/share/ca-certificates/*.crt" > /dev/null; then
+    SYSTEM_CA_BUNDLE="/etc/ssl/certs/ca-certificates.crt"
+    export SSL_CERT_FILE="${SSL_CERT_FILE:-$SYSTEM_CA_BUNDLE}"
+    export GIT_SSL_CAINFO="${GIT_SSL_CAINFO:-$SYSTEM_CA_BUNDLE}"
+    export REQUESTS_CA_BUNDLE="${REQUESTS_CA_BUNDLE:-$SYSTEM_CA_BUNDLE}"
+    export CURL_CA_BUNDLE="${CURL_CA_BUNDLE:-$SYSTEM_CA_BUNDLE}"
+    log "Locally trusted CA detected — HTTPS clients pointed at $SYSTEM_CA_BUNDLE"
 fi
 
 # Ensure runtime directories are writable by appuser.

--- a/server/docker/install_ca_certs.py
+++ b/server/docker/install_ca_certs.py
@@ -1,0 +1,203 @@
+"""Install operator-supplied CA certificates into the container trust store (GH #200).
+
+Runs as **root** from ``docker-entrypoint.sh``, before privileges are dropped to
+``appuser`` and before ``bootstrap_runtime.py`` performs the first HTTPS request.
+
+Why this exists
+---------------
+On a TLS-intercepting network (corporate proxy, or an antivirus product's "HTTPS
+scanning" feature) every HTTPS client inside the container rejects the re-signed
+certificate with ``UnknownIssuer``: the interceptor's root CA lives in the *host's*
+trust store, and Docker does not propagate the host store into containers.
+
+Before GH #200 there was no way to get a CA into the running container at all. The
+trust store was baked once at image-build time (``Dockerfile``: ``update-ca-certificates``),
+nothing re-ran it at runtime, and ``docker-compose.yml`` declared no mount point --
+so the remedy the bootstrap printed ("mount your root CA and run
+update-ca-certificates") described a mechanism that did not exist. This module is
+that mechanism.
+
+Certificate verification always stays **ON**. This only *adds* trust anchors the
+operator explicitly supplied. It never disables verification, and it never drops the
+public roots: ``update-ca-certificates`` regenerates a *concatenated* bundle at
+``/etc/ssl/certs/ca-certificates.crt``, so intercepted and non-intercepted hosts both
+keep working.
+
+Two Debian behaviours drive the design
+--------------------------------------
+* ``update-ca-certificates`` only reads files ending in ``.crt``. A ``.pem`` -- the
+  extension Windows' certmgr and OpenSSL both produce by default -- is *silently
+  ignored*. So extensions are normalized rather than copied verbatim.
+* Its per-file handling is not reliably multi-certificate, while a host root-store
+  export is a single file holding hundreds of concatenated certificates. So bundles
+  are split into one certificate per file.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+# Read-only bind mount fed by compose's EXTRA_CA_CERTS_DIR (default: an empty dir).
+DEFAULT_SOURCE_DIR = "/ca-trust"
+
+# Debian's drop-in dir for locally trusted CAs. update-ca-certificates merges every
+# *.crt found here into /etc/ssl/certs/ca-certificates.crt.
+DEFAULT_ANCHOR_DIR = "/usr/local/share/ca-certificates"
+
+# Extensions a user plausibly exports a CA as. Anything else in the mount is ignored,
+# which is what lets the default ./.empty placeholder mount be a harmless no-op.
+_CERT_SUFFIXES = frozenset({".crt", ".pem", ".cer"})
+
+_PEM_BLOCK = re.compile(
+    r"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----",
+    re.DOTALL,
+)
+
+# Collapse anything that is not a safe filename character. Also defeats a crafted
+# name trying to escape the anchor dir; we only ever use the basename.
+_UNSAFE_NAME_CHARS = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def log(message: str) -> None:
+    print(f"[install-ca-certs] {message}", flush=True)
+
+
+def _run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, check=True, capture_output=True, text=True, timeout=120)
+
+
+def pem_blocks(text: str) -> list[str]:
+    """Return every complete PEM certificate block in *text*.
+
+    Tolerates surrounding noise (OpenSSL "Bag Attributes" preambles, CRLF, trailing
+    junk) and drops unterminated blocks. Returns [] for DER/binary content, which is
+    how a mis-exported certificate is rejected before it can corrupt the bundle.
+    """
+    return [match.group(0).strip() for match in _PEM_BLOCK.finditer(text)]
+
+
+def _safe_stem(name: str) -> str:
+    """Derive a collision-resistant, path-safe stem from a source filename."""
+    stem = _UNSAFE_NAME_CHARS.sub("-", Path(name).name).strip("-.")
+    return stem or "ca"
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="strict")
+    except (OSError, UnicodeDecodeError):
+        # Binary (DER) or unreadable. pem_blocks() would reject it anyway; skipping
+        # here keeps the reason loggable.
+        return ""
+
+
+def stage_certificates(source_dir: Path, anchor_dir: Path) -> list[Path]:
+    """Copy every certificate found in *source_dir* into *anchor_dir* as a ``.crt``.
+
+    Splits multi-certificate bundles into one file per certificate, normalizes the
+    extension so ``update-ca-certificates`` will actually read them, and confines all
+    writes to *anchor_dir*. Returns the paths written, in a stable order.
+    """
+    if not source_dir.is_dir():
+        return []
+
+    anchor_dir.mkdir(parents=True, exist_ok=True)
+
+    staged: list[Path] = []
+    used: set[str] = set()
+
+    for source in sorted(source_dir.iterdir()):
+        if not source.is_file():
+            continue
+        if source.suffix.lower() not in _CERT_SUFFIXES:
+            continue
+
+        blocks = pem_blocks(_read_text(source))
+        if not blocks:
+            log(f"WARNING: {source.name} holds no PEM certificate (DER export?) - skipping")
+            continue
+
+        stem = _safe_stem(source.name)
+        for index, block in enumerate(blocks):
+            candidate = stem if len(blocks) == 1 else f"{stem}-{index + 1}"
+            name = f"{candidate}.crt"
+            suffix = 2
+            while name in used:
+                name = f"{candidate}-{suffix}.crt"
+                suffix += 1
+            used.add(name)
+
+            target = anchor_dir / name
+            target.write_text(f"{block}\n", encoding="utf-8")
+            staged.append(target)
+
+        log(
+            f"Staged {len(blocks)} certificate(s) from {source.name}"
+            if len(blocks) > 1
+            else f"Staged {source.name}"
+        )
+
+    return staged
+
+
+def install_ca_certificates(
+    source_dir: Path,
+    anchor_dir: Path,
+    runner: object = None,
+) -> list[Path]:
+    """Stage operator CAs and rebuild the system bundle. Returns what was installed.
+
+    On failure every certificate staged by *this* call is removed and the bundle is
+    rebuilt, so a malformed CA degrades to "no extra trust" rather than a corrupted
+    ``ca-certificates.crt`` that would break TLS for everything in the container.
+    Certificates baked into a derived image at build time are never touched.
+    """
+    run = _run if runner is None else runner
+
+    staged = stage_certificates(source_dir, anchor_dir)
+    if not staged:
+        return []
+
+    try:
+        run(["update-ca-certificates"])
+    except Exception as exc:  # noqa: BLE001 - any failure must roll back, then report
+        log(
+            f"ERROR: update-ca-certificates failed ({exc}); rolling back {len(staged)} certificate(s)"
+        )
+        for path in staged:
+            path.unlink(missing_ok=True)
+        try:
+            run(["update-ca-certificates"])
+        except Exception as restore_exc:  # noqa: BLE001
+            log(
+                "ERROR: could not restore the system CA bundle after rollback "
+                f"({restore_exc}); container TLS may be degraded"
+            )
+        return []
+
+    log(f"Installed {len(staged)} certificate(s) into the container trust store")
+    return staged
+
+
+def main() -> int:
+    """Entry point. Never fatal: a CA problem must not brick server startup.
+
+    A failure here surfaces downstream as the bootstrap's TLS-interception hint,
+    which is a far more actionable error than a dead entrypoint.
+    """
+    source_dir = Path(os.environ.get("CA_TRUST_SOURCE_DIR", DEFAULT_SOURCE_DIR))
+    anchor_dir = Path(os.environ.get("CA_TRUST_ANCHOR_DIR", DEFAULT_ANCHOR_DIR))
+
+    try:
+        install_ca_certificates(source_dir, anchor_dir)
+    except Exception as exc:  # noqa: BLE001
+        log(f"ERROR: CA installation failed ({exc}); continuing with the default trust store")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes #200.

## The problem

Since PR #169 the bootstrap has printed this when a package download hits an untrusted certificate:

> mount your organization's root CA into the container and run `update-ca-certificates` ... set `UV_NATIVE_TLS=true`

**Neither half of that advice was actionable, and the second half was a no-op.**

- Nothing ran `update-ca-certificates` at container **runtime**. The trust store was written once at image build (`Dockerfile:70-71`) and never touched again. The only other occurrence of the string in `server/docker/` was the hint text itself.
- `docker-compose.yml` declared **no volume** to mount a CA into. The `/certs` mount is the cert the server *presents* for its own HTTPS listener, not a trust anchor.
- Bootstrap runs as unprivileged `appuser` (`docker-entrypoint.sh`, `gosu appuser`), so it could not write `/etc/ssl` even if asked.
- `UV_NATIVE_TLS=true` only swaps uv's bundled webpki roots for the container's stock Ubuntu roots. Both are Mozilla/CCADB-derived, so it adds **zero** new trust anchors. On its own it could never fix an intercepted network.
- The hint points at `docs/deployment-guide.md`, but the packaged `.exe` ships no markdown docs, so that link resolves to nothing on the machine that shows the error.

Net effect: PR #169's CA-trust plumbing is correct, and completely unreachable. The reporter of #200 has been told for a month to do something the image cannot do.

## The fix

**`server/docker/install_ca_certs.py`** (new), run as root from the entrypoint before the `gosu` drop and before the first HTTPS request:

- Normalizes `.pem`/`.cer` to `.crt`. `update-ca-certificates` **only reads `*.crt`**, so a user who exported `corp-root-ca.pem` (the name our own docs told them to produce) was previously ignored in silence.
- Splits multi-certificate PEM bundles into one file per certificate, so a whole-host-root-store export works.
- Skips DER/binary and junk files with a warning instead of corrupting the trust store.
- Rolls back its own certificates and rebuilds the bundle if `update-ca-certificates` fails, so a bad CA degrades to "no extra trust" rather than breaking all TLS in the container. Certificates baked into a derived image at build time are never touched.
- Never fatal. A CA problem surfaces as the bootstrap's TLS hint, not a dead entrypoint.

**`docker-entrypoint.sh`** then points every HTTPS client at the combined bundle whenever the container carries a locally trusted CA. This is needed because the install path spans three trust stores: uv reads `SSL_CERT_FILE`, the `git` subprocess uv shells out to reads `GIT_SSL_CAINFO`, and the `requests` client `huggingface_hub` uses for model downloads reads `REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE` and honors neither of the others. Exporting from the entrypoint covers bootstrap, its child processes and the server alike. It also fixes bootstrap's own model downloads, which built their subprocess env from `os.environ` and so never saw the bundle that `_propagate_ca_bundle()` decorated.

It points at `/etc/ssl/certs/ca-certificates.crt` (public roots **plus** the operator CA), never at a bare root CA. `SSL_CERT_FILE` **replaces** the trust store rather than extending it, so the old `SSL_CERT_FILE=/path/to/corp-root-ca.pem` advice would have broken every host the interceptor does not touch.

**`docker-compose.yml`** gains the surfaces the remedy always assumed existed:

- `EXTRA_CA_CERTS_DIR` bind-mount (unset mounts an empty placeholder, so it is a no-op by default).
- `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` passthrough. Compose only injects variables it lists, so these were being silently dropped for corporate users, who typically need both a proxy and a CA.

**Docs** stop describing an impossible procedure, and now lead with antivirus HTTPS scanning (ESET, Kaspersky, Avast, Bitdefender, Avira), which is on by default, fits a home Windows user, and is a one-checkbox fix nobody had suggested. Corporate proxy was only ever our inference from a rustls error string.

## Verification

Unit tested (24 tests for the installer, 3 pinning compose-env preservation), and **verified end to end in a real `ubuntu:24.04` container** against a forged `download.pytorch.org` leaf signed by a fake interception root:

```
=== BEFORE (reproduces GH #200) ===
  error 20 at 0 depth lookup: unable to get local issuer certificate
  error /leaf.pem: verification failed

=== install the operator CA (what the entrypoint now does) ===
  [install-ca-certs] WARNING: broken.cer holds no PEM certificate (DER export?) - skipping
  [install-ca-certs] Staged corp-root-ca.pem
  [install-ca-certs] Staged 2 certificate(s) from host-roots.crt
  [install-ca-certs] Installed 3 certificate(s) into the container trust store

=== AFTER: intercepted cert now verifies? ===
  /leaf.pem: OK

=== AFTER: are the PUBLIC roots still trusted (not replaced)? ===
  certs in bundle: 124
  ISRG Root X1 (Lets Encrypt) still in bundle: YES

=== real-world sanity: does a NON-intercepted public host still validate? ===
  Verify return code: 0 (ok)
```

And uv 0.10.8 (the pinned version) then resolves against the exact index from the report:

```
uv pip install --index pytorch-cu129=https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match filelock
Resolved 1 package in 402ms
 + filelock==3.29.7
```

Certificate verification stays **ON** throughout. This only *adds* trust anchors the operator explicitly supplied. Nothing disables verification, and `--allow-insecure-host` is not used.

Tests: 2145 backend passed, 4 skipped. 1646 frontend passed (one pre-existing `installerCache` timeout flake under parallel load, green in isolation on `main` too).

## Test plan

- [x] Backend suite green
- [x] Frontend suite green, typecheck clean
- [x] Installer verified in a real container against a simulated intercepting proxy
- [x] Public roots confirmed intact, non-intercepted hosts confirmed still validating
- [x] uv 0.10.8 confirmed to honor the combined bundle against the reporter's exact index
- [ ] **Confirmation from the #200 reporter on a genuinely intercepted network.** Shipping unvalidated is what caused this issue: PR #131 and PR #169 both went to release with CPU-only validation still pending. Worth waiting for his diagnostic output before merging.

## Notes

A packaged-app user reaches this today by adding `EXTRA_CA_CERTS_DIR=...` to `<userData>/docker/.env`, which survives restarts (`upsertComposeEnvValues` only strips keys it owns, and packaging ships no `.env` to clobber it). That contract is now pinned by a test, since a plausible refactor would silently strip it. A proper UI surface for this is the obvious follow-up.

Out of scope, but found while investigating and worth its own issue: `--index name=url` on the CLI **drops uv's `explicit = true` flag** from `pyproject.toml`, so uv probes `download.pytorch.org` for *every* package (which is why `silero-vad` appears in the report), and `--index-strategy unsafe-best-match` can then pull ordinary PyPI packages from the PyTorch index on a version tie. It did not cause #200 (PyPI itself already failed identically on the reporter's v1.3.5 run), but it is a real supply-chain defect.