### PR TITLE
feat(dashboard): explain the HuggingFace token requirement in diarization setup (GH-208)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,25 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **TranscriptionSuite** (19002 symbols, 31742 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **TranscriptionSuite** (14100 symbols, 25580 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
+- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER edit a function, class, or method without first running `impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
-- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
+- NEVER commit changes without running `detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,24 +100,25 @@ feat/fix/chore/etc(impacted area e.g. tests, stt, dashboard, ui, server, etc): s
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **TranscriptionSuite** (19002 symbols, 31742 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **TranscriptionSuite** (14100 symbols, 25580 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
-> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
-- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
-- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+- When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
+- For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER edit a function, class, or method without first running `impact` on it.
 - NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
-- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
-- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+- NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
+- NEVER commit changes without running `detect_changes()` to check affected scope.
 
 ## Resources
 

--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -30,6 +30,7 @@ import { useImportQueueStore, selectIsUploading } from './src/stores/importQueue
 import { QueuePausedBanner } from './components/ui/QueuePausedBanner';
 import { UpdateBanner } from './components/ui/UpdateBanner';
 import { ActivityNotifications } from './components/ui/ActivityNotifications';
+import { HfTokenExplainer } from './components/ui/HfTokenExplainer';
 import { useStarPopup } from './src/hooks/useStarPopup';
 import { useBootstrapDownloads } from './src/hooks/useBootstrapDownloads';
 import { useServerEventReactor } from './src/hooks/useServerEventReactor';
@@ -56,8 +57,6 @@ import { isRuntimeProfile, type RuntimeProfile } from './src/types/runtime';
 
 type HfTokenDecision = 'unset' | 'provided' | 'skipped';
 type MissingFamily = 'whisper' | 'nemo' | 'vibevoice' | 'sensevoice';
-
-const HF_TERMS_URL = 'https://huggingface.co/pyannote/speaker-diarization-community-1';
 
 function normalizeHfDecision(value: unknown): HfTokenDecision {
   if (value === 'provided' || value === 'skipped' || value === 'unset') {
@@ -967,16 +966,7 @@ const AppInner: React.FC = () => {
                 <p className="text-slate-400">
                   If skipped, diarization stays disabled until you add a token.
                 </p>
-                <p className="text-slate-400">
-                  Accept model terms first:{' '}
-                  <button
-                    type="button"
-                    onClick={() => void openExternal(HF_TERMS_URL)}
-                    className="text-accent-cyan hover:underline"
-                  >
-                    {HF_TERMS_URL}
-                  </button>
-                </p>
+                <HfTokenExplainer onOpenLink={(url) => void openExternal(url)} />
                 <div className="relative pt-1">
                   <input
                     type={showHfTokenDraft ? 'text' : 'password'}

--- a/dashboard/components/__tests__/HfTokenExplainer.test.tsx
+++ b/dashboard/components/__tests__/HfTokenExplainer.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { HfTokenExplainer, HF_TERMS_URL, HF_TOKENS_URL } from '../ui/HfTokenExplainer';
+
+describe('HfTokenExplainer (GH-208)', () => {
+  it('explains the why, read-only sufficiency, local inference, and token-free alternatives', () => {
+    render(<HfTokenExplainer onOpenLink={vi.fn()} />);
+    expect(screen.getByText(/gated pyannote model/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/read.?only/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/runs entirely locally/i)).toBeInTheDocument();
+    expect(screen.getByText(/vibevoice/i)).toBeInTheDocument();
+    expect(screen.getByText(/sensevoice/i)).toBeInTheDocument();
+  });
+
+  it('links to both the model terms page and the token creation page', () => {
+    const onOpenLink = vi.fn();
+    render(<HfTokenExplainer onOpenLink={onOpenLink} />);
+    fireEvent.click(screen.getByRole('button', { name: /accept the model terms/i }));
+    expect(onOpenLink).toHaveBeenCalledWith(HF_TERMS_URL);
+    fireEvent.click(screen.getByRole('button', { name: /create a read-only token/i }));
+    expect(onOpenLink).toHaveBeenCalledWith(HF_TOKENS_URL);
+  });
+});

--- a/dashboard/components/ui/HfTokenExplainer.tsx
+++ b/dashboard/components/ui/HfTokenExplainer.tsx
@@ -1,0 +1,52 @@
+export const HF_TERMS_URL = 'https://huggingface.co/pyannote/speaker-diarization-community-1';
+export const HF_TOKENS_URL = 'https://huggingface.co/settings/tokens';
+
+interface HfTokenExplainerProps {
+  onOpenLink: (url: string) => void;
+}
+
+/**
+ * Shared explanation of why speaker diarization needs a Hugging Face token.
+ * Used by the first-run setup modal (App.tsx) and the Settings modal (GH-208).
+ */
+export function HfTokenExplainer({ onOpenLink }: HfTokenExplainerProps) {
+  return (
+    <div className="space-y-2 text-xs leading-relaxed text-slate-400">
+      <p>
+        Speaker diarization (who spoke when) uses the gated PyAnnote model from Hugging Face. The
+        token is used once, to download the model weights. Nothing is uploaded, and there is no
+        payment involved.
+      </p>
+      <ul className="list-disc space-y-1 pl-4">
+        <li>A free, read-only token is sufficient.</li>
+        <li>After the download, diarization runs entirely locally.</li>
+        <li>
+          No token is needed for models with built-in diarization, such as VibeVoice or SenseVoice
+          (CAM++).
+        </li>
+      </ul>
+      <p>
+        1.{' '}
+        <button
+          type="button"
+          onClick={() => onOpenLink(HF_TERMS_URL)}
+          className="text-accent-cyan hover:underline"
+        >
+          Accept the model terms
+        </button>{' '}
+        on Hugging Face (required by PyAnnote before the weights can be downloaded).
+      </p>
+      <p>
+        2.{' '}
+        <button
+          type="button"
+          onClick={() => onOpenLink(HF_TOKENS_URL)}
+          className="text-accent-cyan hover:underline"
+        >
+          Create a read-only token
+        </button>{' '}
+        and paste it below.
+      </p>
+    </div>
+  );
+}

--- a/dashboard/components/views/SettingsModal.tsx
+++ b/dashboard/components/views/SettingsModal.tsx
@@ -28,6 +28,7 @@ import { Button } from '../ui/Button';
 import { AppleSwitch } from '../ui/AppleSwitch';
 import { CustomSelect } from '../ui/CustomSelect';
 import { ShortcutCapture } from '../ui/ShortcutCapture';
+import { HfTokenExplainer } from '../ui/HfTokenExplainer';
 import { useQueryClient } from '@tanstack/react-query';
 import { useBackups } from '../../src/hooks/useBackups';
 import { apiClient } from '../../src/api/client';
@@ -102,6 +103,9 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
     | { available: boolean; reason: string }
     | undefined;
   const metalSupported = mlxFeature?.available ?? false;
+  const diarizationFeature = (adminStatus?.models as any)?.features?.diarization as
+    | { available: boolean; reason: string }
+    | undefined;
   const [activeTab, setActiveTab] = useState('App');
   const { confirm, dialog: confirmDialog } = useConfirm();
   const [showAuthToken, setShowAuthToken] = useState(false);
@@ -1399,18 +1403,17 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
       </Section>
 
       <Section title="HuggingFace Token">
-        <p className="mb-3 text-xs text-slate-400">
-          Required for speaker diarization. Accept the{' '}
-          <a
-            href="https://huggingface.co/pyannote/speaker-diarization-3.1"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-accent-cyan hover:underline"
-          >
-            PyAnnote model terms
-          </a>{' '}
-          on HuggingFace, then paste your token here.
-        </p>
+        <div className="mb-3">
+          <HfTokenExplainer
+            onOpenLink={(url) => {
+              if (window.electronAPI?.app?.openExternal) {
+                void window.electronAPI.app.openExternal(url);
+              } else {
+                window.open(url, '_blank', 'noopener');
+              }
+            }}
+          />
+        </div>
         <div className="relative">
           <input
             type={showHfToken ? 'text' : 'password'}
@@ -1430,6 +1433,17 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
         {clientSettings.hfToken && (
           <p className="mt-1.5 text-xs text-green-400/70">
             Token will be passed to the container on next start.
+          </p>
+        )}
+        {diarizationFeature && (
+          <p
+            className={`mt-1.5 text-xs ${diarizationFeature.available ? 'text-green-400/70' : 'text-amber-400/70'}`}
+          >
+            {diarizationFeature.available
+              ? 'Diarization is available on the running server.'
+              : diarizationFeature.reason === 'token_missing'
+                ? 'Diarization is currently unavailable: the running server has no token. Changes here apply on the next server start.'
+                : 'Diarization is currently unavailable on the running server.'}
           </p>
         )}
       </Section>

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.3.0",
-  "contract_sha256": "444a7c665a71cc83351b46a2361f73760959c1871c28cbda79b2c98c396018d6",
-  "updated_at": "2026-07-14T13:09:34.100Z"
+  "spec_version": "1.4.0",
+  "contract_sha256": "92c79450c39f2f68bee0946e5c5a06b43393e7603627625c1f1e5d462f9a4867",
+  "updated_at": "2026-07-14T13:33:14.538Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.3.0
+  spec_version: 1.4.0
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -11,6 +11,7 @@ meta:
       - components/__tests__/AddNoteModal.canary-language.test.tsx
       - components/__tests__/AddNoteModal.initialFiles.test.tsx
       - components/__tests__/AudioVisualizer.test.tsx
+      - components/__tests__/HfTokenExplainer.test.tsx
       - components/__tests__/LogsView.test.tsx
       - components/__tests__/NotebookView.canary-language.test.tsx
       - components/__tests__/NotebookView.profile-id.test.tsx
@@ -62,6 +63,7 @@ meta:
       - components/ui/CustomSelect.tsx
       - components/ui/ErrorFallback.tsx
       - components/ui/GlassCard.tsx
+      - components/ui/HfTokenExplainer.tsx
       - components/ui/icons/AmdIcon.tsx
       - components/ui/icons/AppleIcon.tsx
       - components/ui/icons/IntelIcon.tsx
@@ -105,7 +107,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-07-14T13:09:20.706Z
+    generated_at: 2026-07-14T13:32:05.693Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -2083,6 +2085,23 @@ component_contracts:
         rule: Do not introduce unregistered utility, arbitrary, or inline style values.
   Harness:
     file: components/editor/FindReplaceTextEditor.test.tsx
+    required_tokens:
+      - colors
+      - motion
+      - radii
+      - shadows
+    allowed_variants: {}
+    structural_invariants:
+      - id: structure-stable
+        rule: Preserve current structural layout and region hierarchy for this component.
+    behavior_rules:
+      - id: motion-locked
+        rule: Use only approved motion tokens and classes from foundation token registry.
+    state_rules:
+      - id: closed-set-styles
+        rule: Do not introduce unregistered utility, arbitrary, or inline style values.
+  HfTokenExplainer:
+    file: components/ui/HfTokenExplainer.tsx
     required_tokens:
       - colors
       - motion


### PR DESCRIPTION
Addresses #208

## Gap

Both token-entry surfaces (the first-run "Optional Diarization Setup" modal in App.tsx and the Settings > HuggingFace Token section) had one bare link and no explanation of why the token is needed, that a free read-only token suffices, that inference runs locally after the one-time download, or that VibeVoice/SenseVoice (CAM++) diarizers need no token. The Settings link was also stale: it pointed at pyannote/speaker-diarization-3.1, while the server actually loads pyannote/speaker-diarization-community-1 (diarization_engine.py default).

## Changes

- New shared presentational component `dashboard/components/ui/HfTokenExplainer.tsx` with the full explanation and two action links (accept model terms, create a read-only token), exported `HF_TERMS_URL`/`HF_TOKENS_URL` constants.
- First-run modal (App.tsx) keeps its intro lines and renders the shared explainer via the existing `openExternal` helper; the local `HF_TERMS_URL` const moved into the component.
- SettingsModal renders the same explainer (fixing the stale terms URL) and opens links through `window.electronAPI.app.openExternal` with a `window.open` fallback, matching App.tsx behavior instead of the previous raw `<a target="_blank">`.
- Live availability line under the token input, driven by `models.features.diarization` from /api/admin/status (same pattern as the existing MLX feature check in the file), including the "applies on next server start" caveat when the running server has no token.
- ui-contract rebaselined at spec_version 1.4.0 for the new component.

## Deviations from the plan

- The plan's test used `getByText(/read.?only/i)`, which throws on multiple matches (the copy intentionally says "read-only" twice); adapted to `getAllByText`. Component copy and behavior are exactly as specified.
- The plan's baseline command path `ui-contract/validate-contract.mjs` is stale; the script lives at `scripts/ui-contract/validate-contract.mjs`.
- Includes a small docs chore commit refreshing the GitNexus guidance blocks in AGENTS.md/CLAUDE.md (pre-staged housekeeping riding along).

## Test plan

- `npx vitest run components/__tests__/HfTokenExplainer.test.tsx` - 2/2 pass (copy coverage + both links)
- `npm test` (dashboard, Node 22) - 107 files / 1662 tests pass
- `npx tsc --noEmit` - clean
- ui-contract: extract -> build -> spec_version bump to 1.4.0 -> --update-baseline -> `npm run ui:contract:check` - green (16 checks)