### PR TITLE
fix(dashboard): disable diarization toggle when server lacks an HF token (GH-209)

### DIFF
--- a/dashboard/components/__tests__/SessionImportTab.diarization-gate.test.tsx
+++ b/dashboard/components/__tests__/SessionImportTab.diarization-gate.test.tsx
@@ -1,0 +1,255 @@
+/**
+ * SessionImportTab — diarization feature gating (GH-209)
+ *
+ * The server computes models.features.diarization = {available, reason} once
+ * at startup and exposes it via /api/admin/status. Before GH-209 the Speaker
+ * Diarization toggle defaulted to ON with zero awareness of that flag, so a
+ * server without a HuggingFace token silently skipped diarization on every
+ * job. These tests verify:
+ *
+ *   1. Feature available → switch enabled, ON by default, payload carries
+ *      enable_diarization: true.
+ *   2. Feature unavailable (token_missing) → switch disabled + OFF, the
+ *      "no HuggingFace token" explanation renders, payload is forced to
+ *      enable_diarization: false.
+ *   3. Admin status not loaded yet (feature undefined) → switch stays usable
+ *      (no false lockout while polling).
+ *   4. A completed job that requested diarization but could not perform it
+ *      shows "diarization skipped: no HF token" on its queue row.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const WHISPER_MODEL = 'openai/whisper-large-v3-turbo';
+
+// ── Hoisted mock state ────────────────────────────────────────────────────
+
+let mockDiarizationFeature: { available: boolean; reason: string } | undefined = {
+  available: true,
+  reason: 'ready',
+};
+
+let mockJobs: Array<Record<string, unknown>> = [];
+
+const mockToastError = vi.fn();
+const mockGetConfig = vi.fn();
+const mockAddFiles = vi.fn();
+
+vi.mock('../../src/hooks/useLanguages', () => ({
+  useLanguages: () => ({
+    languages: [
+      { code: 'auto', name: 'Auto Detect' },
+      { code: 'en', name: 'English' },
+    ],
+    backendType: 'whisper',
+    loading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('../../src/hooks/useAdminStatus', () => ({
+  useAdminStatus: () => ({
+    status: {
+      status: 'running',
+      models: { features: { diarization: mockDiarizationFeature } },
+      config: {
+        main_transcriber: { model: WHISPER_MODEL },
+        transcription: { model: WHISPER_MODEL },
+      },
+    },
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/hooks/useSessionWatcher', () => ({
+  useSessionWatcher: () => ({
+    sessionWatchPath: '',
+    sessionWatchActive: false,
+    setSessionWatchActive: vi.fn(),
+    setWatchPath: vi.fn(),
+    sessionWatchAccessible: true,
+  }),
+}));
+
+vi.mock('../../src/stores/importQueueStore', () => {
+  const fakeState: Record<string, unknown> = {
+    isPaused: false,
+    sessionConfig: {
+      outputDir: '',
+      diarizedFormat: 'srt',
+      hideTimestamps: false,
+      enableDiarization: true,
+      enableWordTimestamps: true,
+      parallelDiarization: false,
+      multitrack: false,
+    },
+    sessionWatchPath: '',
+    sessionWatchActive: false,
+    notebookWatchPath: '',
+    notebookWatchActive: false,
+    watcherServerConnected: true,
+    watchLog: [],
+    avgProcessingMs: 0,
+    addFiles: (...args: unknown[]) => mockAddFiles(...args),
+    removeJob: vi.fn(),
+    retryJob: vi.fn(),
+    clearFinished: vi.fn(),
+    pauseQueue: vi.fn(),
+    resumeQueue: vi.fn(),
+    updateSessionConfig: vi.fn(),
+    setLanguagesCache: vi.fn(),
+    clearWatchLog: vi.fn(),
+  };
+  return {
+    useImportQueueStore: (selector?: (s: Record<string, unknown>) => unknown) => {
+      const state = { ...fakeState, jobs: mockJobs };
+      return typeof selector === 'function' ? selector(state) : state;
+    },
+    selectSessionJobs: (s: { jobs: unknown[] }) => s.jobs,
+    selectPendingCount: () => 0,
+    selectCompletedCount: () => 0,
+    selectErrorCount: () => 0,
+    selectIsProcessing: () => false,
+  };
+});
+
+vi.mock('../../src/api/client', () => ({
+  apiClient: {
+    getAdminStatus: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock('../../src/config/store', () => ({
+  getConfig: (...args: unknown[]) => mockGetConfig(...args),
+  setConfig: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/utils/transcriptionBackend', () => ({
+  supportsExplicitWordTimestampToggle: () => true,
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: (...args: unknown[]) => mockToastError(...args),
+    warning: vi.fn(),
+  },
+}));
+
+import { SessionImportTab } from '../views/SessionImportTab';
+
+function buildFile(name = 'sample.mp3'): File {
+  return new File([new Uint8Array([0])], name, { type: 'audio/mpeg' });
+}
+
+function dropFile(file: File): { dataTransfer: { files: FileList } } {
+  const list = {
+    0: file,
+    length: 1,
+    item: (i: number) => (i === 0 ? file : null),
+    [Symbol.iterator]: function* () {
+      yield file;
+    },
+  } as unknown as FileList;
+  return { dataTransfer: { files: list } };
+}
+
+async function flushMountEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('SessionImportTab diarization gating (GH-209)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockToastError.mockReset();
+    mockAddFiles.mockReset();
+    mockGetConfig.mockReset();
+    mockGetConfig.mockResolvedValue(undefined);
+    mockJobs = [];
+    mockDiarizationFeature = { available: true, reason: 'ready' };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as unknown as { electronAPI?: any }).electronAPI = {
+      fileIO: {
+        getDownloadsPath: vi.fn().mockResolvedValue('/tmp'),
+        selectFolder: vi.fn().mockResolvedValue(null),
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+  });
+
+  it('renders the Speaker Diarization switch enabled and ON when the feature is available', async () => {
+    mockDiarizationFeature = { available: true, reason: 'ready' };
+    const { container } = render(React.createElement(SessionImportTab));
+    await flushMountEffects();
+
+    const toggle = screen.getByRole('switch', { name: /speaker diarization/i });
+    expect(toggle).not.toBeDisabled();
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+
+    const dropZone = container.querySelector('.cursor-pointer');
+    await act(async () => {
+      fireEvent.drop(dropZone as Element, dropFile(buildFile()));
+    });
+    expect(mockAddFiles).toHaveBeenCalledWith(
+      expect.anything(),
+      'session-normal',
+      expect.objectContaining({ enable_diarization: true }),
+    );
+  });
+
+  it('renders the switch disabled and OFF when reason=token_missing, and sends enable_diarization: false', async () => {
+    mockDiarizationFeature = { available: false, reason: 'token_missing' };
+    const { container } = render(React.createElement(SessionImportTab));
+    await flushMountEffects();
+
+    const toggle = screen.getByRole('switch', { name: /speaker diarization/i });
+    expect(toggle).toBeDisabled();
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+    expect(screen.getByText(/no huggingface token/i)).toBeInTheDocument();
+
+    const dropZone = container.querySelector('.cursor-pointer');
+    await act(async () => {
+      fireEvent.drop(dropZone as Element, dropFile(buildFile()));
+    });
+    expect(mockAddFiles).toHaveBeenCalledWith(
+      expect.anything(),
+      'session-normal',
+      expect.objectContaining({ enable_diarization: false }),
+    );
+  });
+
+  it('leaves the switch usable while admin status has not loaded yet (feature undefined)', async () => {
+    mockDiarizationFeature = undefined;
+    render(React.createElement(SessionImportTab));
+    await flushMountEffects();
+
+    const toggle = screen.getByRole('switch', { name: /speaker diarization/i });
+    expect(toggle).not.toBeDisabled();
+  });
+
+  it('labels a completed job whose diarization was requested but skipped', async () => {
+    mockJobs = [
+      {
+        id: 'session-normal-1',
+        file: buildFile('meeting.mp3'),
+        type: 'session-normal',
+        status: 'success',
+        outputFilename: 'meeting.srt',
+        outputPath: '/tmp/meeting.srt',
+        diarizationOutcome: { requested: true, performed: false, reason: 'token_missing' },
+      },
+    ];
+    render(React.createElement(SessionImportTab));
+    await flushMountEffects();
+
+    expect(screen.getByText(/diarization skipped: no HF token/i)).toBeInTheDocument();
+  });
+});

--- a/dashboard/components/ui/AppleSwitch.tsx
+++ b/dashboard/components/ui/AppleSwitch.tsx
@@ -43,6 +43,7 @@ export const AppleSwitch: React.FC<AppleSwitchProps> = ({
         type="button"
         role="switch"
         aria-checked={checked}
+        aria-label={label}
         disabled={disabled}
         onClick={() => {
           if (!disabled) onChange(!checked);

--- a/dashboard/components/views/NotebookView.tsx
+++ b/dashboard/components/views/NotebookView.tsx
@@ -1567,6 +1567,15 @@ const ImportTab = ({
     adminStatus?.config?.main_transcriber?.model ??
     adminStatus?.config?.transcription?.model ??
     null;
+
+  // GH-209: gate the diarization toggle on the server-side feature flag
+  // (computed once at container startup — adding a token needs a restart).
+  const diarizationFeature = (adminStatus?.models as any)?.features?.diarization as
+    | { available: boolean; reason: string }
+    | undefined;
+  const diarizationUnavailable = diarizationFeature?.available === false;
+  const effectiveDiarization = diarizationUnavailable ? false : diarization;
+
   const { languages, loading: languagesLoading } = useLanguages(activeModel);
   const isCanaryMainBidi = isCanaryModel(activeModel) && mainLanguage === 'English';
   const canTranslate = supportsTranslation(activeModel);
@@ -1629,12 +1638,18 @@ const ImportTab = ({
   // handleFiles.
   useEffect(() => {
     updateNotebookConfig({
-      enableDiarization: diarization,
+      enableDiarization: effectiveDiarization,
       enableWordTimestamps: wordTimestamps,
       parallelDiarization,
       language: mainLanguage,
     });
-  }, [diarization, wordTimestamps, parallelDiarization, mainLanguage, updateNotebookConfig]);
+  }, [
+    effectiveDiarization,
+    wordTimestamps,
+    parallelDiarization,
+    mainLanguage,
+    updateNotebookConfig,
+  ]);
 
   // gh-102 #3 — push useLanguages() results into the global languagesCache so
   // handleFilesDetected (a non-React store action) can resolve display name →
@@ -1702,9 +1717,9 @@ const ImportTab = ({
         language: resolvedLang,
         translation_enabled: mainTranslateActive ? true : undefined,
         translation_target_language: mainTranslateActive ? mainTranslateTarget : undefined,
-        enable_diarization: diarization,
+        enable_diarization: effectiveDiarization,
         enable_word_timestamps: supportsExplicitWordTimestampToggle ? wordTimestamps : true,
-        parallel_diarization: diarization ? parallelDiarization : undefined,
+        parallel_diarization: effectiveDiarization ? parallelDiarization : undefined,
         // Sprint 4 deferred-work no. 2 — pass undefined (not null) when no
         // active profile is set so apiClient.uploadAndTranscribe's `!= null`
         // guard correctly omits the FormData field.
@@ -1724,7 +1739,7 @@ const ImportTab = ({
     [
       addFiles,
       activeProfileId,
-      diarization,
+      effectiveDiarization,
       parallelDiarization,
       supportsExplicitWordTimestampToggle,
       wordTimestamps,
@@ -1778,8 +1793,15 @@ const ImportTab = ({
       }
       case 'writing':
         return 'Saving file...';
-      case 'success':
-        return `Done — ID ${job.result?.recording_id}`;
+      case 'success': {
+        const diar = job.diarizationOutcome;
+        const skipped = !!diar?.requested && !diar?.performed;
+        const base = `Done — ID ${job.result?.recording_id}`;
+        if (!skipped) return base;
+        const why =
+          diar?.reason === 'token_missing' ? 'no HF token' : (diar?.reason ?? 'unavailable');
+        return `${base} (diarization skipped: ${why})`;
+      }
       case 'error':
         return job.error ?? 'Failed';
     }
@@ -2054,12 +2076,19 @@ const ImportTab = ({
       <GlassCard title="Import Options">
         <div className="space-y-4">
           <AppleSwitch
-            checked={diarization}
+            checked={effectiveDiarization}
             onChange={handleDiarizationChange}
+            disabled={diarizationUnavailable}
             label="Speaker Diarization"
-            description="Identify distinct speakers in the audio"
+            description={
+              diarizationUnavailable
+                ? diarizationFeature?.reason === 'token_missing'
+                  ? 'Unavailable: no HuggingFace token configured. Add one in Settings, then restart the server.'
+                  : 'Unavailable on this server.'
+                : 'Identify distinct speakers in the audio'
+            }
           />
-          {diarization && (
+          {effectiveDiarization && (
             <>
               <div className="h-px bg-white/5"></div>
               <div className="pl-1">

--- a/dashboard/components/views/SessionImportTab.tsx
+++ b/dashboard/components/views/SessionImportTab.tsx
@@ -104,6 +104,17 @@ export const SessionImportTab: React.FC = () => {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const admin = useAdminStatus();
+
+  // GH-209: gate the diarization toggle on the server-side feature flag.
+  // Computed ONCE at container startup (ModelManager._initialize_diarization_
+  // feature_status) — adding a token in Settings requires a server restart.
+  const diarizationFeature = (admin.status?.models as any)?.features?.diarization as
+    | { available: boolean; reason: string }
+    | undefined;
+  const diarizationUnavailable = diarizationFeature?.available === false;
+  // Effective value: forced OFF when the server says the feature is unavailable.
+  const effectiveDiarization = diarizationUnavailable ? false : diarization;
+
   const activeModel: string | null =
     admin.status?.config?.main_transcriber?.model ??
     admin.status?.config?.transcription?.model ??
@@ -219,7 +230,7 @@ export const SessionImportTab: React.FC = () => {
       outputDir,
       diarizedFormat,
       hideTimestamps,
-      enableDiarization: diarization,
+      enableDiarization: effectiveDiarization,
       enableWordTimestamps: wordTimestamps,
       parallelDiarization,
       multitrack,
@@ -229,7 +240,7 @@ export const SessionImportTab: React.FC = () => {
     outputDir,
     diarizedFormat,
     hideTimestamps,
-    diarization,
+    effectiveDiarization,
     wordTimestamps,
     parallelDiarization,
     multitrack,
@@ -333,9 +344,9 @@ export const SessionImportTab: React.FC = () => {
         language: resolvedLang,
         translation_enabled: mainTranslateActive ? true : undefined,
         translation_target_language: mainTranslateActive ? mainTranslateTarget : undefined,
-        enable_diarization: multitrack ? false : diarization,
+        enable_diarization: multitrack ? false : effectiveDiarization,
         enable_word_timestamps: supportsExplicitWordTimestampToggle ? wordTimestamps : true,
-        parallel_diarization: diarization && !multitrack ? parallelDiarization : undefined,
+        parallel_diarization: effectiveDiarization && !multitrack ? parallelDiarization : undefined,
         multitrack: multitrack || undefined,
       });
 
@@ -351,7 +362,7 @@ export const SessionImportTab: React.FC = () => {
     },
     [
       addFiles,
-      diarization,
+      effectiveDiarization,
       multitrack,
       parallelDiarization,
       supportsExplicitWordTimestampToggle,
@@ -456,8 +467,15 @@ export const SessionImportTab: React.FC = () => {
       }
       case 'writing':
         return 'Saving file...';
-      case 'success':
-        return job.outputFilename ? `Done — ${job.outputFilename}` : 'Done';
+      case 'success': {
+        const diar = job.diarizationOutcome;
+        const skipped = !!diar?.requested && !diar?.performed;
+        const base = job.outputFilename ? `Done — ${job.outputFilename}` : 'Done';
+        if (!skipped) return base;
+        const why =
+          diar?.reason === 'token_missing' ? 'no HF token' : (diar?.reason ?? 'unavailable');
+        return `${base} (diarization skipped: ${why})`;
+      }
       case 'error':
         return job.error ?? 'Failed';
     }
@@ -769,16 +787,21 @@ export const SessionImportTab: React.FC = () => {
       <GlassCard title="Import Options">
         <div className="space-y-4">
           <AppleSwitch
-            checked={diarization}
+            checked={effectiveDiarization}
             onChange={handleDiarizationChange}
+            disabled={diarizationUnavailable}
             label="Speaker Diarization"
             description={
-              hideTimestamps
-                ? 'Identify distinct speakers — output saved as .txt (timestamps disabled in Settings)'
-                : 'Identify distinct speakers — output saved as a subtitle file with speaker labels'
+              diarizationUnavailable
+                ? diarizationFeature?.reason === 'token_missing'
+                  ? 'Unavailable: no HuggingFace token configured. Add one in Settings, then restart the server.'
+                  : 'Unavailable on this server.'
+                : hideTimestamps
+                  ? 'Identify distinct speakers — output saved as .txt (timestamps disabled in Settings)'
+                  : 'Identify distinct speakers — output saved as a subtitle file with speaker labels'
             }
           />
-          {diarization && (
+          {effectiveDiarization && (
             <>
               <div className="h-px bg-white/5"></div>
               <div className="flex items-center justify-between gap-4 pl-1">

--- a/dashboard/src/stores/importQueueStore.ts
+++ b/dashboard/src/stores/importQueueStore.ts
@@ -42,6 +42,8 @@ export interface UnifiedImportJob {
   outputFilename?: string;
   /** Notebook jobs: server result */
   result?: UploadResponse;
