### PR TITLE
test(dashboard): fix the flaky installerCache timeout (1MB Buffer deep-equal)

### DIFF
--- a/dashboard/electron/__tests__/installerCache.test.ts
+++ b/dashboard/electron/__tests__/installerCache.test.ts
@@ -24,6 +24,25 @@ import {
 // expect the happy-path return must therefore write at least 1 MB of bytes.
 const HEALTHY_BYTES = Buffer.alloc(MIN_CACHED_INSTALLER_BYTES, 'a');
 
+/**
+ * Assert two Buffers hold identical bytes.
+ *
+ * Do NOT use `expect(buf).toEqual(otherBuf)` on the 1 MB fixtures above. Vitest's
+ * deep-equal walks a Buffer element by element, so a single such assertion costs
+ * ~3 s for 1,000,000 bytes — enough to push a test that does nothing else to
+ * ~4.3 s, against vitest's 5 s default `testTimeout`. Those tests then passed in
+ * isolation but failed roughly one full-suite run in three, whenever parallel load
+ * starved the worker for a few hundred ms.
+ *
+ * `Buffer.equals()` is a memcmp: the same comparison in ~1 ms. The byteLength check
+ * runs first so a size mismatch still reports concrete numbers rather than
+ * "expected false to be true".
+ */
+function expectBytesEqual(actual: Buffer, expected: Buffer): void {
+  expect(actual.byteLength).toBe(expected.byteLength);
+  expect(actual.equals(expected)).toBe(true);
+}
+
 describe('cachePreviousInstaller', () => {
   let tmp: string;
 
@@ -49,7 +68,7 @@ describe('cachePreviousInstaller', () => {
 
     expect(result.ok).toBe(true);
     expect(result.cachedPath).toBeDefined();
-    expect(readFileSync(result.cachedPath as string)).toEqual(HEALTHY_BYTES);
+    expectBytesEqual(readFileSync(result.cachedPath as string), HEALTHY_BYTES);
     expect(readdirSync(path.join(userData, 'previous-installer'))).toHaveLength(1);
   });
 
@@ -312,7 +331,7 @@ describe('cachePreviousInstaller symlink-collision defense', () => {
     // No filesystem mutation: source dir contents unchanged.
     expect(readdirSync(sourceDir)).toEqual(sourceContentsBefore);
     // Source AppImage still intact.
-    expect(readFileSync(src)).toEqual(HEALTHY_BYTES);
+    expectBytesEqual(readFileSync(src), HEALTHY_BYTES);
   });
 
   it('proceeds normally when previous-installer is a regular dir (not a symlink to source)', async () => {


### PR DESCRIPTION
## Symptom

`electron/__tests__/installerCache.test.ts` fails roughly **one full-suite run in three** on `main`, passes in isolation, and picks a different test each time — usually:

- `aborts with cache-symlink-outside-userdata when previous-installer symlinks to source parent`
- `copies the source AppImage into the cache dir on Linux`

The failure is `Error: Test timed out in 5000ms` — a timeout, never an assertion failure.

## Root cause

Not a real bug in `installerCache.ts`. It's a slow assertion sitting right on vitest's default timeout.

`MIN_CACHED_INSTALLER_BYTES` is `1_000_000`, so the fixture is a 1 MB Buffer:

```ts
const HEALTHY_BYTES = Buffer.alloc(MIN_CACHED_INSTALLER_BYTES, 'a');
```

Two tests then asserted `expect(readFileSync(...)).toEqual(HEALTHY_BYTES)`. Vitest's `toEqual` does **structural deep-equality on Buffers — walking all 1,000,000 elements** — rather than a byte compare. Measured on this machine:

| Assertion | 1 MB Buffer |
|---|---|
| `expect(b).toEqual(a)` | **2969 ms** |
| `expect(b).toStrictEqual(a)` | 4704 ms |
| `expect(b.equals(a)).toBe(true)` | **1 ms** |

That single assertion put the whole test at **4276 ms in isolation**, against vitest's 5000 ms default `testTimeout` — 85% of the budget consumed on a completely idle machine. Run the full suite (103 files across 12 cores) and a few hundred ms of worker starvation tips it over. Hence: passes alone, flakes under load, and alternates between the two tests because both sit on the same cliff.

## Fix

`Buffer.equals()` is a memcmp — the identical comparison, ~3000x faster:

```ts
function expectBytesEqual(actual: Buffer, expected: Buffer): void {
  expect(actual.byteLength).toBe(expected.byteLength);
  expect(actual.equals(expected)).toBe(true);
}
```

The `byteLength` check runs first so a size mismatch still reports concrete numbers instead of `expected false to be true`.

Only the two 1 MB assertions are changed. The other Buffer comparisons in the file (13 bytes at line 210, 1 KB at line 1158) are already fast and are left alone.

## Why this one is worth fixing rather than tolerating

The test that times out is a **security** test — "a hostile `previous-installer` symlink must not cause us to delete the running binary." A red CI run therefore looks like the symlink defense broke. It hasn't: the defense passes, and the *assertion verifying the source file survived* is the slow part. A flake that impersonates a security regression is the kind that gets ignored, then trusted, then disabled.

## Test plan

- [x] The two tests: **4276 ms → 2 ms** and **→ 8 ms**
- [x] The file: **8.15 s → 438 ms** (47/47 pass)
- [x] Full suite run **8x**: **0/8 failures** (was 2/8 on `main` before the fix)
- [x] `tsc --noEmit` clean, prettier clean, ui-contract green

Independent of #217.