### PR TITLE
feat(server,dashboard): visible model download progress during server startup (GH-207)

### DIFF
--- a/dashboard/components/__tests__/ActivityNotifications.test.tsx
+++ b/dashboard/components/__tests__/ActivityNotifications.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * ActivityNotifications — progress bar visibility (GH-207).
+ *
+ * The bar must be data-driven: shown when an active download item carries
+ * progress data, hidden when it does not — regardless of legacyType. The old
+ * logic hard-coded `legacyType !== 'model-preload'`, which suppressed real
+ * byte progress on GGML downloads and rendered a fake indeterminate bar on
+ * legacy items with no progress data at all.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import React from 'react';
+
+import { ActivityNotifications } from '../ui/ActivityNotifications';
+import { useActivityStore } from '../../src/stores/activityStore';
+
+const PROGRESS_BAR_SELECTOR = '.h-1';
+
+beforeEach(() => {
+  useActivityStore.setState({ items: [] });
+});
+
+describe('ActivityNotifications progress bar (GH-207)', () => {
+  it('shows the progress bar and sizes for an active download item carrying progress data', () => {
+    useActivityStore.getState().addActivity({
+      id: 'model-load-x',
+      category: 'download',
+      label: 'Downloading x...',
+      status: 'active',
+      progress: 42,
+      downloadedSize: '300 MB',
+      totalSize: '700 MB',
+    });
+    const { container } = render(<ActivityNotifications />);
+
+    expect(container.querySelector(PROGRESS_BAR_SELECTOR)).not.toBeNull();
+    expect(screen.getByText(/300 MB \/ 700 MB/)).toBeInTheDocument();
+  });
+
+  it('shows the progress bar for a model-preload-typed item that carries progress data (GGML path)', () => {
+    useActivityStore.getState().addActivity({
+      id: 'ggml-download-ggml-large-v3.bin',
+      category: 'download',
+      label: 'Downloading ggml-large-v3.bin...',
+      status: 'active',
+      legacyType: 'model-preload',
+      progress: 55,
+      downloadedSize: '1.6 GB',
+      totalSize: '2.9 GB',
+    });
+    const { container } = render(<ActivityNotifications />);
+
+    expect(container.querySelector(PROGRESS_BAR_SELECTOR)).not.toBeNull();
+    expect(screen.getByText(/1\.6 GB \/ 2\.9 GB/)).toBeInTheDocument();
+  });
+
+  it('shows no progress bar for a legacy spinner-only item without progress data', () => {
+    useActivityStore.getState().addActivity({
+      id: 'model-preload',
+      category: 'download',
+      label: 'Loading Model',
+      status: 'active',
+      legacyType: 'model-preload',
+    });
+    const { container } = render(<ActivityNotifications />);
+
+    expect(container.querySelector(PROGRESS_BAR_SELECTOR)).toBeNull();
+  });
+
+  it('shows no progress bar for a legacy docker-image item without progress data', () => {
+    useActivityStore.getState().addActivity({
+      id: 'docker-pull',
+      category: 'download',
+      label: 'Pulling server image...',
+      status: 'active',
+      legacyType: 'docker-image',
+    });
+    const { container } = render(<ActivityNotifications />);
+
+    expect(container.querySelector(PROGRESS_BAR_SELECTOR)).toBeNull();
+  });
+});

