### PR TITLE
feat(dashboard): immediate feedback when files are dropped on the session import dropzone (GH-210)

### DIFF
--- a/dashboard/components/__tests__/SessionImportTab.drop-feedback.test.tsx
+++ b/dashboard/components/__tests__/SessionImportTab.drop-feedback.test.tsx
@@ -1,0 +1,323 @@
+/**
+ * SessionImportTab immediate drop feedback (GH-210)
+ *
+ * The manual-drop path used to enqueue silently while the Folder-Watch
+ * auto-detect path already fired a toast (importQueueStore.ts). These tests
+ * pin the new feedback surface:
+ *
+ *   1. Single-file drop → toast.success naming the file + polite aria-live
+ *      announcement.
+ *   2. Multi-file drop → count toast ("3 files added ...").
+ *   3. A new job appearing in the queue scrolls the Import Queue card into
+ *      view (job-id diff, not list length).
+ *   4. The dropzone gets the brief `dropzone-flash` class after an add.
+ *   5. The language-guard refusal path (no enqueue) shows NO success toast.
+ */
+
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+
+const WHISPER_MODEL = 'openai/whisper-large-v3-turbo';
+const CANARY_MODEL = 'nvidia/canary-1b-v2';
+
+// ── Hoisted mock state ────────────────────────────────────────────────────
+
+interface MockLanguageSet {
+  languages: Array<{ code: string; name: string }>;
+  loading: boolean;
+  backendType: string;
+}
+
+let mockActiveModel: string | null = WHISPER_MODEL;
+
+let mockLanguageSet: MockLanguageSet = {
+  languages: [
+    { code: 'auto', name: 'Auto Detect' },
+    { code: 'en', name: 'English' },
+  ],
+  loading: false,
+  backendType: 'whisper',
+};
+
+// Mutable so the scroll test can change the queue contents between renders.
+let mockJobs: Array<Record<string, unknown>> = [];
+
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+const mockGetConfig = vi.fn();
+const mockAddFiles = vi.fn();
+
+vi.mock('../../src/hooks/useLanguages', () => ({
+  useLanguages: () => ({
+    languages: mockLanguageSet.languages,
+    backendType: mockLanguageSet.backendType,
+    loading: mockLanguageSet.loading,
+    error: null,
+  }),
+}));
+
+vi.mock('../../src/hooks/useAdminStatus', () => ({
+  useAdminStatus: () => ({
+    status: {
+      models_loaded: true,
+      config: {
+        main_transcriber: { model: mockActiveModel },
+        transcription: { model: mockActiveModel },
+      },
+    },
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/hooks/useSessionWatcher', () => ({
+  useSessionWatcher: () => ({
+    sessionWatchPath: '',
+    sessionWatchActive: false,
+    setSessionWatchActive: vi.fn(),
+    setWatchPath: vi.fn(),
+    sessionWatchAccessible: true,
+  }),
+}));
+
+vi.mock('../../src/stores/importQueueStore', () => {
+  const fakeState: Record<string, unknown> = {
+    jobs: [],
+    isPaused: false,
+    sessionConfig: {
+      outputDir: '',
+      diarizedFormat: 'srt',
+      outputFormat: 'subtitles',
+      hideTimestamps: false,
+      enableDiarization: true,
+      enableWordTimestamps: true,
+      parallelDiarization: false,
+      multitrack: false,
+    },
+    sessionWatchPath: '',
+    sessionWatchActive: false,
+    notebookWatchPath: '',
+    notebookWatchActive: false,
+    watcherServerConnected: true,
+    watchLog: [],
+    avgProcessingMs: 0,
+    addFiles: (...args: unknown[]) => mockAddFiles(...args),
+    removeJob: vi.fn(),
+    retryJob: vi.fn(),
+    clearFinished: vi.fn(),
+    pauseQueue: vi.fn(),
+    resumeQueue: vi.fn(),
+    updateSessionConfig: vi.fn(),
+    setLanguagesCache: vi.fn(),
+    clearWatchLog: vi.fn(),
+  };
+  return {
+    useImportQueueStore: (selector?: (s: Record<string, unknown>) => unknown) =>
+      typeof selector === 'function' ? selector(fakeState) : fakeState,
+    selectSessionJobs: () => mockJobs,
+    selectPendingCount: () => 0,
+    selectCompletedCount: () => 0,
+    selectErrorCount: () => 0,
+    selectIsProcessing: () => false,
+  };
+});
+
+vi.mock('../../src/api/client', () => ({
+  apiClient: {
+    getAdminStatus: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock('../../src/config/store', () => ({
+  getConfig: (...args: unknown[]) => mockGetConfig(...args),
+  setConfig: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/utils/transcriptionBackend', () => ({
+  supportsExplicitWordTimestampToggle: () => true,
+}));
+
+// Real modelCapabilities so the auto-detect / Canary guard behaves end-to-end.
+vi.mock('../../src/services/modelCapabilities', async () => {
+  const actual = await vi.importActual<typeof import('../../src/services/modelCapabilities')>(
+    '../../src/services/modelCapabilities',
+  );
+  return actual;
+});
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+import { SessionImportTab } from '../views/SessionImportTab';
+import { useAriaAnnouncerStore } from '../../src/stores/ariaAnnouncerStore';
+
+function buildFile(name = 'sample.mp3'): File {
+  return new File([new Uint8Array([0])], name, { type: 'audio/mpeg' });
+}
+
+function dropFiles(files: File[]): { dataTransfer: { files: FileList } } {
+  // Construct a FileList-like object since jsdom doesn't expose a constructor.
+  const list = {
+    length: files.length,
+    item: (i: number) => files[i] ?? null,
+    [Symbol.iterator]: function* () {
+      yield* files;
+    },
+  } as unknown as FileList;
+  files.forEach((f, i) => {
+    (list as unknown as Record<number, File>)[i] = f;
+  });
+  return { dataTransfer: { files: list } };
+}
+
+async function renderAndSettle() {
+  const utils = render(React.createElement(SessionImportTab));
+  // Wait for mount-time getConfig promises to resolve.
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return utils;
+}
+
+describe('SessionImportTab drop feedback (GH-210)', () => {
+  beforeAll(() => {
+    // jsdom has no scrollIntoView; run rAF callbacks synchronously.
+    Element.prototype.scrollIntoView = vi.fn();
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockToastSuccess.mockReset();
+    mockToastError.mockReset();
+    mockAddFiles.mockReset();
+    mockGetConfig.mockReset();
+    mockGetConfig.mockResolvedValue(undefined);
+
+    mockActiveModel = WHISPER_MODEL;
+    mockLanguageSet = {
+      languages: [
+        { code: 'auto', name: 'Auto Detect' },
+        { code: 'en', name: 'English' },
+      ],
+      loading: false,
+      backendType: 'whisper',
+    };
+    mockJobs = [];
+
+    useAriaAnnouncerStore.setState({ politeMessage: '', assertiveMessage: '' });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as unknown as { electronAPI?: any }).electronAPI = {
+      fileIO: {
+        getDownloadsPath: vi.fn().mockResolvedValue('/tmp'),
+        selectFolder: vi.fn().mockResolvedValue(null),
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+  });
+
+  it('shows a success toast naming the file and announces politely on a single-file drop', async () => {
+    const { container } = await renderAndSettle();
+
+    const dropZone = container.querySelector('.cursor-pointer');
+    expect(dropZone).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.drop(dropZone as Element, dropFiles([buildFile('lecture.mp3')]));
+    });
+
+    expect(mockAddFiles).toHaveBeenCalledTimes(1);
+    expect(mockToastSuccess).toHaveBeenCalledTimes(1);
+    expect(String(mockToastSuccess.mock.calls[0][0])).toMatch(/lecture\.mp3/);
+    expect(useAriaAnnouncerStore.getState().politeMessage).toMatch(/lecture\.mp3/);
+  });
+
+  it('shows a count toast on a multi-file drop', async () => {
+    const { container } = await renderAndSettle();
+
+    const dropZone = container.querySelector('.cursor-pointer');
+    await act(async () => {
+      fireEvent.drop(
+        dropZone as Element,
+        dropFiles([buildFile('a.mp3'), buildFile('b.mp3'), buildFile('c.mp3')]),
+      );
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledTimes(1);
+    expect(String(mockToastSuccess.mock.calls[0][0])).toMatch(/3 files added/i);
+    expect(useAriaAnnouncerStore.getState().politeMessage).toMatch(/3 files/i);
+  });
+
+  it('scrolls the import queue into view when a new job appears', async () => {
+    const { rerender } = await renderAndSettle();
+
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+
+    mockJobs = [
+      {
+        id: 'session-normal-1',
+        file: buildFile('lecture.mp3'),
+        type: 'session-normal',
+        status: 'pending',
+      },
+    ];
+    await act(async () => {
+      rerender(React.createElement(SessionImportTab));
+    });
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it('flashes the dropzone after files are added', async () => {
+    const { container } = await renderAndSettle();
+
+    expect(container.querySelector('.dropzone-flash')).toBeNull();
+
+    const dropZone = container.querySelector('.cursor-pointer');
+    await act(async () => {
+      fireEvent.drop(dropZone as Element, dropFiles([buildFile()]));
+    });
+
+    expect(container.querySelector('.dropzone-flash')).toBeTruthy();
+  });
+
+  it('shows no success toast when the language guard refuses the drop', async () => {
+    // Canary with an unresolvable picker (Auto Detect) refuses the drop.
+    mockActiveModel = CANARY_MODEL;
+    mockLanguageSet = {
+      languages: [
+        { code: 'auto', name: 'Auto Detect' },
+        { code: 'en', name: 'English' },
+      ],
+      loading: false,
+      backendType: 'canary',
+    };
+    mockGetConfig.mockImplementation(async (key: string) => {
+      if (key === 'session.mainLanguage') return 'Auto Detect';
+      return undefined;
+    });
+
+    const { container } = await renderAndSettle();
+
+    const dropZone = container.querySelector('.cursor-pointer');
+    await act(async () => {
+      fireEvent.drop(dropZone as Element, dropFiles([buildFile()]));
+    });
+
+    expect(mockAddFiles).not.toHaveBeenCalled();
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(useAriaAnnouncerStore.getState().politeMessage).toBe('');
+  });
+});

--- a/dashboard/components/views/SessionImportTab.tsx
+++ b/dashboard/components/views/SessionImportTab.tsx
@@ -37,6 +37,7 @@ import { apiClient } from '../../src/api/client';
 import { supportsExplicitWordTimestampToggle as supportsExplicitWordTimestampToggleForModel } from '../../src/utils/transcriptionBackend';
 import { getConfig, setConfig } from '../../src/config/store';
 import { useSessionWatcher } from '../../src/hooks/useSessionWatcher';
+import { useAriaAnnouncerStore } from '../../src/stores/ariaAnnouncerStore';
 import {
   supportsAutoDetect,
   supportsTranslation,
@@ -98,6 +99,21 @@ export const SessionImportTab: React.FC = () => {
   const [isDragOver, setIsDragOver] = useState(false);
   const [isDragOverWatch, setIsDragOverWatch] = useState(false);
   const [logExpanded, setLogExpanded] = useState(false);
+
+  // GH-210: brief dropzone flash after files are added.
+  const [justAdded, setJustAdded] = useState(false);
+  const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
+    },
+    [],
+  );
+
+  // GH-210: scroll the Import Queue into view when a NEW job appears. Diff
+  // job ids, not array length (clearFinished/removeJob also change length).
+  const queueRef = useRef<HTMLDivElement | null>(null);
+  const prevJobIdsRef = useRef<Set<string>>(new Set());
 
   // 4.6 — first-run hint state
   const manualImportCountRef = useRef(0);
@@ -289,6 +305,18 @@ export const SessionImportTab: React.FC = () => {
     }
   }, [sessionWatchPath, showWatchHint]);
 
+  useEffect(() => {
+    const ids = new Set(jobs.map((j) => j.id));
+    const hasNew = jobs.some((j) => !prevJobIdsRef.current.has(j.id));
+    prevJobIdsRef.current = ids;
+    if (hasNew) {
+      // rAF: the queue card may be mounting in this very commit on the first drop
+      requestAnimationFrame(() => {
+        queueRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      });
+    }
+  }, [jobs]);
+
   const handleDiarizationChange = useCallback((enabled: boolean) => {
     setDiarization(enabled);
     if (enabled) {
@@ -355,7 +383,8 @@ export const SessionImportTab: React.FC = () => {
         ? (resolveLanguage(mainBidiTarget) ?? 'en')
         : 'en';
 
-      addFiles(Array.from(files), 'session-normal', {
+      const fileArray = Array.from(files);
+      addFiles(fileArray, 'session-normal', {
         language: resolvedLang,
         translation_enabled: mainTranslateActive ? true : undefined,
         translation_target_language: mainTranslateActive ? mainTranslateTarget : undefined,
@@ -364,6 +393,27 @@ export const SessionImportTab: React.FC = () => {
         parallel_diarization: effectiveDiarization && !multitrack ? parallelDiarization : undefined,
         multitrack: multitrack || undefined,
       });
+
+      // GH-210: immediate feedback on manual add. The Folder-Watch path
+      // already toasts in handleFilesDetected; this mirrors it for drops and
+      // file-picker selections. Only fires after addFiles (the guard above
+      // early-returns without enqueueing).
+      toast.success(
+        fileArray.length === 1
+          ? `Added "${fileArray[0].name}" to the Import Queue`
+          : `${fileArray.length} files added to the Import Queue`,
+      );
+      useAriaAnnouncerStore
+        .getState()
+        .announce(
+          fileArray.length === 1
+            ? `${fileArray[0].name} added to import queue`
+            : `${fileArray.length} files added to import queue`,
+          'polite',
+        );
+      setJustAdded(true);
+      if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
+      flashTimerRef.current = setTimeout(() => setJustAdded(false), 700);
 
       // 4.6 — track manual import count and possibly show hint
       const newCount = manualImportCountRef.current + files.length;
@@ -526,7 +576,7 @@ export const SessionImportTab: React.FC = () => {
           isDragOver
             ? 'border-accent-cyan bg-accent-cyan/10 scale-[1.02]'
             : 'hover:border-accent-cyan/50 hover:bg-accent-cyan/5 border-white/20'
-        }`}
+        } ${justAdded ? 'dropzone-flash' : ''}`}
       >
         <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-white/5 transition-transform group-hover:scale-110">
           <Upload size={32} className="group-hover:text-accent-cyan text-slate-300" />
@@ -553,6 +603,103 @@ export const SessionImportTab: React.FC = () => {
           >
             <XCircle size={14} />
           </button>
+        </div>
+      )}
+
+      {/* Queue List: directly under the dropzone so a fresh drop is visible
+          without scrolling (GH-210) */}
+      {jobs.length > 0 && (
+        <div ref={queueRef}>
+          <GlassCard
+            title={`Import Queue${isProcessing ? ' — Processing' : ''}`}
+            action={
+              <div className="flex items-center gap-3 text-xs text-slate-400">
+                {completedCount > 0 && (
+                  <span className="text-green-400">{completedCount} done</span>
+                )}
+                {pendingCount > 0 && (
+                  <span>
+                    {pendingCount} pending
+                    {/* 4.5 — time estimate */}
+                    {avgProcessingMs > 0 && (
+                      <span className="ml-1 text-slate-500">
+                        (~{formatTimeEst(pendingCount * avgProcessingMs)})
+                      </span>
+                    )}
+                  </span>
+                )}
+                {errorCount > 0 && <span className="text-red-400">{errorCount} failed</span>}
+                <button
+                  onClick={isPaused ? resumeQueue : pauseQueue}
+                  className="ml-1 text-slate-500 transition-colors hover:text-white"
+                  title={isPaused ? 'Resume queue' : 'Pause queue'}
+                >
+                  {isPaused ? <Play size={18} /> : <Pause size={18} />}
+                </button>
+                {(completedCount > 0 || errorCount > 0) && (
+                  <button
+                    onClick={clearFinished}
+                    className="ml-1 text-slate-500 transition-colors hover:text-white"
+                    title="Clear finished"
+                  >
+                    <Trash2 size={18} />
+                  </button>
+                )}
+              </div>
+            }
+          >
+            <div className="max-h-60 space-y-2 overflow-y-auto">
+              {jobs.map((job) => (
+                <div
+                  key={job.id}
+                  className="flex items-center gap-3 rounded-lg bg-white/5 px-3 py-2 transition-colors hover:bg-white/8"
+                >
+                  {statusIcon(job)}
+                  {(job.type === 'session-auto' || job.type === 'notebook-auto') && (
+                    <span title="Auto-watch">
+                      <Eye size={14} className="shrink-0 text-slate-500" />
+                    </span>
+                  )}
+                  <span className="flex-1 truncate text-sm text-white">
+                    {typeof job.file === 'string' ? job.file.split('/').pop() : job.file.name}
+                  </span>
+                  <span
+                    className={`text-xs whitespace-nowrap ${
+                      job.status === 'success' && job.outputPath
+                        ? 'cursor-pointer text-green-400 hover:text-green-300'
+                        : 'text-slate-400'
+                    }`}
+                    onClick={
+                      job.status === 'success' && job.outputPath
+                        ? () => handleOpenOutputPath(job.outputPath!)
+                        : undefined
+                    }
+                    title={job.status === 'success' && job.outputPath ? 'Open folder' : undefined}
+                  >
+                    {statusLabel(job)}
+                  </span>
+                  {job.status === 'error' && (
+                    <button
+                      onClick={() => retryJob(job.id)}
+                      className="hover:text-accent-cyan p-1 text-slate-400 transition-colors"
+                      title="Retry"
+                    >
+                      <RotateCcw size={18} />
+                    </button>
+                  )}
+                  {job.status !== 'processing' && job.status !== 'writing' && (
+                    <button
+                      onClick={() => removeJob(job.id)}
+                      className="p-1 text-slate-500 transition-colors hover:text-red-400"
+                      title="Remove"
+                    >
+                      <XCircle size={18} />
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          </GlassCard>
         </div>
       )}
 
@@ -692,98 +839,6 @@ export const SessionImportTab: React.FC = () => {
                 )}
               </div>
             )}
-          </div>
-        </GlassCard>
-      )}
-
-      {/* Queue List */}
-      {jobs.length > 0 && (
-        <GlassCard
-          title={`Import Queue${isProcessing ? ' — Processing' : ''}`}
-          action={
-            <div className="flex items-center gap-3 text-xs text-slate-400">
-              {completedCount > 0 && <span className="text-green-400">{completedCount} done</span>}
-              {pendingCount > 0 && (
-                <span>
-                  {pendingCount} pending
-                  {/* 4.5 — time estimate */}
-                  {avgProcessingMs > 0 && (
-                    <span className="ml-1 text-slate-500">
-                      (~{formatTimeEst(pendingCount * avgProcessingMs)})
-                    </span>
-                  )}
-                </span>
-              )}
-              {errorCount > 0 && <span className="text-red-400">{errorCount} failed</span>}
-              <button
-                onClick={isPaused ? resumeQueue : pauseQueue}
-                className="ml-1 text-slate-500 transition-colors hover:text-white"
-                title={isPaused ? 'Resume queue' : 'Pause queue'}
-              >
-                {isPaused ? <Play size={18} /> : <Pause size={18} />}
-              </button>
-              {(completedCount > 0 || errorCount > 0) && (
-                <button
-                  onClick={clearFinished}
-                  className="ml-1 text-slate-500 transition-colors hover:text-white"
-                  title="Clear finished"
-                >
-                  <Trash2 size={18} />
-                </button>
-              )}
-            </div>
-          }
-        >
-          <div className="max-h-60 space-y-2 overflow-y-auto">
-            {jobs.map((job) => (
-              <div
-                key={job.id}
-                className="flex items-center gap-3 rounded-lg bg-white/5 px-3 py-2 transition-colors hover:bg-white/8"
-              >
-                {statusIcon(job)}
-                {(job.type === 'session-auto' || job.type === 'notebook-auto') && (
-                  <span title="Auto-watch">
-                    <Eye size={14} className="shrink-0 text-slate-500" />
-                  </span>
-                )}
-                <span className="flex-1 truncate text-sm text-white">
-                  {typeof job.file === 'string' ? job.file.split('/').pop() : job.file.name}
-                </span>
-                <span
-                  className={`text-xs whitespace-nowrap ${
-                    job.status === 'success' && job.outputPath
-                      ? 'cursor-pointer text-green-400 hover:text-green-300'
-                      : 'text-slate-400'
-                  }`}
-                  onClick={
-                    job.status === 'success' && job.outputPath
-                      ? () => handleOpenOutputPath(job.outputPath!)
-                      : undefined
-                  }
-                  title={job.status === 'success' && job.outputPath ? 'Open folder' : undefined}
-                >
-                  {statusLabel(job)}
-                </span>
-                {job.status === 'error' && (
-                  <button
-                    onClick={() => retryJob(job.id)}
-                    className="hover:text-accent-cyan p-1 text-slate-400 transition-colors"
-                    title="Retry"
-                  >
-                    <RotateCcw size={18} />
-                  </button>
-                )}
-                {job.status !== 'processing' && job.status !== 'writing' && (
-                  <button
-                    onClick={() => removeJob(job.id)}
-                    className="p-1 text-slate-500 transition-colors hover:text-red-400"
-                    title="Remove"
-                  >
-                    <XCircle size={18} />
-                  </button>
-                )}
-              </div>
-            ))}
           </div>
         </GlassCard>
       )}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -298,6 +298,28 @@ body {
   }
 }
 
+/* Dropzone flash: brief confirmation pulse when files are added to the
+ * session import queue (GH-210). Colors mirror the drag-over state
+ * (accent-cyan border/tint) decaying back to the resting border. */
+@keyframes dropzone-flash {
+  0% {
+    border-color: rgb(34 211 238 / 0.9);
+    background-color: rgb(34 211 238 / 0.12);
+  }
+  100% {
+    border-color: rgb(255 255 255 / 0.2);
+    background-color: transparent;
+  }
+}
+.dropzone-flash {
+  animation: dropzone-flash 700ms ease-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .dropzone-flash {
+    animation: none;
+  }
+}
+
 /* ── Capture gain slider (System Audio card) ──────────────────────────── */
 .ts-gain-slider {
   -webkit-appearance: none;

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.4.2",
-  "contract_sha256": "88be10a3889dbddda43d91cc33eba56834486f86294e7f06833c6bf8603fff76",
-  "updated_at": "2026-07-14T14:10:57.905Z"
+  "spec_version": "1.4.3",
+  "contract_sha256": "e47bba72fb8c15bc5b7fe393c04d72bf541738c69d0bb78cc2416b4b76183e88",
+  "updated_at": "2026-07-14T16:51:12.603Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.4.2
+  spec_version: 1.4.3
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -19,6 +19,7 @@ meta:
       - components/__tests__/ServerView.test.tsx
       - components/__tests__/SessionImportTab.canary-language.test.tsx
       - components/__tests__/SessionImportTab.diarization-gate.test.tsx
+      - components/__tests__/SessionImportTab.drop-feedback.test.tsx
       - components/__tests__/SessionImportTab.output-format.test.tsx
       - components/__tests__/SessionView.canary-language.test.tsx
       - components/__tests__/SessionView.test.tsx
@@ -109,7 +110,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-07-14T14:09:56.454Z
+    generated_at: 2026-07-14T16:50:51.018Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -194,6 +195,9 @@ foundation:
         - hsla(339, 49%, 30%, 1)
         - hsla(339,49%,30%,1)
         - rgb(230,230,230)
+        - rgb(255 255 255 / 0.2)
+        - rgb(34 211 238 / 0.12)
+        - rgb(34 211 238 / 0.9)
         - rgba(${r}, ${g}, ${b}, ${alpha})
         - rgba(0, 0, 0, 0.3)
         - rgba(0, 0, 0, 0.4)
@@ -337,6 +341,7 @@ foundation:
         - ease-in-out
       keyframes:
         - dropdown-appear
+        - dropzone-flash
         - idle-wave-cyan
         - idle-wave-magenta
         - idle-wave-orange
@@ -1319,6 +1324,7 @@ inline_style_allowlist:
     - visible
   keyframes:
     - dropdown-appear
+    - dropzone-flash
     - idle-wave-cyan
     - idle-wave-magenta
     - idle-wave-orange


### PR DESCRIPTION
Addresses #210

## Problem

Dropping files on the Session import dropzone gave no feedback: jobs were enqueued silently, and the Import Queue card rendered below Output Location and Folder Watch (below the fold on laptop screens), only mounting once a job existed. The Folder-Watch auto-detect path already fired a success toast; the manual-drop path never got the same treatment.

## Changes

- Success toast on manual add: filename for a single drop, count for multi-file drops. Fires only on the path that actually enqueued (the Canary language-guard refusal path shows no success toast).
- Polite aria-live announcement via the existing announcer store, so screen-reader users get the same confirmation.
- Brief dropzone flash animation (700ms, colors decay from the drag-over accent back to the resting border), disabled under prefers-reduced-motion following the existing idle-wave pattern in index.css.
- Auto-scroll to the Import Queue when a new job appears. Diffs job ids rather than list length so clearFinished/removeJob do not trigger scrolls; wrapped in requestAnimationFrame because the queue card mounts in the same commit on the first drop.
- Section reorder: Drop Zone -> watch hint -> Import Queue -> Output Location -> Folder Watch -> Info Note -> Import Options (previously the queue sat between Folder Watch and the Info Note).
- ui-contract rebaselined at spec_version 1.4.3 for the structure reorder and the new dropzone-flash class.

## Test Plan

- New test file components/__tests__/SessionImportTab.drop-feedback.test.tsx (5 tests: single-file toast + aria message, multi-file count toast, scrollIntoView on new job id, flash class after drop, no success toast on guard refusal). Written first and confirmed failing (4/5) before implementation; all pass after.
- Full dashboard suite: npm test, 110 files / 1689 tests passed.
- npx tsc --noEmit clean; eslint clean on changed files.
- Full ui-contract workflow: extract -> build -> spec_version bump to 1.4.3 -> validate --update-baseline -> ui:contract:check (16 checks passed).