+  /** Diarization outcome from the server result (GH-209): shown when requested but not performed. */
+  diarizationOutcome?: { requested: boolean; performed: boolean; reason: string | null };
   error?: string;
 }
 
@@ -408,7 +410,15 @@ async function processSessionJob(
 
   store.setState((s) => ({
     jobs: s.jobs.map((j) =>
-      j.id === job.id ? { ...j, status: 'success' as const, outputPath, outputFilename } : j,
+      j.id === job.id
+        ? {
+            ...j,
+            status: 'success' as const,
+            outputPath,
+            outputFilename,
+            ...(result.diarization ? { diarizationOutcome: result.diarization } : {}),
+          }
+        : j,
     ),
   }));
 }
@@ -446,7 +456,14 @@ async function processNotebookJob(
 
   store.setState((s) => ({
     jobs: s.jobs.map((j) =>
-      j.id === job.id ? { ...j, status: 'success' as const, result: uploadResult } : j,
+      j.id === job.id
+        ? {
+            ...j,
+            status: 'success' as const,
+            result: uploadResult,
+            diarizationOutcome: result.diarization ?? undefined,
+          }
+        : j,
     ),
   }));
 

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.4.0",
-  "contract_sha256": "92c79450c39f2f68bee0946e5c5a06b43393e7603627625c1f1e5d462f9a4867",
-  "updated_at": "2026-07-14T13:33:14.538Z"
+  "spec_version": "1.4.1",
+  "contract_sha256": "905aac895de9715a8667401d1217e58d38aebbe07f1d8cc1aca065d8ff0351f7",
+  "updated_at": "2026-07-14T13:48:15.075Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.4.0
+  spec_version: 1.4.1
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -18,6 +18,7 @@ meta:
       - components/__tests__/NotebookView.test.tsx
       - components/__tests__/ServerView.test.tsx
       - components/__tests__/SessionImportTab.canary-language.test.tsx
+      - components/__tests__/SessionImportTab.diarization-gate.test.tsx
       - components/__tests__/SessionView.canary-language.test.tsx
       - components/__tests__/SessionView.test.tsx
       - components/__tests__/StartupActivityInline.test.tsx
@@ -107,7 +108,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-07-14T13:32:05.693Z
+    generated_at: 2026-07-14T13:47:48.029Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -510,6 +511,7 @@ utility_allowlist:
     - animate-ping
     - animate-pulse
     - aria-activedescendant
+    - aria-checked
     - aria-invalid
     - aria-label
     - aria-labels


### PR DESCRIPTION
Addresses #209

## Root cause

`SessionImportTab` and `NotebookView`'s ImportTab both hardcoded `useState(true)` for the Speaker Diarization toggle with zero awareness of the server's feature state. The server already computes the exact signal needed - `models.features.diarization = {available, reason}` in `/api/admin/status` - and when a diarization-enabled job runs with no HuggingFace token it silently completes WITHOUT diarization, recording `{requested: true, performed: false, reason: 'token_missing'}` in the result. The dashboard captured that outcome on the notebook path but never rendered it anywhere, and dropped it entirely on the session path.

## Fix (dashboard only, no server changes)

- Gate the toggle on `models.features.diarization` in both components: when `available === false` the switch renders disabled and OFF with an explanation (including the restart-required caveat, since the flag is computed once at container startup), and `enable_diarization: false` is forced into request payloads and the Folder Watch config bridge. The raw toggle state is kept as the user's preference so it springs back if the server gains a token.
- New `UnifiedImportJob.diarizationOutcome` field, populated on BOTH the session path (`processSessionJob`, which previously discarded `result.diarization`) and the notebook path. Completed jobs that requested diarization but could not perform it now show `Done - <file> (diarization skipped: no HF token)` on their queue row.
- `AppleSwitch` now sets `aria-label` from its `label` prop - it previously had no accessible name, so no switch in the app was selectable by role. Strict accessibility improvement.
- ui-contract rebaselined (spec_version 1.4.1): the new test file introduces the `aria-checked` token into the scanned utility allowlist.

## Deferred (sanctioned by the plan)

The store-level test asserting `processSessionJob` copies `result.diarization` onto the job is deferred to issue #212's Task 212.2, which builds the (currently nonexistent) `processSessionJob` test scaffold. The behavior is covered indirectly by the component-level skipped-label test.

## Test plan

- `npx vitest run components/__tests__/SessionImportTab.diarization-gate.test.tsx` - 4/4 pass (available, token_missing, admin-status-not-loaded, skipped-outcome label); failed before the fix as required by TDD.
- `npm test` (dashboard, Node 22) - 108 files / 1666 tests, all green.
- `npx tsc --noEmit` - clean.
- `npm run ui:contract:check` - schema + semantic valid, 16 checks pass after rebaseline.