### PR TITLE
fix(dashboard): explicit txt/srt/both output selector for session imports (GH-212)

### DIFF
--- a/dashboard/components/__tests__/SessionImportTab.output-format.test.tsx
+++ b/dashboard/components/__tests__/SessionImportTab.output-format.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * SessionImportTab — explicit output-format selector (GH-212)
+ *
+ * The output format for Session imports used to be inferred from the global
+ * hideTimestamps setting, while the UI copy falsely claimed the Speaker
+ * Diarization toggle controlled it. These tests pin the decoupled design:
+ *
+ *   1. The "Output Format" select is always visible — even when the
+ *      diarization switch is OFF.
+ *   2. Selecting "Plain text (.txt)" hides the "Subtitle format" select;
+ *      selecting "Both" shows it.
+ *   3. A pending job stamped with plannedFormat renders `Queued (<format>)`.
+ *   4. The info note no longer claims diarization controls the format.
+ */
+
+import React from 'react';
+import { render, fireEvent, act, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const WHISPER_MODEL = 'openai/whisper-large-v3-turbo';
+
+// ── Hoisted mock state ────────────────────────────────────────────────────
+
+const mockGetConfig = vi.fn();
+const mockSetConfig = vi.fn();
+const mockAddFiles = vi.fn();
+
+interface MockJob {
+  id: string;
+  file: File | string;
+  type: string;
+  status: string;
+  plannedFormat?: string;
+}
+
+let mockJobs: MockJob[] = [];
+
+vi.mock('../../src/hooks/useLanguages', () => ({
+  useLanguages: () => ({
+    languages: [
+      { code: 'auto', name: 'Auto Detect' },
+      { code: 'en', name: 'English' },
+    ],
+    backendType: 'whisper',
+    loading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('../../src/hooks/useAdminStatus', () => ({
+  useAdminStatus: () => ({
+    status: {
+      models_loaded: true,
+      models: { features: { diarization: { available: true, reason: 'ready' } } },
+      config: {
+        main_transcriber: { model: WHISPER_MODEL },
+        transcription: { model: WHISPER_MODEL },
+      },
+    },
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/hooks/useSessionWatcher', () => ({
+  useSessionWatcher: () => ({
+    sessionWatchPath: '',
+    sessionWatchActive: false,
+    setSessionWatchActive: vi.fn(),
+    setWatchPath: vi.fn(),
+    sessionWatchAccessible: true,
+  }),
+}));
+
+vi.mock('../../src/stores/importQueueStore', () => {
+  const fakeState: Record<string, unknown> = {
+    isPaused: false,
+    sessionConfig: {
+      outputDir: '',
+      diarizedFormat: 'srt',
+      outputFormat: 'subtitles',
+      hideTimestamps: false,
+      enableDiarization: true,
+      enableWordTimestamps: true,
+      parallelDiarization: false,
+      multitrack: false,
+    },
+    sessionWatchPath: '',
+    sessionWatchActive: false,
+    notebookWatchPath: '',
+    notebookWatchActive: false,
+    watcherServerConnected: true,
+    watchLog: [],
+    avgProcessingMs: 0,
+    addFiles: (...args: unknown[]) => mockAddFiles(...args),
+    removeJob: vi.fn(),
+    retryJob: vi.fn(),
+    clearFinished: vi.fn(),
+    pauseQueue: vi.fn(),
+    resumeQueue: vi.fn(),
+    updateSessionConfig: vi.fn(),
+    setLanguagesCache: vi.fn(),
+    clearWatchLog: vi.fn(),
+  };
+  return {
+    useImportQueueStore: (selector?: (s: Record<string, unknown>) => unknown) => {
+      const state = { ...fakeState, jobs: mockJobs };
+      return typeof selector === 'function' ? selector(state) : state;
+    },
+    // Reads the mutable module-level jobs so tests can vary the queue.
+    selectSessionJobs: () => mockJobs,
+    selectPendingCount: () => mockJobs.filter((j) => j.status === 'pending').length,
+    selectCompletedCount: () => 0,
+    selectErrorCount: () => 0,
+    selectIsProcessing: () => false,
+  };
+});
+
+vi.mock('../../src/api/client', () => ({
+  apiClient: {
+    getAdminStatus: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock('../../src/config/store', () => ({
+  getConfig: (...args: unknown[]) => mockGetConfig(...args),
+  setConfig: (...args: unknown[]) => {
+    mockSetConfig(...args);
+    return Promise.resolve(undefined);
+  },
+}));
+
+vi.mock('../../src/utils/transcriptionBackend', () => ({
+  supportsExplicitWordTimestampToggle: () => true,
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { SessionImportTab } from '../views/SessionImportTab';
+
+async function renderTab() {
+  const result = render(React.createElement(SessionImportTab));
+  // Wait for mount-time getConfig promises to resolve.
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return result;
+}
+
+function outputFormatSelect(): HTMLSelectElement {
+  return screen.getByRole('combobox', { name: /output format/i }) as HTMLSelectElement;
+}
+
+function querySubtitleFormatSelect(): HTMLSelectElement | null {
+  return screen.queryByRole('combobox', { name: /subtitle format/i }) as HTMLSelectElement | null;
+}
+
+describe('SessionImportTab — explicit output-format selector (GH-212)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetConfig.mockReset();
+    mockSetConfig.mockReset();
+    mockAddFiles.mockReset();
+    mockJobs = [];
+
+    // Default: no persisted config keys.
+    mockGetConfig.mockResolvedValue(undefined);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as unknown as { electronAPI?: any }).electronAPI = {
+      fileIO: {
+        getDownloadsPath: vi.fn().mockResolvedValue('/tmp'),
+        selectFolder: vi.fn().mockResolvedValue(null),
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+  });
+
+  it('shows the Output Format select even when the diarization switch is OFF', async () => {
+    await renderTab();
+
+    const diarizationSwitch = screen.getByRole('switch', { name: /speaker diarization/i });
+    expect(diarizationSwitch).toHaveAttribute('aria-checked', 'true');
+
+    await act(async () => {
+      fireEvent.click(diarizationSwitch);
+    });
+
+    expect(diarizationSwitch).toHaveAttribute('aria-checked', 'false');
+    expect(outputFormatSelect()).toBeInTheDocument();
+  });
+
+  it('hides the Subtitle format select for Plain text and shows it for Both', async () => {
+    await renderTab();
+
+    // Default 'subtitles' → the subtitle-flavor select is visible.
+    expect(querySubtitleFormatSelect()).not.toBeNull();
+
+    await act(async () => {
+      fireEvent.change(outputFormatSelect(), { target: { value: 'txt' } });
+    });
+    expect(querySubtitleFormatSelect()).toBeNull();
+
+    await act(async () => {
+      fireEvent.change(outputFormatSelect(), { target: { value: 'both' } });
+    });
+    expect(querySubtitleFormatSelect()).not.toBeNull();
+  });
+
+  it('persists the selection under sessionImport.outputFormat', async () => {
+    await renderTab();
+
+    await act(async () => {
+      fireEvent.change(outputFormatSelect(), { target: { value: 'txt' } });
+    });
+
+    expect(mockSetConfig).toHaveBeenCalledWith('sessionImport.outputFormat', 'txt');
+  });
+
+  it('renders Queued (<format>) on a pending job stamped with plannedFormat', async () => {
+    mockJobs = [
+      {
+        id: 'job-1',
+        file: new File([new Uint8Array([0])], 'memo.m4a', { type: 'audio/mp4' }),
+        type: 'session-normal',
+        status: 'pending',
+        plannedFormat: '.srt',
+      },
+    ];
+
+    await renderTab();
+
+    expect(screen.getByText('Queued (.srt)')).toBeInTheDocument();
+  });
+
+  it('no longer claims diarization controls the output format', async () => {
+    const { container } = await renderTab();
+
+    expect(container.textContent).not.toContain('when diarization is enabled');
+  });
+});

--- a/dashboard/components/views/SessionImportTab.tsx
+++ b/dashboard/components/views/SessionImportTab.tsx
@@ -30,6 +30,7 @@ import {
   selectIsProcessing,
 } from '../../src/stores/importQueueStore';
 import type { UnifiedImportJob } from '../../src/stores/importQueueStore';
+import type { SessionOutputFormat } from '../../src/services/transcriptionFormatters';
 import { useAdminStatus } from '../../src/hooks/useAdminStatus';
 import { useLanguages } from '../../src/hooks/useLanguages';
 import { apiClient } from '../../src/api/client';
@@ -88,6 +89,7 @@ export const SessionImportTab: React.FC = () => {
   const [outputDir, setOutputDir] = useState('');
   const [diarization, setDiarization] = useState(true);
   const [diarizedFormat, setDiarizedFormat] = useState<'srt' | 'ass'>('srt');
+  const [outputFormat, setOutputFormat] = useState<SessionOutputFormat>('subtitles');
   const [wordTimestamps, setWordTimestamps] = useState(true);
   const [hideTimestamps, setHideTimestamps] = useState(false);
   const [parallelDiarization, setParallelDiarization] = useState<boolean>(false);
@@ -147,6 +149,17 @@ export const SessionImportTab: React.FC = () => {
       const electronAPI = (window as any).electronAPI;
 
       getConfig<boolean>('output.hideTimestamps').then((v) => setHideTimestamps(v ?? false));
+
+      // GH-212: explicit output format. Default preserves pre-selector
+      // behavior: txt when the global hideTimestamps was on, else subtitles.
+      getConfig<SessionOutputFormat>('sessionImport.outputFormat').then(async (v) => {
+        if (v) {
+          setOutputFormat(v);
+          return;
+        }
+        const hide = (await getConfig<boolean>('output.hideTimestamps')) ?? false;
+        setOutputFormat(hide ? 'txt' : 'subtitles');
+      });
 
       // Try to load persisted output dir from config
       const savedDir = await getConfig('sessionImport.outputDir');
@@ -229,6 +242,7 @@ export const SessionImportTab: React.FC = () => {
     updateSessionConfig({
       outputDir,
       diarizedFormat,
+      outputFormat,
       hideTimestamps,
       enableDiarization: effectiveDiarization,
       enableWordTimestamps: wordTimestamps,
@@ -239,6 +253,7 @@ export const SessionImportTab: React.FC = () => {
   }, [
     outputDir,
     diarizedFormat,
+    outputFormat,
     hideTimestamps,
     effectiveDiarization,
     wordTimestamps,
@@ -457,7 +472,7 @@ export const SessionImportTab: React.FC = () => {
   const statusLabel = (job: UnifiedImportJob) => {
     switch (job.status) {
       case 'pending':
-        return 'Queued';
+        return job.plannedFormat ? `Queued (${job.plannedFormat})` : 'Queued';
       case 'processing': {
         const progress = (admin.status?.models as any)?.job_tracker?.progress;
         if (progress?.total > 0) {
@@ -777,15 +792,55 @@ export const SessionImportTab: React.FC = () => {
       <div className="flex items-start gap-2 rounded-lg bg-white/5 px-3 py-2.5">
         <Info size={14} className="mt-0.5 shrink-0 text-slate-500" />
         <p className="text-xs leading-relaxed text-slate-500">
-          {hideTimestamps
-            ? 'Transcriptions are saved as .txt (plain text) to the output folder. Timestamp output is disabled in Settings.'
-            : 'Transcriptions are saved as .txt (plain text) or .srt/.ass (subtitles with speaker labels when diarization is enabled) to the output folder.'}
+          {outputFormat === 'txt'
+            ? 'Transcriptions are saved as .txt (plain text) to the output folder.'
+            : outputFormat === 'both'
+              ? `Transcriptions are saved as .txt plus .${diarizedFormat} to the output folder.`
+              : `Transcriptions are saved as .${diarizedFormat} subtitles to the output folder.`}
         </p>
       </div>
 
       {/* Import Options */}
       <GlassCard title="Import Options">
         <div className="space-y-4">
+          <div className="flex items-center justify-between gap-4 pl-1">
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-white">Output Format</p>
+              <p className="text-xs text-slate-400">Applies to every imported file</p>
+            </div>
+            <select
+              aria-label="Output Format"
+              value={outputFormat}
+              onChange={(e) => {
+                const v = e.target.value as SessionOutputFormat;
+                setOutputFormat(v);
+                void setConfig('sessionImport.outputFormat', v);
+              }}
+              className="focus:border-accent-cyan/50 shrink-0 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 text-sm text-white scheme-dark outline-none"
+            >
+              <option value="txt">Plain text (.txt)</option>
+              <option value="subtitles">Subtitles (.srt/.ass)</option>
+              <option value="both">Both</option>
+            </select>
+          </div>
+          {outputFormat !== 'txt' && (
+            <div className="flex items-center justify-between gap-4 pl-1">
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-white">Subtitle format</p>
+                <p className="text-xs text-slate-400">File type for subtitle output</p>
+              </div>
+              <select
+                aria-label="Subtitle format"
+                value={diarizedFormat}
+                onChange={(e) => setDiarizedFormat(e.target.value as 'srt' | 'ass')}
+                className="focus:border-accent-cyan/50 shrink-0 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 text-sm text-white scheme-dark outline-none"
+              >
+                <option value="srt">.srt</option>
+                <option value="ass">.ass</option>
+              </select>
+            </div>
+          )}
+          <div className="h-px bg-white/5"></div>
           <AppleSwitch
             checked={effectiveDiarization}
             onChange={handleDiarizationChange}
@@ -796,28 +851,11 @@ export const SessionImportTab: React.FC = () => {
                 ? diarizationFeature?.reason === 'token_missing'
                   ? 'Unavailable: no HuggingFace token configured. Add one in Settings, then restart the server.'
                   : 'Unavailable on this server.'
-                : hideTimestamps
-                  ? 'Identify distinct speakers — output saved as .txt (timestamps disabled in Settings)'
-                  : 'Identify distinct speakers — output saved as a subtitle file with speaker labels'
+                : 'Identify distinct speakers. Speaker labels appear in subtitle output; plain text output is unaffected.'
             }
           />
           {effectiveDiarization && (
             <>
-              <div className="h-px bg-white/5"></div>
-              <div className="flex items-center justify-between gap-4 pl-1">
-                <div className="min-w-0">
-                  <p className="text-sm font-medium text-white">Output Format</p>
-                  <p className="text-xs text-slate-400">Subtitle format for diarized output</p>
-                </div>
-                <select
-                  value={diarizedFormat}
-                  onChange={(e) => setDiarizedFormat(e.target.value as 'srt' | 'ass')}
-                  className="focus:border-accent-cyan/50 shrink-0 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 text-sm text-white scheme-dark outline-none"
-                >
-                  <option value="srt">.srt</option>
-                  <option value="ass">.ass</option>
-                </select>
-              </div>
               <div className="h-px bg-white/5"></div>
               <div className="pl-1">
                 <AppleSwitch

--- a/dashboard/src/services/transcriptionFormatters.test.ts
+++ b/dashboard/src/services/transcriptionFormatters.test.ts
@@ -7,6 +7,7 @@ import {
   renderAss,
   renderTxt,
   resolveTranscriptionOutput,
+  resolveTranscriptionOutputs,
 } from './transcriptionFormatters';
 
 /* ------------------------------------------------------------------ */
@@ -170,5 +171,55 @@ describe('resolveTranscriptionOutput', () => {
     });
     expect(result.outputFilename).toBe('recording.txt');
     expect(result.content).toBe('Hello world. Goodbye world.');
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  resolveTranscriptionOutputs — explicit format (GH-212)            */
+/* ------------------------------------------------------------------ */
+
+describe('resolveTranscriptionOutputs (explicit format, GH-212)', () => {
+  it('outputFormat=txt → single .txt file', () => {
+    const outs = resolveTranscriptionOutputs('memo.m4a', timedResponse, {
+      outputFormat: 'txt',
+      subtitleFormat: 'srt',
+    });
+    expect(outs).toHaveLength(1);
+    expect(outs[0].outputFilename).toBe('memo.txt');
+    expect(outs[0].content).toBe(timedResponse.text);
+  });
+
+  it('outputFormat=subtitles + srt → single .srt file', () => {
+    const outs = resolveTranscriptionOutputs('memo.m4a', timedResponse, {
+      outputFormat: 'subtitles',
+      subtitleFormat: 'srt',
+    });
+    expect(outs).toHaveLength(1);
+    expect(outs[0].outputFilename).toBe('memo.srt');
+  });
+
+  it('outputFormat=subtitles + ass → single .ass file', () => {
+    const outs = resolveTranscriptionOutputs('memo.m4a', timedResponse, {
+      outputFormat: 'subtitles',
+      subtitleFormat: 'ass',
+    });
+    expect(outs[0].outputFilename).toBe('memo.ass');
+  });
+
+  it('outputFormat=both → .txt AND subtitle file', () => {
+    const outs = resolveTranscriptionOutputs('memo.m4a', timedResponse, {
+      outputFormat: 'both',
+      subtitleFormat: 'srt',
+    });
+    expect(outs.map((o) => o.outputFilename)).toEqual(['memo.txt', 'memo.srt']);
+  });
+
+  it('falls back to .txt only when the response has no usable segments, regardless of format', () => {
+    const outs = resolveTranscriptionOutputs('memo.m4a', textOnlyResponse, {
+      outputFormat: 'subtitles',
+      subtitleFormat: 'srt',
+    });
+    expect(outs).toHaveLength(1);
+    expect(outs[0].outputFilename).toBe('memo.txt');
   });
 });

--- a/dashboard/src/services/transcriptionFormatters.ts
+++ b/dashboard/src/services/transcriptionFormatters.ts
@@ -173,3 +173,36 @@ export function resolveTranscriptionOutput(
 
   return { outputFilename: `${stem}.txt`, content: renderTxt(transcription) };
 }
+
+export type SessionOutputFormat = 'txt' | 'subtitles' | 'both';
+
+export interface ResolvedOutput {
+  outputFilename: string;
+  content: string;
+}
+
+/**
+ * Resolve one or more output files from an explicit, user-chosen format
+ * (GH-212). Replaces the implicit hideTimestamps/hasSegments inference for
+ * the Session import path. Falls back to .txt when the response carries no
+ * usable segments (nothing to build subtitle cues from).
+ */
+export function resolveTranscriptionOutputs(
+  filename: string,
+  transcription: TranscriptionResponse,
+  options: { outputFormat: SessionOutputFormat; subtitleFormat: 'srt' | 'ass' },
+): ResolvedOutput[] {
+  const stem = filename.replace(/\.[^.]+$/, '');
+  const txt: ResolvedOutput = { outputFilename: `${stem}.txt`, content: renderTxt(transcription) };
+
+  const hasSegments =
+    transcription.segments && transcription.segments.some((s) => s.text.trim().length > 0);
+  if (options.outputFormat === 'txt' || !hasSegments) return [txt];
+
+  const sub: ResolvedOutput = {
+    outputFilename: `${stem}.${options.subtitleFormat}`,
+    content:
+      options.subtitleFormat === 'ass' ? renderAss(transcription, stem) : renderSrt(transcription),
+  };
+  return options.outputFormat === 'both' ? [txt, sub] : [sub];
+}

--- a/dashboard/src/stores/importQueueStore.test.ts
+++ b/dashboard/src/stores/importQueueStore.test.ts
@@ -10,16 +10,19 @@ vi.mock('../api/client', () => ({
   },
 }));
 
-// Mock transcription formatters
-vi.mock('../services/transcriptionFormatters', () => ({
-  renderSrt: vi.fn(() => 'srt-content'),
-  renderAss: vi.fn(() => 'ass-content'),
-  renderTxt: vi.fn(() => 'txt-content'),
-  resolveTranscriptionOutput: vi.fn(() => ({
-    outputFilename: 'test.txt',
-    content: 'txt-content',
-  })),
-}));
+// Mock transcription formatters. resolveTranscriptionOutputs (GH-212) stays
+// REAL so the processSessionJob tests exercise genuine multi-file resolution;
+// only the legacy single-output resolver keeps its historical stub.
+vi.mock('../services/transcriptionFormatters', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/transcriptionFormatters')>();
+  return {
+    ...actual,
+    resolveTranscriptionOutput: vi.fn(() => ({
+      outputFilename: 'test.txt',
+      content: 'txt-content',
+    })),
+  };
+});
 
 // Mock sonner so the new gh-102 #3 tests can assert on toast.warning calls
 // without rendering. Existing tests don't assert on toast and stay unaffected.
@@ -46,6 +49,7 @@ Object.defineProperty(globalThis, 'window', {
 });
 
 import { toast } from 'sonner';
+import { apiClient } from '../api/client';
 import {
   useImportQueueStore,
   resolveDuplicateChoice,
@@ -70,6 +74,7 @@ function resetStore() {
     sessionConfig: {
       outputDir: '',
       diarizedFormat: 'srt',
+      outputFormat: 'subtitles',
       hideTimestamps: false,
       enableDiarization: true,
       enableWordTimestamps: true,
@@ -191,6 +196,34 @@ describe('importQueueStore', () => {
       options.enable_diarization = false;
 
       expect(getState().jobs[0].options?.enable_diarization).toBe(true);
+    });
+
+    // GH-212 — queued session jobs display the format chosen at enqueue time.
+    it('stamps plannedFormat on session jobs from the current sessionConfig', () => {
+      getState().updateSessionConfig({ outputFormat: 'both', diarizedFormat: 'srt' });
+      getState().addFiles([new File(['a'], 'memo.m4a')], 'session-normal');
+
+      expect(getState().jobs[0].plannedFormat).toBe('.txt + .srt');
+    });
+
+    it('stamps plannedFormat=.txt when the session format is plain text', () => {
+      getState().updateSessionConfig({ outputFormat: 'txt' });
+      getState().addFiles([new File(['a'], 'memo.m4a')], 'session-normal');
+
+      expect(getState().jobs[0].plannedFormat).toBe('.txt');
+    });
+
+    it('stamps the subtitle flavor when the session format is subtitles', () => {
+      getState().updateSessionConfig({ outputFormat: 'subtitles', diarizedFormat: 'ass' });
+      getState().addFiles([new File(['a'], 'memo.m4a')], 'session-normal');
+
+      expect(getState().jobs[0].plannedFormat).toBe('.ass');
+    });
+
+    it('does not stamp plannedFormat on notebook jobs', () => {
+      getState().addFiles([new File(['a'], 'note.mp3')], 'notebook-normal');
+
+      expect(getState().jobs[0].plannedFormat).toBeUndefined();
     });
   });
 
@@ -477,6 +510,111 @@ describe('importQueueStore', () => {
         fileMeta: [],
       });
       expect(getState().jobs).toHaveLength(0);
+    });
+
+    // GH-212 — Folder Watch enqueues via addFiles, so auto jobs inherit the
+    // plannedFormat stamp with no extra wiring.
+    it('stamps plannedFormat on session-auto jobs from the current sessionConfig', () => {
+      getState().updateSessionConfig({ outputFormat: 'txt' });
+      getState().handleFilesDetected({
+        type: 'session',
+        files: ['/watch/memo.wav'],
+        count: 1,
+        fileMeta: [],
+      });
+      expect(getState().jobs[0].plannedFormat).toBe('.txt');
+    });
+  });
+
+  // ── processSessionJob — explicit output formats (GH-212) ───────────────
+  //
+  // Drives the real queue end-to-end under fake timers: addFiles schedules
+  // processQueue via setTimeout(0); pollForSessionResult waits one
+  // POLL_INTERVAL_MS (5s) before reading the mocked job tracker; the queue
+  // loop sleeps 500ms after the job. A single 10s advance covers all three.
+
+  describe('processSessionJob — explicit output formats (GH-212)', () => {
+    const sessionTranscription = {
+      text: 'Hello world.',
+      segments: [{ text: 'Hello world.', start: 0, end: 1.5 }],
+      words: [],
+      language_probability: 0.99,
+      duration: 1.5,
+      num_speakers: 0,
+    };
+
+    let writeText: Mock;
+
+    beforeEach(() => {
+      writeText = vi.fn().mockResolvedValue(undefined);
+      (window as any).electronAPI = { fileIO: { writeText } };
+      vi.mocked(getConfig).mockReset();
+      vi.mocked(apiClient.importAndTranscribe).mockResolvedValue({
+        job_id: 'server-job-1',
+      } as never);
+    });
+
+    afterEach(() => {
+      delete (window as any).electronAPI;
+    });
+
+    function mockConfig(values: Record<string, unknown>) {
+      vi.mocked(getConfig).mockImplementation(
+        (key: string) => Promise.resolve(values[key]) as never,
+      );
+    }
+
+    function mockPollResult(result: Record<string, unknown>) {
+      vi.mocked(apiClient.getAdminStatus).mockResolvedValue({
+        models: { job_tracker: { is_busy: false, result: { job_id: 'server-job-1', ...result } } },
+      } as never);
+    }
+
+    async function runQueue() {
+      getState().updateSessionConfig({ outputDir: '/out' });
+      getState().addFiles([new File(['audio'], 'memo.m4a')], 'session-normal');
+      await vi.advanceTimersByTimeAsync(10_000);
+    }
+
+    it("writes .txt AND subtitle file when the stored format is 'both'", async () => {
+      mockConfig({ 'sessionImport.outputFormat': 'both', 'output.hideTimestamps': false });
+      mockPollResult({ transcription: sessionTranscription });
+
+      await runQueue();
+
+      expect(writeText).toHaveBeenCalledTimes(2);
+      expect(writeText).toHaveBeenCalledWith('/out/memo.txt', expect.any(String));
+      expect(writeText).toHaveBeenCalledWith('/out/memo.srt', expect.any(String));
+      const job = getState().jobs[0];
+      expect(job.status).toBe('success');
+      expect(job.outputFilename).toBe('memo.txt, memo.srt');
+      expect(job.outputPath).toBe('/out/memo.srt');
+    });
+
+    it('falls back to the hideTimestamps-derived default when no explicit format is stored', async () => {
+      mockConfig({ 'output.hideTimestamps': true });
+      mockPollResult({ transcription: sessionTranscription });
+
+      await runQueue();
+
+      expect(writeText).toHaveBeenCalledTimes(1);
+      expect(writeText).toHaveBeenCalledWith('/out/memo.txt', 'Hello world.');
+    });
+
+    it('copies result.diarization onto the job as diarizationOutcome (deferred from GH-209)', async () => {
+      mockConfig({ 'sessionImport.outputFormat': 'txt' });
+      mockPollResult({
+        transcription: sessionTranscription,
+        diarization: { requested: true, performed: false, reason: 'token_missing' },
+      });
+
+      await runQueue();
+
+      expect(getState().jobs[0].diarizationOutcome).toEqual({
+        requested: true,
+        performed: false,
+        reason: 'token_missing',
+      });
     });
   });
 

--- a/dashboard/src/stores/importQueueStore.ts
+++ b/dashboard/src/stores/importQueueStore.ts
@@ -16,7 +16,10 @@ import type {
   UploadResponse,
   DedupMatch,
 } from '../api/types';
-import { resolveTranscriptionOutput } from '../services/transcriptionFormatters';
+import {
+  resolveTranscriptionOutputs,
+  type SessionOutputFormat,
+} from '../services/transcriptionFormatters';
 import { supportsAutoDetect } from '../services/modelCapabilities';
 import { getConfig } from '../config/store';
 import { useDedupChoiceStore } from './dedupChoiceStore';
@@ -44,12 +47,18 @@ export interface UnifiedImportJob {
   result?: UploadResponse;
   /** Diarization outcome from the server result (GH-209): shown when requested but not performed. */
   diarizationOutcome?: { requested: boolean; performed: boolean; reason: string | null };
+  /** Display-only: the output format chosen at enqueue time, e.g. ".srt" or ".txt + .srt" (GH-212) */
+  plannedFormat?: string;
   error?: string;
 }
 
 export interface SessionConfig {
   outputDir: string;
+  /** Subtitle flavor for subtitle output (GH-212: no longer coupled to diarization) */
   diarizedFormat: 'srt' | 'ass';
+  /** Explicit output selection for session imports (GH-212) */
+  outputFormat: SessionOutputFormat;
+  /** Retained for the non-format consumers (LiveTranscriptView, notebook flows, ...) */
   hideTimestamps: boolean;
   /** Toggles bridged from SessionImportTab so Folder Watch jobs honor them (Issue #93) */
   enableDiarization: boolean;
@@ -217,6 +226,21 @@ function filenameFromPath(filePath: string): string {
   return parts[parts.length - 1] || filePath;
 }
 
+/** Human-readable planned-format label stamped on queued session jobs (GH-212). */
+export function describePlannedFormat(
+  cfg: Pick<SessionConfig, 'outputFormat' | 'diarizedFormat'>,
+): string {
+  const sub = `.${cfg.diarizedFormat ?? 'srt'}`;
+  switch (cfg.outputFormat ?? 'subtitles') {
+    case 'txt':
+      return '.txt';
+    case 'both':
+      return `.txt + ${sub}`;
+    default:
+      return sub;
+  }
+}
+
 // ─── Duplicate resolution (GH-120) ───────────────────────────────────────────
 
 /** How Folder Watch (session-auto) jobs resolve a server-detected duplicate
@@ -382,14 +406,18 @@ async function processSessionJob(
   if (result.error) throw new Error(result.error);
   if (!result.transcription) throw new Error('Server returned no transcription data');
 
-  // Read hideTimestamps from the authoritative config store at write time,
-  // not from a value captured at enqueue time, so mid-queue setting changes
-  // are respected (see Issue #67).
+  // Read the format from the authoritative config store at WRITE time, not
+  // from a value captured at enqueue time, so mid-queue setting changes are
+  // respected (mirrors the Issue #67 convention it replaces). The
+  // hideTimestamps fallback preserves pre-GH-212 behavior for users who never
+  // touched the explicit selector.
+  const storedFormat = await getConfig<SessionOutputFormat>('sessionImport.outputFormat');
   const hideTimestamps = (await getConfig<boolean>('output.hideTimestamps')) ?? false;
+  const outputFormat: SessionOutputFormat = storedFormat ?? (hideTimestamps ? 'txt' : 'subtitles');
   const { sessionConfig } = store.getState();
-  const { outputFilename, content } = resolveTranscriptionOutput(filename, result.transcription, {
-    hideTimestamps,
-    diarizedFormat: sessionConfig.diarizedFormat ?? 'srt',
+  const outputs = resolveTranscriptionOutputs(filename, result.transcription, {
+    outputFormat,
+    subtitleFormat: sessionConfig.diarizedFormat ?? 'srt',
   });
 
   // Update status to 'writing'
@@ -402,11 +430,17 @@ async function processSessionJob(
 
   if (electronAPI?.fileIO) {
     const dir = sessionConfig.outputDir;
-    outputPath = `${dir}/${outputFilename}`;
-    await electronAPI.fileIO.writeText(outputPath, content);
+    for (const out of outputs) {
+      await electronAPI.fileIO.writeText(`${dir}/${out.outputFilename}`, out.content);
+    }
+    outputPath = `${dir}/${outputs[outputs.length - 1].outputFilename}`;
   } else {
-    browserDownload(outputFilename, content);
+    for (const out of outputs) {
+      browserDownload(out.outputFilename, out.content);
+    }
   }
+
+  const outputFilename = outputs.map((o) => o.outputFilename).join(', ');
 
   store.setState((s) => ({
     jobs: s.jobs.map((j) =>
@@ -547,6 +581,7 @@ export const useImportQueueStore = create<ImportQueueState>()((set) => ({
   sessionConfig: {
     outputDir: '',
     diarizedFormat: 'srt',
+    outputFormat: 'subtitles',
     hideTimestamps: false,
     enableDiarization: true,
     enableWordTimestamps: true,
@@ -582,14 +617,22 @@ export const useImportQueueStore = create<ImportQueueState>()((set) => ({
 
   addFiles: (files, type, options) => {
     const capturedOptions = options ? { ...options } : undefined;
-    const newJobs: UnifiedImportJob[] = files.map((file) => ({
-      id: nextJobId(type),
-      file,
-      type,
-      options: capturedOptions,
-      status: 'pending' as const,
-    }));
-    set((s) => ({ jobs: [...s.jobs, ...newJobs] }));
+    // The store creator only has `set` in scope, so sessionConfig is read
+    // inside the callback to stamp the planned format at enqueue time (GH-212).
+    set((s) => {
+      const plannedFormat = type.startsWith('session')
+        ? describePlannedFormat(s.sessionConfig)
+        : undefined;
+      const newJobs: UnifiedImportJob[] = files.map((file) => ({
+        id: nextJobId(type),
+        file,
+        type,
+        options: capturedOptions,
+        status: 'pending' as const,
+        ...(plannedFormat ? { plannedFormat } : {}),
+      }));
+      return { jobs: [...s.jobs, ...newJobs] };
+    });
     setTimeout(() => processQueue(), 0);
   },
 

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.4.1",
-  "contract_sha256": "905aac895de9715a8667401d1217e58d38aebbe07f1d8cc1aca065d8ff0351f7",
-  "updated_at": "2026-07-14T13:48:15.075Z"
+  "spec_version": "1.4.2",
+  "contract_sha256": "88be10a3889dbddda43d91cc33eba56834486f86294e7f06833c6bf8603fff76",
+  "updated_at": "2026-07-14T14:10:57.905Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.4.1
+  spec_version: 1.4.2
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -19,6 +19,7 @@ meta:
       - components/__tests__/ServerView.test.tsx
       - components/__tests__/SessionImportTab.canary-language.test.tsx
       - components/__tests__/SessionImportTab.diarization-gate.test.tsx
+      - components/__tests__/SessionImportTab.output-format.test.tsx
       - components/__tests__/SessionView.canary-language.test.tsx
       - components/__tests__/SessionView.test.tsx
       - components/__tests__/StartupActivityInline.test.tsx
@@ -108,7 +109,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-07-14T13:47:48.029Z
+    generated_at: 2026-07-14T14:09:56.454Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:


### PR DESCRIPTION
Addresses #212

## Root cause

Output format for Session imports was decided entirely client-side by `resolveTranscriptionOutput`, keyed off the global `output.hideTimestamps` setting (in a different modal) and `hasSegments` (always true for real transcriptions). The per-job Speaker Diarization toggle never had any connection to the format - the coupling existed only in the UI copy and in the fact that the srt/ass select was nested inside the diarization-gated block. Diarization OFF still produced `.srt`, and a voice-memo user had no visible way to get `.txt`.

## Changes

- New `resolveTranscriptionOutputs` resolver in `transcriptionFormatters.ts` supporting `txt` / `subtitles` / `both`, with a `.txt` fallback when the response has no usable segments. The legacy single-output resolver stays for the dead legacy hook.
- `SessionConfig` gains `outputFormat` (persisted under `sessionImport.outputFormat`); `addFiles` stamps a display-only `plannedFormat` on session jobs at enqueue time, so queued rows show e.g. `Queued (.txt + .srt)`. Folder Watch jobs inherit this automatically since `handleFilesDetected` enqueues via `addFiles`.
- `processSessionJob` reads the format from config at write time (mid-queue changes respected, mirroring the Issue #67 convention), writes multiple files for `both`, and falls back to the hideTimestamps-derived default when no explicit format is stored - preserving pre-existing behavior for users who never touch the new selector.
- Import Options UI: an always-visible "Output Format" select (Plain text / Subtitles / Both) placed first in the card; the old srt/ass select becomes "Subtitle format", gated on the chosen format instead of the diarization toggle. The info note and diarization description no longer claim diarization controls the format.
- The store test scaffold for `processSessionJob` (built here) also covers the `diarizationOutcome` copy whose test was deferred from the GH-209 PR.

## Test plan

- `cd dashboard && npm test` - 109 files, 1684 tests, all green (includes the new formatter matrix, the fake-timer `processSessionJob` scaffold with both-writes/fallback/diarization-outcome coverage, and `SessionImportTab.output-format.test.tsx`)
- `npm run typecheck` - clean
- Full ui-contract workflow (extract, build, spec bump to 1.4.2, baseline update, check) - 16 checks passed