--- a/dashboard/components/__tests__/StartupActivityInline.test.tsx
+++ b/dashboard/components/__tests__/StartupActivityInline.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * StartupActivityInline — inline mirror of active download/startup activity
+ * for the Server tab (GH-207).
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import React from 'react';
+
+import { StartupActivityInline } from '../views/server/StartupActivityInline';
+import { useActivityStore } from '../../src/stores/activityStore';
+
+beforeEach(() => {
+  useActivityStore.setState({ items: [] });
+});
+
+describe('StartupActivityInline (GH-207)', () => {
+  it('renders label, percentage, and sizes for an active download item', () => {
+    useActivityStore.getState().addActivity({
+      id: 'model-load-parakeet',
+      category: 'download',
+      label: 'Downloading parakeet-tdt-0.6b-v2...',
+      status: 'active',
+      progress: 37,
+      downloadedSize: '1.1 GB',
+      totalSize: '2.9 GB',
+    });
+    render(<StartupActivityInline />);
+
+    expect(screen.getByText('Downloading parakeet-tdt-0.6b-v2...')).toBeInTheDocument();
+    expect(screen.getByText('37%')).toBeInTheDocument();
+    expect(screen.getByText('1.1 GB / 2.9 GB')).toBeInTheDocument();
+  });
+
+  it('renders an active item without progress data as label only', () => {
+    useActivityStore.getState().addActivity({
+      id: 'model-load-x',
+      category: 'download',
+      label: 'Loading test-model into memory...',
+      status: 'active',
+    });
+    render(<StartupActivityInline />);
+
+    expect(screen.getByText('Loading test-model into memory...')).toBeInTheDocument();
+    expect(screen.queryByText(/%$/)).toBeNull();
+  });
+
+  it('renders nothing when all items are complete', () => {
+    useActivityStore.getState().addActivity({
+      id: 'model-load-x',
+      category: 'download',
+      label: 'test-model ready',
+      status: 'complete',
+    });
+    const { container } = render(<StartupActivityInline />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing for dismissed items', () => {
+    useActivityStore.getState().addActivity({
+      id: 'model-load-x',
+      category: 'download',
+      label: 'Downloading x...',
+      status: 'active',
+    });
+    useActivityStore.getState().dismissActivity('model-load-x');
+    const { container } = render(<StartupActivityInline />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/dashboard/components/ui/ActivityNotifications.tsx
+++ b/dashboard/components/ui/ActivityNotifications.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useEffect } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import {
   X,
   Container,
@@ -82,7 +83,7 @@ function ActivityCard({ item }: { item: ActivityItem }) {
   const dismiss = useActivityStore((s) => s.dismissActivity);
   const isActive = item.status === 'active';
   const isDownload = item.category === 'download';
-  const showProgress = isActive && isDownload && item.legacyType !== 'model-preload';
+  const showProgress = isActive && isDownload && item.progress !== undefined;
 
   // Auto-dismiss completed notifications. Persistent items are never auto-dismissed.
   useEffect(() => {
@@ -153,7 +154,7 @@ function ActivityCard({ item }: { item: ActivityItem }) {
 // ─── Main widget ─────────────────────────────────────────────────────────────
 
 export const ActivityNotifications: React.FC = () => {
-  const items = useActivityStore(selectVisibleNotifications);
+  const items = useActivityStore(useShallow(selectVisibleNotifications));
 
   if (items.length === 0) return null;
 

--- a/dashboard/components/views/ServerView.tsx
+++ b/dashboard/components/views/ServerView.tsx
@@ -38,6 +38,7 @@ import { GpuHealthCard } from './GpuHealthCard';
 import { GpuDiagnosticModal, type GpuDiagnosticResultProp } from './GpuDiagnosticModal';
 import { InstanceSettingsSelectors } from './server/InstanceSettingsSelectors';
 import { RemoteConnectionCard } from './server/RemoteConnectionCard';
+import { StartupActivityInline } from './server/StartupActivityInline';
 
 import { useActivityStore } from '../../src/stores/activityStore';
 import { useAdminStatus } from '../../src/hooks/useAdminStatus';
@@ -2049,6 +2050,8 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                     {docker.operationError}
                   </div>
                 )}
+                {/* Active model downloads while the server is starting (GH-207) */}
+                {isRunning && !isRunningAndHealthy && <StartupActivityInline />}
                 {containerStatus.startedAt && isRunning && (
                   <div className="mt-2 font-mono text-xs text-slate-500">
                     Started: {new Date(containerStatus.startedAt).toLocaleString()}

--- a/dashboard/components/views/server/StartupActivityInline.tsx
+++ b/dashboard/components/views/server/StartupActivityInline.tsx
@@ -1,0 +1,34 @@
+import { Loader2 } from 'lucide-react';
+import { useShallow } from 'zustand/react/shallow';
+import { useActivityStore, type ActivityItem } from '../../../src/stores/activityStore';
+
+const selectActiveVisibleItems = (state: { items: ActivityItem[] }): ActivityItem[] =>
+  state.items.filter((item) => item.status === 'active' && !item.dismissed);
+
+/**
+ * Inline mirror of active download/startup activity for the Server tab
+ * (GH-207): the floating widget is easy to miss or dismiss; while the
+ * server is starting this shows the same items next to the status light.
+ */
+export function StartupActivityInline() {
+  const items = useActivityStore(useShallow(selectActiveVisibleItems));
+  if (items.length === 0) return null;
+  return (
+    <div className="mt-2 space-y-1.5">
+      {items.map((item) => (
+        <div key={item.id} className="flex items-center gap-2 text-xs text-slate-400">
+          <Loader2 size={12} className="shrink-0 animate-spin" />
+          <span className="min-w-0 truncate">{item.label}</span>
+          {item.progress !== undefined && (
+            <span className="shrink-0 font-mono text-slate-500">{item.progress}%</span>
+          )}
+          {item.downloadedSize && item.totalSize && (
+            <span className="shrink-0 font-mono text-[10px] text-slate-600">
+              {item.downloadedSize} / {item.totalSize}
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/dashboard/electron/__tests__/startupEventWatcher.test.ts
+++ b/dashboard/electron/__tests__/startupEventWatcher.test.ts
@@ -230,6 +230,64 @@ describe('[P1] StartupEventWatcher', () => {
     expect(received.filter((e) => e.id === 'after-stop')).toHaveLength(0);
   });
 
+  it('warns once after 90s when no events were ever observed (GH-207 silent-channel diagnostic)', () => {
+    vi.useFakeTimers();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      fs.writeFileSync(eventsFile, '');
+      const watcher = new StartupEventWatcher();
+      watcher.start(eventsFile, () => {});
+
+      vi.advanceTimersByTime(90_000);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(String(warnSpy.mock.calls[0][0])).toContain('no startup events observed');
+
+      watcher.stop();
+    } finally {
+      warnSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not warn when at least one event was observed', () => {
+    vi.useFakeTimers();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      // Event present before start — the initial synchronous read sees it.
+      fs.writeFileSync(eventsFile, makeEvent({ id: 'x', category: 'c', label: 'l' }) + '\n');
+      const watcher = new StartupEventWatcher();
+      watcher.start(eventsFile, () => {});
+
+      vi.advanceTimersByTime(90_000);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      watcher.stop();
+    } finally {
+      warnSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not warn after stop()', () => {
+    vi.useFakeTimers();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      fs.writeFileSync(eventsFile, '');
+      const watcher = new StartupEventWatcher();
+      watcher.start(eventsFile, () => {});
+      watcher.stop();
+
+      vi.advanceTimersByTime(90_000);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it('retries when file does not exist yet', async () => {
     // Don't create the file yet
     const received: StartupEvent[] = [];

--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -3039,6 +3039,24 @@ export interface BootstrapDownloadEvent {
   type: DownloadEventType;
   label: string;
   error?: string;
+  progress?: number; // 0-100 (GH-207)
+  downloadedSize?: string; // human-readable, e.g. "312 MB"
+  totalSize?: string;
+}
+
+/**
+ * Human-readable byte size matching the server-side `_format_bytes` in
+ * `download_progress.py`, so both download pipelines render consistently
+ * in the dashboard (GH-207).
+ */
+function formatBytes(num: number): string {
+  for (const unit of ['B', 'KB', 'MB', 'GB']) {
+    if (num < 1024) {
+      return unit === 'B' ? `${Math.trunc(num)} ${unit}` : `${num.toFixed(1)} ${unit}`;
+    }
+    num /= 1024;
+  }
+  return `${num.toFixed(1)} TB`;
 }
 
 interface BootstrapPattern {
@@ -3183,10 +3201,15 @@ function bootstrapLogParser(line: string): void {
       event.error = line.slice(idx).trim() || 'Unknown error';
     }
 
-    for (const cb of downloadEventSubscribers) {
-      cb(event);
-    }
+    emitBootstrapDownloadEvent(event);
     return; // First match wins per line
+  }
+}
+
+/** Fan a download event out to all registered subscribers. */
+function emitBootstrapDownloadEvent(event: BootstrapDownloadEvent): void {
+  for (const cb of downloadEventSubscribers) {
+    cb(event);
   }
 }
 
@@ -3469,6 +3492,14 @@ async function downloadGgmlModelToHost(fileName: string): Promise<void> {
 
   const { net } = await import('electron');
 
+  const eventId = `ggml-download-${sanitized}`;
+  emitBootstrapDownloadEvent({
+    action: 'start',
+    id: eventId,
+    type: 'model-preload',
+    label: `Downloading ${sanitized}...`,
+  });
+
   await new Promise<void>((resolve, reject) => {
     const request = net.request({ url, redirect: 'follow' });
     const file = fs.createWriteStream(tmp);
@@ -3479,7 +3510,27 @@ async function downloadGgmlModelToHost(fileName: string): Promise<void> {
         reject(new Error(`HTTP ${response.statusCode} downloading ${sanitized}`));
         return;
       }
-      response.on('data', (chunk) => file.write(chunk));
+      const rawLength = response.headers['content-length'];
+      const totalBytes = Number(Array.isArray(rawLength) ? rawLength[0] : (rawLength ?? 0));
+      let downloadedBytes = 0;
+      let lastEmit = 0;
+      response.on('data', (chunk) => {
+        file.write(chunk);
+        downloadedBytes += chunk.length;
+        const now = Date.now();
+        if (totalBytes > 0 && now - lastEmit >= 1000) {
+          lastEmit = now;
+          emitBootstrapDownloadEvent({
+            action: 'start',
+            id: eventId,
+            type: 'model-preload',
+            label: `Downloading ${sanitized}...`,
+            progress: Math.min(100, Math.round((downloadedBytes / totalBytes) * 100)),
+            downloadedSize: formatBytes(downloadedBytes),
+            totalSize: formatBytes(totalBytes),
+          });
+        }
+      });
       response.on('end', () => file.close(() => resolve()));
       response.on('error', (err) => {
         file.destroy();
@@ -3498,10 +3549,23 @@ async function downloadGgmlModelToHost(fileName: string): Promise<void> {
     } catch {
       /* best-effort */
     }
+    emitBootstrapDownloadEvent({
+      action: 'fail',
+      id: eventId,
+      type: 'model-preload',
+      label: `Downloading ${sanitized}...`,
+      error: err instanceof Error ? err.message : String(err),
+    });
     throw err;
   });
 
   fs.renameSync(tmp, dest);
+  emitBootstrapDownloadEvent({
+    action: 'complete',
+    id: eventId,
+    type: 'model-preload',
+    label: `${sanitized} downloaded`,
+  });
 }
 
 /**
@@ -3824,6 +3888,16 @@ async function downloadGgmlModel(fileName: string): Promise<void> {
   const tmp = `${dest}.tmp`;
   const bin = await runtimeBin();
 
+  // Coarse events only: byte counting is not available through docker exec
+  // + curl, but the card still shows start/complete/fail (GH-207).
+  const eventId = `ggml-download-${sanitized}`;
+  emitBootstrapDownloadEvent({
+    action: 'start',
+    id: eventId,
+    type: 'model-preload',
+    label: `Downloading ${sanitized}...`,
+  });
+
   try {
     await execFileAsync(bin, ['exec', CONTAINER_NAME, 'curl', '-fsSL', '-o', tmp, url], {
       maxBuffer: 1 * 1024 * 1024,
@@ -3831,6 +3905,12 @@ async function downloadGgmlModel(fileName: string): Promise<void> {
     });
     // Atomically rename temp file to final destination
     await exec(bin, ['exec', CONTAINER_NAME, 'mv', tmp, dest]);
+    emitBootstrapDownloadEvent({
+      action: 'complete',
+      id: eventId,
+      type: 'model-preload',
+      label: `${sanitized} downloaded`,
+    });
   } catch (err) {
     // Best-effort cleanup of partial download — ignore cleanup errors
     try {
@@ -3838,6 +3918,13 @@ async function downloadGgmlModel(fileName: string): Promise<void> {
     } catch {
       /* ignore */
     }
+    emitBootstrapDownloadEvent({
+      action: 'fail',
+      id: eventId,
+      type: 'model-preload',
+      label: `Downloading ${sanitized}...`,
+      error: err instanceof Error ? err.message : String(err),
+    });
     throw err;
   }
 }

--- a/dashboard/electron/startupEventWatcher.ts
+++ b/dashboard/electron/startupEventWatcher.ts
@@ -30,12 +30,22 @@ export interface StartupEvent {
   ts?: number;
 }
 
+/**
+ * How long to wait for the first event before warning that the channel looks
+ * dead (GH-207). A healthy startup emits its first event within seconds; 90s
+ * of silence while the container runs points at a broken STARTUP_EVENTS_DIR
+ * bind mount (suspected on Docker Desktop/WSL2 setups).
+ */
+const SILENT_CHANNEL_DIAGNOSTIC_MS = 90_000;
+
 export class StartupEventWatcher {
   private watcher: fs.FSWatcher | null = null;
   private offset = 0;
   private filePath: string | null = null;
   private onEvent: ((event: StartupEvent) => void) | null = null;
   private retryTimer: ReturnType<typeof setTimeout> | null = null;
+  private diagnosticTimer: ReturnType<typeof setTimeout> | null = null;
+  private sawAnyEvent = false;
 
   /**
    * Start watching a file for new JSON Lines.
@@ -49,6 +59,16 @@ export class StartupEventWatcher {
     this.onEvent = onEvent;
     this.offset = 0;
 
+    this.sawAnyEvent = false;
+    this.diagnosticTimer = setTimeout(() => {
+      if (!this.sawAnyEvent) {
+        console.warn(
+          `[StartupEventWatcher] no startup events observed after ${SILENT_CHANNEL_DIAGNOSTIC_MS / 1000}s (file: ${this.filePath}). ` +
+            'If the container is running, the STARTUP_EVENTS_DIR bind mount may not be working on this platform.',
+        );
+      }
+    }, SILENT_CHANNEL_DIAGNOSTIC_MS);
+
     this.tryWatch();
   }
 
@@ -61,6 +81,10 @@ export class StartupEventWatcher {
     if (this.retryTimer) {
       clearTimeout(this.retryTimer);
       this.retryTimer = null;
+    }
+    if (this.diagnosticTimer) {
+      clearTimeout(this.diagnosticTimer);
+      this.diagnosticTimer = null;
     }
     this.filePath = null;
     this.onEvent = null;
@@ -131,6 +155,13 @@ export class StartupEventWatcher {
       try {
         const event = JSON.parse(trimmed) as StartupEvent;
         if (event.id && event.category && event.label) {
+          if (!this.sawAnyEvent) {
+            this.sawAnyEvent = true;
+            if (this.diagnosticTimer) {
+              clearTimeout(this.diagnosticTimer);
+              this.diagnosticTimer = null;
+            }
+          }
           this.onEvent!(event);
         }
       } catch {

--- a/dashboard/src/hooks/useBootstrapDownloads.test.ts
+++ b/dashboard/src/hooks/useBootstrapDownloads.test.ts
@@ -1,0 +1,107 @@
+/**
+ * useBootstrapDownloads — IPC-to-activity-store bridge (GH-207).
+ *
+ * Covers the legacy-card dedupe (a granular `model-load-*` event dismisses
+ * the coarse `model-preload` spinner card) and byte-progress forwarding on
+ * the legacy download-event bridge (GGML downloads).
+ */
+
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { useBootstrapDownloads } from './useBootstrapDownloads';
+import { useActivityStore } from '../stores/activityStore';
+
+type Callback = (event: Record<string, unknown>) => void;
+
+let downloadEventCallback: Callback | null = null;
+let activityEventCallback: Callback | null = null;
+
+beforeEach(() => {
+  useActivityStore.setState({ items: [] });
+  downloadEventCallback = null;
+  activityEventCallback = null;
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    docker: {
+      onDownloadEvent: (cb: Callback) => {
+        downloadEventCallback = cb;
+        return vi.fn();
+      },
+      onActivityEvent: (cb: Callback) => {
+        activityEventCallback = cb;
+        return vi.fn();
+      },
+    },
+  };
+});
+
+afterEach(() => {
+  delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+});
+
+describe('useBootstrapDownloads (GH-207)', () => {
+  it('dismisses the legacy model-preload card when a granular model-load-* event arrives', () => {
+    renderHook(() => useBootstrapDownloads());
+
+    downloadEventCallback!({
+      action: 'start',
+      id: 'model-preload',
+      type: 'model-preload',
+      label: 'Loading Model',
+    });
+    expect(useActivityStore.getState().items.find((i) => i.id === 'model-preload')?.dismissed).toBe(
+      false,
+    );
+
+    activityEventCallback!({
+      id: 'model-load-nvidia--parakeet-tdt-0.6b-v2',
+      category: 'download',
+      label: 'Downloading parakeet-tdt-0.6b-v2...',
+      status: 'active',
+      progress: 10,
+    });
+
+    const items = useActivityStore.getState().items;
+    expect(items.find((i) => i.id === 'model-preload')?.dismissed).toBe(true);
+    expect(items.find((i) => i.id === 'model-load-nvidia--parakeet-tdt-0.6b-v2')?.dismissed).toBe(
+      false,
+    );
+  });
+
+  it('is a no-op when a granular event arrives without a legacy card present', () => {
+    renderHook(() => useBootstrapDownloads());
+
+    activityEventCallback!({
+      id: 'model-load-large-v3-turbo',
+      category: 'download',
+      label: 'Downloading large-v3-turbo...',
+      status: 'active',
+    });
+
+    const items = useActivityStore.getState().items;
+    expect(items).toHaveLength(1);
+    expect(items[0].id).toBe('model-load-large-v3-turbo');
+  });
+
+  it('forwards byte progress fields on legacy download events (GGML path)', () => {
+    renderHook(() => useBootstrapDownloads());
+
+    downloadEventCallback!({
+      action: 'start',
+      id: 'ggml-download-ggml-large-v3.bin',
+      type: 'model-preload',
+      label: 'Downloading ggml-large-v3.bin...',
+      progress: 55,
+      downloadedSize: '1.6 GB',
+      totalSize: '2.9 GB',
+    });
+
+    const item = useActivityStore
+      .getState()
+      .items.find((i) => i.id === 'ggml-download-ggml-large-v3.bin');
+    expect(item).toBeDefined();
+    expect(item!.progress).toBe(55);
+    expect(item!.downloadedSize).toBe('1.6 GB');
+    expect(item!.totalSize).toBe('2.9 GB');
+  });
+});

--- a/dashboard/src/hooks/useBootstrapDownloads.ts
+++ b/dashboard/src/hooks/useBootstrapDownloads.ts
@@ -42,6 +42,9 @@ export function useBootstrapDownloads(): void {
           label: event.label,
           status,
           legacyType: event.type as LegacyDownloadType,
+          ...(event.progress !== undefined ? { progress: event.progress } : {}),
+          ...(event.downloadedSize ? { downloadedSize: event.downloadedSize } : {}),
+          ...(event.totalSize ? { totalSize: event.totalSize } : {}),
           ...(status === 'error' && event.error ? { error: event.error } : {}),
           ...(status === 'complete' ? { completedAt: Date.now() } : {}),
         });
@@ -53,6 +56,13 @@ export function useBootstrapDownloads(): void {
     if (api.onActivityEvent) {
       const cleanup = api.onActivityEvent((event) => {
         const store = useActivityStore.getState();
+
+        // A granular model-load event supersedes the coarse log-parser card:
+        // without this the legacy spinner-only "Loading Model" card stands in
+        // front of the card that actually carries progress data (GH-207).
+        if (event.id.startsWith('model-load-')) {
+          store.dismissActivity('model-preload');
+        }
 
         store.addActivity({
           id: event.id,

--- a/dashboard/src/types/electron.d.ts
+++ b/dashboard/src/types/electron.d.ts
@@ -70,6 +70,9 @@ interface BootstrapDownloadEvent {
   type: DownloadEventType;
   label: string;
   error?: string;
+  progress?: number; // 0-100 (GH-207)
+  downloadedSize?: string; // human-readable, e.g. "312 MB"
+  totalSize?: string;
 }
 
 interface StartupActivityEvent {

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.2.0",
-  "contract_sha256": "2de9497d7a4b8a5b4159a4749eaae1a86e46fc8bdb9484d75ab12d1829514d2a",
-  "updated_at": "2026-07-14T08:05:49.332Z"
+  "spec_version": "1.3.0",
+  "contract_sha256": "444a7c665a71cc83351b46a2361f73760959c1871c28cbda79b2c98c396018d6",
+  "updated_at": "2026-07-14T13:09:34.100Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.2.0
+  spec_version: 1.3.0
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -7,6 +7,7 @@ meta:
     repo_path: /home/Bill/Code_Projects/Python_Projects/TranscriptionSuite/dashboard
     source_files:
       - App.tsx
+      - components/__tests__/ActivityNotifications.test.tsx
       - components/__tests__/AddNoteModal.canary-language.test.tsx
       - components/__tests__/AddNoteModal.initialFiles.test.tsx
       - components/__tests__/AudioVisualizer.test.tsx
@@ -18,6 +19,7 @@ meta:
       - components/__tests__/SessionImportTab.canary-language.test.tsx
       - components/__tests__/SessionView.canary-language.test.tsx
       - components/__tests__/SessionView.test.tsx
+      - components/__tests__/StartupActivityInline.test.tsx
       - components/AriaLiveRegion.tsx
       - components/AudioVisualizer.tsx
       - components/editor/FindReplaceTextEditor.test.tsx
@@ -92,6 +94,7 @@ meta:
       - components/views/NotebookView.tsx
       - components/views/server/InstanceSettingsSelectors.tsx
       - components/views/server/RemoteConnectionCard.tsx
+      - components/views/server/StartupActivityInline.tsx
       - components/views/ServerConfigEditor.tsx
       - components/views/ServerView.tsx
       - components/views/SessionImportTab.tsx
@@ -102,7 +105,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-07-14T08:05:41.637Z
+    generated_at: 2026-07-14T13:09:20.706Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -2801,6 +2804,23 @@ component_contracts:
         rule: Do not introduce unregistered utility, arbitrary, or inline style values.
   StarPopupModal:
     file: components/views/StarPopupModal.tsx
+    required_tokens:
+      - colors
+      - motion
+      - radii
+      - shadows
+    allowed_variants: {}
+    structural_invariants:
+      - id: structure-stable
+        rule: Preserve current structural layout and region hierarchy for this component.
+    behavior_rules:
+      - id: motion-locked
+        rule: Use only approved motion tokens and classes from foundation token registry.
+    state_rules:
+      - id: closed-set-styles
+        rule: Do not introduce unregistered utility, arbitrary, or inline style values.
+  StartupActivityInline:
+    file: components/views/server/StartupActivityInline.tsx
     required_tokens:
       - colors
       - motion

--- a/server/backend/api/main.py
+++ b/server/backend/api/main.py
@@ -643,6 +643,16 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
                 )
                 logger.warning(warning_message, exc_info=True)
                 _log_time(timing_label)
+                # Surface the failure in the dashboard (GH-207): without this
+                # a failed preload looks like an infinite server start.
+                emit_event(
+                    "model-preload-error",
+                    "download",
+                    warning_message,
+                    status="error",
+                    severity="warning",
+                    persistent=True,
+                )
             else:
                 # A non-dependency model-load failure (bad model id, corrupt
                 # cache, OOM, ...) must not brick the whole server: the dashboard,
@@ -660,6 +670,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
                     exc_info=True,
                 )
                 _log_time("model preload failed (continuing without model)")
+                emit_event(
+                    "model-preload-error",
+                    "download",
+                    f"Model preload failed for {selected_main_model}. The server started without a loaded model - fix the model selection in the dashboard and restart.",
+                    status="error",
+                    severity="error",
+                    persistent=True,
+                )
         else:
             _log_time("model preload complete")
 

--- a/server/backend/core/download_progress.py
+++ b/server/backend/core/download_progress.py
@@ -37,6 +37,15 @@ _thread_local = threading.local()
 _MIN_TRACKABLE_BYTES = 1024
 
 
+def _format_bytes(num: float) -> str:
+    """Human-readable byte size for dashboard display (GH-207)."""
+    for unit in ("B", "KB", "MB", "GB"):
+        if num < 1024:
+            return f"{int(num)} {unit}" if unit == "B" else f"{num:.1f} {unit}"
+        num /= 1024
+    return f"{num:.1f} TB"
+
+
 def _get_tracker() -> _DownloadTracker | None:
     return getattr(_thread_local, "tracker", None)
 
@@ -55,6 +64,7 @@ class _DownloadTracker:
         self.total_bytes = 0
         self.downloaded_bytes = 0
         self._last_emit_time = 0.0
+        self._load_phase_emitted = False
 
     def on_tqdm_created(self, total: int | float | None) -> None:
         """Register a new download file's total size."""
@@ -70,6 +80,23 @@ class _DownloadTracker:
         if now - self._last_emit_time >= 1.0:
             self._emit_progress()
             self._last_emit_time = now
+        # total_bytes grows as snapshot_download opens per-file tqdms, so
+        # downloaded >= total only holds once every file finished — the point
+        # where the (possibly long, CPU-bound) weight-instantiation phase
+        # begins (GH-207).
+        if (
+            self.total_bytes > 0
+            and self.downloaded_bytes >= self.total_bytes
+            and not self._load_phase_emitted
+        ):
+            self._load_phase_emitted = True
+            emit_event(
+                self.event_id,
+                "download",
+                f"Loading {self.label} into memory...",
+                status="active",
+                progress=100,
+            )
 
     def _emit_progress(self) -> None:
         progress = (
@@ -83,8 +110,8 @@ class _DownloadTracker:
             f"Downloading {self.label}...",
             status="active",
             progress=progress,
-            downloadedSize=self.downloaded_bytes,
-            totalSize=self.total_bytes,
+            downloadedSize=_format_bytes(self.downloaded_bytes),
+            totalSize=_format_bytes(self.total_bytes),
         )
 
 
@@ -277,8 +304,8 @@ def track_model_download(model_name: str) -> Generator[None]:
                 f"{label} ready",
                 status="complete",
                 durationMs=elapsed_ms,
-                downloadedSize=tracker.downloaded_bytes,
-                totalSize=tracker.total_bytes,
+                downloadedSize=_format_bytes(tracker.downloaded_bytes),
+                totalSize=_format_bytes(tracker.total_bytes),
             )
         else:
             emit_event(

--- a/server/backend/tests/test_download_progress.py
+++ b/server/backend/tests/test_download_progress.py
@@ -254,6 +254,85 @@ class TestProgressTqdm:
         bar.set_postfix({"speed": "10MB/s"}, refresh=True)  # should not raise
 
 
+# ── Loading phase + byte formatting (GH-207) ──────────────────────────
+
+
+class TestLoadingPhase:
+    def test_emits_loading_phase_when_download_bytes_complete(self, mock_emit):
+        from server.core.download_progress import _DownloadTracker
+
+        tracker = _DownloadTracker("model-load-test", "test-model")
+        tracker.on_tqdm_created(2_000_000)
+        tracker.on_tqdm_update(2_000_000)  # bytes complete
+
+        labels = [e["label"] for e in mock_emit]
+        assert any("Loading test-model into memory" in label for label in labels)
+        # and it fires exactly once even if more updates arrive
+        tracker.on_tqdm_update(0)
+        assert sum("into memory" in e["label"] for e in mock_emit) == 1
+
+    def test_no_loading_phase_before_bytes_complete(self, mock_emit):
+        from server.core.download_progress import _DownloadTracker
+
+        tracker = _DownloadTracker("model-load-test", "test-model")
+        tracker.on_tqdm_created(2_000_000)
+        tracker.on_tqdm_update(1_000_000)  # halfway
+
+        assert not any("into memory" in e["label"] for e in mock_emit)
+
+    def test_no_loading_phase_without_tracked_total(self, mock_emit):
+        from server.core.download_progress import _DownloadTracker
+
+        tracker = _DownloadTracker("model-load-test", "test-model")
+        tracker.on_tqdm_update(500)  # no on_tqdm_created — total_bytes stays 0
+
+        assert not any("into memory" in e["label"] for e in mock_emit)
+
+
+class TestByteFormatting:
+    SIZE_PATTERN = r"^\d+(\.\d)? (B|KB|MB|GB|TB)$"
+
+    def test_format_bytes_units(self, mock_emit):
+        from server.core.download_progress import _format_bytes
+
+        assert _format_bytes(0) == "0 B"
+        assert _format_bytes(512) == "512 B"
+        assert _format_bytes(2048) == "2.0 KB"
+        assert _format_bytes(31_457_280) == "30.0 MB"
+        assert _format_bytes(2 * 1024**3) == "2.0 GB"
+        assert _format_bytes(3 * 1024**4) == "3.0 TB"
+
+    def test_progress_events_carry_human_readable_sizes(self, mock_emit):
+        import re
+
+        from server.core.download_progress import _DownloadTracker
+
+        tracker = _DownloadTracker("test-id", "test-model")
+        tracker.on_tqdm_created(2_000_000)
+        tracker.on_tqdm_update(1_000_000)
+
+        size_events = [e for e in mock_emit if "downloadedSize" in e]
+        assert size_events
+        for event in size_events:
+            assert re.match(self.SIZE_PATTERN, event["downloadedSize"])
+            assert re.match(self.SIZE_PATTERN, event["totalSize"])
+
+    def test_completion_event_carries_human_readable_sizes(self, mock_emit):
+        import re
+
+        from server.core.download_progress import _ProgressTqdm, track_model_download
+
+        with track_model_download("nvidia/test-model"):
+            bar = _ProgressTqdm(total=2_000_000)
+            bar.update(2_000_000)
+            bar.close()
+
+        complete_event = mock_emit[-1]
+        assert complete_event["status"] == "complete"
+        assert re.match(self.SIZE_PATTERN, complete_event["downloadedSize"])
+        assert re.match(self.SIZE_PATTERN, complete_event["totalSize"])
+
+
 # ── Throttling ─────────────────────────────────────────────────────────
 
 
@@ -320,8 +399,9 @@ class TestTrackModelDownload:
         complete_event = mock_emit[-1]
         assert complete_event["status"] == "complete"
         assert complete_event["label"] == "test-model ready"
-        assert complete_event["downloadedSize"] == 2_000_000
-        assert complete_event["totalSize"] == 2_000_000
+        # Sizes are emitted pre-formatted for dashboard display (GH-207).
+        assert complete_event["downloadedSize"] == "1.9 MB"
+        assert complete_event["totalSize"] == "1.9 MB"
 
     def test_error_emits_error_event_and_reraises(self, mock_emit):
         from server.core.download_progress import track_model_download


### PR DESCRIPTION
Addresses #207

## Why the reporter saw nothing

About 90% of this feature already existed. The server intercepts huggingface_hub's tqdm (`download_progress.py`) and emits per-second progress events through the startup-events JSONL channel, which the Electron watcher forwards to a floating notification card that has a progress bar. It was invisible in practice because of a two-pipeline conflict:

1. A second, legacy pipeline (the `dockerManager.ts` bootstrap log parser) fires a coarse `model-preload` card in parallel, and `ActivityNotifications.tsx` hard-coded `showProgress = ... && legacyType !== 'model-preload'` - a spinner-only duplicate that stood in front of the granular card.
2. The lifespan preload failure path logged but never emitted an event, so a failed download looked like an infinite start.
3. The whisper.cpp GGML download path emitted zero progress.
4. Nothing appeared in the Server tab itself, only in the dismissable floating widget.
5. The emitted `downloadedSize`/`totalSize` were raw ints, rendered verbatim (users saw `31457280 / 73400320`).

## What this PR does

**Server (`download_progress.py`, `main.py`)**
- Emits a one-shot "Loading <model> into memory..." phase event when download bytes complete, giving the Downloading -> Loading -> ready/error phase distinction the issue asks for.
- Formats `downloadedSize`/`totalSize` as human-readable strings at the single server-side choke point.
- Emits a persistent `model-preload-error` event on both lifespan preload failure paths (dependency error and generic). This branch lives inside the FastAPI lifespan closure and is not practically unit-testable; it was manually inspected and the full suite passes.

**Dashboard renderer**
- `ActivityNotifications` progress bar is now data-driven (`item.progress !== undefined`) instead of special-casing `model-preload`.
- A granular `model-load-*` event dismisses the legacy duplicate card, making the granular pipeline the single visible source of truth.
- The legacy IPC bridge forwards `progress`/`downloadedSize`/`totalSize`.
- New `StartupActivityInline` component mirrors active download items (label, percent, sizes) in the Server tab beneath the status light while the container runs but is not yet healthy. Note: an HTTP progress endpoint is impossible for this window - the lifespan blocks the event loop before yield, so the file-based channel is the only viable one.
- Fixed an unstable-snapshot loop in `ActivityNotifications` (zustand v5 selector returning a fresh array) via `useShallow`.

**Electron main**
- `downloadGgmlModelToHost` streams content-length-based byte progress (throttled to 1/s) with sizes formatted identically to the server side; the docker-exec `downloadGgmlModel` path gets coarse start/complete/fail events.
- `StartupEventWatcher` warns once if no startup event is observed for 90s: a cheap field diagnostic for the suspected dead STARTUP_EVENTS_DIR bind mount on Docker Desktop/WSL2, instead of a speculative Windows path-translation fix. If field reports confirm it, path translation should be a follow-up issue.

## Test plan

- `cd server/backend && ../../build/.venv/bin/pytest tests/ -v --tb=short`: 2161 passed, 4 skipped (full suite)
- `cd dashboard && npm test`: 1660 passed (full suite; new files: `ActivityNotifications.test.tsx`, `useBootstrapDownloads.test.ts`, `StartupActivityInline.test.tsx`, extended `startupEventWatcher.test.ts` and `test_download_progress.py`)
- `npx tsc --noEmit`: clean
- `npm run ui:contract:check`: clean (rebaselined for the new component, spec_version 1.3.0)