### PR TITLE
fix(stt): remove the ~2x-real-time cap on whisper.cpp inference

### DIFF
--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -172,6 +172,10 @@ export const SessionView: React.FC<SessionViewProps> = ({
   // Session main-result editing (client-only): hand-corrections flow into
   // Copy/Download. Reset whenever a new transcription replaces the text.
   const [editedResultText, setEditedResultText] = useState('');
+  // A partial transcript is persisted as a 'completed' job, so without this the
+  // user cannot tell a truncated transcript from a whole one. Retry is their only
+  // recourse.
+  const [retryingPartial, setRetryingPartial] = useState(false);
   useEffect(() => {
     setEditedResultText(transcription.result?.text ?? '');
   }, [transcription.result?.text]);
@@ -877,6 +881,26 @@ export const SessionView: React.FC<SessionViewProps> = ({
     const seconds = Math.min(60, Math.max(10, raw ?? 20));
     transcription.preview(seconds);
   }, [transcription]);
+
+  // Re-transcribe a truncated result from the job's saved audio. The server
+  // accepts /retry for a partial job even though its status is 'completed'.
+  const handleRetryPartial = useCallback(async () => {
+    const jobId = transcription.jobId;
+    if (!jobId || retryingPartial) return;
+    setRetryingPartial(true);
+    try {
+      await apiClient.retryTranscription(jobId);
+      toast.success('Retrying transcription', {
+        description: 'Re-transcribing from the saved audio.',
+      });
+    } catch (err) {
+      toast.error('Could not retry the transcription', {
+        description: err instanceof Error ? err.message : undefined,
+      });
+    } finally {
+      setRetryingPartial(false);
+    }
+  }, [transcription.jobId, retryingPartial]);
 
   // Copy transcription result to clipboard (prefers the edited text)
   const handleCopyTranscription = useCallback(() => {
@@ -1775,6 +1799,33 @@ export const SessionView: React.FC<SessionViewProps> = ({
                   {/* Transcription Result */}
                   {transcription.result && (
                     <div className="space-y-2">
+                      {/* Incomplete transcript: the sidecar failed partway through
+                          long audio, or the user cancelled mid-file. The job is
+                          stored as 'completed', so this banner is the only signal
+                          that the text stops early. Warning tone, not error — the
+                          transcript is usable, just truncated. */}
+                      {transcription.result.partial && (
+                        <div
+                          role="alert"
+                          className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-xs text-amber-300"
+                        >
+                          <span>
+                            This transcript is incomplete and may be missing the end of the
+                            recording
+                            {transcription.result.partialReason
+                              ? ` (${transcription.result.partialReason})`
+                              : ''}
+                            .
+                          </span>
+                          <Button
+                            variant="secondary"
+                            disabled={retryingPartial || !transcription.jobId}
+                            onClick={handleRetryPartial}
+                          >
+                            {retryingPartial ? 'Retrying…' : 'Retry'}
+                          </Button>
+                        </div>
+                      )}
                       <FindReplaceTextEditor
                         value={editedResultText}
                         onChange={setEditedResultText}

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -322,6 +322,17 @@ export class APIClient {
     });
   }
 
+  /**
+   * POST /api/transcribe/retry/{jobId} — re-transcribe from the job's saved audio.
+   *
+   * Accepted for jobs that failed, and for jobs that completed only PARTIALLY
+   * (an incomplete transcript is stored as 'completed' with `partial: true`, so
+   * retry is the user's only recourse for a truncated result).
+   */
+  async retryTranscription(jobId: string): Promise<{ job_id: string; status: string }> {
+    return this.post(`/api/transcribe/retry/${jobId}`);
+  }
+
   /** POST /api/transcribe/result/{jobId}/dismiss — mark a recovered result dismissed. */
   async dismissTranscriptionResult(jobId: string): Promise<Response> {
     return fetch(`${this.baseUrl}/api/transcribe/result/${jobId}/dismiss`, {

--- a/dashboard/src/hooks/useTranscription.test.ts
+++ b/dashboard/src/hooks/useTranscription.test.ts
@@ -211,6 +211,12 @@ describe('[P1] useTranscription', () => {
         words: [{ word: 'Hello', start: 0, end: 0.5, probability: 0.99 }],
         language: 'en',
         duration: 1.5,
+        // A whole transcript. The server omits these on a complete result, and the
+        // hook must normalise them rather than leave them undefined — the partial
+        // banner keys off `partial`, so an undefined here would be indistinguishable
+        // from false at the type level but noisier to reason about.
+        partial: false,
+        partialReason: null,
       });
       expect(lastSocket.disconnect).toHaveBeenCalled();
     });

--- a/dashboard/src/hooks/useTranscription.ts
+++ b/dashboard/src/hooks/useTranscription.ts
@@ -24,6 +24,16 @@ export interface TranscriptionResult {
   words: Array<{ word: string; start: number; end: number; probability?: number }>;
   language?: string;
   duration?: number;
+  /**
+   * True when the backend salvaged an INCOMPLETE transcript — the sidecar failed
+   * partway through long audio, or the user cancelled mid-file. The text stops
+   * early, so this must be surfaced: the job is stored as 'completed', and
+   * without a visible banner the user cannot tell a truncated transcript from a
+   * whole one.
+   */
+  partial?: boolean;
+  /** Human-readable reason the transcript is incomplete. */
+  partialReason?: string | null;
 }
 
 export interface TranscriptionState {
@@ -235,6 +245,8 @@ export function useTranscription(): TranscriptionState {
             words: (msg.data?.words as TranscriptionResult['words']) ?? [],
             language: msg.data?.language as string | undefined,
             duration: msg.data?.duration as number | undefined,
+            partial: (msg.data?.partial as boolean | undefined) ?? false,
+            partialReason: (msg.data?.partial_reason as string | null | undefined) ?? null,
           });
           setProcessingProgress(null);
           setStatusTracked('complete');
@@ -260,6 +272,8 @@ export function useTranscription(): TranscriptionState {
                   words: r.words ?? [],
                   language: r.language,
                   duration: r.duration,
+                  partial: r.partial ?? false,
+                  partialReason: r.partial_reason ?? null,
                 });
                 setProcessingProgress(null);
                 setStatusTracked('complete');
@@ -387,6 +401,8 @@ export function useTranscription(): TranscriptionState {
                     words: r.words ?? [],
                     language: r.language,
                     duration: r.duration,
+                    partial: r.partial ?? false,
+                    partialReason: r.partial_reason ?? null,
                   });
                   setProcessingProgress(null);
                   setStatusTracked('complete');

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.1.0",
-  "contract_sha256": "16caf2da9ede97dc76a0117064c86c02834e48ce2a695308347140c7ee72df5c",
-  "updated_at": "2026-07-11T18:11:59.700Z"
+  "spec_version": "1.2.0",
+  "contract_sha256": "2de9497d7a4b8a5b4159a4749eaae1a86e46fc8bdb9484d75ab12d1829514d2a",
+  "updated_at": "2026-07-14T08:05:49.332Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,10 +1,10 @@
 meta:
-  spec_version: 1.1.0
+  spec_version: 1.2.0
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
   generated_from:
-    repo_path: /home/Bill/Code_Projects/Python_Projects/TranscriptionSuite/.claude/worktrees/server-tab-matrix-redesign/dashboard
+    repo_path: /home/Bill/Code_Projects/Python_Projects/TranscriptionSuite/dashboard
     source_files:
       - App.tsx
       - components/__tests__/AddNoteModal.canary-language.test.tsx
@@ -102,7 +102,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-07-11T18:11:50.540Z
+    generated_at: 2026-07-14T08:05:41.637Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -298,6 +298,7 @@ foundation:
         - shadow-[0_0_5px_rgba(239,68,68,0.6)]
         - shadow-[0_0_5px_rgba(34,211,238,0.5)]
         - shadow-[0_2px_8px_rgba(0,0,0,0.4)]
+        - shadow-[inset_0_2px_4px_rgba(0,0,0,0.3)]
         - shadow-2xl
         - shadow-accent-cyan/20
         - shadow-accent-cyan/40
@@ -378,6 +379,7 @@ foundation:
         - min-h-[8rem]
         - min-h-[calc(100vh-30rem)]
         - min-w-[2.5rem]
+        - min-w-[3ch]
         - min-w-[5rem]
         - p-[3px]
         - shadow-[0_0_10px_#22d3ee]
@@ -401,6 +403,7 @@ foundation:
         - shadow-[0_0_5px_rgba(239,68,68,0.6)]
         - shadow-[0_0_5px_rgba(34,211,238,0.5)]
         - shadow-[0_2px_8px_rgba(0,0,0,0.4)]
+        - shadow-[inset_0_2px_4px_rgba(0,0,0,0.3)]
         - text-[10px]
         - text-[11px]
         - text-[8px]
@@ -524,7 +527,6 @@ utility_allowlist:
     - bg-accent-orange/10
     - bg-accent-orange/20
     - bg-accent-rose/5
-    - bg-accent-violet/15
     - bg-amber-400/10
     - bg-amber-400/20
     - bg-amber-400/5
@@ -901,11 +903,13 @@ utility_allowlist:
     - mt-1.5
     - mt-10
     - mt-2
+    - mt-2.5
     - mt-3
     - mt-4
     - mt-6
     - mt-8
     - mt-auto
+    - mx-0.5
     - mx-auto
     - my-1
     - my-2
@@ -924,6 +928,7 @@ utility_allowlist:
     - outline-none
     - overflow-auto
     - overflow-hidden
+    - overflow-visible
     - overflow-x-auto
     - overflow-y-auto
     - p-0.5
@@ -1053,7 +1058,6 @@ utility_allowlist:
     - space-y-2.5
     - space-y-3
     - space-y-4
-    - space-y-5
     - space-y-6
     - space-y-8
     - sticky
@@ -1066,12 +1070,10 @@ utility_allowlist:
     - text-accent-orange
     - text-accent-rose
     - text-accent-violet
-    - text-accent-violet/80
     - text-amber-100
     - text-amber-200
     - text-amber-300
     - text-amber-300/60
-    - text-amber-300/70
     - text-amber-300/80
     - text-amber-400
     - text-amber-400/60
@@ -1214,6 +1216,7 @@ utility_allowlist:
     - min-h-[8rem]
     - min-h-[calc(100vh-30rem)]
     - min-w-[2.5rem]
+    - min-w-[3ch]
     - min-w-[5rem]
     - p-[3px]
     - shadow-[0_0_10px_#22d3ee]
@@ -1237,6 +1240,7 @@ utility_allowlist:
     - shadow-[0_0_5px_rgba(239,68,68,0.6)]
     - shadow-[0_0_5px_rgba(34,211,238,0.5)]
     - shadow-[0_2px_8px_rgba(0,0,0,0.4)]
+    - shadow-[inset_0_2px_4px_rgba(0,0,0,0.3)]
     - text-[10px]
     - text-[11px]
     - text-[8px]

--- a/docs/project-context.md
+++ b/docs/project-context.md
@@ -150,8 +150,8 @@ durability:
 - **Model passthrough**: `POST /load {"model": model_name}` — `load()` tolerates HTTP failure (sidecar may pre-load)
 - **Diarization**: `transcribe_with_diarization()` returns `None` — falls back to legacy two-step pipeline
 - **Device parameter ignored**: Sidecar container manages Vulkan device via `/dev/dri`
-- **Long-audio chunking**: Audio longer than `_MAX_CHUNK_DURATION_S` (10 min) is split into chunks, each POSTed to `/inference` separately with timestamp-offset stitching (mirrors the NeMo backends; GH #168). Bounds per-request size/time and emits per-chunk progress.
-- **Timeouts**: Inference timeout scales with chunk duration via `_inference_timeout_for` (floored at 300s, ~2×-realtime headroom); load 60s
+- **Long-audio chunking**: Audio longer than `_MAX_CHUNK_DURATION_S` (10 min) is split into chunks, each POSTed to `/inference` separately with timestamp-offset stitching (mirrors the NeMo backends; GH #168). Bounds per-request MEMORY (never time) and emits per-chunk progress.
+- **Timeouts**: Inference has NO time limit — a slow machine takes as long as it needs, and Cancel is the only interrupt. `/inference` goes through `whispercpp_transport.post_inference()`, which uses an abortable async request (`read=None`) whenever a `cancellation_check` is supplied. Callers with no abort path (warmup, live, preview — all seconds of audio) keep a finite `_UNCANCELLABLE_READ_TIMEOUT_S` (300s). Connect/write/pool stay bounded. `/load` is 60s.
 - **Warmup**: Sends 1s of silence (16kHz zeros) to prime Vulkan pipeline
 - **Docker**: `docker-compose.vulkan.yml` adds `whisper-server` sidecar with health check; main container depends on it
 

--- a/docs/superpowers/plans/2026-07-13-whispercpp-remove-inference-timeout.md
+++ b/docs/superpowers/plans/2026-07-13-whispercpp-remove-inference-timeout.md
@@ -1,0 +1,1375 @@
+# Remove the whisper.cpp Inference Time Limit — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the ~2x-real-time cap on whisper.cpp inference so low-end machines can take as long as they need, without letting a wedged sidecar hang the server forever.
+
+**Architecture:** An unbounded read is permitted only where an abort path exists. First we restore the abort path (the Cancel button is currently not wired to the main longform path at all), then we replace the sync `httpx.Client` `/inference` call with an abortable `httpx.AsyncClient` request whose read timeout is `None` and which is cancelled via `asyncio.Task.cancel()`. Chunking is unchanged — it bounds memory, and was never the time limit.
+
+**Tech Stack:** Python 3.13, httpx 0.28.1 (sync `Client` for `/load`, async `AsyncClient` for `/inference`), pytest, FastAPI, React/TypeScript (Vitest).
+
+**Spec:** `docs/superpowers/specs/2026-07-13-whispercpp-remove-inference-timeout-design.md`
+
+**Branch:** `fix/whispercpp-remove-inference-timeout` (already created; spec already committed)
+
+---
+
+## Background the engineer needs
+
+**Why the timeout exists.** `_transcribe_chunk` POSTs one audio chunk to the whisper.cpp sidecar and sets an httpx read timeout of `max(300, ceil(chunk_seconds * 2.0))`. httpx's `read` timeout bounds a *single socket read*, not the whole request — but whisper-server sends **zero bytes** until inference finishes, so the first read blocks for the entire inference. The read timeout therefore behaves as a work deadline of ~2x real-time.
+
+**Why it cannot just be deleted.** Two verified facts:
+
+1. `resp.close()` / `client.close()` from another thread do **not** abort a blocked sync read on Linux. `httpcore/_backends/sync.py:141` calls `self._sock.close()`, and closing an fd does not wake a thread already blocked in `recv()`. Measured: the request hung the full 30s and then *completed normally*.
+2. `httpx.AsyncClient` + `asyncio.Task.cancel()` **does** abort promptly (measured: 2.04s against a server that stalls 30s before sending headers), because asyncio uses a selector rather than a blocking `recv()`. This is the primitive we build on. Public API only.
+
+**Why Task 1 must land first.** The read timeout is currently the *only* thing that terminates a stuck job, because `websocket.py:459` binds `cancellation_check` to `_client_disconnected` (set only on a real socket drop) rather than `job_tracker.is_cancelled` (what `POST /cancel` flips). Removing the timeout before fixing this would turn "slow machines get truncated" into "slow machines can wedge the server".
+
+**Testing commands.** Backend tests run from `server/backend/` using the **build venv**:
+```bash
+cd server/backend && ../../build/.venv/bin/pytest tests/ -v --tb=short
+```
+Frontend tests need Node 22: `cd dashboard && nvm use && npm test`.
+
+---
+
+## File Structure
+
+**Create:**
+- `server/backend/core/stt/backends/whispercpp_transport.py` — the abortable HTTP POST to `/inference`. Owns timeouts, the response-size ceiling, and the cancel-abort loop. Extracted because `whispercpp_backend.py` is already 957 lines (the style rules cap files at 800), and because a standalone transport can be tested against a **real stalling socket server** instead of a mock.
+- `server/backend/tests/test_whispercpp_transport.py` — tests for the above, using a real localhost server.
+
+**Modify:**
+- `server/backend/api/routes/websocket.py:459` — bind cancel to the job tracker.
+- `server/backend/api/routes/notebook.py:1031` — pass `cancellation_check`.
+- `server/backend/api/routes/transcription.py:1103` — pass `cancellation_check`.
+- `server/backend/api/routes/transcription.py:1466` — let `/retry` accept a partial job.
+- `server/backend/core/stt/backends/whispercpp_backend.py` — use the transport; delete the timeout knobs; make cancel preserve completed chunks.
+- `server/config.yaml:159-180` — delete the two timeout knobs.
+- `server/backend/config.py:250-254` — delete their env mappings.
+- `server/backend/tests/test_whispercpp_backend.py` — async mock seam; delete knob tests.
+- `dashboard/src/hooks/useTranscription.ts:22` — add `partial` / `partialReason` to `TranscriptionResult`.
+- `dashboard/components/views/SessionView.tsx` — partial banner with Retry.
+
+---
+
+## Task 1: Wire the Cancel button to the backend
+
+**Files:**
+- Modify: `server/backend/api/routes/websocket.py:459`
+- Modify: `server/backend/api/routes/notebook.py:1031`
+- Modify: `server/backend/api/routes/transcription.py:1103`
+- Test: `server/backend/tests/test_cancel_wiring.py` (create)
+
+This is an independent, user-facing bug fix: today, pressing Cancel on a whisper.cpp longform job does nothing. The job transcribes to completion, persists, auto-adds to the notebook, fires the webhook, and holds the single job slot so no new recording can start.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/backend/tests/test_cancel_wiring.py`:
+
+```python
+"""The Cancel button (POST /cancel -> job_tracker) must reach every transcribe path.
+
+Regression guard for the bug where websocket.py bound cancellation_check to
+_client_disconnected, so POST /cancel never reached the backend on the main
+longform path.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+ROUTES = Path(__file__).resolve().parents[1] / "api" / "routes"
+
+
+def _transcribe_calls(path: Path) -> list[ast.Call]:
+    """Every engine.transcribe_file(...) call in a route module."""
+    tree = ast.parse(path.read_text())
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "transcribe_file"
+    ]
+
+
+def _cancellation_source(call: ast.Call) -> str | None:
+    for kw in call.keywords:
+        if kw.arg == "cancellation_check":
+            return ast.unparse(kw.value)
+    return None
+
+
+@pytest.mark.parametrize("module", ["websocket.py", "notebook.py", "transcription.py"])
+def test_every_transcribe_call_passes_cancellation_check(module: str) -> None:
+    calls = _transcribe_calls(ROUTES / module)
+    assert calls, f"expected at least one transcribe_file call in {module}"
+    for call in calls:
+        src = _cancellation_source(call)
+        assert src is not None, (
+            f"{module}: transcribe_file() called without cancellation_check — "
+            "a job started here can never be cancelled"
+        )
+
+
+@pytest.mark.parametrize("module", ["websocket.py", "notebook.py", "transcription.py"])
+def test_cancellation_check_consults_the_job_tracker(module: str) -> None:
+    """POST /cancel flips job_tracker._cancelled. Every path must read it."""
+    for call in _transcribe_calls(ROUTES / module):
+        src = _cancellation_source(call) or ""
+        assert "job_tracker.is_cancelled" in src, (
+            f"{module}: cancellation_check={src!r} does not consult "
+            "job_tracker.is_cancelled, so POST /cancel cannot stop this job"
+        )
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cd server/backend && ../../build/.venv/bin/pytest tests/test_cancel_wiring.py -v --tb=short
+```
+Expected: `test_every_transcribe_call_passes_cancellation_check[notebook.py]` and `[transcription.py]` FAIL (no `cancellation_check` kwarg), and `test_cancellation_check_consults_the_job_tracker[websocket.py]` FAILS (it binds `_client_disconnected`).
+
+- [ ] **Step 3: Fix websocket.py**
+
+`server/backend/api/routes/websocket.py:459`. `model_manager` is already in scope (bound at line 429). Replace:
+
+```python
+                    cancellation_check=lambda: self._client_disconnected,
+```
+with:
+```python
+                    # Two independent stop signals, both of which must reach the
+                    # backend: the client vanished, or the user pressed Cancel
+                    # (POST /cancel -> job_tracker). Binding only the former left
+                    # Cancel a no-op on this, the main longform path.
+                    cancellation_check=lambda: (
+                        self._client_disconnected or model_manager.job_tracker.is_cancelled()
+                    ),
+```
+
+Flag hygiene is already safe: `try_start_job` / `end_job` reset `_cancelled` (`model_manager.py:90, 113`) and `_release_job()` runs in `stop_recording`'s `finally` (`websocket.py:786-788`), so no stale flag leaks into the next job.
+
+- [ ] **Step 4: Fix notebook.py**
+
+`server/backend/api/routes/notebook.py:1031`. `model_manager` is in scope (used at line 1025). Add the kwarg to the `engine.transcribe_file(...)` call:
+
+```python
+                result = engine.transcribe_file(
+                    str(tmp_path),
+                    language=language,
+                    task="translate" if translation_enabled else "transcribe",
+                    translation_target_language=(
+                        translation_target_language if translation_enabled else None
+                    ),
+                    word_timestamps=need_word_timestamps,
+                    progress_callback=on_progress,
+                    cancellation_check=model_manager.job_tracker.is_cancelled,
+                )
+```
+
+Note `notebook.py:1345` already calls `job_tracker.cancel_job()` — until now that flag had no reader.
+
+- [ ] **Step 5: Fix transcription.py (_run_file_import)**
+
+`server/backend/api/routes/transcription.py:1103`. `model_manager` is in scope (used at line 1098). Same addition:
+
+```python
+                result = engine.transcribe_file(
+                    str(tmp_path),
+                    language=language,
+                    task="translate" if translation_enabled else "transcribe",
+                    translation_target_language=(
+                        translation_target_language if translation_enabled else None
+                    ),
+                    word_timestamps=need_word_timestamps,
+                    progress_callback=on_progress,
+                    cancellation_check=model_manager.job_tracker.is_cancelled,
+                )
+```
+
+- [ ] **Step 6: Run the tests and watch them pass**
+
+```bash
+cd server/backend && ../../build/.venv/bin/pytest tests/test_cancel_wiring.py -v --tb=short
+```
+Expected: 6 passed.
+
+- [ ] **Step 7: Run the affected route suites for regressions**
+
+```bash
+cd server/backend && ../../build/.venv/bin/pytest tests/ -k "websocket or notebook or transcription or cancel" -q
+```
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/backend/api/routes/websocket.py server/backend/api/routes/notebook.py \
+        server/backend/api/routes/transcription.py server/backend/tests/test_cancel_wiring.py
+git commit -m "fix(server): make the Cancel button actually stop a running transcription
+
+* fix(websocket): bind cancellation_check to the job tracker, not just client disconnect
+  * websocket.py:459 polled _client_disconnected, which is only set on a real socket drop
+  * POST /cancel flips job_tracker._cancelled, which the longform path never read, so Cancel was a no-op on the main dashboard path
+
+* fix(notebook): pass cancellation_check to transcribe_file (notebook.py:1345 already called cancel_job(), a flag with no reader)
+
+* fix(transcription): pass cancellation_check to transcribe_file in _run_file_import
+
+* test(server): AST guard asserting every transcribe_file call consults job_tracker.is_cancelled"
+```
+
+---
+
+## Task 2: Build the abortable transport
+
+**Files:**
+- Create: `server/backend/core/stt/backends/whispercpp_transport.py`
+- Test: `server/backend/tests/test_whispercpp_transport.py`
+
+The read timeout is `None` (no time limit) whenever a `cancellation_check` is supplied, and finite otherwise. Tested against a **real** localhost server that stalls before sending headers — the exact shape of a wedged whisper-server — because a MagicMock cannot prove an abort actually interrupts a blocked read.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/backend/tests/test_whispercpp_transport.py`:
+
+```python
+"""Transport tests against a REAL stalling socket server.
+
+A wedged whisper-server accepts the POST, drains the body, and then sends
+nothing at all — not even response headers — while the GPU chews. Mocks cannot
+prove an abort interrupts that, so these tests use a real socket.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import time
+
+import httpx
+import pytest
+from server.core.stt.backends.whispercpp_transport import (
+    InferenceAborted,
+    ResponseTooLarge,
+    post_inference,
+)
+
+
+class StallingSidecar:
+    """Accepts a POST, drains it, waits `stall` seconds, then optionally replies."""
+
+    def __init__(self, stall: float, reply: dict | None = None) -> None:
+        self._stall = stall
+        self._reply = reply
+        self._sock = socket.socket()
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind(("127.0.0.1", 0))
+        self._sock.listen(5)
+        self.port = self._sock.getsockname()[1]
+        threading.Thread(target=self._accept_loop, daemon=True).start()
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.port}/inference"
+
+    def _accept_loop(self) -> None:
+        while True:
+            try:
+                conn, _ = self._sock.accept()
+            except OSError:
+                return
+            threading.Thread(target=self._handle, args=(conn,), daemon=True).start()
+
+    def _handle(self, conn: socket.socket) -> None:
+        conn.settimeout(0.5)
+        try:
+            while conn.recv(65536):
+                pass
+        except OSError:
+            pass
+        time.sleep(self._stall)
+        if self._reply is not None:
+            body = json.dumps(self._reply).encode()
+            try:
+                conn.sendall(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+                    b"Content-Length: %d\r\n\r\n" % len(body) + body
+                )
+            except OSError:
+                pass
+        try:
+            conn.close()
+        except OSError:
+            pass
+
+    def close(self) -> None:
+        self._sock.close()
+
+
+@pytest.fixture()
+def wav() -> bytes:
+    return b"RIFF" + b"\x00" * 2048
+
+
+def test_slow_but_healthy_completes_with_no_time_limit(wav: bytes) -> None:
+    """The whole point: work that exceeds the old 2x budget must still finish."""
+    sidecar = StallingSidecar(stall=3.0, reply={"segments": [{"text": "ok"}]})
+    try:
+        started = time.monotonic()
+        body = post_inference(
+            sidecar.url, wav, {"response_format": "verbose_json"},
+            cancellation_check=lambda: False,
+        )
+        elapsed = time.monotonic() - started
+    finally:
+        sidecar.close()
+    assert json.loads(body) == {"segments": [{"text": "ok"}]}
+    assert elapsed >= 3.0, "should have waited for the slow sidecar, not timed out"
+
+
+def test_cancel_aborts_a_wedged_request_promptly(wav: bytes) -> None:
+    """A wedged sidecar must be escapable — this is what makes read=None safe."""
+    sidecar = StallingSidecar(stall=30.0)
+    cancelled = {"value": False}
+    threading.Timer(1.0, lambda: cancelled.update(value=True)).start()
+    try:
+        started = time.monotonic()
+        with pytest.raises(InferenceAborted):
+            post_inference(
+                sidecar.url, wav, {}, cancellation_check=lambda: cancelled["value"]
+            )
+        elapsed = time.monotonic() - started
+    finally:
+        sidecar.close()
+    assert elapsed < 5.0, f"abort took {elapsed:.1f}s; it must not wait out the sidecar"
+
+
+def test_connect_stays_bounded_against_a_dead_host(wav: bytes) -> None:
+    """read=None must not disable the connect timeout (httpx expands a bare
+    scalar to all four fields, which is how the old code hung 20-60min here)."""
+    started = time.monotonic()
+    with pytest.raises(httpx.ConnectError):
+        post_inference(
+            "http://127.0.0.1:1/inference", wav, {}, cancellation_check=lambda: False
+        )
+    assert time.monotonic() - started < 15.0
+
+
+def test_uncancellable_caller_gets_a_finite_read(wav: bytes) -> None:
+    """warmup/live/preview pass no cancellation_check, so they must NOT get an
+    unbounded read — a wedge there would be unrecoverable."""
+    sidecar = StallingSidecar(stall=30.0)
+    try:
+        started = time.monotonic()
+        with pytest.raises(httpx.ReadTimeout):
+            post_inference(sidecar.url, wav, {}, cancellation_check=None, read_timeout_s=2.0)
+        assert time.monotonic() - started < 10.0
+    finally:
+        sidecar.close()
+
+
+def test_oversized_response_is_rejected_during_the_read(wav: bytes) -> None:
+    big = {"segments": [{"text": "x" * 5000}]}
+    sidecar = StallingSidecar(stall=0.0, reply=big)
+    try:
+        with pytest.raises(ResponseTooLarge):
+            post_inference(
+                sidecar.url, wav, {}, cancellation_check=lambda: False, max_response_bytes=100
+            )
+    finally:
+        sidecar.close()
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cd server/backend && ../../build/.venv/bin/pytest tests/test_whispercpp_transport.py -v --tb=short
+```
+Expected: collection error — `ModuleNotFoundError: server.core.stt.backends.whispercpp_transport`.
+
+- [ ] **Step 3: Write the transport**
+
+Create `server/backend/core/stt/backends/whispercpp_transport.py`:
+
+```python
+"""Abortable HTTP transport for the whisper.cpp sidecar's /inference endpoint.
+
+WHY THIS EXISTS AS ITS OWN MODULE
+---------------------------------
+whisper-server sends no bytes at all — not even response headers — until
+inference completes. httpx's ``read`` timeout bounds a single socket read, so
+that first read blocks for the entire inference and the read timeout therefore
+behaves as a *work deadline*. Bounding it at ~2x real-time failed honest but
+slow machines and silently truncated their transcripts (see the design spec).
+
+We want no time limit. But an unbounded read is only safe if the request can be
+aborted, and a blocked SYNC read cannot be: ``resp.close()`` / ``client.close()``
+from another thread are no-ops, because httpcore's close() calls ``sock.close()``
+and closing an fd does not wake a thread already blocked in ``recv()`` (the
+request completes normally when the data finally arrives).
+
+asyncio does not issue a blocking ``recv()``; it registers the fd with a
+selector. So ``asyncio.Task.cancel()`` aborts a pending read immediately, using
+only public API. This module therefore runs the request on a private event loop
+inside the calling worker thread, polling ``cancellation_check`` while it waits.
+
+RULE: an unbounded read is permitted only where an abort path exists.
+Callers with a ``cancellation_check`` get ``read=None``; callers without one
+(warmup, live, preview — all short audio) must pass a finite ``read_timeout_s``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# A wedged sidecar is indistinguishable from a busy one on the wire, so these
+# bound only the phases where silence genuinely means "broken".
+CONNECT_TIMEOUT_S = 10.0
+WRITE_TIMEOUT_S = 120.0
+POOL_TIMEOUT_S = 10.0
+
+# How often the in-flight request is checked against cancellation_check.
+CANCEL_POLL_INTERVAL_S = 0.25
+
+# Hard ceiling on a single /inference response body, enforced WHILE reading so a
+# hostile or misconfigured sidecar cannot exhaust memory before any post-parse
+# cap could reject it (GH #193).
+MAX_RESPONSE_BYTES = 256 * 1024 * 1024  # 256 MiB
+
+
+class InferenceAborted(RuntimeError):
+    """The caller's cancellation_check went True while the request was in flight.
+
+    Distinct from a sidecar crash: the caller asked for this, so the caller is
+    responsible for deciding whether completed work should still be persisted.
+    """
+
+
+class ResponseTooLarge(RuntimeError):
+    """The sidecar's response body exceeded the ceiling; the read was aborted."""
+
+
+def post_inference(
+    url: str,
+    wav_bytes: bytes,
+    data: dict[str, Any],
+    *,
+    cancellation_check: Callable[[], bool] | None,
+    read_timeout_s: float | None = None,
+    max_response_bytes: int = MAX_RESPONSE_BYTES,
+) -> bytes:
+    """POST one audio chunk to /inference and return the raw response body.
+
+    Blocking; call from a worker thread (the backend already runs inside one).
+
+    ``read_timeout_s`` is ignored when ``cancellation_check`` is supplied — such
+    a caller gets an unbounded read, because it has a way out. A caller with no
+    ``cancellation_check`` MUST supply a finite ``read_timeout_s``; without one
+    a wedged sidecar would hang that thread forever with no recovery.
+
+    Raises:
+        InferenceAborted: cancellation_check went True mid-flight.
+        ResponseTooLarge: response body exceeded ``max_response_bytes``.
+        httpx.*: connect/read/protocol failures, unchanged, for the caller to map.
+    """
+    cancellable = cancellation_check is not None
+    if not cancellable and read_timeout_s is None:
+        raise ValueError(
+            "post_inference() requires a finite read_timeout_s when no "
+            "cancellation_check is given — an unbounded read with no abort path "
+            "would hang forever on a wedged sidecar"
+        )
+
+    timeout = httpx.Timeout(
+        None if cancellable else read_timeout_s,
+        connect=CONNECT_TIMEOUT_S,
+        write=WRITE_TIMEOUT_S,
+        pool=POOL_TIMEOUT_S,
+    )
+
+    async def _run() -> bytes:
+        # The AsyncClient must be created inside this loop; asyncio.run() makes a
+        # fresh one per call. Per-chunk client construction is negligible next to
+        # inference, and it sidesteps httpx keep-alive connection reuse.
+        async with httpx.AsyncClient(timeout=timeout) as client:
+
+            async def _request() -> bytes:
+                async with client.stream(
+                    "POST",
+                    url,
+                    files={"file": ("audio.wav", wav_bytes, "audio/wav")},
+                    data=data,
+                ) as resp:
+                    resp.raise_for_status()
+                    declared = resp.headers.get("Content-Length")
+                    # isascii() first: str.isdigit() is True for non-ASCII digit
+                    # codepoints (e.g. "²") that int() then rejects, and a hostile
+                    # sidecar can smuggle byte 0xB2 -> "²" into the header.
+                    if (
+                        declared
+                        and declared.isascii()
+                        and declared.isdigit()
+                        and int(declared) > max_response_bytes
+                    ):
+                        raise ResponseTooLarge(
+                            f"sidecar declared a {int(declared)}-byte /inference "
+                            f"response (max {max_response_bytes}); refusing to read it"
+                        )
+                    body = bytearray()
+                    async for piece in resp.aiter_bytes():
+                        body += piece
+                        if len(body) > max_response_bytes:
+                            raise ResponseTooLarge(
+                                f"sidecar returned a /inference response exceeding "
+                                f"{max_response_bytes} bytes; aborting read to bound memory"
+                            )
+                    return bytes(body)
+
+            task = asyncio.create_task(_request())
+            while True:
+                done, _ = await asyncio.wait({task}, timeout=CANCEL_POLL_INTERVAL_S)
+                if done:
+                    return task.result()
+                if cancellation_check is not None and cancellation_check():
+                    task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await task
+                    raise InferenceAborted("cancelled while awaiting the sidecar")
+
+    return asyncio.run(_run())
+```
+
+- [ ] **Step 4: Run the tests and watch them pass**
+
+```bash
+cd server/backend && ../../build/.venv/bin/pytest tests/test_whispercpp_transport.py -v --tb=short
+```
+Expected: 5 passed. `test_cancel_aborts_a_wedged_request_promptly` is the load-bearing one — it must abort in ~1s against a sidecar that would stall for 30.
+
+- [ ] **Step 5: Do NOT commit yet**
+
+The transport is dead code until Task 3 wires it in, and this PR ships as three commits (one per wave). Leave these two files staged; Task 3's commit covers them.
+
+```bash
+git add server/backend/core/stt/backends/whispercpp_transport.py \
+        server/backend/tests/test_whispercpp_transport.py
+```
+
+---
+
+## Task 3: Use the transport, delete the knobs, preserve work on cancel
+
+**Files:**
+- Modify: `server/backend/core/stt/backends/whispercpp_backend.py`
+- Modify: `server/backend/tests/test_whispercpp_backend.py`
+
+Three things at once because they are one behavioural change: the chunk POST moves to the transport, the timeout knobs disappear, and cancel stops discarding completed chunks.
+
+**On that last point:** `whispercpp_backend.py:683` currently raises `TranscriptionCancelledError` on cancel, discarding every completed chunk. That is survivable today only because the *timeout* produces a partial instead. Once the escape hatch from a wedge **is** cancel, a user cancelling at chunk 29/30 would throw away 29 chunks — a durability regression. `engine.py:969-975` already refuses to discard salvaged work on a late cancel ("discarding salvaged work to honour a late cancel would violate the avoid-data-loss invariant"); we make the backend consistent with it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `server/backend/tests/test_whispercpp_backend.py`:
+
+```python
+class TestUnboundedInference:
+    """The 2x-real-time cap is gone; cancellation is the only interrupt."""
+
+    def test_no_timeout_knobs_remain(self):
+        """The knobs are deleted, not merely defaulted to something generous."""
+        import server.core.stt.backends.whispercpp_backend as mod
+
+        for gone in (
+            "_INFERENCE_TIMEOUT",
+            "_TIMEOUT_SECONDS_PER_AUDIO_SECOND",
+            "_inference_timeout_for",
+            "_resolve_timeout_config",
+        ):
+            assert not hasattr(mod, gone), f"{gone} should have been deleted"
+
+    def test_chunk_post_is_unbounded_when_cancellable(
+        self, loaded_backend: WhisperCppBackend
+    ):
+        """A cancellable caller must get read_timeout_s=None (no work deadline)."""
+        seen: dict = {}
+
+        def _fake_post(url, wav, data, *, cancellation_check, **kwargs):
+            seen["cancellation_check"] = cancellation_check
+            seen["read_timeout_s"] = kwargs.get("read_timeout_s")
+            return json.dumps({"segments": [{"text": "hi", "start": 0, "end": 1}]}).encode()
+
+        with patch(
+            "server.core.stt.backends.whispercpp_backend.post_inference", _fake_post
+        ):
+            loaded_backend.transcribe(
+                np.zeros(16000, dtype=np.float32), cancellation_check=lambda: False
+            )
+        assert seen["cancellation_check"] is not None
+        assert seen["read_timeout_s"] is None
+
+    def test_chunk_post_is_bounded_when_not_cancellable(
+        self, loaded_backend: WhisperCppBackend
+    ):
+        """warmup/live/preview pass no cancellation_check -> must get a finite read."""
+        seen: dict = {}
+
+        def _fake_post(url, wav, data, *, cancellation_check, **kwargs):
+            seen["cancellation_check"] = cancellation_check
+            seen["read_timeout_s"] = kwargs.get("read_timeout_s")
+            return json.dumps({"segments": []}).encode()
+
+        with patch(
+            "server.core.stt.backends.whispercpp_backend.post_inference", _fake_post
+        ):
+            loaded_backend.transcribe(np.zeros(16000, dtype=np.float32))
+        assert seen["cancellation_check"] is None
+        assert seen["read_timeout_s"] == _UNCANCELLABLE_READ_TIMEOUT_S
+
+
+class TestCancelPreservesCompletedChunks:
+    def test_cancel_midway_returns_a_partial_not_an_empty_discard(
+        self, loaded_backend: WhisperCppBackend
+    ):
+        """Cancelling at chunk 3/4 must persist chunks 1-2, not throw them away."""
+        loaded_backend._max_chunk_duration_s = 1  # 1s chunks
+        audio = np.zeros(16000 * 4, dtype=np.float32)  # 4 chunks
+        calls = {"n": 0}
+
+        def _fake_post(url, wav, data, *, cancellation_check, **kwargs):
+            calls["n"] += 1
+            if cancellation_check and cancellation_check():
+                raise InferenceAborted("cancelled while awaiting the sidecar")
+            return json.dumps(
+                {"segments": [{"text": f"chunk{calls['n']}", "start": 0, "end": 1}]}
+            ).encode()
+
+        # Cancel becomes true once two chunks are done.
+        with (
+            patch("server.core.stt.backends.whispercpp_backend.post_inference", _fake_post),
+            pytest.raises(PartialTranscriptionError) as exc,
+        ):
+            loaded_backend.transcribe(audio, cancellation_check=lambda: calls["n"] >= 2)
+
+        assert len(exc.value.segments) == 2
+        assert exc.value.segments[0].text == "chunk1"
+        assert exc.value.completed_seconds == pytest.approx(2.0, abs=0.01)
+
+    def test_cancel_before_any_chunk_completes_still_cancels(
+        self, loaded_backend: WhisperCppBackend
+    ):
+        """Nothing to salvage -> a real cancellation, not a bogus empty partial."""
+        from server.core.model_manager import TranscriptionCancelledError
+
+        loaded_backend._max_chunk_duration_s = 1
+        audio = np.zeros(16000 * 4, dtype=np.float32)
+
+        with (
+            patch(
+                "server.core.stt.backends.whispercpp_backend.post_inference",
+                lambda *a, **k: (_ for _ in ()).throw(InferenceAborted("cancelled")),
+            ),
+            pytest.raises(TranscriptionCancelledError),
+        ):
+            loaded_backend.transcribe(audio, cancellation_check=lambda: True)
+```
+
+Add to the module's imports at the top of the test file:
+```python
+from server.core.stt.backends.whispercpp_backend import _UNCANCELLABLE_READ_TIMEOUT_S
+from server.core.stt.backends.whispercpp_transport import InferenceAborted
+```
+and **delete** `_INFERENCE_TIMEOUT`, `_TIMEOUT_SECONDS_PER_AUDIO_SECOND`, `_inference_timeout_for`, `_resolve_timeout_config` from that same import block.
+
+- [ ] **Step 2: Delete the obsolete knob tests**
+
+In `server/backend/tests/test_whispercpp_backend.py`, delete these four tests (they assert on the knobs we are removing):
+- `test_timeout_config_env_wins` (~line 1652)
+- `test_timeout_config_floors_enforced` (~line 1661)
+- `test_timeout_config_defaults_when_no_source` (~line 1671)
+
+and in `test_load_resolves_config_into_instance_vars` (~line 1682) remove the two timeout env vars and the two timeout assertions, keeping only the chunk-duration ones:
+
+```python
+    def test_load_resolves_config_into_instance_vars(
+        self, backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        """load() must populate the chunk instance var from env/config."""
+        mock_httpx.post.return_value = MagicMock(status_code=200)
+        with patch.dict(
+            "os.environ",
+            {
+                "WHISPERCPP_SERVER_URL": "http://test:8080",
+                "WHISPERCPP_CHUNK_DURATION_S": "300",
+            },
+        ):
+            backend.load("ggml-large-v3.bin", "cpu")
+        assert backend._max_chunk_duration_s == 300
+```
+
+Also delete any `_inference_timeout_for` tests (grep for them).
+
+- [ ] **Step 3: Run and watch the new tests fail**
+
+```bash
+cd server/backend && ../../build/.venv/bin/pytest tests/test_whispercpp_backend.py -k "Unbounded or CancelPreserves" -v --tb=short
+```
+Expected: FAIL — `post_inference` is not imported in `whispercpp_backend`, `_UNCANCELLABLE_READ_TIMEOUT_S` does not exist.
+
+- [ ] **Step 4: Rewrite `_transcribe_chunk` in whispercpp_backend.py**
+
+Add to the imports:
+```python
+from server.core.stt.backends.whispercpp_transport import (
+    InferenceAborted,
+    ResponseTooLarge,
+    post_inference,
+)
+```
+
+Replace the timeout constants block (lines ~39-53) with:
+```python
+_DEFAULT_SERVER_URL = "http://whisper-server:8080"
+_MAX_CHUNK_DURATION_S = 10 * 60  # 10 min per /inference POST (mirrors the NeMo backends)
+# Hard ceiling on the configurable chunk duration. Even a deliberately huge
+# WHISPERCPP_CHUNK_DURATION_S must not route a whole multi-hour file through a
+# single un-chunked /inference request — that path re-exposes the GH #172
+# truncation and defeats per-chunk progress/cancellation.
+_MAX_CHUNK_DURATION_CEILING_S = 30 * 60
+_LOAD_TIMEOUT = 60
+
+# Inference has NO time limit when the caller can cancel (the normal longform
+# case): a slow machine is allowed to take as long as it needs. Callers with no
+# cancellation_check — warmup, live mode, preview — have no way out of a wedged
+# sidecar, so they keep a finite read. Their audio is seconds long, so this is
+# already orders of magnitude above any honest inference time.
+_UNCANCELLABLE_READ_TIMEOUT_S = 300.0
+```
+
+Delete `_INFERENCE_TIMEOUT`, `_TIMEOUT_SECONDS_PER_AUDIO_SECOND`, `_MAX_RESPONSE_BYTES`, `_SIDECAR_INFERENCE_TIMEOUT_MSG`, `_inference_timeout_for` (lines ~124-140) and `_resolve_timeout_config` (lines ~204-231).
+
+Fix the dead client default at line 514 (it never applied, because httpx replaces the client default wholesale when a per-request `timeout=` is passed — and `/load` passes one):
+```python
+        if self._client is None:
+            # Only /load uses this sync client now; /inference goes through the
+            # abortable async transport. /load passes its own explicit timeout.
+            self._client = httpx.Client(timeout=_LOAD_TIMEOUT)
+```
+
+In `load()` (line ~527), drop the timeout resolution and the log fields:
+```python
+        self._max_chunk_duration_s = _resolve_chunk_duration_config()
+        logger.info(
+            "WhisperCppBackend: loading model %s via %s (chunk=%ds, inference=unbounded)",
+            model_name,
+            self._server_url,
+            self._max_chunk_duration_s,
+        )
+```
+and delete `self._inference_timeout` / `self._timeout_seconds_per_audio_second` from `__init__` (lines ~499-500).
+
+Replace the whole body of `_transcribe_chunk` (lines ~743-840) with:
+
+```python
+    def _transcribe_chunk(
+        self,
+        chunk: np.ndarray,
+        sample_rate: int,
+        data: dict[str, Any],
+        cancellation_check: Callable[[], bool] | None = None,
+    ) -> tuple[list[BackendSegment], BackendTranscriptionInfo]:
+        """POST a single (already-bounded) audio chunk to /inference and parse it.
+
+        There is no time limit on inference when ``cancellation_check`` is given:
+        a slow machine takes as long as it takes, and the only interrupt is the
+        user. See whispercpp_transport for why an unbounded read is safe there
+        and why it is refused everywhere else.
+        """
+        wav_bytes = _audio_to_wav_bytes(chunk, sample_rate)
+        try:
+            body = post_inference(
+                f"{self._server_url}/inference",
+                wav_bytes,
+                data,
+                cancellation_check=cancellation_check,
+                read_timeout_s=(
+                    None if cancellation_check is not None else _UNCANCELLABLE_READ_TIMEOUT_S
+                ),
+            )
+        except InferenceAborted:
+            raise
+        except ResponseTooLarge as exc:
+            raise WhisperCppResponseError(
+                f"whisper.cpp sidecar at {self._server_url}: {exc}"
+            ) from exc
+        except (httpx.NetworkError, OSError) as exc:
+            raise RuntimeError(_SIDECAR_UNREACHABLE_MSG.format(url=self._server_url)) from exc
+        except httpx.TimeoutException as exc:
+            # Only reachable on the uncancellable paths (warmup/live/preview).
+            raise RuntimeError(
+                f"whisper.cpp sidecar at {self._server_url} did not respond within "
+                f"{_UNCANCELLABLE_READ_TIMEOUT_S:.0f}s. The sidecar may be wedged; "
+                "check the container logs."
+            ) from exc
+        except HttpxHTTPStatusError as exc:
+            raise RuntimeError(
+                f"whisper.cpp sidecar at {self._server_url} returned HTTP "
+                f"{exc.response.status_code} for /inference"
+            ) from exc
+
+        audio_duration_s = len(chunk) / sample_rate if sample_rate > 0 else 0.0
+        try:
+            result = json.loads(body)
+        except json.JSONDecodeError as exc:
+            body_preview = _sanitize_for_error_preview(body)
+            raise RuntimeError(
+                f"whisper.cpp sidecar at {self._server_url} returned a non-JSON "
+                f"response from /inference: {body_preview}"
+            ) from exc
+        return self._parse_response(result, audio_duration_s)
+```
+
+`_parse_response` (defined at line 854) is unchanged, and the `_segment_cap_for` / `_word_cap_for` proportional caps come with it. The rewritten `_transcribe_chunk` still ends by calling it exactly as the current code does at line 836.
+
+- [ ] **Step 5: Thread `cancellation_check` through `transcribe()` and preserve work on cancel**
+
+In `transcribe()`, the short-audio fast path (line ~672) becomes:
+```python
+        if chunk_samples <= 0 or total_samples <= chunk_samples:
+            try:
+                return self._transcribe_chunk(audio, audio_sample_rate, data, cancellation_check)
+            except InferenceAborted as exc:
+                from server.core.model_manager import TranscriptionCancelledError
+
+                raise TranscriptionCancelledError("Transcription cancelled by user") from exc
+```
+
+In the chunk loop, replace the between-chunk cancel block (lines ~683-691) and the call at line ~696:
+```python
+        for i in range(num_chunks):
+            if cancellation_check is not None and cancellation_check():
+                logger.info(
+                    "WhisperCppBackend: transcription cancelled at chunk %d/%d", i + 1, num_chunks
+                )
+                raise self._cancelled_or_partial(all_segments, first_info, offset)
+
+            start = i * chunk_samples
+            chunk = audio[start : min(start + chunk_samples, total_samples)]
+            try:
+                segments, info = self._transcribe_chunk(
+                    chunk, audio_sample_rate, chunk_data, cancellation_check
+                )
+            except InferenceAborted:
+                # The user cancelled while this chunk was in flight. Completed
+                # chunks are real transcription work — surface them rather than
+                # discard them ("avoid data loss at all costs").
+                logger.info(
+                    "WhisperCppBackend: cancelled mid-chunk %d/%d", i + 1, num_chunks
+                )
+                raise self._cancelled_or_partial(all_segments, first_info, offset) from None
+            except Exception as exc:
+                if first_info is None:
+                    raise
+                logger.warning(
+                    "WhisperCppBackend: chunk %d/%d failed (%s); returning %.0fs partial transcript",
+                    i + 1,
+                    num_chunks,
+                    exc,
+                    offset,
+                )
+                raise PartialTranscriptionError(
+                    str(exc),
+                    segments=all_segments,
+                    info=first_info,
+                    completed_seconds=offset,
+                ) from exc
+```
+
+Add the helper next to `_transcribe_chunk`:
+```python
+    @staticmethod
+    def _cancelled_or_partial(
+        segments: list[BackendSegment],
+        info: BackendTranscriptionInfo | None,
+        completed_seconds: float,
+    ) -> Exception:
+        """The exception to raise when the user cancels mid-file.
+
+        With completed chunks in hand, cancelling must NOT throw them away — a
+        cancel five hours into a six-hour file would otherwise destroy five hours
+        of real transcription. Mirrors engine.py's own refusal to discard salvaged
+        work on a late cancel. With nothing done yet, it is a plain cancellation.
+        """
+        from server.core.model_manager import TranscriptionCancelledError
+
+        if info is None or not segments:
+            return TranscriptionCancelledError("Transcription cancelled by user")
+        return PartialTranscriptionError(
+            "Cancelled by user",
+            segments=segments,
+            info=info,
+            completed_seconds=completed_seconds,
+        )
+```
+
+- [ ] **Step 6: Run the whole whispercpp suite**
+
+```bash
+cd server/backend && ../../build/.venv/bin/pytest tests/test_whispercpp_backend.py tests/test_whispercpp_transport.py -v --tb=short
+```
+Expected: all pass. Some pre-existing `/inference` tests mock `httpx.Client.stream`; those now need to patch `whispercpp_backend.post_inference` instead. Update each by replacing the `_inf(mock_httpx).return_value = _inference_response({...})` setup with:
+```python
+        with patch(
+            "server.core.stt.backends.whispercpp_backend.post_inference",
+            return_value=json.dumps({...}).encode(),
+        ):
+```
+The `/load` tests are untouched — `/load` still uses the sync client.
+
+- [ ] **Step 7: Delete the config knobs**
+
+`server/config.yaml` — delete lines 167-180 (the `inference_timeout_s` and `timeout_seconds_per_audio_second` blocks, comments included). Leave `chunk_duration_s`. Add above it:
+```yaml
+    # NOTE: inference has no time limit. A slow machine takes as long as it needs;
+    # the only interrupt is the user pressing Cancel. (Previously capped at ~2x
+    # real-time, which silently truncated transcripts on low-end hardware.)
+```
+
+`server/backend/config.py` — delete lines 250-254:
+```python
+        ("WHISPERCPP_INFERENCE_TIMEOUT_S", ("whisper_cpp", "inference_timeout_s")),
+        (
+            "WHISPERCPP_TIMEOUT_SECONDS_PER_AUDIO_SECOND",
+            ("whisper_cpp", "timeout_seconds_per_audio_second"),
+        ),
+```
+
+- [ ] **Step 8: Verify no references survive**
+
+```bash
+cd /home/Bill/Code_Projects/Python_Projects/TranscriptionSuite
+grep -rn "WHISPERCPP_INFERENCE_TIMEOUT_S\|WHISPERCPP_TIMEOUT_SECONDS_PER_AUDIO_SECOND\|inference_timeout_s\|timeout_seconds_per_audio_second\|_inference_timeout_for" \
+  --include="*.py" --include="*.yaml" --include="*.yml" --include="*.md" . | grep -v node_modules | grep -v "\.venv" | grep -v docs/superpowers
+```
+Expected: no output.
+
+- [ ] **Step 9: Full backend suite**
+
+```bash
+cd server/backend && ../../build/.venv/bin/pytest tests/ -q
+```
+Expected: all pass (2 known pre-existing failures: db migration version, swr_linear resample).
+
+- [ ] **Step 10: Lint**
+
+```bash
+cd server/backend && ../../build/.venv/bin/ruff check . && ../../build/.venv/bin/ruff format --check .
+```
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add server/backend/core/stt/backends/whispercpp_transport.py \
+        server/backend/tests/test_whispercpp_transport.py \
+        server/backend/core/stt/backends/whispercpp_backend.py \
+        server/backend/tests/test_whispercpp_backend.py \
+        server/config.yaml server/backend/config.py
+git commit -m "fix(stt): remove the ~2x-real-time cap on whisper.cpp inference
+
+* fix(stt): inference now has no time limit — a slow machine takes as long as it needs
+  * the read timeout was max(300, chunk_seconds * 2.0); whisper-server sends no bytes until inference completes, so that read timeout acted as a work deadline
+  * exceeding it raised PartialTranscriptionError, which save_result() wrote as status='completed' — low-end hardware got a silently truncated transcript it could not retry
+  * cancellation is now the only interrupt
+
+* feat(stt): add whispercpp_transport.post_inference() — an abortable /inference request
+  * a blocked SYNC read cannot be interrupted: httpcore's close() calls sock.close(), which does not wake a thread already in recv(), so the request just completes later
+  * asyncio uses a selector instead, so task.cancel() aborts a pending read immediately, using public API only
+  * read=None when the caller can cancel; a finite read_timeout_s is REQUIRED otherwise (warmup/live/preview have no way out of a wedge)
+  * connect/write/pool stay bounded — httpx expands a bare scalar timeout to all four fields, which is why the old code could hang 20-60min in connect
+
+* fix(stt): cancelling mid-file no longer discards completed chunks
+  * cancel with >=1 chunk done now raises PartialTranscriptionError so the work is persisted, matching engine.py's existing refusal to discard salvaged work on a late cancel
+
+* chore(stt): delete the inference_timeout_s and timeout_seconds_per_audio_second knobs
+* chore(stt): drop the dead client-level httpx timeout default (a per-request timeout replaces it wholesale)
+
+* test(stt): exercise the transport against a real stalling socket server, not a mock"
+```
+
+---
+
+## Task 4: Stop laundering partial results into "completed"
+
+**Files:**
+- Modify: `server/backend/api/routes/transcription.py` (`/retry`, ~line 1466)
+- Test: `server/backend/tests/test_partial_result_retry.py` (create)
+
+`engine.py:99-100` already serializes `partial` / `partial_reason` into `result_json`, so `GET /result` already returns them nested under `result` — the client simply never reads them. The only server-side gap is `/retry`, which refuses anything that is not `'failed'`.
+
+Keep `status='completed'`. **No migration, no new status value:** a new status would have to be retrofitted into `get_recent_undelivered` and `get_jobs_for_cleanup`, and the failure mode of forgetting either is silent data loss. Staying inside `'completed'` means partial jobs keep being re-delivered on reconnect and keep having their audio GC'd, for free.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/backend/tests/test_partial_result_retry.py`. Uses the direct-call route pattern from `CLAUDE.md`:
+
+```python
+"""A partial transcript must be retryable.
+
+A partial is saved with status='completed' (so it is still delivered and its
+audio still GC'd), with result_json.partial = true. /retry previously refused
+it, leaving the user with a truncated transcript and no recourse.
+
+Direct-call route pattern per CLAUDE.md; mirrors tests/test_transcription_durability_routes.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from server.api.routes import transcription
+
+
+class _BG:
+    """Stand-in for FastAPI's BackgroundTasks."""
+
+    def __init__(self) -> None:
+        self.tasks: list = []
+
+    def add_task(self, fn, *args, **kwargs) -> None:
+        self.tasks.append((fn, args, kwargs))
+
+
+def _request() -> SimpleNamespace:
+    """A Request whose app.state.model_manager reports an idle job tracker.
+
+    /retry pre-checks model_manager.job_tracker.is_busy() before resetting the
+    job (transcription.py:1475-1481), so an idle tracker is required to reach
+    the status gate under test.
+    """
+    job_tracker = SimpleNamespace(is_busy=lambda: (False, None))
+    model_manager = SimpleNamespace(job_tracker=job_tracker)
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(model_manager=model_manager)))
+
+
+def _job(status: str, *, partial: bool, audio_path: str) -> dict:
+    return {
+        "id": "job-1",
+        "status": status,
+        "client_name": "test-client",
+        "audio_path": audio_path,
+        "result_json": json.dumps({"text": "half a transcript", "partial": partial}),
+    }
+
+
+@pytest.fixture()
+def repo(monkeypatch):
+    mod = importlib.import_module("server.database.job_repository")
+    monkeypatch.setattr(transcription, "get_client_name", lambda _: "test-client")
+    return mod
+
+
+@pytest.fixture()
+def audio(tmp_path):
+    """/retry 410s unless the saved audio still exists on disk."""
+    path = tmp_path / "saved.wav"
+    path.write_bytes(b"RIFF")
+    return str(path)
+
+
+def test_retry_accepts_a_partial_completed_job(monkeypatch, repo, audio):
+    reset: list[str] = []
+    monkeypatch.setattr(repo, "get_job", lambda _id: _job("completed", partial=True, audio_path=audio))
+    monkeypatch.setattr(repo, "reset_for_retry", lambda job_id: reset.append(job_id))
+
+    bg = _BG()
+    resp = asyncio.run(transcription.retry_transcription("job-1", _request(), bg))
+
+    assert resp.status_code == 202
+    assert reset == ["job-1"], "a partial retry must actually reset the job"
+    assert bg.tasks, "a partial retry must schedule the re-transcription"
+
+
+def test_retry_still_refuses_a_fully_complete_job(monkeypatch, repo, audio):
+    monkeypatch.setattr(repo, "get_job", lambda _id: _job("completed", partial=False, audio_path=audio))
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(transcription.retry_transcription("job-1", _request(), _BG()))
+    assert exc.value.status_code == 409
+
+
+def test_retry_still_accepts_a_failed_job(monkeypatch, repo, audio):
+    """The pre-existing path must not regress."""
+    monkeypatch.setattr(repo, "get_job", lambda _id: _job("failed", partial=False, audio_path=audio))
+    monkeypatch.setattr(repo, "reset_for_retry", lambda _id: None)
+    resp = asyncio.run(transcription.retry_transcription("job-1", _request(), _BG()))
+    assert resp.status_code == 202
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cd server/backend && ../../build/.venv/bin/pytest tests/test_partial_result_retry.py -v --tb=short
+```
+Expected: `test_retry_accepts_a_partial_completed_job` FAILS with HTTP 409 "Only failed jobs can be retried".
+
+- [ ] **Step 3: Let /retry accept a partial**
+
+In `server/backend/api/routes/transcription.py`, replace the status gate (~line 1466):
+
+```python
+    if job["status"] == "processing":
+        raise HTTPException(status_code=409, detail="Job is already processing")
+
+    # A partial transcript is stored with status='completed' (so it is still
+    # delivered, and its audio still GC'd) but with result_json.partial = true.
+    # It is an incomplete transcription, so it MUST be retryable — otherwise the
+    # user is stuck with a truncated transcript and no recourse.
+    is_partial = False
+    if job.get("result_json"):
+        try:
+            is_partial = bool(_json.loads(job["result_json"]).get("partial"))
+        except _json.JSONDecodeError:
+            is_partial = False
+
+    if job["status"] != "failed" and not is_partial:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Only failed or partial jobs can be retried (current status: {job['status']})",
+        )
+```
+
+- [ ] **Step 4: Run and watch it pass**
+
+```bash
+cd server/backend && ../../build/.venv/bin/pytest tests/test_partial_result_retry.py -v --tb=short
+```
+Expected: 3 passed.
+
+- [ ] **Step 5: Add the retry call to the API client**
+
+`dashboard/src/api/client.ts` — there is no retry method yet. Add one next to
+`fetchTranscriptionResult` (line 312), using the existing private `post<T>()` helper (line 232),
+which already handles `ensureConfigured`, auth headers, and `APIError`:
+
+```typescript
+  /** POST /api/transcribe/retry/{jobId} — re-transcribe from the job's saved audio. */
+  async retryTranscription(jobId: string): Promise<{ job_id: string; status: string }> {
+    return this.post(`/api/transcribe/retry/${jobId}`);
+  }
+```
+
+- [ ] **Step 6: Surface partial in the dashboard type**
+
+`dashboard/src/hooks/useTranscription.ts:22` — extend the interface:
+
+```typescript
+export interface TranscriptionResult {
+  text: string;
+  words: Word[];
+  language?: string;
+  duration?: number;
+  /** True when the backend salvaged an incomplete transcript (sidecar failure
+   * or user cancellation partway through). The text stops early. */
+  partial?: boolean;
+  /** Human-readable reason the transcript is incomplete. */
+  partialReason?: string | null;
+}
+```
+
+Then, everywhere the hook builds a `TranscriptionResult` from a server payload (the `result_ready` WebSocket handler and the `resp.status === 200` recovery poll around lines 245 and 380), carry the fields through:
+
+```typescript
+                  setResult({
+                    text: r.text ?? '',
+                    words: r.words ?? [],
+                    language: r.language,
+                    duration: r.duration,
+                    partial: r.partial ?? false,
+                    partialReason: r.partial_reason ?? null,
+                  });
+```
+
+- [ ] **Step 7: Add the banner**
+
+In `dashboard/components/views/SessionView.tsx`, where the transcript result is rendered, add a
+handler and the banner above the transcript body. `jobId` is already tracked by `useTranscription`;
+expose it from the hook's return value if it is not already exposed.
+
+```tsx
+const [retrying, setRetrying] = useState(false);
+
+const handleRetryPartial = async () => {
+  if (!jobId) return;
+  setRetrying(true);
+  try {
+    await apiClient.retryTranscription(jobId);
+  } catch (err) {
+    setError(err instanceof Error ? err.message : 'Retry failed');
+  } finally {
+    setRetrying(false);
+  }
+};
+```
+
+```tsx
+{result?.partial && (
+  <div className="transcript-partial-banner" role="alert">
+    <span className="transcript-partial-banner__text">
+      This transcript is incomplete{result.partialReason ? ` (${result.partialReason})` : ''}.
+      It may be missing the end of the recording.
+    </span>
+    <button
+      type="button"
+      className="transcript-partial-banner__retry"
+      onClick={() => void handleRetryPartial()}
+      disabled={retrying || !jobId}
+    >
+      {retrying ? 'Retrying…' : 'Retry'}
+    </button>
+  </div>
+)}
+```
+
+Style `.transcript-partial-banner`, `.transcript-partial-banner__text`, and
+`.transcript-partial-banner__retry` alongside the existing transcript styles. Use a warning
+tone, not an error tone — the transcript is usable, just incomplete.
+
+- [ ] **Step 8: Frontend tests + UI contract**
+
+```bash
+cd dashboard && nvm use && npm test
+npm run ui:contract:extract && npm run ui:contract:build
+node scripts/ui-contract/validate-contract.mjs --update-baseline
+npm run ui:contract:check
+```
+Remember to bump `meta.spec_version` in the contract YAML **before** `--update-baseline`, or validate fails `semver_bump_required`. Note the scanner gotchas: an apostrophe in a `//` comment silently swallows subsequent className tokens, and `#NNN` hex-shaped text in a comment is read as a CSS color — write "GH-125", not "GH #125".
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add server/backend/api/routes/transcription.py \
+        server/backend/tests/test_partial_result_retry.py \
+        dashboard/src/api/client.ts \
+        dashboard/src/hooks/useTranscription.ts \
+        dashboard/components/views/SessionView.tsx \
+        dashboard/ui-contract/
+git commit -m "fix(server,dashboard): surface partial transcripts and let them be retried
+
+* fix(server): /retry now accepts a partial job
+  * a partial is stored with status='completed' + result_json.partial, so /retry refused it — the user was left with a truncated transcript and no recourse
+  * kept inside status='completed' deliberately: a new status value would have to be retrofitted into get_recent_undelivered and get_jobs_for_cleanup, and forgetting either is silent data loss
+
+* feat(dashboard): show a banner with a Retry action when a transcript is incomplete
+* feat(dashboard): carry partial/partial_reason through TranscriptionResult"
+```
+
+---
+
+## Task 5: Full verification and PR
+
+- [ ] **Step 1: Full backend suite**
+
+```bash
+cd server/backend && ../../build/.venv/bin/pytest tests/ -q
+```
+Expected: all pass except the 2 known pre-existing failures (db migration version, swr_linear resample). Run the FULL suite, not a `-k` subset — a past change passed its own subset while breaking 15 audio-durability tests.
+
+- [ ] **Step 2: Full frontend suite**
+
+```bash
+cd dashboard && nvm use && npm test && npm run typecheck && npm run ui:contract:check
+```
+
+- [ ] **Step 3: Confirm the change scope**
+
+```bash
+npx gitnexus analyze   # index is stale
+```
+Then `gitnexus_detect_changes()` and confirm only the expected symbols/flows are affected.
+
+- [ ] **Step 4: Open the PR**
+
+Open the PR directly on GitHub (no local draft file, per CLAUDE.md):
+
+```bash
+git push -u origin fix/whispercpp-remove-inference-timeout
+gh pr create --title "fix(stt): remove the ~2x-real-time cap on whisper.cpp inference" --body "$(cat <<'EOF'
+## The bug
+
+`WhisperCppBackend` capped each `/inference` request at a read timeout of
+`max(300, ceil(chunk_seconds * 2.0))` — about 2x real-time. whisper-server sends no bytes at all
+until inference completes, so httpx's read timeout (which bounds a single socket read) was acting
+as a **work deadline**. A healthy machine that is merely slow was being failed.
+
+Worse, it failed *silently*. Exceeding the budget raised `PartialTranscriptionError`, which
+`engine.py` turns into a partial result, which `save_result()` writes as **`status='completed'`**.
+The dashboard never read the `partial` flag, and `/retry` refused the job because it only accepted
+`'failed'`. A user on low-end hardware recorded a 2-hour lecture, got 40 minutes back, saw it
+marked complete, and had no way to retry.
+
+## Why it could not just be deleted
+
+Removing the timeout naively would have made things worse, for two reasons:
+
+1. **Cancel was never wired to the main path.** `websocket.py:459` bound `cancellation_check` to
+   `_client_disconnected` (set only on a real socket drop), not `job_tracker.is_cancelled` (what
+   `POST /cancel` flips). The read timeout was therefore the *only* thing that terminated a stuck
+   job. Fixed in commit 1 — this is a user-facing bug fix in its own right.
+2. **A blocked sync read cannot be aborted.** `resp.close()` / `client.close()` from another thread
+   are no-ops: httpcore calls `sock.close()`, and closing an fd does not wake a thread already
+   blocked in `recv()`. Measured against a stalling server, the request hung the full 30s and then
+   *completed normally*. `httpx.AsyncClient` + `asyncio.Task.cancel()` aborts in ~2s instead,
+   because asyncio uses a selector rather than a blocking read. Public API only.
+
+## The rule
+
+**An unbounded read is permitted only where an abort path exists.** Longform paths (which have a
+`cancellation_check`) get `read=None` — no time limit, ever. warmup / live / preview have no way
+out of a wedge, so they keep a finite read; their audio is seconds long.
+
+Chunking is unchanged — it bounds memory per forward pass and was never the time limit.
+
+## Also fixed
+
+- Cancelling mid-file no longer discards completed chunks (it would have thrown away 29 of 30).
+- A bare scalar `timeout=` expands to all four httpx fields, so a blackholed sidecar used to hang
+  in the **connect** phase for 20-60 minutes. Connect is now bounded at 10s.
+- The client-level httpx default was dead code (a per-request timeout replaces it wholesale).
+
+## Test plan
+
+- [x] Backend suite green (full run, not a subset)
+- [x] Transport tested against a real stalling socket server: slow-but-healthy completes with no
+      limit; cancel aborts a wedged request in ~1s; connect stays bounded against a dead host
+- [x] Frontend suite + typecheck + UI contract green
+- [ ] **Manual smoke test on real hardware**: a genuinely slow / CPU-only run against the Vulkan
+      sidecar, confirming a transcript that previously truncated now completes
+- [ ] **Windows and macOS check** — the abort primitive was only verified on Linux/CPython 3.13
+EOF
+)"
+```
+
+---
+
+## Out of scope
+
+- `/import` never calls `save_result` / `mark_failed`, so every completed import stays `'processing'` and is later marked **failed** by the orphan sweep (`transcription.py:1241-1245` acknowledges the row is unused). Real bug, unrelated to this one. File separately.
+- Chunking (`_MAX_CHUNK_DURATION_S`, `_MAX_CHUNK_DURATION_CEILING_S`) stays exactly as-is. It bounds memory per forward pass and preserves per-chunk progress and cancellation; it was never the time limit.

--- a/docs/superpowers/plans/2026-07-13-whispercpp-remove-inference-timeout.md
+++ b/docs/superpowers/plans/2026-07-13-whispercpp-remove-inference-timeout.md
@@ -234,6 +234,11 @@ git commit -m "fix(server): make the Cancel button actually stop a running trans
 
 The read timeout is `None` (no time limit) whenever a `cancellation_check` is supplied, and finite otherwise. Tested against a **real** localhost server that stalls before sending headers — the exact shape of a wedged whisper-server — because a MagicMock cannot prove an abort actually interrupts a blocked read.
 
+**Lint constraints (verified — do not trip these):**
+- ruff TID251 bans `httpx.Client`, `httpx.AsyncClient`, `time.sleep`, and `datetime.now` **in `tests/` only**. It is suppressed for `core/**/*.py` (`pyproject.toml:132`), so the transport module may use `httpx.AsyncClient` freely.
+- The **test** file must therefore avoid `time.sleep` (use `threading.Event().wait(...)`) and must not construct `httpx.Client` / `httpx.AsyncClient`. Referencing httpx *exception classes* (`httpx.ConnectError`, `httpx.ReadTimeout`) is fine — only the two client constructors are banned.
+- `time.monotonic()` is not banned.
+
 - [ ] **Step 1: Write the failing test**
 
 Create `server/backend/tests/test_whispercpp_transport.py`:
@@ -294,7 +299,9 @@ class StallingSidecar:
                 pass
         except OSError:
             pass
-        time.sleep(self._stall)
+        # NOT time.sleep(): ruff TID251 bans it in tests/ (pyproject.toml:149).
+        # Event.wait() is the sanctioned equivalent and blocks this thread the same way.
+        threading.Event().wait(self._stall)
         if self._reply is not None:
             body = json.dumps(self._reply).encode()
             try:

--- a/docs/superpowers/specs/2026-07-13-whispercpp-remove-inference-timeout-design.md
+++ b/docs/superpowers/specs/2026-07-13-whispercpp-remove-inference-timeout-design.md
@@ -1,0 +1,173 @@
+# Remove the whisper.cpp inference time limit
+
+**Date:** 2026-07-13
+**Status:** Approved, ready for implementation planning
+**Area:** `server/backend/core/stt/backends/whispercpp_backend.py`, cancellation wiring, partial-result surfacing
+
+## Problem
+
+`WhisperCppBackend` caps each `/inference` request at a read timeout of
+`max(inference_timeout_s, ceil(chunk_seconds * timeout_seconds_per_audio_second))`
+(`whispercpp_backend.py:124-140`). With the shipped defaults (600s chunks, 300s floor, 2.0x
+factor) this permits roughly 2x real-time inference. A low-end machine that is slower than
+that is failed, even though it is healthy and would have finished given time.
+
+This is not merely an inconvenience. It silently truncates transcripts:
+
+1. A chunk exceeds the budget, and httpx raises a read timeout (`whispercpp_backend.py:803`).
+2. If at least one earlier chunk succeeded, the backend raises `PartialTranscriptionError`
+   carrying the completed chunks (`:712`).
+3. `engine.py:947` catches it, sets `partial=True` / `partial_reason`, and keeps only the
+   chunks completed so far.
+4. That flows into the ordinary result path, and `save_result()` writes
+   **`status = 'completed'`** (`job_repository.py:163`).
+5. The dashboard never reads `partial` or `partial_reason` (zero occurrences in the frontend).
+6. `/retry` refuses the job, accepting only `status == 'failed'` (`transcription.py:1466`).
+
+A user on a slow machine therefore records a 2-hour lecture, receives a transcript that stops
+40 minutes in, sees it marked complete with no warning, and cannot retry it. This is the exact
+failure class `CLAUDE.md` forbids: a completed transcription silently discarded.
+
+The partial-salvage machinery (GH #168) was designed as a safety net for a genuinely dead
+sidecar, where half a transcript beats none. Once a healthy-but-slow machine raises the same
+exception, the net becomes a trap, because "we gave up early" and "the sidecar died" are
+indistinguishable downstream.
+
+## Why the timeout exists, and why it cannot simply be deleted
+
+The read timeout is currently the **only** mechanism that terminates a stuck whisper.cpp job.
+Two facts make a naive `read=None` actively dangerous, and both were verified empirically:
+
+**Cancel is not wired up on the main path.** `websocket.py:459` binds
+`cancellation_check=lambda: self._client_disconnected`, and that flag is only ever set on a
+real socket disconnect (`websocket.py:220, 1065, 1083`). `POST /cancel`
+(`transcription.py:770`) flips `job_tracker._cancelled`, which the WebSocket path never reads.
+Every other caller polls `job_tracker.is_cancelled` (`transcription.py:313, 488, 543, 716, 890`;
+`openai_audio.py:246`). Two further paths pass no `cancellation_check` at all
+(`notebook.py:1031`, `transcription.py:1103`) - and `notebook.py:1345` calls `cancel_job()`
+anyway, a flag with no reader.
+
+**A blocked read cannot be interrupted by closing the client.** Driven against a fake sidecar
+that accepts the POST, drains the body, and then sends nothing (the GPU-wedge shape):
+
+| Abort mechanism | Result |
+|---|---|
+| `resp.close()` from another thread | request hung the full 30s, then **completed normally** |
+| `client.close()` from another thread | same |
+| httpcore `NetworkStream.close()` | same |
+| `sock.shutdown(SHUT_RDWR)` | aborted in 2.0s |
+
+`httpcore/_backends/sync.py:141` calls `self._sock.close()`, and on Linux closing an fd does not
+wake a thread already blocked in `recv()` on it. The kernel keeps the file description alive for
+the in-flight syscall.
+
+Consequently, with a sync client and `read=None`, a wedged sidecar blocks forever in an
+unkillable thread, holding both the single `job_tracker` slot and `engine.transcription_lock`,
+which deadlocks the notebook, OpenAI-compat, and retry paths too. That is a server restart,
+not a lost job. Measured: with `read=None`, warmup, live, and longform all remained blocked
+past 20s **even with `cancellation_check` flipping to True**, because it is polled only between
+chunks and never during the blocked read.
+
+## Design principle
+
+> **An unbounded read is permitted only where an abort path exists.**
+
+The current code inverts this: it bounds the read (harming honest slow machines) while leaving
+the abort path disconnected (so a wedge is unrecoverable anyway).
+
+## The abort primitive
+
+`httpx.AsyncClient` + `asyncio.Task.cancel()` aborts a request blocked before response headers,
+using only public API. asyncio registers the socket with a selector rather than issuing a
+blocking `recv()`, so cancellation is a first-class operation.
+
+Verified against a stalling server, from a synchronous caller (the `STTBackend.transcribe()`
+contract) that runs its own event loop inside the executor thread:
+
+| Scenario | Result |
+|---|---|
+| Wedged sidecar, user cancels at t=2s | aborted in **2.04s** |
+| Slow but healthy, 12s of work (old cap would have killed it) | **completed**, no limit |
+| Dead sidecar host | failed in **0.01s** (connect still bounded) |
+| fd hygiene after abort | no leak |
+
+No httpcore internals, no socket surgery, no subprocess, no async rewrite of the backend.
+
+## Changes
+
+Shipped as **one PR, three commits**. Wave 1 must land first: it restores the escape hatch that
+Wave 2 relies on.
+
+### Commit 1 - fix cancellation wiring
+
+Independent user-facing bug fix. Today, pressing Cancel on a whisper.cpp longform job does
+nothing: the job transcribes to completion, persists, auto-adds to the notebook, fires the
+webhook, and holds the job slot so no new recording can start.
+
+- `websocket.py:459` - bind to both signals:
+  `cancellation_check=lambda: self._client_disconnected or model_manager.job_tracker.is_cancelled()`
+  (`model_manager` is already in scope). Flag hygiene is already safe: `try_start_job` and
+  `end_job` reset `_cancelled` (`model_manager.py:90, 113`), and `_release_job()` runs in
+  `stop_recording`'s `finally` (`websocket.py:786-788`), so no stale flag leaks into the next job.
+- `notebook.py:1031` - pass `cancellation_check=model_manager.job_tracker.is_cancelled`.
+- `transcription.py:1103` (`_run_file_import`) - same.
+
+### Commit 2 - remove the time limit
+
+- Rewrite `_transcribe_chunk` around the abortable POST: `httpx.Timeout(None, connect=10.0,
+  write=120.0, pool=10.0)`, request issued as an asyncio task, `cancellation_check` polled every
+  250ms, `task.cancel()` on request.
+- `read=None` applies wherever a `cancellation_check` is available (every longform path, after
+  Commit 1). Warmup, live, and preview keep a finite read via a module constant - their audio is
+  seconds long, they have no abort path, and no legitimate slow machine needs 20 minutes for a
+  3-second utterance.
+- **Delete the knobs entirely**: `inference_timeout_s` and `timeout_seconds_per_audio_second`
+  from `config.yaml:159-180` and `config.py:250-254`; `_INFERENCE_TIMEOUT`,
+  `_TIMEOUT_SECONDS_PER_AUDIO_SECOND`, `_inference_timeout_for`, `_resolve_timeout_config` from
+  the backend. Unbounded is the only behavior.
+- **Fixes a latent bug**: line 775 passes a bare scalar, and httpx expands a scalar to all four
+  timeout fields, so today a blackholed sidecar host hangs in the **connect** phase for 20-60
+  minutes. Bounding connect at 10s fixes this.
+- **Removes dead code**: the client-level default at line 514 never applies, because httpx
+  replaces the client default wholesale when a per-request `timeout=` is passed
+  (`_client.py:371-377`). It also reads the module constant rather than the config-resolved value.
+
+Chunking (`_MAX_CHUNK_DURATION_S`, `_MAX_CHUNK_DURATION_CEILING_S`) is **retained unchanged**.
+It bounds memory per forward pass and preserves per-chunk progress and cancellation. It was
+never the time limit.
+
+### Commit 3 - stop laundering partials into "completed"
+
+Partials remain possible after the cap is gone (sidecar crash, connection reset mid-chunk), so
+they must stop being silently truncated "completed" jobs.
+
+Keep `status='completed'` and drive off the `partial` / `partial_reason` fields that
+`engine.py:99-100` already persists. **No migration, no new status value.** A new status would
+have to be retrofitted into `get_recent_undelivered` and `get_jobs_for_cleanup`, and the failure
+mode of forgetting either is silent data loss. Staying inside `'completed'` means partial jobs
+keep being re-delivered on reconnect and keep having their audio GC'd, for free.
+
+- `GET /result` (`transcription.py:~1428`) - echo `partial` and `partial_reason`.
+- `/retry` (`transcription.py:1466`) - accept a completed-but-partial job.
+- Dashboard - banner on a partial result with a Retry action.
+
+## Testing
+
+- Backend suite from `server/backend/` using the build venv, per `CLAUDE.md`.
+- `test_whispercpp_backend.py:1656-1693` asserts on the deleted knobs and must be rewritten.
+- New tests, against a fake stalling sidecar: unbounded read completes slow-but-healthy work;
+  cancel aborts a wedged request promptly; connect stays bounded against a dead host; a partial
+  result is surfaced and is retryable.
+- A regression test asserting the abort actually fires, so an upstream httpx change cannot
+  silently degrade back into a hang.
+- Frontend: Vitest for the partial banner. Node 22 required (`cd dashboard && nvm use`).
+
+## Risks
+
+- Abort verified on Linux/CPython 3.13 only. The sidecar also ships on Windows and macOS; the
+  asyncio primitive is platform-independent by construction, but should be smoke-tested there.
+- A wedged sidecar on a no-cancel path (warmup, live, preview) still relies on the finite read
+  constant. This is intentional and is strictly better than today.
+- `RemoteProtocolError` from a self-requested abort is indistinguishable from a genuine sidecar
+  crash, so the caller must consult its own "I requested this" flag before labelling the job, and
+  must persist any partial state first.

--- a/server/backend/api/routes/notebook.py
+++ b/server/backend/api/routes/notebook.py
@@ -1037,6 +1037,7 @@ def _run_transcription(
                     ),
                     word_timestamps=need_word_timestamps,
                     progress_callback=on_progress,
+                    cancellation_check=model_manager.job_tracker.is_cancelled,
                 )
 
         # Determine recorded_at timestamp

--- a/server/backend/api/routes/transcription.py
+++ b/server/backend/api/routes/transcription.py
@@ -1463,10 +1463,23 @@ async def retry_transcription(
     if job["status"] == "processing":
         raise HTTPException(status_code=409, detail="Job is already processing")
 
-    if job["status"] != "failed":
+    # A partial transcript is stored with status='completed' (so it is still
+    # delivered, and its audio still garbage-collected) but with
+    # result_json.partial = true. It is an INCOMPLETE transcription, so it must be
+    # retryable — otherwise the user is left with a truncated transcript and no
+    # recourse. A malformed result_json is treated as not-partial: it must never
+    # accidentally unlock retry on a genuinely complete job.
+    is_partial = False
+    if job.get("result_json"):
+        try:
+            is_partial = bool(_json.loads(job["result_json"]).get("partial"))
+        except (_json.JSONDecodeError, AttributeError):
+            is_partial = False
+
+    if job["status"] != "failed" and not is_partial:
         raise HTTPException(
             status_code=409,
-            detail=f"Only failed jobs can be retried (current status: {job['status']})",
+            detail=f"Only failed or partial jobs can be retried (current status: {job['status']})",
         )
 
     # Pre-check model availability so we don't reset the job to 'processing'

--- a/server/backend/api/routes/transcription.py
+++ b/server/backend/api/routes/transcription.py
@@ -1109,6 +1109,7 @@ def _run_file_import(
                     ),
                     word_timestamps=need_word_timestamps,
                     progress_callback=on_progress,
+                    cancellation_check=model_manager.job_tracker.is_cancelled,
                 )
 
         # Store successful result for client polling

--- a/server/backend/api/routes/websocket.py
+++ b/server/backend/api/routes/websocket.py
@@ -456,7 +456,13 @@ class TranscriptionSession:
                     task=task,
                     translation_target_language=translation_target,
                     progress_callback=_on_progress,
-                    cancellation_check=lambda: self._client_disconnected,
+                    # Two independent stop signals, both of which must reach the
+                    # backend: the client vanished, or the user pressed Cancel
+                    # (POST /cancel -> job_tracker). Binding only the former left
+                    # Cancel a no-op on this, the main longform path.
+                    cancellation_check=lambda: (
+                        self._client_disconnected or model_manager.job_tracker.is_cancelled()
+                    ),
                 ),
             )
 

--- a/server/backend/config.py
+++ b/server/backend/config.py
@@ -247,11 +247,6 @@ class ServerConfig:
         ("SENSEVOICE_DIARIZATION_ENGINE", ("diarization", "sensevoice_engine")),
         ("WHISPERCPP_SERVER_URL", ("whisper_cpp", "server_url")),
         ("WHISPERCPP_CHUNK_DURATION_S", ("whisper_cpp", "chunk_duration_s")),
-        ("WHISPERCPP_INFERENCE_TIMEOUT_S", ("whisper_cpp", "inference_timeout_s")),
-        (
-            "WHISPERCPP_TIMEOUT_SECONDS_PER_AUDIO_SECOND",
-            ("whisper_cpp", "timeout_seconds_per_audio_second"),
-        ),
     )
 
     _ENV_LOGGING_OVERRIDES = (

--- a/server/backend/core/stt/backends/whispercpp_backend.py
+++ b/server/backend/core/stt/backends/whispercpp_backend.py
@@ -23,6 +23,11 @@ from server.core.stt.backends.base import (
     PartialTranscriptionError,
     STTBackend,
 )
+from server.core.stt.backends.whispercpp_transport import (
+    InferenceAborted,
+    ResponseTooLarge,
+    post_inference,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -36,21 +41,24 @@ class WhisperCppResponseError(RuntimeError):
 
 
 _DEFAULT_SERVER_URL = "http://whisper-server:8080"
-# Floor for the per-request httpx timeout. The actual budget scales with chunk
-# duration via ``_inference_timeout_for`` (GH #168 / #153): long audio is split
-# into ``_MAX_CHUNK_DURATION_S`` chunks in ``transcribe``, so each /inference POST
-# is bounded in size and time — replacing the old single un-chunked request whose
-# fixed 300s ceiling a 5h+ file could never satisfy.
-_INFERENCE_TIMEOUT = 300  # seconds — minimum per-request budget
 _MAX_CHUNK_DURATION_S = 10 * 60  # 10 min per /inference POST (mirrors the NeMo backends)
 # Hard ceiling on the configurable chunk duration. Even a deliberately huge
 # WHISPERCPP_CHUNK_DURATION_S must not route a whole multi-hour file through a
 # single un-chunked /inference request — that path re-exposes the GH #172
 # truncation and defeats per-chunk progress/cancellation. 30 min keeps each
 # chunk's plausible segment count far below any proportional cap.
+#
+# NOTE: chunking bounds MEMORY per forward pass. It is not, and never was, a time
+# limit — a chunk may take as long as it takes.
 _MAX_CHUNK_DURATION_CEILING_S = 30 * 60
-_TIMEOUT_SECONDS_PER_AUDIO_SECOND = 2.0  # tolerate inference up to ~2× real-time
 _LOAD_TIMEOUT = 60
+
+# Inference has NO time limit when the caller can cancel (the normal longform
+# case): a slow machine is allowed to take as long as it needs. Callers with no
+# cancellation_check — warmup, live mode, preview — have no way out of a wedged
+# sidecar, so they keep a finite read. Their audio is seconds long, so this is
+# already orders of magnitude above any honest inference time.
+_UNCANCELLABLE_READ_TIMEOUT_S = 300.0
 
 # whisper-server's own default for beam_size (see
 # ``examples/server/server.cpp``). Named so the client-vs-server default
@@ -73,14 +81,10 @@ _MAX_WORDS_PER_AUDIO_SECOND = 40
 _SEGMENT_CAP_FLOOR = 200
 _WORDS_CAP_FLOOR = 1_000
 
-# Hard ceiling on a single /inference response body, enforced WHILE reading so a
-# hostile or misconfigured ``WHISPERCPP_SERVER_URL`` returning a multi-GB body is
-# rejected before it is deserialized into memory. The proportional segment/word
-# caps above only run AFTER the body is parsed, so they cannot bound the read —
-# this is the real memory guard the old post-parse list slice only pretended to
-# be (GH #193). A 6-hour verbose_json transcript with word timestamps is well
-# under this, so it never trips on legitimate output.
-_MAX_RESPONSE_BYTES = 256 * 1024 * 1024  # 256 MiB
+# NOTE: the ceiling on a single /inference response body (GH #193) now lives in
+# ``whispercpp_transport.MAX_RESPONSE_BYTES``, where it is enforced WHILE the
+# body is read. The proportional segment/word caps above only run AFTER the body
+# is parsed, so they never could bound the read.
 
 # Practical cap on user-supplied initial_prompt. whisper.cpp uses the prompt
 # as a decoder hint in the context window (~224 tokens ≈ ~1 KB of text). A
@@ -113,31 +117,12 @@ _SIDECAR_LOAD_TIMEOUT_MSG = (
     "the model. Wait a moment and retry, or check the sidecar container logs."
 )
 
-_SIDECAR_INFERENCE_TIMEOUT_MSG = (
-    "whisper.cpp sidecar at {url} accepted the request but transcription "
-    "timed out after {timeout}s. This usually means the audio is too long for "
-    "the current timeout, or the Vulkan device is under heavy load. Try "
-    "shorter audio or check the sidecar container logs."
+_SIDECAR_WEDGED_MSG = (
+    "whisper.cpp sidecar at {url} accepted the request but sent no response "
+    "within {timeout:.0f}s. This path (warmup / live mode / preview) sends only "
+    "a few seconds of audio, so the sidecar is almost certainly wedged — check "
+    "the sidecar container logs. (File transcription has no time limit.)"
 )
-
-
-def _inference_timeout_for(
-    num_samples: int,
-    sample_rate: int,
-    floor: int = _INFERENCE_TIMEOUT,
-    factor: float = _TIMEOUT_SECONDS_PER_AUDIO_SECOND,
-) -> int:
-    """Per-request httpx read-timeout (seconds), scaled to the chunk's duration.
-
-    Floored at ``floor``. Because audio is chunked before it reaches the sidecar
-    (see ``WhisperCppBackend.transcribe``), every request is bounded, so scaling
-    the timeout to the chunk length lets a slow or heavily-loaded Vulkan GPU
-    finish without the client giving up prematurely (GH #168 / #153). ``floor``
-    and ``factor`` default to the module constants but are overridable via config
-    (``WHISPERCPP_INFERENCE_TIMEOUT_S`` / ``WHISPERCPP_TIMEOUT_SECONDS_PER_AUDIO_SECOND``).
-    """
-    duration_s = num_samples / sample_rate if sample_rate > 0 else 0.0
-    return max(floor, math.ceil(duration_s * factor))
 
 
 def _read_whispercpp_setting(env_key: str, cfg_key: str) -> str | None:
@@ -199,36 +184,6 @@ def _word_cap_for(audio_duration_s: float) -> int:
     exceeding it means a malformed/hostile sidecar payload (GH #172).
     """
     return max(_WORDS_CAP_FLOOR, math.ceil(audio_duration_s * _MAX_WORDS_PER_AUDIO_SECOND))
-
-
-def _resolve_timeout_config() -> tuple[int, float]:
-    """``(inference_timeout_floor_s, seconds_per_audio_second)`` from env → config → default."""
-    raw_floor = _read_whispercpp_setting("WHISPERCPP_INFERENCE_TIMEOUT_S", "inference_timeout_s")
-    floor = _INFERENCE_TIMEOUT
-    if raw_floor is not None:
-        try:
-            floor = max(60, int(float(raw_floor)))
-        except (TypeError, ValueError):
-            logger.warning(
-                "Ignoring invalid whisper.cpp inference timeout %r (expected a number ≥ 60); using %ds",
-                raw_floor,
-                _INFERENCE_TIMEOUT,
-            )
-
-    raw_factor = _read_whispercpp_setting(
-        "WHISPERCPP_TIMEOUT_SECONDS_PER_AUDIO_SECOND", "timeout_seconds_per_audio_second"
-    )
-    factor = _TIMEOUT_SECONDS_PER_AUDIO_SECOND
-    if raw_factor is not None:
-        try:
-            factor = max(0.5, float(raw_factor))
-        except (TypeError, ValueError):
-            logger.warning(
-                "Ignoring invalid whisper.cpp timeout factor %r (expected a number ≥ 0.5); using %.1f",
-                raw_factor,
-                _TIMEOUT_SECONDS_PER_AUDIO_SECOND,
-            )
-    return floor, factor
 
 
 def _resolve_server_url() -> str:
@@ -490,17 +445,23 @@ class WhisperCppBackend(STTBackend):
         self._model_name: str | None = None
         self._loaded: bool = False
         self._client: httpx.Client | None = None
-        # Chunking + timeout knobs. Default to the module constants; ``load()``
-        # overrides them from env/config (WHISPERCPP_*). Instance attributes so
-        # tests can shrink them; mirrors ``ParakeetBackend._max_chunk_duration_s``.
+        # Chunking knob. Defaults to the module constant; ``load()`` overrides it
+        # from env/config (WHISPERCPP_CHUNK_DURATION_S). An instance attribute so
+        # tests can shrink it; mirrors ``ParakeetBackend._max_chunk_duration_s``.
         # Audio longer than ``_max_chunk_duration_s`` (seconds) is split into
-        # chunks before being sent to the sidecar (GH #168).
+        # chunks before being sent to the sidecar (GH #168). This bounds memory
+        # per forward pass — it is NOT a time limit.
         self._max_chunk_duration_s: int = _MAX_CHUNK_DURATION_S
-        self._inference_timeout: int = _INFERENCE_TIMEOUT
-        self._timeout_seconds_per_audio_second: float = _TIMEOUT_SECONDS_PER_AUDIO_SECOND
 
     def _ensure_client(self) -> httpx.Client:
-        """Return (or create) a persistent httpx.Client.
+        """Return (or create) the persistent sync httpx.Client used by ``/load``.
+
+        ONLY ``/load`` uses this client now: ``/inference`` goes through
+        ``whispercpp_transport.post_inference``, because a blocked *sync* read
+        cannot be aborted and inference is no longer time-limited. ``/load``
+        passes its own explicit ``_LOAD_TIMEOUT``, so no client-level default is
+        set here (httpx replaces the client default wholesale when a per-request
+        ``timeout=`` is given, which made the old default dead code anyway).
 
         TODO(GH-62-followup #G): this is not thread-safe — two concurrent
         callers both passing the ``self._client is None`` check would each
@@ -511,7 +472,7 @@ class WhisperCppBackend(STTBackend):
         ambient assumption.
         """
         if self._client is None:
-            self._client = httpx.Client(timeout=_INFERENCE_TIMEOUT)
+            self._client = httpx.Client()
         return self._client
 
     # ------------------------------------------------------------------
@@ -521,18 +482,14 @@ class WhisperCppBackend(STTBackend):
     def load(self, model_name: str, device: str, **kwargs: Any) -> None:
         self._server_url = _resolve_server_url()
         self._model_name = model_name
-        # Resolve chunking / timeout knobs once at load time (env → config →
-        # default), mirroring how _resolve_server_url is consumed here.
+        # Resolve the chunking knob once at load time (env → config → default),
+        # mirroring how _resolve_server_url is consumed here.
         self._max_chunk_duration_s = _resolve_chunk_duration_config()
-        self._inference_timeout, self._timeout_seconds_per_audio_second = _resolve_timeout_config()
         logger.info(
-            "WhisperCppBackend: loading model %s via %s "
-            "(chunk=%ds, timeout_floor=%ds, timeout_factor=%.1fx)",
+            "WhisperCppBackend: loading model %s via %s (chunk=%ds, inference=unbounded)",
             model_name,
             self._server_url,
             self._max_chunk_duration_s,
-            self._inference_timeout,
-            self._timeout_seconds_per_audio_second,
         )
 
         client = self._ensure_client()
@@ -625,12 +582,14 @@ class WhisperCppBackend(STTBackend):
         #     English; non-English targets are rejected upstream in
         #     capabilities.py::validate_translation_request.
         # ``progress_callback`` IS honoured for chunked (long) audio — one tick
-        # per chunk (GH #168). Short audio goes out in a single synchronous POST
-        # and so still cannot report sub-call progress.
-        # ``cancellation_check`` IS honoured for chunked audio: it is polled
-        # between chunks (the engine forwards it because supports_cancellation()
-        # is True) so a long job stops within one chunk instead of after the
-        # whole file. A single /inference POST cannot be interrupted mid-flight.
+        # per chunk (GH #168). Short audio goes out in a single POST and so still
+        # cannot report sub-call progress.
+        # ``cancellation_check`` IS honoured, and is now the ONLY interrupt:
+        # inference itself has no time limit. It is polled between chunks AND
+        # forwarded into the in-flight POST (whispercpp_transport aborts a read
+        # blocked on a silent sidecar), so a job stops within ~a quarter second
+        # rather than at the next chunk boundary. Passing it also switches the
+        # request to an unbounded read — see _UNCANCELLABLE_READ_TIMEOUT_S.
 
         if not self._loaded:
             raise RuntimeError("WhisperCppBackend: model is not loaded")
@@ -665,11 +624,18 @@ class WhisperCppBackend(STTBackend):
             # form value to that literal (see server.cpp ``req.has_file``).
             data["split_on_word"] = "true"
 
-        # Short audio: one synchronous POST (the original fast path).
+        # Short audio: one POST (the original fast path).
         total_samples = len(audio)
         chunk_samples = int(self._max_chunk_duration_s * audio_sample_rate)
         if chunk_samples <= 0 or total_samples <= chunk_samples:
-            return self._transcribe_chunk(audio, audio_sample_rate, data)
+            try:
+                return self._transcribe_chunk(audio, audio_sample_rate, data, cancellation_check)
+            except InferenceAborted as exc:
+                # Single chunk: there is no completed work to salvage, so this is
+                # a plain cancellation.
+                from server.core.model_manager import TranscriptionCancelledError
+
+                raise TranscriptionCancelledError("Transcription cancelled by user") from exc
 
         # Long audio: split into bounded chunks and stitch with time offsets so
         # no single request must cover the whole file (GH #168). Mirrors
@@ -681,19 +647,24 @@ class WhisperCppBackend(STTBackend):
         chunk_data = data
         for i in range(num_chunks):
             if cancellation_check is not None and cancellation_check():
-                # Lazy import avoids a circular dependency (model_manager imports
-                # backend factories at module load).
-                from server.core.model_manager import TranscriptionCancelledError
-
                 logger.info(
                     "WhisperCppBackend: transcription cancelled at chunk %d/%d", i + 1, num_chunks
                 )
-                raise TranscriptionCancelledError("Transcription cancelled by user")
+                raise self._cancelled_or_partial(all_segments, first_info, offset)
 
             start = i * chunk_samples
             chunk = audio[start : min(start + chunk_samples, total_samples)]
             try:
-                segments, info = self._transcribe_chunk(chunk, audio_sample_rate, chunk_data)
+                segments, info = self._transcribe_chunk(
+                    chunk, audio_sample_rate, chunk_data, cancellation_check
+                )
+            except InferenceAborted:
+                # The user cancelled while this chunk was in flight. Completed
+                # chunks are real transcription work — surface them rather than
+                # discard them ("avoid data loss at all costs"). MUST precede the
+                # generic handler below, which would otherwise swallow this.
+                logger.info("WhisperCppBackend: cancelled mid-chunk %d/%d", i + 1, num_chunks)
+                raise self._cancelled_or_partial(all_segments, first_info, offset) from None
             except Exception as exc:
                 if first_info is None:
                     # Failed on the very first chunk — nothing to salvage, so the
@@ -741,68 +712,49 @@ class WhisperCppBackend(STTBackend):
         )
 
     def _transcribe_chunk(
-        self, chunk: np.ndarray, sample_rate: int, data: dict[str, Any]
+        self,
+        chunk: np.ndarray,
+        sample_rate: int,
+        data: dict[str, Any],
+        cancellation_check: Callable[[], bool] | None = None,
     ) -> tuple[list[BackendSegment], BackendTranscriptionInfo]:
         """POST a single (already-bounded) audio chunk to /inference and parse it.
 
-        The read-timeout scales with the chunk's duration (floored at
-        ``_INFERENCE_TIMEOUT``) so a slow Vulkan GPU does not false-time-out on
-        an otherwise-healthy request.
+        There is NO time limit on inference when ``cancellation_check`` is given:
+        a slow machine takes as long as it takes, and the only interrupt is the
+        user. See ``whispercpp_transport`` for why an unbounded read is safe there
+        and why it is refused everywhere else.
+
+        The response body is bounded at read time by the transport (GH #193).
         """
         wav_bytes = _audio_to_wav_bytes(chunk, sample_rate)
-        timeout = _inference_timeout_for(
-            len(chunk),
-            sample_rate,
-            self._inference_timeout,
-            self._timeout_seconds_per_audio_second,
-        )
-
-        client = self._ensure_client()
-        body = bytearray()
         try:
-            # Stream the response and bound it AT READ TIME (GH #193): a hostile
-            # or misconfigured sidecar could otherwise return a multi-GB body
-            # that ``resp.json()`` would materialize whole, exhausting memory
-            # before any segment/word cap (which only runs post-parse) could
-            # reject it. Reject early on an honest server's declared
-            # Content-Length, and — for servers that omit or lie about it —
-            # abort the read the instant the accumulated bytes cross the ceiling.
-            with client.stream(
-                "POST",
+            body = post_inference(
                 f"{self._server_url}/inference",
-                files={"file": ("audio.wav", wav_bytes, "audio/wav")},
-                data=data,
-                timeout=timeout,
-            ) as resp:
-                resp.raise_for_status()
-                declared = resp.headers.get("Content-Length")
-                # ``isascii()`` first: str.isdigit() is True for non-ASCII digit
-                # codepoints (e.g. "²") that int() then rejects, and a hostile
-                # sidecar can smuggle byte 0xB2 → "²" into the header.
-                if (
-                    declared
-                    and declared.isascii()
-                    and declared.isdigit()
-                    and int(declared) > _MAX_RESPONSE_BYTES
-                ):
-                    raise WhisperCppResponseError(
-                        f"whisper.cpp sidecar at {self._server_url} declared a "
-                        f"{int(declared)}-byte /inference response "
-                        f"(max {_MAX_RESPONSE_BYTES}); refusing to read it"
-                    )
-                for piece in resp.iter_bytes():
-                    body += piece
-                    if len(body) > _MAX_RESPONSE_BYTES:
-                        raise WhisperCppResponseError(
-                            f"whisper.cpp sidecar at {self._server_url} returned a "
-                            f"/inference response exceeding {_MAX_RESPONSE_BYTES} "
-                            f"bytes; aborting read to bound memory"
-                        )
+                wav_bytes,
+                data,
+                cancellation_check=cancellation_check,
+                read_timeout_s=(
+                    None if cancellation_check is not None else _UNCANCELLABLE_READ_TIMEOUT_S
+                ),
+            )
+        except InferenceAborted:
+            # The caller asked for this, and only the caller knows whether there
+            # is completed work worth keeping — propagate untouched.
+            raise
+        except ResponseTooLarge as exc:
+            raise WhisperCppResponseError(
+                f"whisper.cpp sidecar at {self._server_url}: {exc}"
+            ) from exc
         except (httpx.NetworkError, OSError) as exc:
             raise RuntimeError(_SIDECAR_UNREACHABLE_MSG.format(url=self._server_url)) from exc
         except httpx.TimeoutException as exc:
+            # Only reachable on the uncancellable paths (warmup / live / preview),
+            # which are the only ones that still carry a read deadline.
             raise RuntimeError(
-                _SIDECAR_INFERENCE_TIMEOUT_MSG.format(url=self._server_url, timeout=timeout)
+                _SIDECAR_WEDGED_MSG.format(
+                    url=self._server_url, timeout=_UNCANCELLABLE_READ_TIMEOUT_S
+                )
             ) from exc
         except HttpxHTTPStatusError as exc:
             raise RuntimeError(
@@ -820,8 +772,6 @@ class WhisperCppBackend(STTBackend):
             ) from exc
 
         try:
-            # json.loads / the preview accept the bytearray directly — no full
-            # copy, so a near-cap body isn't transiently doubled in memory.
             result = json.loads(body)
         except ValueError as exc:
             # Sidecar returned non-JSON (e.g. plain-text error page) or an empty
@@ -835,11 +785,39 @@ class WhisperCppBackend(STTBackend):
         audio_duration_s = len(chunk) / sample_rate if sample_rate else 0.0
         return self._parse_response(result, audio_duration_s)
 
+    @staticmethod
+    def _cancelled_or_partial(
+        segments: list[BackendSegment],
+        info: BackendTranscriptionInfo | None,
+        completed_seconds: float,
+    ) -> Exception:
+        """The exception to raise when the user cancels mid-file.
+
+        With completed chunks in hand, cancelling must NOT throw them away — a
+        cancel five hours into a six-hour file would otherwise destroy five hours
+        of real transcription. Mirrors engine.py's own refusal to discard salvaged
+        work on a late cancel. With nothing done yet, it is a plain cancellation.
+        """
+        # Lazy import avoids a circular dependency (model_manager imports the
+        # backend factories at module load).
+        from server.core.model_manager import TranscriptionCancelledError
+
+        if info is None or not segments:
+            return TranscriptionCancelledError("Transcription cancelled by user")
+        return PartialTranscriptionError(
+            "Cancelled by user",
+            segments=segments,
+            info=info,
+            completed_seconds=completed_seconds,
+        )
+
     def supports_translation(self) -> bool:
         return True
 
     def supports_cancellation(self) -> bool:
-        # transcribe() polls cancellation_check between chunks (GH #168 follow-up).
+        # transcribe() polls cancellation_check between chunks AND forwards it
+        # into the in-flight /inference request, which the transport can abort.
+        # Since inference is no longer time-limited, this is the ONLY interrupt.
         return True
 
     @property

--- a/server/backend/core/stt/backends/whispercpp_transport.py
+++ b/server/backend/core/stt/backends/whispercpp_transport.py
@@ -1,0 +1,153 @@
+"""Abortable HTTP transport for the whisper.cpp sidecar's /inference endpoint.
+
+WHY THIS EXISTS AS ITS OWN MODULE
+---------------------------------
+whisper-server sends no bytes at all — not even response headers — until
+inference completes. httpx's ``read`` timeout bounds a single socket read, so
+that first read blocks for the entire inference and the read timeout therefore
+behaves as a *work deadline*. Bounding it at ~2x real-time failed honest but
+slow machines and silently truncated their transcripts.
+
+We want no time limit. But an unbounded read is only safe if the request can be
+aborted, and a blocked SYNC read cannot be: ``resp.close()`` / ``client.close()``
+from another thread are no-ops, because httpcore's close() calls ``sock.close()``
+and closing an fd does not wake a thread already blocked in ``recv()`` (the
+request completes normally when the data finally arrives).
+
+asyncio does not issue a blocking ``recv()``; it registers the fd with a
+selector. So ``asyncio.Task.cancel()`` aborts a pending read immediately, using
+only public API. This module therefore runs the request on a private event loop
+inside the calling worker thread, polling ``cancellation_check`` while it waits.
+
+RULE: an unbounded read is permitted only where an abort path exists.
+Callers with a ``cancellation_check`` get ``read=None``; callers without one
+(warmup, live, preview — all short audio) must pass a finite ``read_timeout_s``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# A wedged sidecar is indistinguishable from a busy one on the wire, so these
+# bound only the phases where silence genuinely means "broken".
+CONNECT_TIMEOUT_S = 10.0
+WRITE_TIMEOUT_S = 120.0
+POOL_TIMEOUT_S = 10.0
+
+# How often the in-flight request is checked against cancellation_check.
+CANCEL_POLL_INTERVAL_S = 0.25
+
+# Hard ceiling on a single /inference response body, enforced WHILE reading so a
+# hostile or misconfigured sidecar cannot exhaust memory before any post-parse
+# cap could reject it (GH #193).
+MAX_RESPONSE_BYTES = 256 * 1024 * 1024  # 256 MiB
+
+
+class InferenceAborted(RuntimeError):
+    """The caller's cancellation_check went True while the request was in flight.
+
+    Distinct from a sidecar crash: the caller asked for this, so the caller is
+    responsible for deciding whether completed work should still be persisted.
+    """
+
+
+class ResponseTooLarge(RuntimeError):
+    """The sidecar's response body exceeded the ceiling; the read was aborted."""
+
+
+def post_inference(
+    url: str,
+    wav_bytes: bytes,
+    data: dict[str, Any],
+    *,
+    cancellation_check: Callable[[], bool] | None,
+    read_timeout_s: float | None = None,
+    max_response_bytes: int = MAX_RESPONSE_BYTES,
+) -> bytes:
+    """POST one audio chunk to /inference and return the raw response body.
+
+    Blocking; call from a worker thread (the backend already runs inside one).
+
+    ``read_timeout_s`` is ignored when ``cancellation_check`` is supplied — such
+    a caller gets an unbounded read, because it has a way out. A caller with no
+    ``cancellation_check`` MUST supply a finite ``read_timeout_s``; without one
+    a wedged sidecar would hang that thread forever with no recovery.
+
+    Raises:
+        InferenceAborted: cancellation_check went True mid-flight.
+        ResponseTooLarge: response body exceeded ``max_response_bytes``.
+        httpx.*: connect/read/protocol failures, unchanged, for the caller to map.
+    """
+    cancellable = cancellation_check is not None
+    if not cancellable and read_timeout_s is None:
+        raise ValueError(
+            "post_inference() requires a finite read_timeout_s when no "
+            "cancellation_check is given — an unbounded read with no abort path "
+            "would hang forever on a wedged sidecar"
+        )
+
+    timeout = httpx.Timeout(
+        None if cancellable else read_timeout_s,
+        connect=CONNECT_TIMEOUT_S,
+        write=WRITE_TIMEOUT_S,
+        pool=POOL_TIMEOUT_S,
+    )
+
+    async def _run() -> bytes:
+        # The AsyncClient must be created inside this loop; asyncio.run() makes a
+        # fresh one per call. Per-chunk client construction is negligible next to
+        # inference, and it sidesteps httpx keep-alive connection reuse.
+        async with httpx.AsyncClient(timeout=timeout) as client:
+
+            async def _request() -> bytes:
+                async with client.stream(
+                    "POST",
+                    url,
+                    files={"file": ("audio.wav", wav_bytes, "audio/wav")},
+                    data=data,
+                ) as resp:
+                    resp.raise_for_status()
+                    declared = resp.headers.get("Content-Length")
+                    # isascii() first: str.isdigit() is True for non-ASCII digit
+                    # codepoints (e.g. "²") that int() then rejects, and a hostile
+                    # sidecar can smuggle byte 0xB2 -> "²" into the header.
+                    if (
+                        declared
+                        and declared.isascii()
+                        and declared.isdigit()
+                        and int(declared) > max_response_bytes
+                    ):
+                        raise ResponseTooLarge(
+                            f"sidecar declared a {int(declared)}-byte /inference "
+                            f"response (max {max_response_bytes}); refusing to read it"
+                        )
+                    body = bytearray()
+                    async for piece in resp.aiter_bytes():
+                        body += piece
+                        if len(body) > max_response_bytes:
+                            raise ResponseTooLarge(
+                                f"sidecar returned a /inference response exceeding "
+                                f"{max_response_bytes} bytes; aborting read to bound memory"
+                            )
+                    return bytes(body)
+
+            task = asyncio.create_task(_request())
+            while True:
+                done, _ = await asyncio.wait({task}, timeout=CANCEL_POLL_INTERVAL_S)
+                if done:
+                    return task.result()
+                if cancellation_check is not None and cancellation_check():
+                    task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await task
+                    raise InferenceAborted("cancelled while awaiting the sidecar")
+
+    return asyncio.run(_run())

--- a/server/backend/tests/test_cancel_wiring.py
+++ b/server/backend/tests/test_cancel_wiring.py
@@ -1,0 +1,57 @@
+"""The Cancel button (POST /cancel -> job_tracker) must reach every transcribe path.
+
+Regression guard for the bug where websocket.py bound cancellation_check to
+_client_disconnected, so POST /cancel never reached the backend on the main
+longform path.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+ROUTES = Path(__file__).resolve().parents[1] / "api" / "routes"
+
+
+def _transcribe_calls(path: Path) -> list[ast.Call]:
+    """Every engine.transcribe_file(...) call in a route module."""
+    tree = ast.parse(path.read_text())
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "transcribe_file"
+    ]
+
+
+def _cancellation_source(call: ast.Call) -> str | None:
+    for kw in call.keywords:
+        if kw.arg == "cancellation_check":
+            return ast.unparse(kw.value)
+    return None
+
+
+@pytest.mark.parametrize("module", ["websocket.py", "notebook.py", "transcription.py"])
+def test_every_transcribe_call_passes_cancellation_check(module: str) -> None:
+    calls = _transcribe_calls(ROUTES / module)
+    assert calls, f"expected at least one transcribe_file call in {module}"
+    for call in calls:
+        src = _cancellation_source(call)
+        assert src is not None, (
+            f"{module}: transcribe_file() called without cancellation_check — "
+            "a job started here can never be cancelled"
+        )
+
+
+@pytest.mark.parametrize("module", ["websocket.py", "notebook.py", "transcription.py"])
+def test_cancellation_check_consults_the_job_tracker(module: str) -> None:
+    """POST /cancel flips job_tracker._cancelled. Every path must read it."""
+    for call in _transcribe_calls(ROUTES / module):
+        src = _cancellation_source(call) or ""
+        assert "job_tracker.is_cancelled" in src, (
+            f"{module}: cancellation_check={src!r} does not consult "
+            "job_tracker.is_cancelled, so POST /cancel cannot stop this job"
+        )

--- a/server/backend/tests/test_transcription_durability_routes.py
+++ b/server/backend/tests/test_transcription_durability_routes.py
@@ -505,3 +505,82 @@ class TestTranscribeDecodeErrorRouting:
         # The user-facing detail must never carry the server-side temp path.
         assert "/tmp" not in exc.value.detail
         assert "/var/folders" not in exc.value.detail
+
+
+# ── Partial transcripts must be retryable ────────────────────────────────────
+
+
+class TestRetryPartialResult:
+    """A partial transcript is stored with status='completed' + result_json.partial.
+
+    It is deliberately NOT given its own status value: a new status would have to
+    be retrofitted into get_recent_undelivered and get_jobs_for_cleanup, and the
+    failure mode of forgetting either is silent data loss. But an incomplete
+    transcript MUST be retryable, otherwise the user is stuck with a truncated
+    transcript and no recourse.
+    """
+
+    @staticmethod
+    def _job(*, partial: bool, audio_path: str) -> dict:
+        return {
+            "id": "job-partial",
+            "status": "completed",
+            "client_name": "test-client",
+            "audio_path": audio_path,
+            "result_json": json.dumps({"text": "half a transcript", "partial": partial}),
+        }
+
+    def test_retry_accepts_a_partial_completed_job(self, repo, monkeypatch, tmp_path):
+        audio = tmp_path / "saved.wav"
+        audio.write_bytes(b"RIFF")
+        resets: list[str] = []
+        monkeypatch.setattr(
+            repo, "get_job", lambda _: self._job(partial=True, audio_path=str(audio))
+        )
+        monkeypatch.setattr(repo, "reset_for_retry", lambda job_id: resets.append(job_id))
+
+        bg = _BgTasksMock()
+        resp = asyncio.run(
+            transcription.retry_transcription("job-partial", _request_with_state(), bg)
+        )
+
+        assert resp.status_code == 202
+        assert resets == ["job-partial"], "a partial retry must actually reset the job"
+
+    def test_retry_still_refuses_a_fully_complete_job(self, repo, monkeypatch, tmp_path):
+        """The guard must key on `partial`, not merely on having a result_json."""
+        audio = tmp_path / "saved.wav"
+        audio.write_bytes(b"RIFF")
+        monkeypatch.setattr(
+            repo, "get_job", lambda _: self._job(partial=False, audio_path=str(audio))
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(
+                transcription.retry_transcription(
+                    "job-partial", _request_with_state(), _BgTasksMock()
+                )
+            )
+        assert exc.value.status_code == 409
+
+    def test_malformed_result_json_is_not_treated_as_partial(self, repo, monkeypatch, tmp_path):
+        """A corrupt result_json must not accidentally unlock retry on a completed job."""
+        audio = tmp_path / "saved.wav"
+        audio.write_bytes(b"RIFF")
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {
+                "id": "job-bad",
+                "status": "completed",
+                "client_name": "test-client",
+                "audio_path": str(audio),
+                "result_json": "{not json",
+            },
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(
+                transcription.retry_transcription("job-bad", _request_with_state(), _BgTasksMock())
+            )
+        assert exc.value.status_code == 409

--- a/server/backend/tests/test_whispercpp_backend.py
+++ b/server/backend/tests/test_whispercpp_backend.py
@@ -10,88 +10,78 @@ import numpy as np
 import pytest
 from server.core.stt.backends.base import PartialTranscriptionError
 from server.core.stt.backends.whispercpp_backend import (
-    _INFERENCE_TIMEOUT,
     _MAX_CHUNK_DURATION_CEILING_S,
     _MAX_CHUNK_DURATION_S,
     _MAX_SEGMENTS_PER_AUDIO_SECOND,
     _MAX_WORDS_PER_AUDIO_SECOND,
     _SEGMENT_CAP_FLOOR,
-    _TIMEOUT_SECONDS_PER_AUDIO_SECOND,
+    _UNCANCELLABLE_READ_TIMEOUT_S,
     _WORDS_CAP_FLOOR,
     WhisperCppBackend,
     WhisperCppResponseError,
     _audio_to_wav_bytes,
     _coerce_float,
-    _inference_timeout_for,
     _resolve_chunk_duration_config,
     _resolve_server_url,
-    _resolve_timeout_config,
     _sanitize_for_error_preview,
     _sanitize_language_code,
     _segment_cap_for,
     _validate_server_url,
     _word_cap_for,
 )
+from server.core.stt.backends.whispercpp_transport import InferenceAborted, ResponseTooLarge
 
 # ---------------------------------------------------------------------------
-# /inference response seam (GH #193)
+# /inference seam
 # ---------------------------------------------------------------------------
 #
-# GH #193: production will read the /inference response via client.stream(...)
-# (accumulating resp.iter_bytes() under a byte ceiling) instead of
-# client.post(...) + resp.json(). To make that switch a ONE-LINE change here
-# (flip _INFERENCE_METHOD), _inference_response() builds a DUAL-CAPABLE mock
-# response usable by BOTH read paths:
-#   * legacy post path: resp.json() returns the payload
-#   * streaming path:   `with ... as resp: resp.iter_bytes()` yields the body
-# /load still uses client.post directly, so its mocks stay on .post.
-_INFERENCE_METHOD = "stream"  # production reads /inference via client.stream() (GH #193)
+# /inference no longer goes through the sync httpx.Client at all. It goes through
+# ``whispercpp_transport.post_inference(url, wav_bytes, data, *, cancellation_check,
+# read_timeout_s, ...)``, which returns the raw response body as BYTES and raises
+# InferenceAborted / ResponseTooLarge / httpx.* on failure.
+#
+# WHY: whisper-server sends no bytes until inference completes, so httpx's read
+# timeout was acting as a ~2x-real-time WORK DEADLINE that silently truncated
+# transcripts on slow machines. The transport removes that limit by making the
+# request abortable (asyncio task.cancel() instead of an uninterruptible sync
+# read). The streaming/byte-ceiling logic moved there too, and is covered against
+# a REAL stalling socket server in tests/test_whispercpp_transport.py — a mock
+# cannot prove an abort actually interrupts a blocked read.
+#
+# These tests therefore mock post_inference and assert on WhisperCppBackend's own
+# behaviour: request shape, response parsing, chunk stitching, error mapping.
+# /load still uses the sync client, so its mocks stay on mock_httpx.post.
 
 
 def _inf(mock_httpx: MagicMock) -> MagicMock:
-    """The mocked httpx.Client method production uses to call /inference."""
-    return getattr(mock_httpx, _INFERENCE_METHOD)
+    """The mocked callable production uses to reach /inference."""
+    return mock_httpx.post_inference
 
 
 def _inference_response(
     payload: dict | None = None,
     *,
     raw: bytes | None = None,
-    status_code: int = 200,
-    headers: dict | None = None,
-    raise_status: Exception | None = None,
-) -> MagicMock:
-    """Build a mock /inference response that works for BOTH the post path
-    (resp.json()) and the stream path (context manager + resp.iter_bytes()).
-    Pass `raw=` for a non-JSON body (resp.json() then raises ValueError and the
-    streamed bytes fail json.loads). Pass `raise_status=` to make
-    resp.raise_for_status() raise."""
-    body = raw if raw is not None else json.dumps({} if payload is None else payload).encode()
-    resp = MagicMock(status_code=status_code, content=body)
-    resp.headers = dict(headers or {})
-    if raise_status is not None:
-        resp.raise_for_status.side_effect = raise_status
-    else:
-        resp.raise_for_status.return_value = None
+) -> bytes:
+    """Build a fake /inference response body. post_inference() returns raw bytes,
+    so that is what the mock returns. Pass ``raw=`` for a non-JSON body (the
+    backend must then map the json.loads failure to a RuntimeError)."""
     if raw is not None:
-        resp.json.side_effect = ValueError("not json")
-    else:
-        resp.json.return_value = {} if payload is None else payload
-    resp.iter_bytes.return_value = [body]
-    # Context-manager protocol for the future streaming path.
-    resp.__enter__.return_value = resp
-    resp.__exit__.return_value = False
-    return resp
+        return raw
+    return json.dumps({} if payload is None else payload).encode()
 
 
 def _inference_url(mock_httpx: MagicMock) -> str:
-    """The URL of the last /inference call, regardless of post-vs-stream shape.
-    post(url, ...) puts the url at args[0]; stream("POST", url, ...) at args[1]."""
+    """The URL of the last /inference call. post_inference(url, wav, data, ...)."""
     call = _inf(mock_httpx).call_args
     assert call is not None, "expected an /inference call to have been issued"
-    if _INFERENCE_METHOD == "stream":
-        return call.args[1] if len(call.args) > 1 else call.kwargs.get("url", "")
     return call.args[0] if call.args else call.kwargs.get("url", "")
+
+
+def _inference_data(call) -> dict:
+    """The form-data dict of an /inference call. post_inference passes it as the
+    third positional arg."""
+    return call.args[2] if len(call.args) > 2 else call.kwargs["data"]
 
 
 # ---------------------------------------------------------------------------
@@ -106,7 +96,13 @@ def backend() -> WhisperCppBackend:
 
 @pytest.fixture()
 def mock_httpx():
-    """Patch httpx.Client so no real HTTP calls are made.
+    """Patch both seams so no real HTTP call is made:
+
+      * ``httpx.Client``  -> used by /load (still a plain sync POST).
+      * ``post_inference`` -> used by /inference (the abortable async transport).
+
+    The post_inference mock is exposed as ``mock_httpx.post_inference`` so the
+    ``_inf()`` helper can reach it, keeping every existing call site unchanged.
 
     IMPORTANT: only replace the ``Client`` attribute, not the whole ``httpx``
     module. The production code catches real exception classes
@@ -115,18 +111,28 @@ def mock_httpx():
     with ``TypeError: catching classes that do not inherit from
     BaseException``.
 
-    PATCH-TARGET NOTE: the production code does ``self._client =
-    httpx.Client(...)`` through the module-level ``httpx`` name. If a
-    refactor changes that to ``from httpx import Client`` and ``Client(...)``
-    directly, this patch silently stops applying and every test runs against
-    real httpx. ``test_mock_httpx_patches_the_call_site`` below pins the
-    coupling so such a refactor fails loudly.
+    PATCH-TARGET NOTE: production does ``self._client = httpx.Client(...)``
+    through the module-level ``httpx`` name, and calls ``post_inference(...)``
+    as a module-level name imported into whispercpp_backend. If a refactor
+    changes either binding, these patches silently stop applying and the tests
+    run against the real thing. ``test_mock_httpx_patches_the_call_site`` and
+    ``test_mock_patches_the_post_inference_call_site`` pin both couplings so
+    such a refactor fails loudly.
     """
     mock_client = MagicMock()
-    with patch(
-        "server.core.stt.backends.whispercpp_backend.httpx.Client",
-        return_value=mock_client,
+    mock_post_inference = MagicMock()
+    with (
+        patch(
+            "server.core.stt.backends.whispercpp_backend.httpx.Client",
+            return_value=mock_client,
+        ),
+        patch(
+            "server.core.stt.backends.whispercpp_backend.post_inference",
+            mock_post_inference,
+        ),
     ):
+        # Reachable via _inf(); keeps the 70-odd existing call sites unchanged.
+        mock_client.post_inference = mock_post_inference
         yield mock_client
 
 
@@ -143,10 +149,17 @@ def loaded_backend(backend: WhisperCppBackend, mock_httpx: MagicMock) -> Whisper
 
 
 def _post_data(mock_httpx: MagicMock) -> dict:
-    """Return the ``data`` kwarg of the last POST call on the mocked client."""
+    """Return the form-data of the last /inference call."""
     call = _inf(mock_httpx).call_args
-    assert call is not None, "expected a POST to have been issued"
-    return call.kwargs.get("data") or call[1].get("data", {}) or {}
+    assert call is not None, "expected an /inference call to have been issued"
+    return _inference_data(call) or {}
+
+
+def _post_wav(mock_httpx: MagicMock) -> bytes:
+    """Return the WAV bytes of the last /inference call. post_inference(url, wav, data)."""
+    call = _inf(mock_httpx).call_args
+    assert call is not None, "expected an /inference call to have been issued"
+    return call.args[1] if len(call.args) > 1 else call.kwargs["wav_bytes"]
 
 
 def _seconds_of_audio(seconds: float) -> np.ndarray:
@@ -593,8 +606,13 @@ class TestTranscribe:
         with pytest.raises(RuntimeError, match="not loaded"):
             backend.transcribe(audio)
 
-    def test_sends_multipart_post(self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock):
-        """Request must go to /inference and carry a multipart 'file' field.
+    def test_sends_wav_to_inference(self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock):
+        """Request must go to /inference and carry real WAV bytes.
+
+        The multipart wrapping itself (filename "audio.wav", content-type
+        "audio/wav") is now the transport's job and is covered in
+        test_whispercpp_transport.py. What the backend owes is the right URL and
+        a real encoded WAV.
 
         Tightened from an ``isinstance``-only check so a mutation that
         short-circuits the HTTP call (``return [], BackendTranscriptionInfo(...)``
@@ -604,15 +622,10 @@ class TestTranscribe:
         audio = np.zeros(16000, dtype=np.float32)
         loaded_backend.transcribe(audio)
         call = _inf(mock_httpx).call_args
-        assert call is not None, "expected a POST to have been issued"
+        assert call is not None, "expected an /inference call to have been issued"
         # URL assertion — catches any routing regression.
         assert _inference_url(mock_httpx).endswith("/inference")
-        files = call.kwargs.get("files")
-        assert files is not None, "expected a multipart 'file' upload"
-        assert "file" in files
-        filename, wav_bytes, content_type = files["file"]
-        assert filename == "audio.wav"
-        assert content_type == "audio/wav"
+        wav_bytes = _post_wav(mock_httpx)
         assert wav_bytes[:4] == b"RIFF", "body must be a real WAV, not a placeholder"
 
     def test_parses_segments(self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock):
@@ -1170,23 +1183,22 @@ class TestTranscribe:
     def test_transcribe_raises_on_timeout(
         self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
     ):
-        """Inference timeout must surface the inference-timeout message."""
+        """A read timeout is only reachable on the UNCANCELLABLE paths now
+        (warmup/live/preview). File transcription has no time limit at all, so
+        the message must say so rather than blame the audio for being too long."""
         _inf(mock_httpx).side_effect = httpx.ReadTimeout("deadline")
         audio = np.zeros(16000, dtype=np.float32)
-        with pytest.raises(RuntimeError, match="transcription timed out"):
+        with pytest.raises(RuntimeError, match="sent no response within"):
             loaded_backend.transcribe(audio)
 
     def test_transcribe_raises_on_http_5xx(
         self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
     ):
         """A 5xx from /inference must surface as an actionable RuntimeError."""
-        _inf(mock_httpx).return_value = _inference_response(
-            status_code=503,
-            raise_status=httpx.HTTPStatusError(
-                "503 Service Unavailable",
-                request=MagicMock(),
-                response=MagicMock(status_code=503),
-            ),
+        _inf(mock_httpx).side_effect = httpx.HTTPStatusError(
+            "503 Service Unavailable",
+            request=MagicMock(),
+            response=MagicMock(status_code=503),
         )
         audio = np.zeros(16000, dtype=np.float32)
         with pytest.raises(RuntimeError, match="returned HTTP 503"):
@@ -1200,126 +1212,6 @@ class TestTranscribe:
         audio = np.zeros(16000, dtype=np.float32)
         with pytest.raises(RuntimeError, match="non-JSON"):
             loaded_backend.transcribe(audio)
-
-
-# ---------------------------------------------------------------------------
-# /inference response byte guard (GH #193) — bound the read BEFORE deserializing
-# ---------------------------------------------------------------------------
-
-
-class TestResponseByteGuard:
-    """The /inference body is bounded at HTTP read time so a hostile or
-    misconfigured WHISPERCPP_SERVER_URL cannot exhaust memory before any
-    segment/word cap (which only runs post-parse) gets a chance to reject it.
-
-    Both the declared ``Content-Length`` (honest servers) and the actual
-    streamed bytes (servers that omit/lie about it) are checked, and the read
-    aborts as soon as the ceiling is crossed — this is the real memory bound
-    the old post-parse list slice only pretended to be.
-    """
-
-    @staticmethod
-    def _stream_resp(*, headers=None, iter_bytes=None):
-        """A minimal streaming-response mock: a context manager exposing
-        ``headers``/``raise_for_status``/``iter_bytes`` (the surface the byte
-        guard reads), independent of the dual-capable ``_inference_response``."""
-        resp = MagicMock(status_code=200)
-        resp.headers = dict(headers or {})
-        resp.raise_for_status.return_value = None
-        if iter_bytes is not None:
-            resp.iter_bytes = iter_bytes
-        resp.__enter__.return_value = resp
-        resp.__exit__.return_value = False
-        return resp
-
-    def test_oversized_streamed_body_is_rejected_before_full_read(
-        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
-    ):
-        """A body with no/dishonest Content-Length that exceeds the cap must be
-        rejected, and the read must STOP at the ceiling (proving the memory
-        bound) rather than materialize the whole over-cap body."""
-        from server.core.stt.backends.whispercpp_backend import _MAX_RESPONSE_BYTES
-
-        piece = b"x" * (1024 * 1024)  # 1 MiB
-        # Enough pieces to blow well past the cap if the read ran to completion.
-        n_pieces = (_MAX_RESPONSE_BYTES // len(piece)) + 100
-        consumed = {"n": 0}
-
-        def iter_bytes():
-            for _ in range(n_pieces):
-                consumed["n"] += 1
-                yield piece
-
-        # No Content-Length header → the accumulator guard is what must fire.
-        mock_httpx.stream.return_value = self._stream_resp(iter_bytes=iter_bytes)
-        with pytest.raises(WhisperCppResponseError):
-            loaded_backend.transcribe(_seconds_of_audio(1))
-        # Bounded memory: the guard stopped reading once the cap was crossed,
-        # not after consuming every (over-cap) piece.
-        assert consumed["n"] <= (_MAX_RESPONSE_BYTES // len(piece)) + 1
-
-    def test_oversized_content_length_header_is_rejected_before_read(
-        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
-    ):
-        """An honest server that declares a Content-Length above the cap must be
-        rejected BEFORE the body is read at all."""
-        from server.core.stt.backends.whispercpp_backend import _MAX_RESPONSE_BYTES
-
-        def iter_bytes():
-            raise AssertionError("must reject on Content-Length before reading the body")
-            yield  # pragma: no cover — makes this a generator
-
-        resp = self._stream_resp(
-            headers={"Content-Length": str(_MAX_RESPONSE_BYTES + 1)},
-            iter_bytes=iter_bytes,
-        )
-        mock_httpx.stream.return_value = resp
-        with pytest.raises(WhisperCppResponseError):
-            loaded_backend.transcribe(_seconds_of_audio(1))
-
-    def test_non_ascii_content_length_is_ignored(
-        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
-    ):
-        """A bogus non-ASCII Content-Length must be ignored, not crash the read.
-
-        A hostile sidecar can put raw byte 0xB2 in the header, which httpx
-        decodes (latin-1) to ``"²"``. ``str.isdigit()`` is True for it but
-        ``int("²")`` raises ValueError — which none of the read handlers catch.
-        The guard must only honour ASCII digits and otherwise fall through to
-        the streamed-bytes accumulator, reading the (valid) body normally.
-        """
-        body = json.dumps({"segments": [], "language": "en"}).encode()
-
-        def iter_bytes():
-            yield body
-
-        mock_httpx.stream.return_value = self._stream_resp(
-            headers={"Content-Length": "²"},  # superscript two: isdigit() True, int() raises
-            iter_bytes=iter_bytes,
-        )
-        segments, info = loaded_backend.transcribe(_seconds_of_audio(1))
-        assert segments == []
-        assert info.language == "en"
-
-    def test_response_at_cap_is_accepted(
-        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
-    ):
-        """A well-formed response whose body is at/under the cap streams through
-        normally — the guard must not false-trip on legitimate transcripts."""
-        from server.core.stt.backends.whispercpp_backend import _MAX_RESPONSE_BYTES
-
-        body = json.dumps({"segments": [], "language": "en"}).encode()
-        assert len(body) <= _MAX_RESPONSE_BYTES
-
-        def iter_bytes():
-            # Deliberately chunked to exercise the accumulator loop.
-            yield body[: len(body) // 2]
-            yield body[len(body) // 2 :]
-
-        mock_httpx.stream.return_value = self._stream_resp(iter_bytes=iter_bytes)
-        segments, info = loaded_backend.transcribe(_seconds_of_audio(1))
-        assert segments == []
-        assert info.language == "en"
 
 
 # ---------------------------------------------------------------------------
@@ -1420,28 +1312,118 @@ class TestWordProportionalCap:
 
 
 # ---------------------------------------------------------------------------
-# _inference_timeout_for — duration-scaled per-request timeout (GH #168)
+# Unbounded inference — the ~2x-real-time cap is gone
 # ---------------------------------------------------------------------------
 
 
-class TestInferenceTimeoutFor:
-    def test_floors_at_inference_timeout(self):
-        # 10s of audio → 20s scaled, floored up to the 300s minimum.
-        assert _inference_timeout_for(10 * 16000, 16000) == _INFERENCE_TIMEOUT
+class TestUnboundedInference:
+    """Inference has no time limit. A slow machine takes as long as it needs,
+    and cancellation is the only interrupt.
 
-    def test_scales_above_floor(self):
-        # A 10-min chunk → 600 * 2.0 = 1200s, comfortably above the floor.
-        assert _inference_timeout_for(600 * 16000, 16000) == 1200
-
-    def test_zero_samples_is_floor(self):
-        assert _inference_timeout_for(0, 16000) == _INFERENCE_TIMEOUT
-
-    def test_zero_sample_rate_is_guarded(self):
-        # Must not divide by zero — fall back to the floor.
-        assert _inference_timeout_for(16000, 0) == _INFERENCE_TIMEOUT
+    The old budget was max(300, ceil(chunk_seconds * 2.0)). Because whisper-server
+    sends no bytes until inference completes, that read timeout acted as a WORK
+    DEADLINE: honest-but-slow hardware tripped it, raised PartialTranscriptionError,
+    and the partial was persisted as status='completed' — a silently truncated
+    transcript the user could not even retry.
+    """
 
     def test_default_chunk_duration_is_ten_minutes(self):
+        # Chunking survives: it bounds MEMORY per forward pass, and was never the
+        # time limit. Only the timeout was removed.
         assert _MAX_CHUNK_DURATION_S == 10 * 60
+
+    def test_no_timeout_knobs_remain(self):
+        """The cap is deleted, not merely defaulted to something generous."""
+        import server.core.stt.backends.whispercpp_backend as mod
+
+        for gone in (
+            "_INFERENCE_TIMEOUT",
+            "_TIMEOUT_SECONDS_PER_AUDIO_SECOND",
+            "_inference_timeout_for",
+            "_resolve_timeout_config",
+        ):
+            assert not hasattr(mod, gone), f"{gone} should have been deleted"
+
+    def test_chunk_post_is_unbounded_when_cancellable(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        """A caller that can cancel gets read_timeout_s=None: no work deadline."""
+        _inf(mock_httpx).return_value = _inference_response({"segments": []})
+        loaded_backend.transcribe(_seconds_of_audio(1), cancellation_check=lambda: False)
+
+        call = _inf(mock_httpx).call_args
+        assert call.kwargs["cancellation_check"] is not None
+        assert call.kwargs["read_timeout_s"] is None
+
+    def test_chunk_post_is_bounded_when_not_cancellable(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        """warmup/live/preview pass no cancellation_check, so they have no way out
+        of a wedged sidecar — they must keep a finite read."""
+        _inf(mock_httpx).return_value = _inference_response({"segments": []})
+        loaded_backend.transcribe(_seconds_of_audio(1))
+
+        call = _inf(mock_httpx).call_args
+        assert call.kwargs["cancellation_check"] is None
+        assert call.kwargs["read_timeout_s"] == _UNCANCELLABLE_READ_TIMEOUT_S
+
+    def test_oversized_response_maps_to_a_response_error(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        """The byte ceiling itself now lives in the transport (and is tested there
+        against a real socket). The backend's job is to map it."""
+        _inf(mock_httpx).side_effect = ResponseTooLarge("body exceeded 256 MiB")
+        with pytest.raises(WhisperCppResponseError):
+            loaded_backend.transcribe(_seconds_of_audio(1))
+
+
+class TestCancelPreservesCompletedChunks:
+    """Cancelling mid-file must NOT throw away chunks that already finished.
+
+    Cancel is now the escape hatch from a wedged sidecar, so a user cancelling
+    five hours into a six-hour file would otherwise destroy five hours of real
+    transcription. Mirrors engine.py's own refusal to discard salvaged work on a
+    late cancel.
+    """
+
+    def test_cancel_midway_returns_a_partial_not_an_empty_discard(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        loaded_backend._max_chunk_duration_s = 1  # 1s chunks
+        calls = {"n": 0}
+
+        def _fake_post(*args, **kwargs):
+            check = kwargs["cancellation_check"]
+            if check is not None and check():
+                raise InferenceAborted("cancelled while awaiting the sidecar")
+            calls["n"] += 1
+            return _inference_response(
+                {"segments": [{"text": f"chunk{calls['n']}", "start": 0.0, "end": 1.0}]}
+            )
+
+        _inf(mock_httpx).side_effect = _fake_post
+
+        # Cancel goes True once two chunks are done.
+        with pytest.raises(PartialTranscriptionError) as exc:
+            loaded_backend.transcribe(
+                _seconds_of_audio(4), cancellation_check=lambda: calls["n"] >= 2
+            )
+
+        assert len(exc.value.segments) == 2, "completed chunks must be preserved"
+        assert exc.value.segments[0].text == "chunk1"
+        assert exc.value.completed_seconds == pytest.approx(2.0, abs=0.01)
+
+    def test_cancel_before_any_chunk_completes_still_cancels(
+        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        """Nothing to salvage -> a real cancellation, not a bogus empty partial."""
+        from server.core.model_manager import TranscriptionCancelledError
+
+        loaded_backend._max_chunk_duration_s = 1
+        _inf(mock_httpx).side_effect = InferenceAborted("cancelled")
+
+        with pytest.raises(TranscriptionCancelledError):
+            loaded_backend.transcribe(_seconds_of_audio(4), cancellation_check=lambda: True)
 
 
 # ---------------------------------------------------------------------------
@@ -1548,9 +1530,9 @@ class TestTranscribeChunking:
         ]
         loaded_backend.transcribe(np.zeros(3 * 16000, dtype=np.float32), language=None)
         calls = _inf(mock_httpx).call_args_list
-        assert "language" not in (calls[0].kwargs.get("data") or {})  # chunk 0 auto-detects
-        assert calls[1].kwargs["data"].get("language") == "el"  # pinned thereafter
-        assert calls[2].kwargs["data"].get("language") == "el"
+        assert "language" not in (_inference_data(calls[0]) or {})  # chunk 0 auto-detects
+        assert _inference_data(calls[1]).get("language") == "el"  # pinned thereafter
+        assert _inference_data(calls[2]).get("language") == "el"
 
     def test_explicit_language_sent_to_every_chunk(
         self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
@@ -1562,27 +1544,16 @@ class TestTranscribeChunking:
         ]
         loaded_backend.transcribe(np.zeros(2 * 16000, dtype=np.float32), language="fr")
         for call in _inf(mock_httpx).call_args_list:
-            assert call.kwargs["data"].get("language") == "fr"
+            assert _inference_data(call).get("language") == "fr"
 
-    def test_each_chunk_post_uses_scaled_timeout(
+    def test_long_subthreshold_audio_stays_single_post(
         self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
     ):
-        """Every chunk POST carries the duration-scaled timeout (floored at 300)."""
-        loaded_backend._max_chunk_duration_s = 1
-        _inf(mock_httpx).side_effect = [self._resp({"segments": []}) for _ in range(2)]
-        loaded_backend.transcribe(np.zeros(2 * 16000, dtype=np.float32))
-        expected = _inference_timeout_for(16000, 16000)  # 1s chunk → floored at 300
-        for call in _inf(mock_httpx).call_args_list:
-            assert call.kwargs.get("timeout") == expected
-
-    def test_single_post_timeout_scales_for_long_subthreshold_audio(
-        self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
-    ):
-        """A 200s file (< 600s threshold) stays single-POST but its timeout scales past 300."""
+        """A 200s file (< the 600s chunk threshold) stays a single POST. It used to
+        also carry a scaled 400s deadline; there is no deadline any more."""
         _inf(mock_httpx).return_value = self._resp({"segments": []})
         loaded_backend.transcribe(np.zeros(200 * 16000, dtype=np.float32))
         assert _inf(mock_httpx).call_count == 1
-        assert _inf(mock_httpx).call_args.kwargs.get("timeout") == 400  # max(300, 200 * 2)
 
     def test_empty_middle_chunk_still_advances_offset(
         self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock
@@ -1649,54 +1620,25 @@ class TestWhisperCppConfigResolution:
         ):
             assert _resolve_chunk_duration_config() == _MAX_CHUNK_DURATION_S
 
-    def test_timeout_config_env_wins(self):
-        with patch.dict(
-            "os.environ",
-            {
-                "WHISPERCPP_INFERENCE_TIMEOUT_S": "500",
-                "WHISPERCPP_TIMEOUT_SECONDS_PER_AUDIO_SECOND": "3.0",
-            },
-        ):
-            assert _resolve_timeout_config() == (500, 3.0)
-
-    def test_timeout_config_floors_enforced(self):
-        with patch.dict(
-            "os.environ",
-            {
-                "WHISPERCPP_INFERENCE_TIMEOUT_S": "10",  # below 60 floor
-                "WHISPERCPP_TIMEOUT_SECONDS_PER_AUDIO_SECOND": "0.1",  # below 0.5 floor
-            },
-        ):
-            assert _resolve_timeout_config() == (60, 0.5)
-
-    def test_timeout_config_defaults_when_no_source(self):
-        with (
-            patch.dict("os.environ", {}, clear=True),
-            patch("server.config.get_config", side_effect=RuntimeError("no config")),
-        ):
-            assert _resolve_timeout_config() == (
-                _INFERENCE_TIMEOUT,
-                _TIMEOUT_SECONDS_PER_AUDIO_SECOND,
-            )
-
     def test_load_resolves_config_into_instance_vars(
         self, backend: WhisperCppBackend, mock_httpx: MagicMock
     ):
-        """load() must populate the chunk/timeout instance vars from env/config."""
+        """load() must populate the chunk instance var from env/config.
+
+        There are no longer any timeout instance vars: inference is unbounded.
+        """
         mock_httpx.post.return_value = MagicMock(status_code=200)
         with patch.dict(
             "os.environ",
             {
                 "WHISPERCPP_SERVER_URL": "http://test:8080",
                 "WHISPERCPP_CHUNK_DURATION_S": "300",
-                "WHISPERCPP_INFERENCE_TIMEOUT_S": "450",
-                "WHISPERCPP_TIMEOUT_SECONDS_PER_AUDIO_SECOND": "1.5",
             },
         ):
             backend.load("ggml-large-v3.bin", "cpu")
         assert backend._max_chunk_duration_s == 300
-        assert backend._inference_timeout == 450
-        assert backend._timeout_seconds_per_audio_second == 1.5
+        assert not hasattr(backend, "_inference_timeout")
+        assert not hasattr(backend, "_timeout_seconds_per_audio_second")
 
 
 # ---------------------------------------------------------------------------
@@ -1849,7 +1791,7 @@ class TestTranscribePartialPersistence:
         with pytest.raises(RuntimeError) as excinfo:
             loaded_backend.transcribe(np.zeros(3 * 16000, dtype=np.float32))
         assert not isinstance(excinfo.value, PartialTranscriptionError)
-        assert "transcription timed out" in str(excinfo.value)
+        assert "sent no response within" in str(excinfo.value)
 
     def test_short_audio_failure_is_not_partial(
         self, loaded_backend: WhisperCppBackend, mock_httpx: MagicMock

--- a/server/backend/tests/test_whispercpp_transport.py
+++ b/server/backend/tests/test_whispercpp_transport.py
@@ -1,0 +1,229 @@
+"""Behavioural tests for the abortable whisper.cpp /inference transport.
+
+These run against a REAL localhost socket server, not a mock. That is
+deliberate: the property under test is that an abort actually interrupts a
+socket read that is blocked with zero bytes received. A mock transport cannot
+prove that — it would happily "abort" something that was never really blocked,
+which is exactly the failure mode that made the previous sync-httpx approach
+look correct while being impossible.
+
+The fake sidecar reproduces whisper-server's defining wire behaviour: it accepts
+the POST, drains the request body, and then sends NOTHING AT ALL — not even
+response headers — for ``stall`` seconds. Every timeout/abort property of the
+transport hangs off that silence.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import time
+
+import httpx
+import pytest
+from server.core.stt.backends.whispercpp_transport import (
+    InferenceAborted,
+    ResponseTooLarge,
+    post_inference,
+)
+
+# A stall long enough that any accidental "it just completed normally" would be
+# unmistakable in the elapsed time.
+WEDGED_STALL_S = 30.0
+
+WAV = b"RIFF____WAVEfmt " + b"\x00" * 32
+FORM = {"response_format": "json", "temperature": "0.0"}
+
+
+def _drain_request(conn: socket.socket) -> None:
+    """Read the full HTTP request (headers + Content-Length body) off the wire.
+
+    Without this the client could block writing, and we would be testing the
+    wrong silence.
+    """
+    conn.settimeout(10.0)
+    buf = b""
+    while b"\r\n\r\n" not in buf:
+        chunk = conn.recv(65536)
+        if not chunk:
+            return
+        buf += chunk
+
+    head, _, rest = buf.partition(b"\r\n\r\n")
+    length = 0
+    for line in head.split(b"\r\n"):
+        if line.lower().startswith(b"content-length:"):
+            length = int(line.split(b":", 1)[1].strip())
+
+    remaining = length - len(rest)
+    while remaining > 0:
+        chunk = conn.recv(min(65536, remaining))
+        if not chunk:
+            return
+        remaining -= len(chunk)
+    conn.settimeout(None)
+
+
+def _http_reply(body: bytes, *, declare_length: bool) -> bytes:
+    """A 200 response, either Content-Length framed or close-framed."""
+    if declare_length:
+        headers = (
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: application/json\r\n"
+            b"Content-Length: " + str(len(body)).encode() + b"\r\n\r\n"
+        )
+    else:
+        # No Content-Length and no chunked encoding: the body is terminated by
+        # the connection close. This forces the transport to discover the size
+        # WHILE streaming rather than from a header it can pre-check.
+        headers = b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n"
+    return headers + body
+
+
+def _start_fake_sidecar(
+    stall_s: float,
+    reply: bytes | None,
+) -> tuple[str, socket.socket]:
+    """Serve exactly one /inference request: drain, stay silent, then reply.
+
+    Returns the URL and the listening socket (the caller must close it).
+    """
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    port = listener.getsockname()[1]
+
+    def _serve() -> None:
+        try:
+            conn, _ = listener.accept()
+        except OSError:  # listener closed by the test's finally block
+            return
+        with conn:
+            try:
+                _drain_request(conn)
+                # The whole point: total silence, no headers, for stall_s.
+                threading.Event().wait(stall_s)
+                if reply is not None:
+                    conn.sendall(reply)
+            except OSError:
+                # Client aborted mid-flight — that is a passing outcome here.
+                pass
+
+    threading.Thread(target=_serve, daemon=True).start()
+    return f"http://127.0.0.1:{port}/inference", listener
+
+
+def test_slow_but_healthy_completes_with_no_time_limit() -> None:
+    """A slow-but-honest sidecar must be waited for, not cut off.
+
+    This is the entire reason for the change: the old ~2x-real-time read cap
+    killed requests like this one and silently truncated the transcript.
+    """
+    payload = json.dumps({"text": "the slow machine finished"}).encode()
+    url, listener = _start_fake_sidecar(3.0, _http_reply(payload, declare_length=True))
+    try:
+        started = time.monotonic()
+        body = post_inference(url, WAV, dict(FORM), cancellation_check=lambda: False)
+        elapsed = time.monotonic() - started
+    finally:
+        listener.close()
+
+    assert json.loads(body)["text"] == "the slow machine finished"
+    # It waited rather than timing out — no work deadline is being applied.
+    assert elapsed >= 3.0, f"returned in {elapsed:.2f}s, so it cannot have waited out the stall"
+
+
+def test_cancel_aborts_a_wedged_request_promptly() -> None:
+    """LOAD-BEARING: cancellation must interrupt a read blocked on zero bytes.
+
+    An unbounded read is only defensible because of this. If this ever regresses,
+    a wedged sidecar pins a worker thread forever and the Cancel button lies.
+    """
+    url, listener = _start_fake_sidecar(WEDGED_STALL_S, None)
+    cancelled = threading.Event()
+    timer = threading.Timer(1.0, cancelled.set)
+    timer.start()
+    try:
+        started = time.monotonic()
+        with pytest.raises(InferenceAborted):
+            post_inference(url, WAV, dict(FORM), cancellation_check=cancelled.is_set)
+        elapsed = time.monotonic() - started
+    finally:
+        timer.cancel()
+        listener.close()
+
+    assert elapsed < 5.0, (
+        f"abort took {elapsed:.2f}s against a {WEDGED_STALL_S:.0f}s stall — "
+        "the read was not actually interrupted"
+    )
+
+
+def test_connect_stays_bounded_against_a_dead_host() -> None:
+    """No cancellation_check means read=None, but connect must STILL be bounded.
+
+    A bare scalar timeout would have expanded to all four phases; the regression
+    this guards is the inverse — that removing the read cap does not also remove
+    the connect cap and let a blackholed host hang for tens of minutes.
+    """
+    started = time.monotonic()
+    with pytest.raises(httpx.ConnectError):
+        post_inference(
+            "http://127.0.0.1:1/inference",
+            WAV,
+            dict(FORM),
+            cancellation_check=lambda: False,
+        )
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 15.0, f"connect phase took {elapsed:.2f}s; it is not bounded"
+
+
+def test_uncancellable_caller_gets_a_finite_read() -> None:
+    """Callers with no abort path (warmup/live/preview) keep a real read deadline."""
+    url, listener = _start_fake_sidecar(WEDGED_STALL_S, None)
+    try:
+        started = time.monotonic()
+        with pytest.raises(httpx.ReadTimeout):
+            post_inference(url, WAV, dict(FORM), cancellation_check=None, read_timeout_s=2.0)
+        elapsed = time.monotonic() - started
+    finally:
+        listener.close()
+
+    assert elapsed < 10.0, f"read timeout did not fire (took {elapsed:.2f}s)"
+
+
+def test_uncancellable_caller_without_a_read_timeout_is_rejected() -> None:
+    """An unbounded read with no way out is a hang, so it must be refused up front."""
+    with pytest.raises(ValueError, match="read_timeout_s"):
+        post_inference(
+            "http://127.0.0.1:1/inference",
+            WAV,
+            dict(FORM),
+            cancellation_check=None,
+            read_timeout_s=None,
+        )
+
+
+@pytest.mark.parametrize("declare_length", [True, False], ids=["declared", "undeclared"])
+def test_oversized_response_is_rejected_during_the_read(declare_length: bool) -> None:
+    """The ceiling must hold whether or not the sidecar declares Content-Length.
+
+    A post-parse cap is too late: the memory is already spent. The undeclared
+    case is the one that matters — it proves the guard fires while streaming.
+    """
+    payload = json.dumps({"text": "x" * 500}).encode()
+    assert len(payload) > 100
+    url, listener = _start_fake_sidecar(0.0, _http_reply(payload, declare_length=declare_length))
+    try:
+        with pytest.raises(ResponseTooLarge):
+            post_inference(
+                url,
+                WAV,
+                dict(FORM),
+                cancellation_check=lambda: False,
+                max_response_bytes=100,
+            )
+    finally:
+        listener.close()

--- a/server/config.yaml
+++ b/server/config.yaml
@@ -161,23 +161,17 @@ whisper_cpp:
     # WHISPERCPP_SERVER_URL or the built-in default (http://whisper-server:8080).
     # server_url: http://whisper-server:8080
 
+    # NOTE: inference has NO time limit. A slow machine takes as long as it needs;
+    # the only interrupt is the user pressing Cancel. (It was previously capped at
+    # ~2x real-time, which silently truncated transcripts on low-end hardware.)
+    # There is deliberately no timeout knob here to raise.
+    #
     # Maximum chunk duration (seconds) for long audio. Audio longer than this is
-    # split into sequential /inference POSTs (GH #168) so no single request can
-    # time out on a multi-hour file. Must be >= 60. Default: 600 (10 minutes).
+    # split into sequential /inference POSTs (GH #168) so each request is bounded
+    # in MEMORY (this is not, and never was, a time limit) and progress/cancel can
+    # be reported per chunk. Must be >= 60. Default: 600 (10 minutes).
     # Env override: WHISPERCPP_CHUNK_DURATION_S
     chunk_duration_s: 600
-
-    # Minimum per-request read timeout (seconds). The actual timeout scales with
-    # the chunk's duration but never drops below this floor. Raise it for very
-    # slow/loaded Vulkan GPUs. Must be >= 60. Default: 300.
-    # Env override: WHISPERCPP_INFERENCE_TIMEOUT_S
-    inference_timeout_s: 300
-
-    # Timeout scaling: seconds of budget per second of audio. Each request's
-    # timeout = max(inference_timeout_s, ceil(chunk_seconds * this)). Higher
-    # tolerates slower inference. Must be >= 0.5. Default: 2.0 (~2x real-time).
-    # Env override: WHISPERCPP_TIMEOUT_SECONDS_PER_AUDIO_SECOND
-    timeout_seconds_per_audio_second: 2.0
 
 # ----------------------------------------------------------------------------
 # Sortformer Diarization Settings (Apple Silicon only)


### PR DESCRIPTION
## The bug

`WhisperCppBackend` capped each `/inference` request at a read timeout of `max(300, ceil(chunk_seconds * 2.0))` — about 2x real-time. whisper-server sends no bytes at all until inference completes, so httpx's read timeout (which bounds a *single socket read*, not a whole request) was in practice acting as a **work deadline**. A healthy machine that is merely slow was being failed.

Worse, it failed *silently*:

1. A chunk exceeds the budget, the read timeout fires.
2. The backend raises `PartialTranscriptionError` carrying the chunks that completed.
3. `engine.py:947` catches it and sets `partial=True`.
4. `save_result()` writes **`status='completed'`** (`job_repository.py:163`).
5. The dashboard never read the `partial` flag — zero occurrences in the frontend.
6. `/retry` refused the job, because it only accepted `status == 'failed'`.

Net effect: a user on low-end hardware records a 2-hour lecture, gets a transcript that stops 40 minutes in, sees it marked complete with no warning, and cannot retry it. That is the exact failure class `CLAUDE.md` puts first.

## Why it could not just be deleted

Two things made a naive `read=None` actively dangerous, both found by testing rather than reading:

**1. The Cancel button was never wired to the main path.** `websocket.py:459` bound `cancellation_check` to `_client_disconnected` (only set on a real socket drop), not `job_tracker.is_cancelled` (the flag `POST /cancel` actually flips). `notebook.py` and `_run_file_import` passed no `cancellation_check` at all — and `notebook.py:1345` already called `cancel_job()`, a flag with no reader. So the read timeout was the **only** mechanism terminating a stuck job. Fixed first, in its own commit; it is a user-facing bug fix in its own right.

**2. A blocked sync read cannot be aborted.** Against a fake sidecar that accepts the POST, drains the body, then sends nothing (not even headers — the GPU-wedge shape):

| Abort mechanism | Result against a 30s stall |
|---|---|
| `resp.close()` from another thread | hung the full 30s, then **completed normally** |
| `client.close()` from another thread | same |
| httpcore `NetworkStream.close()` | same |
| `httpx.AsyncClient` + `asyncio.Task.cancel()` | **aborted in ~1s** |

`httpcore/_backends/sync.py` calls `sock.close()`, and on Linux closing an fd does not wake a thread already blocked in `recv()`. asyncio never issues a blocking `recv()` — it registers the fd with a selector — so cancellation is a first-class operation. Public API only; no httpcore internals, no socket surgery.

## The rule

> **An unbounded read is permitted only where an abort path exists.**

Longform paths (which have a `cancellation_check`) get `read=None` — no time limit, ever. warmup / live / preview have no way out of a wedge, so they keep a finite read; their audio is seconds long, so no honest slow machine needs 20 minutes for a 3-second utterance. `post_inference()` raises `ValueError` if a caller asks for an unbounded read with no abort path.

Chunking is **unchanged**. It bounds memory per forward pass and was never the time limit.

## Also fixed

- **Cancelling mid-file no longer discards completed chunks.** It previously threw away every finished chunk; now that cancel *is* the escape hatch from a wedge, cancelling at chunk 29/30 would have destroyed 29 chunks. Matches `engine.py:969-975`, which already refuses to discard salvaged work on a late cancel.
- **A bare scalar `timeout=` expands to all four httpx fields**, so a blackholed sidecar used to hang in the **connect** phase for 20-60 minutes. Connect is now bounded at 10s.
- **The client-level httpx default was dead code** — a per-request timeout replaces it wholesale (`_client.py:371-377`).
- Both timeout config knobs (`inference_timeout_s`, `timeout_seconds_per_audio_second`) deleted outright. There is no knob to raise, because there is no limit.

## Commits

1. `8cf960dc` — make the Cancel button actually stop a running transcription
2. `2b5b1e73` — remove the cap; add the abortable transport
3. `3dbbcc4c` — surface partial transcripts and let them be retried

Partials stay inside `status='completed'` deliberately: a new status value would have to be retrofitted into `get_recent_undelivered` and `get_jobs_for_cleanup`, and the failure mode of forgetting either is silent data loss.

## Test plan

- [x] Backend: **2155 passed**, 4 skipped (full suite, not a subset)
- [x] Transport tested against a **real stalling socket server**, not a mock: slow-but-healthy work completes with no limit; cancel aborts a wedged request in ~1s; connect stays bounded against a dead host; no fd leak
- [x] Frontend: 103/103 files, typecheck clean, ui-contract green (spec 1.2.0)
- [ ] **Manual smoke test on real hardware** — a genuinely slow / CPU-only run against the Vulkan sidecar, confirming a transcript that previously truncated now completes
- [ ] **Windows and macOS check** — the abort primitive was only verified on Linux/CPython 3.13. Note the inverse trap: on Windows `closesocket()` *does* abort a blocked recv, so a Windows-only test could pass while validating the wrong mechanism.

## Unrelated, noted while here

`dashboard/electron/__tests__/installerCache.test.ts` is flaky **on `main` too** — fails roughly 1 in 3 full-suite runs, passes in isolation, different test each time. Not caused by this branch; worth its own issue.