### PR TITLE
fix(dashboard): restore the scroll-edge fade when Session and Notebook collapse to one column

### DIFF
--- a/dashboard/components/ui/ScrollFadeOverlay.tsx
+++ b/dashboard/components/ui/ScrollFadeOverlay.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+type ScrollFadeEdge = 'top' | 'bottom';
+
+interface ScrollFadeOverlayProps {
+  /** Which edge of the scroll container this bar sits on. */
+  edge: ScrollFadeEdge;
+  /** True when the container is clipping content past this edge. */
+  visible: boolean;
+  /** Extra classes, e.g. a container-query variant that disables the bar in a layout. */
+  className?: string;
+}
+
+const EDGE_ANCHOR: Record<ScrollFadeEdge, string> = {
+  top: 'top-0',
+  bottom: 'bottom-0',
+};
+
+// The gradient and the mask both point away from the edge, so the bar is densest where
+// content is being cut off and dissolves into the content below or above it.
+const EDGE_GRADIENT: Record<ScrollFadeEdge, string> = {
+  top: 'bg-linear-to-b',
+  bottom: 'bg-linear-to-t',
+};
+
+const EDGE_MASK: Record<ScrollFadeEdge, string> = {
+  top: 'linear-gradient(to bottom, black 50%, transparent 100%)',
+  bottom: 'linear-gradient(to top, black 50%, transparent 100%)',
+};
+
+/**
+ * A fading blur bar pinned to the top or bottom edge of a scroll container, shown when
+ * that container is clipping content.
+ *
+ * Must be rendered as a sibling of the scroll container inside a non-scrolling
+ * `relative` wrapper. Placing it inside the scroller would make it scroll away with the
+ * content, since an absolutely positioned child is laid out against the scrolled box.
+ *
+ * The right inset clears the 8px `.custom-scrollbar` track so the bar does not wash over
+ * the scrollbar thumb.
+ */
+export const ScrollFadeOverlay: React.FC<ScrollFadeOverlayProps> = ({
+  edge,
+  visible,
+  className = '',
+}) => (
+  <div
+    className={`pointer-events-none absolute right-3 left-0 z-20 h-6 overflow-hidden transition-opacity duration-300 ${EDGE_ANCHOR[edge]} ${visible ? 'opacity-100' : 'opacity-0'} ${className}`}
+  >
+    <div
+      className={`h-full w-full from-white/10 to-transparent backdrop-blur-sm ${EDGE_GRADIENT[edge]}`}
+      style={{ maskImage: EDGE_MASK[edge], WebkitMaskImage: EDGE_MASK[edge] }}
+    />
+  </div>
+);

--- a/dashboard/components/ui/__tests__/ScrollFadeOverlay.test.tsx
+++ b/dashboard/components/ui/__tests__/ScrollFadeOverlay.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * ScrollFadeOverlay — the fading blur bar pinned to a scroll container edge.
+ *
+ * The bar is always mounted and toggles opacity, rather than mounting and unmounting, so
+ * that it can transition rather than pop. These tests pin that down along with the
+ * per-edge anchoring and gradient direction.
+ */
+
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { ScrollFadeOverlay } from '../ScrollFadeOverlay';
+
+/** The outer positioned bar is the only child the component renders at the root. */
+function renderBar(ui: React.ReactElement): HTMLElement {
+  const { container } = render(ui);
+  return container.firstElementChild as HTMLElement;
+}
+
+describe('ScrollFadeOverlay', () => {
+  it('stays mounted but transparent when the edge is not clipping', () => {
+    const bar = renderBar(<ScrollFadeOverlay edge="top" visible={false} />);
+
+    expect(bar).toBeTruthy();
+    expect(bar.className).toContain('opacity-0');
+    expect(bar.className).not.toContain('opacity-100');
+    expect(bar.className).toContain('transition-opacity');
+  });
+
+  it('becomes opaque when the edge is clipping', () => {
+    const bar = renderBar(<ScrollFadeOverlay edge="top" visible={true} />);
+
+    expect(bar.className).toContain('opacity-100');
+  });
+
+  // `to bottom` is the CSS default gradient direction, so jsdom serializes it away and
+  // reports a bare `linear-gradient(black 50%, ...)`. `to top` is non-default and
+  // survives. The assertions below are written to survive that normalization.
+  it('anchors to the top and fades downward on the top edge', () => {
+    const bar = renderBar(<ScrollFadeOverlay edge="top" visible={true} />);
+    const gradient = bar.firstElementChild as HTMLElement;
+
+    expect(bar.className).toContain('top-0');
+    expect(bar.className).not.toContain('bottom-0');
+    expect(gradient.className).toContain('bg-linear-to-b');
+    expect(gradient.style.maskImage).toContain('black 50%');
+    expect(gradient.style.maskImage).toContain('transparent 100%');
+    expect(gradient.style.maskImage).not.toContain('to top');
+  });
+
+  it('anchors to the bottom and fades upward on the bottom edge', () => {
+    const bar = renderBar(<ScrollFadeOverlay edge="bottom" visible={true} />);
+    const gradient = bar.firstElementChild as HTMLElement;
+
+    expect(bar.className).toContain('bottom-0');
+    expect(bar.className).not.toContain('top-0');
+    expect(gradient.className).toContain('bg-linear-to-t');
+    expect(gradient.style.maskImage).toContain('to top');
+    expect(gradient.style.maskImage).toContain('transparent 100%');
+  });
+
+  it('never intercepts pointer events, so it cannot block the content beneath it', () => {
+    const bar = renderBar(<ScrollFadeOverlay edge="bottom" visible={true} />);
+
+    expect(bar.className).toContain('pointer-events-none');
+  });
+
+  it('insets from the right so it does not wash over the scrollbar track', () => {
+    const bar = renderBar(<ScrollFadeOverlay edge="top" visible={true} />);
+
+    expect(bar.className).toContain('right-3');
+  });
+
+  it('forwards a caller className, which is how each view disables the bar in its wide layout', () => {
+    const bar = renderBar(
+      <ScrollFadeOverlay edge="top" visible={true} className="@min-[840px]:hidden" />,
+    );
+
+    expect(bar.className).toContain('@min-[840px]:hidden');
+  });
+});

--- a/dashboard/components/views/NotebookView.tsx
+++ b/dashboard/components/views/NotebookView.tsx
@@ -61,6 +61,8 @@ import { useConfirm } from '../../src/hooks/useConfirm';
 import { DeleteRecordingDialog } from '../recording/DeleteRecordingDialog';
 import { useActiveProfileStore } from '../../src/stores/activeProfileStore';
 import { getConfig, setConfig } from '../../src/config/store';
+import { useScrollFade } from '../../src/hooks/useScrollFade';
+import { ScrollFadeOverlay } from '../ui/ScrollFadeOverlay';
 
 // GH #92: same allow-list as AddNoteModal's <input accept="…"> below — keep
 // the two in sync so per-hour drag-drop and the modal's browse/drop accept
@@ -1030,6 +1032,10 @@ const CalendarTab: React.FC<{
   const [slideDirection, setSlideDirection] = useState<'left' | 'right' | null>(null);
   const [animKey, setAnimKey] = useState(0);
   const [visibleSlots, setVisibleSlots] = useState(3);
+
+  // Edge fades for the stacked layout, where this grid is the scroller.
+  const stackedScrollRef = useRef<HTMLDivElement>(null);
+  const stackedScrollState = useScrollFade(stackedScrollRef, [visibleSlots, refreshNonce]);
   const year = currentDate.getFullYear();
   const month = currentDate.getMonth();
   const daysInMonth = new Date(year, month + 1, 0).getDate();
@@ -1165,154 +1171,179 @@ const CalendarTab: React.FC<{
   );
 
   return (
-    <div className="custom-scrollbar grid h-full min-h-0 grid-cols-1 gap-6 @max-[860px]:overflow-y-auto @min-[860px]:grid-cols-3">
-      <style>{`
+    // Below the 860px container breakpoint the two panels are pinned to 70vh each and
+    // this grid becomes the scroller, so it needs edge fades that the wide layout does
+    // not. They sit outside the scroller: an absolutely positioned child of a scrolling
+    // box is laid out against the scrolled content and would slide away with it.
+    <div className="relative h-full min-h-0">
+      <ScrollFadeOverlay
+        edge="top"
+        visible={stackedScrollState.top}
+        className="@min-[860px]:hidden"
+      />
+      <div
+        ref={stackedScrollRef}
+        className="custom-scrollbar grid h-full min-h-0 grid-cols-1 gap-6 @max-[860px]:overflow-y-auto @min-[860px]:grid-cols-3"
+      >
+        <style>{`
                 @keyframes slideInRight { from { transform: translateX(20px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
                 @keyframes slideInLeft { from { transform: translateX(-20px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
                 .anim-slide-right { animation: slideInRight 0.3s cubic-bezier(0.16, 1, 0.3, 1) forwards; }
                 .anim-slide-left { animation: slideInLeft 0.3s cubic-bezier(0.16, 1, 0.3, 1) forwards; }
             `}</style>
-      <div className="flex min-h-0 flex-col @max-[860px]:h-[70vh] @max-[860px]:min-h-[440px] @min-[860px]:col-span-2">
-        <GlassCard
-          className="flex h-full flex-col"
-          title={calendarHeader}
-          action={
-            <div className="flex gap-2">
-              <Button
-                variant="ghost"
-                size="sm"
-                icon={<Clock size={14} />}
-                onClick={() => {
-                  if (gridRef.current) {
-                    setTriggerRect(gridRef.current.getBoundingClientRect());
-                    setIsHistoryOpen(true);
-                  }
-                }}
-                className={isHistoryOpen ? 'bg-white/10 text-white' : ''}
-              >
-                Month/Year
-              </Button>
-            </div>
-          }
-        >
-          <div
-            ref={gridRef}
-            key={animKey}
-            className={`grid h-full grid-cols-7 gap-px overflow-hidden rounded-2xl border border-white/10 bg-white/5 ${slideDirection === 'right' ? 'anim-slide-right' : ''} ${slideDirection === 'left' ? 'anim-slide-left' : ''}`}
-            style={{ gridTemplateRows: `auto repeat(${gridRows}, 1fr)` }}
+        <div className="flex min-h-0 flex-col @max-[860px]:h-[70vh] @max-[860px]:min-h-[440px] @min-[860px]:col-span-2">
+          <GlassCard
+            className="flex h-full flex-col"
+            title={calendarHeader}
+            action={
+              <div className="flex gap-2">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  icon={<Clock size={14} />}
+                  onClick={() => {
+                    if (gridRef.current) {
+                      setTriggerRect(gridRef.current.getBoundingClientRect());
+                      setIsHistoryOpen(true);
+                    }
+                  }}
+                  className={isHistoryOpen ? 'bg-white/10 text-white' : ''}
+                >
+                  Month/Year
+                </Button>
+              </div>
+            }
           >
-            {['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'].map(
-              (d, i) => (
-                <div
-                  key={i}
-                  className="bg-glass-100/50 flex items-center justify-center border-b border-white/5 py-1 text-center text-[10px] font-bold tracking-widest text-slate-500 uppercase"
-                >
-                  {d.slice(0, 3)}
-                </div>
-              ),
-            )}
-            {emptyDays.map((_, i) => (
-              <div key={`empty-${i}`} className="border-t border-r border-white/5 bg-black/20 p-2">
-                <span className="text-xs text-slate-600">
-                  {prevMonthDays - startOffset + 1 + i}
-                </span>
-              </div>
-            ))}
-            {monthDays.map((_, i) => {
-              const dayNum = i + 1;
-              const dayEvents = eventsByDay[dayNum] || [];
-              const hasEvents = dayEvents.length > 0;
-              const count = dayEvents.length;
-              const dayKey = `${year}-${String(month + 1).padStart(2, '0')}-${String(dayNum).padStart(2, '0')}`;
-              const isSelected = selectedDay === dayKey;
-              const isToday = dayKey === todayKey;
-              return (
-                <div
-                  key={i}
-                  className={`bg-glass-100/30 hover:bg-glass-100 group relative flex min-h-0 cursor-pointer flex-col items-start overflow-hidden border-t border-r border-white/5 p-2 transition-colors ${isSelected ? 'ring-accent-cyan/50 bg-accent-cyan/5 ring-1' : ''}`}
-                  onClick={() => handleDayClick(dayNum)}
-                >
-                  <div className="mb-1 flex w-full items-center justify-between">
-                    <span
-                      className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs transition-all ${isSelected ? 'bg-accent-cyan font-bold text-black' : isToday ? 'bg-[rgb(230,230,230)] font-bold text-black' : 'text-slate-400 group-hover:text-white'}`}
-                    >
-                      {dayNum}
-                    </span>
-                    {hasEvents && (
-                      <div className="mr-1 flex h-4 min-w-6 items-center justify-center rounded-full bg-red-500 px-2 shadow-[0_0_5px_rgba(239,68,68,0.6)]">
-                        <span className="text-[9px] leading-none font-bold text-white">
-                          {count}
-                        </span>
-                      </div>
-                    )}
+            <div
+              ref={gridRef}
+              key={animKey}
+              className={`grid h-full grid-cols-7 gap-px overflow-hidden rounded-2xl border border-white/10 bg-white/5 ${slideDirection === 'right' ? 'anim-slide-right' : ''} ${slideDirection === 'left' ? 'anim-slide-left' : ''}`}
+              style={{ gridTemplateRows: `auto repeat(${gridRows}, 1fr)` }}
+            >
+              {['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'].map(
+                (d, i) => (
+                  <div
+                    key={i}
+                    className="bg-glass-100/50 flex items-center justify-center border-b border-white/5 py-1 text-center text-[10px] font-bold tracking-widest text-slate-500 uppercase"
+                  >
+                    {d.slice(0, 3)}
                   </div>
-                  <div className="flex min-h-0 w-full flex-1 flex-col gap-1 overflow-hidden pt-1">
-                    {dayEvents.slice(0, 2).map((evt) => (
-                      <button
-                        key={evt.id}
-                        type="button"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onNoteClick(evt);
-                        }}
-                        className="bg-accent-cyan w-full cursor-pointer truncate rounded-full px-2 py-0.5 text-left text-[10px] font-medium text-black shadow-sm transition-opacity hover:opacity-85"
+                ),
+              )}
+              {emptyDays.map((_, i) => (
+                <div
+                  key={`empty-${i}`}
+                  className="border-t border-r border-white/5 bg-black/20 p-2"
+                >
+                  <span className="text-xs text-slate-600">
+                    {prevMonthDays - startOffset + 1 + i}
+                  </span>
+                </div>
+              ))}
+              {monthDays.map((_, i) => {
+                const dayNum = i + 1;
+                const dayEvents = eventsByDay[dayNum] || [];
+                const hasEvents = dayEvents.length > 0;
+                const count = dayEvents.length;
+                const dayKey = `${year}-${String(month + 1).padStart(2, '0')}-${String(dayNum).padStart(2, '0')}`;
+                const isSelected = selectedDay === dayKey;
+                const isToday = dayKey === todayKey;
+                return (
+                  <div
+                    key={i}
+                    className={`bg-glass-100/30 hover:bg-glass-100 group relative flex min-h-0 cursor-pointer flex-col items-start overflow-hidden border-t border-r border-white/5 p-2 transition-colors ${isSelected ? 'ring-accent-cyan/50 bg-accent-cyan/5 ring-1' : ''}`}
+                    onClick={() => handleDayClick(dayNum)}
+                  >
+                    <div className="mb-1 flex w-full items-center justify-between">
+                      <span
+                        className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs transition-all ${isSelected ? 'bg-accent-cyan font-bold text-black' : isToday ? 'bg-[rgb(230,230,230)] font-bold text-black' : 'text-slate-400 group-hover:text-white'}`}
                       >
-                        {evt.title}
-                      </button>
-                    ))}
-                    {dayEvents.length > 2 && (
-                      <div className="pl-2 text-[9px] text-slate-500">
-                        +{dayEvents.length - 2} more
-                      </div>
-                    )}
+                        {dayNum}
+                      </span>
+                      {hasEvents && (
+                        <div className="mr-1 flex h-4 min-w-6 items-center justify-center rounded-full bg-red-500 px-2 shadow-[0_0_5px_rgba(239,68,68,0.6)]">
+                          <span className="text-[9px] leading-none font-bold text-white">
+                            {count}
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                    <div className="flex min-h-0 w-full flex-1 flex-col gap-1 overflow-hidden pt-1">
+                      {dayEvents.slice(0, 2).map((evt) => (
+                        <button
+                          key={evt.id}
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onNoteClick(evt);
+                          }}
+                          className="bg-accent-cyan w-full cursor-pointer truncate rounded-full px-2 py-0.5 text-left text-[10px] font-medium text-black shadow-sm transition-opacity hover:opacity-85"
+                        >
+                          {evt.title}
+                        </button>
+                      ))}
+                      {dayEvents.length > 2 && (
+                        <div className="pl-2 text-[9px] text-slate-500">
+                          +{dayEvents.length - 2} more
+                        </div>
+                      )}
+                    </div>
                   </div>
+                );
+              })}
+              {trailingDays.map((_, i) => (
+                <div
+                  key={`trail-${i}`}
+                  className="border-t border-r border-white/5 bg-black/20 p-2"
+                >
+                  <span className="text-xs text-slate-600">{i + 1}</span>
                 </div>
-              );
-            })}
-            {trailingDays.map((_, i) => (
-              <div key={`trail-${i}`} className="border-t border-r border-white/5 bg-black/20 p-2">
-                <span className="text-xs text-slate-600">{i + 1}</span>
-              </div>
-            ))}
-          </div>
-        </GlassCard>
-      </div>
-      <div className="flex h-full min-h-0 flex-col space-y-4 overflow-hidden @max-[860px]:h-[70vh] @max-[860px]:min-h-[440px] @max-[860px]:motion-safe:animate-[reflowStackIn_0.3s_cubic-bezier(0.16,1,0.3,1)]">
-        <TimeSection
-          title="Morning"
-          headerColor="text-accent-orange"
-          headerGradient="bg-linear-to-r from-accent-orange/10 via-red-900/10 to-transparent"
-          startHour={0}
-          endHour={12}
-          events={morningEvents}
-          visibleSlots={visibleSlots}
-          onZoomChange={setVisibleSlots}
-          onNoteClick={onNoteClick}
-          onAddNote={(hour) => onAddNote(hour, addNoteDateKey)}
-          onDropFilesAtSlot={handleDropAtHour}
-          onRefresh={calendar.refresh}
+              ))}
+            </div>
+          </GlassCard>
+        </div>
+        <div className="flex h-full min-h-0 flex-col space-y-4 overflow-hidden @max-[860px]:h-[70vh] @max-[860px]:min-h-[440px] @max-[860px]:motion-safe:animate-[reflowStackIn_0.3s_cubic-bezier(0.16,1,0.3,1)]">
+          <TimeSection
+            title="Morning"
+            headerColor="text-accent-orange"
+            headerGradient="bg-linear-to-r from-accent-orange/10 via-red-900/10 to-transparent"
+            startHour={0}
+            endHour={12}
+            events={morningEvents}
+            visibleSlots={visibleSlots}
+            onZoomChange={setVisibleSlots}
+            onNoteClick={onNoteClick}
+            onAddNote={(hour) => onAddNote(hour, addNoteDateKey)}
+            onDropFilesAtSlot={handleDropAtHour}
+            onRefresh={calendar.refresh}
+          />
+          <TimeSection
+            title="Afternoon"
+            headerColor="text-indigo-400"
+            headerGradient="bg-linear-to-r from-indigo-500/10 via-blue-900/10 to-transparent"
+            startHour={12}
+            endHour={24}
+            events={afternoonEvents}
+            visibleSlots={visibleSlots}
+            onZoomChange={setVisibleSlots}
+            onNoteClick={onNoteClick}
+            onAddNote={(hour) => onAddNote(hour, addNoteDateKey)}
+            onDropFilesAtSlot={handleDropAtHour}
+            onRefresh={calendar.refresh}
+          />
+        </div>
+        <HistoryPicker
+          isOpen={isHistoryOpen}
+          onClose={() => setIsHistoryOpen(false)}
+          selectedDate={currentDate}
+          onSelect={setCurrentDate}
+          triggerRect={triggerRect}
         />
-        <TimeSection
-          title="Afternoon"
-          headerColor="text-indigo-400"
-          headerGradient="bg-linear-to-r from-indigo-500/10 via-blue-900/10 to-transparent"
-          startHour={12}
-          endHour={24}
-          events={afternoonEvents}
-          visibleSlots={visibleSlots}
-          onZoomChange={setVisibleSlots}
-          onNoteClick={onNoteClick}
-          onAddNote={(hour) => onAddNote(hour, addNoteDateKey)}
-          onDropFilesAtSlot={handleDropAtHour}
-          onRefresh={calendar.refresh}
-        />
       </div>
-      <HistoryPicker
-        isOpen={isHistoryOpen}
-        onClose={() => setIsHistoryOpen(false)}
-        selectedDate={currentDate}
-        onSelect={setCurrentDate}
-        triggerRect={triggerRect}
+      <ScrollFadeOverlay
+        edge="bottom"
+        visible={stackedScrollState.bottom}
+        className="@min-[860px]:hidden"
       />
     </div>
   );

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -29,6 +29,7 @@ import { AppleSwitch } from '../ui/AppleSwitch';
 import { StatusLight } from '../ui/StatusLight';
 import { AudioVisualizer } from '../AudioVisualizer';
 import { CustomSelect } from '../ui/CustomSelect';
+import { ScrollFadeOverlay } from '../ui/ScrollFadeOverlay';
 import { FullscreenVisualizer } from './FullscreenVisualizer';
 import { PopOutWindow } from '../PopOutWindow';
 import { FindReplaceTextEditor } from '../editor/FindReplaceTextEditor';
@@ -42,6 +43,7 @@ import { useDockerContext } from '../../src/hooks/DockerContext';
 import { useTraySync } from '../../src/hooks/useTraySync';
 import type { ServerConnectionInfo } from '../../src/hooks/useServerStatus';
 import { useAdminStatus } from '../../src/hooks/useAdminStatus';
+import { useScrollFade } from '../../src/hooks/useScrollFade';
 import { apiClient } from '../../src/api/client';
 import { getAuthToken, getConfig, setConfig } from '../../src/config/store';
 import { logClientEvent } from '../../src/services/clientDebugLog';
@@ -1101,6 +1103,12 @@ export const SessionView: React.FC<SessionViewProps> = ({
   const leftContentRef = useRef<HTMLDivElement>(null);
   const rightContentRef = useRef<HTMLDivElement>(null);
 
+  // Stacked (single-column) scroll state. Below the 840px container breakpoint the two
+  // columns go overflow-visible and the grid below scrolls instead, so the per-column
+  // indicators can never fire and this container needs its own pair.
+  const stackedScrollRef = useRef<HTMLDivElement>(null);
+  const stackedScrollState = useScrollFade(stackedScrollRef);
+
   // Live transcript auto-scroll
   const liveTranscriptRef = useRef<HTMLDivElement>(null);
   const liveAutoScrollRef = useRef(true);
@@ -1319,1146 +1327,1184 @@ export const SessionView: React.FC<SessionViewProps> = ({
       )}
 
       {/* 2. Main Content Area */}
-      <div className="custom-scrollbar grid min-h-0 flex-1 grid-cols-1 items-stretch gap-6 @max-[840px]:overflow-y-auto @min-[840px]:grid-cols-[minmax(480px,5fr)_minmax(300px,7fr)]">
-        {/* Left Column: Controls (40%) */}
-        {/* min-h-0 is gated to @min-[840px] (wide mode) ON PURPOSE: in the two-column
+      {/* The scroll container moves between layouts: wide, each column scrolls itself;
+          stacked, the columns go overflow-visible and the grid scrolls instead. The
+          stacked fades therefore cannot live inside the grid, because an absolutely
+          positioned child of a scroller is laid out against the scrolled box and would
+          slide away with the content. They hang off this non-scrolling wrapper instead. */}
+      <div className="relative flex min-h-0 flex-1 flex-col">
+        <ScrollFadeOverlay
+          edge="top"
+          visible={stackedScrollState.top}
+          className="@min-[840px]:hidden"
+        />
+        <div
+          ref={stackedScrollRef}
+          className="custom-scrollbar grid min-h-0 flex-1 grid-cols-1 items-stretch gap-6 @max-[840px]:overflow-y-auto @min-[840px]:grid-cols-[minmax(480px,5fr)_minmax(300px,7fr)]"
+        >
+          {/* Left Column: Controls (40%) */}
+          {/* min-h-0 is gated to @min-[840px] (wide mode) ON PURPOSE: in the two-column
             layout it lets the inner flex-1 scroll area engage. In stacked mode it must
             NOT apply — with min-h-0 the grid treats each row minimum as 0, sees the
             fixed grid height as free space, and stretches both auto rows to equal
             heights; the real (taller) content then spills out via overflow-visible and
             the two columns paint on top of each other. Without min-h-0 the rows size to
             content and stack cleanly as one scrolling column. */}
-        <div className="relative flex min-w-0 flex-col overflow-hidden rounded-2xl @max-[840px]:overflow-visible @min-[840px]:min-h-0">
-          {/* Left Top Scroll Indicator */}
-          <div
-            className={`pointer-events-none absolute top-0 right-3 left-0 z-20 h-6 overflow-hidden rounded-t-2xl transition-opacity duration-300 ${leftScrollState.top ? 'opacity-100' : 'opacity-0'}`}
-          >
+          <div className="relative flex min-w-0 flex-col overflow-hidden rounded-2xl @max-[840px]:overflow-visible @min-[840px]:min-h-0">
+            {/* Left Top Scroll Indicator */}
             <div
-              className="h-full w-full bg-linear-to-b from-white/10 to-transparent backdrop-blur-sm"
+              className={`pointer-events-none absolute top-0 right-3 left-0 z-20 h-6 overflow-hidden rounded-t-2xl transition-opacity duration-300 ${leftScrollState.top ? 'opacity-100' : 'opacity-0'}`}
+            >
+              <div
+                className="h-full w-full bg-linear-to-b from-white/10 to-transparent backdrop-blur-sm"
+                style={{
+                  maskImage: 'linear-gradient(to bottom, black 50%, transparent 100%)',
+                  WebkitMaskImage: 'linear-gradient(to bottom, black 50%, transparent 100%)',
+                }}
+              ></div>
+            </div>
+            {/* Left Top Corner Mask */}
+            <div
+              className="pointer-events-none absolute top-0 right-3 z-20 h-4 w-4 @max-[840px]:hidden"
               style={{
-                maskImage: 'linear-gradient(to bottom, black 50%, transparent 100%)',
-                WebkitMaskImage: 'linear-gradient(to bottom, black 50%, transparent 100%)',
+                ...maskStyle,
+                maskImage: 'radial-gradient(circle at bottom left, transparent 1rem, black 1rem)',
+                WebkitMaskImage:
+                  'radial-gradient(circle at bottom left, transparent 1rem, black 1rem)',
               }}
-            ></div>
-          </div>
-          {/* Left Top Corner Mask */}
-          <div
-            className="pointer-events-none absolute top-0 right-3 z-20 h-4 w-4 @max-[840px]:hidden"
-            style={{
-              ...maskStyle,
-              maskImage: 'radial-gradient(circle at bottom left, transparent 1rem, black 1rem)',
-              WebkitMaskImage:
-                'radial-gradient(circle at bottom left, transparent 1rem, black 1rem)',
-            }}
-          />
+            />
 
-          {/* Main Scrollable Area for Left Column */}
-          <div
-            ref={leftScrollRef}
-            className="custom-scrollbar flex-1 overflow-y-auto pt-0 pr-3 pb-0 @max-[840px]:overflow-visible"
-          >
-            {/* Baseline min-height keeps short content filling the column in the two-column
+            {/* Main Scrollable Area for Left Column */}
+            <div
+              ref={leftScrollRef}
+              className="custom-scrollbar flex-1 overflow-y-auto pt-0 pr-3 pb-0 @max-[840px]:overflow-visible"
+            >
+              {/* Baseline min-height keeps short content filling the column in the two-column
                 layout only — applied via a CSS var gated behind @min-[840px] so it no-ops
                 when stacked (spec: baseline-height effect must no-op when stacked). */}
-            <div
-              ref={leftContentRef}
-              className="space-y-6 @min-[840px]:[min-height:var(--ts-col-baseline)]"
-              style={
-                leftColumnBaselineHeight
-                  ? ({
-                      '--ts-col-baseline': `${leftColumnBaselineHeight}px`,
-                    } as React.CSSProperties)
-                  : undefined
-              }
-            >
-              {/* Unified Control Center */}
-              <GlassCard
-                title="Control Center"
-                className={`blur-panel from-glass-200 to-glass-100 relative flex-none bg-linear-to-b transition-all duration-500 ease-in-out ${isSystemHealthy ? 'border-accent-cyan/50! z-10 shadow-[0_20px_25px_-5px_rgba(0,0,0,0.3),0_8px_10px_-6px_rgba(0,0,0,0.3),inset_0_0_30px_rgba(34,211,238,0.15)]!' : ''}`}
-              >
-                <div className="space-y-5">
-                  {/* Server Control */}
-                  <div className="flex flex-col space-y-4 rounded-xl border border-white/5 bg-white/5 p-4 shadow-sm">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-3">
-                        <div className={`bg-accent-magenta/10 text-accent-magenta rounded-lg p-2`}>
-                          <Server size={20} />
-                        </div>
-                        <div className="text-sm font-semibold tracking-wide text-white">
-                          Inference Server
-                        </div>
-                      </div>
-                      <div className="flex items-center gap-2.5">
-                        <span className="text-xs font-medium text-slate-400">
-                          {isRemoteMode
-                            ? serverConnection.reachable
-                              ? serverConnection.ready
-                                ? 'Remote Server Ready'
-                                : 'Remote Server Loading\u2026'
-                              : 'Remote Server Offline'
-                            : isBareMetal
-                              ? serverRunning
-                                ? 'Native Process Running'
-                                : 'Server Offline'
-                              : serverRunning && docker.container.health === 'healthy'
-                                ? 'Docker Container Running'
-                                : serverRunning
-                                  ? 'Container Starting\u2026'
-                                  : docker.container.exists
-                                    ? 'Container Stopped'
-                                    : 'Container Missing'}
-                        </span>
-                        {isBareMetal && serverRunning && (
-                          <span className="bg-accent-violet/15 text-accent-violet flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-bold tracking-wide uppercase">
-                            <Zap size={10} />
-                            metal
-                          </span>
-                        )}
-                        {!isBareMetal && serverRunning && serverMode && (
-                          <span
-                            className={`flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-bold tracking-wide uppercase ${serverMode === 'local' ? 'bg-accent-cyan/15 text-accent-cyan' : 'bg-accent-magenta/15 text-accent-magenta'}`}
-                          >
-                            {serverMode === 'local' ? <Laptop size={10} /> : <Radio size={10} />}
-                            {serverMode}
-                          </span>
-                        )}
-                        <StatusLight
-                          status={
-                            isRemoteMode
-                              ? serverConnection.reachable
-                                ? serverConnection.ready
-                                  ? 'active'
-                                  : 'warning'
-                                : 'inactive'
-                              : isBareMetal
-                                ? serverRunning
-                                  ? 'active'
-                                  : 'inactive'
-                                : serverRunning && docker.container.health === 'healthy'
-                                  ? 'active'
-                                  : docker.container.exists
-                                    ? 'warning'
-                                    : 'inactive'
-                          }
-                          className="h-2 w-2"
-                        />
-                      </div>
-                    </div>
-                    <div className="flex flex-wrap items-center gap-2">
-                      {isBareMetal ? (
-                        <div className="text-accent-violet/80 flex items-center gap-1.5 text-xs">
-                          <Zap size={12} />
-                          Managed by native process — start from Server view
-                        </div>
-                      ) : (
-                        <div className="flex flex-wrap gap-2">
-                          <Button
-                            variant="secondary"
-                            size="sm"
-                            onClick={() => onStartServer('local', runtimeProfile)}
-                            disabled={serverRunning || docker.operating || startupFlowPending}
-                            className="px-3 text-xs"
-                          >
-                            {docker.operating || startupFlowPending ? (
-                              <Loader2 size={14} className="animate-spin" />
-                            ) : (
-                              'Start Local'
-                            )}
-                          </Button>
-                          <Button
-                            variant="secondary"
-                            size="sm"
-                            onClick={() => onStartServer('remote', runtimeProfile)}
-                            disabled={serverRunning || docker.operating || startupFlowPending}
-                            className="px-3 text-xs"
-                          >
-                            Start Remote
-                          </Button>
-                          <Button
-                            variant="danger"
-                            size="sm"
-                            onClick={() => docker.stopContainer()}
-                            disabled={!serverRunning || docker.operating}
-                            className="px-3 text-xs"
-                          >
-                            Stop
-                          </Button>
-                        </div>
-                      )}
-                      <div className="ml-auto shrink-0">
-                        <Button
-                          variant={showUnloadModelsState ? 'danger' : 'secondary'}
-                          size="sm"
-                          onClick={isAsrModelsLoaded ? handleUnloadAllModels : handleReloadModels}
-                          disabled={!serverConnection.reachable || modelsOperationPending}
-                          className="px-3 text-xs"
-                        >
-                          {modelsOperationPending ? (
-                            <>
-                              <Loader2 size={14} className="mr-1 animate-spin" />
-                              {modelsOperationType === 'loading' ? 'Loading...' : 'Unloading...'}
-                            </>
-                          ) : showUnloadModelsState ? (
-                            'Unload Models'
-                          ) : (
-                            'Reload Models'
-                          )}
-                        </Button>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Client Control */}
-                  <div className="flex flex-col space-y-4 rounded-xl border border-white/5 bg-white/5 p-4 shadow-sm">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-3">
-                        <div className={`bg-accent-cyan/10 text-accent-cyan rounded-lg p-2`}>
-                          <Activity size={20} />
-                        </div>
-                        <div className="text-sm font-semibold tracking-wide text-white">
-                          Client Link
-                        </div>
-                      </div>
-                      <div className="flex items-center gap-2.5">
-                        <span className="text-xs font-medium text-slate-400">
-                          {clientStatusLabel}
-                        </span>
-                        {clientRunning && clientMode && (
-                          <span
-                            className={`flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-bold tracking-wide uppercase ${clientMode === 'local' ? 'bg-accent-cyan/15 text-accent-cyan' : 'bg-accent-magenta/15 text-accent-magenta'}`}
-                          >
-                            {clientMode === 'local' ? <Laptop size={10} /> : <Radio size={10} />}
-                            {clientMode}
-                          </span>
-                        )}
-                        <StatusLight
-                          status={
-                            clientRunning && !serverConnection.reachable
-                              ? 'warning'
-                              : clientRunning
-                                ? 'active'
-                                : 'inactive'
-                          }
-                          className="h-2 w-2"
-                        />
-                      </div>
-                    </div>
-                    <div className="flex flex-wrap gap-2">
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        onClick={handleStartClientLocal}
-                        disabled={clientRunning}
-                        className="px-3 text-xs"
-                      >
-                        Start Local
-                      </Button>
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        onClick={handleStartClientRemote}
-                        disabled={clientRunning || isBareMetal}
-                        title={
-                          isBareMetal
-                            ? 'Remote client link is not supported in Metal mode'
-                            : undefined
-                        }
-                        className="px-3 text-xs"
-                      >
-                        Start Remote
-                      </Button>
-                      <Button
-                        variant="danger"
-                        size="sm"
-                        onClick={handleStopClient}
-                        disabled={!clientRunning}
-                        className="px-3 text-xs"
-                      >
-                        Stop
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-              </GlassCard>
-
-              {/* Main Transcription */}
-              <GlassCard
-                title="Main Transcription"
-                className="flex-none"
-                action={
-                  <button
-                    onClick={() => live.toggleMute()}
-                    className={`flex h-7 w-7 items-center justify-center rounded-lg border transition-colors ${live.muted ? 'border-red-500/30 bg-red-500/20 text-red-400 hover:bg-red-500/30' : 'border-white/10 bg-white/5 text-slate-400 hover:bg-white/10 hover:text-white'}`}
-                    title={live.muted ? 'Unmute' : 'Mute'}
-                  >
-                    {live.muted ? <VolumeX size={14} /> : <Volume2 size={14} />}
-                  </button>
+              <div
+                ref={leftContentRef}
+                className="space-y-6 @min-[840px]:[min-height:var(--ts-col-baseline)]"
+                style={
+                  leftColumnBaselineHeight
+                    ? ({
+                        '--ts-col-baseline': `${leftColumnBaselineHeight}px`,
+                      } as React.CSSProperties)
+                    : undefined
                 }
               >
-                <div className="space-y-4">
-                  <div className="flex items-center justify-between gap-6 p-1">
-                    <div className="flex min-w-0 flex-1 flex-col">
-                      <label className="mb-2 ml-1 text-[11px] font-semibold tracking-wider text-slate-500 uppercase">
-                        Source Language
-                      </label>
-                      <div className="flex items-center gap-2">
-                        <div className="bg-accent-magenta/10 text-accent-magenta border-accent-magenta/5 rounded-xl border p-2.5 shadow-inner">
-                          <Languages size={18} />
-                        </div>
-                        <CustomSelect
-                          value={mainLanguage}
-                          onChange={handleMainLanguageChange}
-                          options={mainLanguageOptions}
-                          accentColor="magenta"
-                          className="focus:ring-accent-magenta flex-1 rounded-xl border border-white/10 bg-white/5 px-4 py-2.5 text-sm text-white transition-all outline-none hover:border-white/20 focus:ring-1"
-                        />
-                      </div>
-                    </div>
-                    <div className="mb-1 h-12 w-px self-end bg-white/10"></div>
-                    <div
-                      className="flex min-w-25 flex-col items-center"
-                      title={canTranslate ? '' : 'Current model does not support translation'}
-                    >
-                      <label
-                        className={`mt-1 mb-2 text-center text-[9px] font-bold tracking-widest whitespace-nowrap uppercase ${canTranslate ? 'text-slate-500' : 'text-slate-600 line-through'}`}
-                      >
-                        {isCanaryMainBidi ? 'Translate to' : 'Translate to English'}
-                      </label>
-                      <div className="flex h-11.5 items-center justify-center">
-                        {isCanaryMainBidi ? (
-                          <CustomSelect
-                            value={mainBidiTarget}
-                            onChange={setMainBidiTarget}
-                            options={['Off', ...CANARY_TRANSLATION_TARGETS]}
-                            accentColor="magenta"
-                            className="focus:ring-accent-magenta h-full min-w-25 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-sm text-slate-300 outline-none focus:ring-1"
-                          />
-                        ) : (
-                          <AppleSwitch
-                            checked={mainTranslate && canTranslate}
-                            onChange={setMainTranslate}
-                            size="sm"
-                            disabled={!canTranslate}
-                          />
-                        )}
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Record / Stop Button */}
-                  <div className="flex flex-col gap-2">
-                    {(serverRunning || isRemoteMode) && serverConnection.details?.gpu_error && (
-                      <div className="flex items-start gap-2 rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-300">
-                        <AlertTriangle size={14} className="mt-0.5 shrink-0" />
-                        <span>
-                          {serverConnection.details.gpu_error_action ??
-                            'GPU unavailable — restart your computer to reset the GPU driver, or switch to CPU mode in Settings > Server.'}
-                        </span>
-                      </div>
-                    )}
-                    {(serverRunning || isRemoteMode) &&
-                      serverConnection.ready &&
-                      mainModelDisabled && (
-                        <div className="rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
-                          Main model not selected.
-                        </div>
-                      )}
-                    {isRemoteMode && serverConnection.ready && !admin.status && !admin.loading && (
-                      <div className="flex items-start gap-2 rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
-                        <AlertTriangle size={14} className="mt-0.5 shrink-0" />
-                        <span>
-                          Auth token not configured — enter the server token in Settings to enable
-                          recording.
-                        </span>
-                      </div>
-                    )}
-                    {/* gh-86 #1: review-cycle patches — drop `!mainModelDisabled`
-                        gate (existing model warning needs `serverConnection.ready`,
-                        so the two warnings are naturally non-overlapping; the prior
-                        gate created a silent-disabled gap when both fired); also
-                        suppress when `gpu_error` is set so the red GPU warning
-                        above owns that surface (the "loading" text would be
-                        misleading when the model can't load at all). */}
-                    {canStartRecording &&
-                      recordingDisabledReason !== '' &&
-                      !serverConnection.details?.gpu_error && (
-                        <div
-                          data-testid="recording-disabled-reason"
-                          className="flex items-start gap-2 rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-300"
-                        >
-                          <AlertTriangle size={14} className="mt-0.5 shrink-0" />
-                          <span>{recordingDisabledReason}</span>
-                        </div>
-                      )}
-                    <div className="flex items-center gap-2">
-                      {canStartRecording ? (
-                        <Button
-                          variant="primary"
-                          className="bg-accent-cyan/20 border-accent-cyan/40 text-accent-cyan hover:bg-accent-cyan/30 w-full"
-                          icon={
-                            isConnecting ? (
-                              <Loader2 size={16} className="animate-spin" />
-                            ) : (
-                              <Mic size={16} />
-                            )
-                          }
-                          onClick={handleStartRecording}
-                          disabled={
-                            isLive || !clientRunning || !serverConnection.ready || mainModelDisabled
-                          }
-                        >
-                          {isConnecting ? 'Connecting...' : 'Start Recording'}
-                        </Button>
-                      ) : (
-                        <>
-                          <Button
-                            variant="danger"
-                            className="w-full"
-                            icon={
-                              isProcessing ? (
-                                <Loader2 size={16} className="animate-spin" />
-                              ) : (
-                                <Square size={16} />
-                              )
-                            }
-                            onClick={handleStopRecording}
-                            disabled={isProcessing}
+                {/* Unified Control Center */}
+                <GlassCard
+                  title="Control Center"
+                  className={`blur-panel from-glass-200 to-glass-100 relative flex-none bg-linear-to-b transition-all duration-500 ease-in-out ${isSystemHealthy ? 'border-accent-cyan/50! z-10 shadow-[0_20px_25px_-5px_rgba(0,0,0,0.3),0_8px_10px_-6px_rgba(0,0,0,0.3),inset_0_0_30px_rgba(34,211,238,0.15)]!' : ''}`}
+                >
+                  <div className="space-y-5">
+                    {/* Server Control */}
+                    <div className="flex flex-col space-y-4 rounded-xl border border-white/5 bg-white/5 p-4 shadow-sm">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-3">
+                          <div
+                            className={`bg-accent-magenta/10 text-accent-magenta rounded-lg p-2`}
                           >
-                            {isProcessing
-                              ? transcription.processingProgress?.total
-                                ? `Processing... ${transcription.processingProgress.current}/${transcription.processingProgress.total}`
-                                : 'Processing...'
-                              : 'Stop Recording'}
-                          </Button>
-                          {isRecording && (
-                            <Button
-                              variant="secondary"
-                              className="shrink-0"
-                              icon={
-                                transcription.previewLoading ? (
-                                  <Loader2 size={16} className="animate-spin" />
-                                ) : (
-                                  <Eye size={16} />
-                                )
-                              }
-                              onClick={handlePreview}
-                              disabled={transcription.previewLoading}
-                            >
-                              Preview
-                            </Button>
-                          )}
-                          {(isConnecting || isRecording || isProcessing) && (
-                            <Button
-                              variant="secondary"
-                              className="shrink-0"
-                              icon={<X size={16} />}
-                              onClick={handleCancelProcessing}
-                            >
-                              Cancel
-                            </Button>
-                          )}
-                        </>
-                      )}
-                      {transcription.vadActive && (
-                        <span className="animate-pulse font-mono text-xs whitespace-nowrap text-green-400">
-                          VAD Active
-                        </span>
-                      )}
-                    </div>
-                  </div>
-
-                  {/* Preview — ephemeral "last N seconds" reminder during recording */}
-                  {isRecording &&
-                    (transcription.previewLoading ||
-                      transcription.previewText !== null ||
-                      transcription.previewError) && (
-                      <div className="space-y-2">
-                        <div className="flex items-center gap-2 text-xs font-medium text-slate-400">
-                          <Eye size={14} className="text-accent-cyan" />
-                          <span>
-                            Preview
-                            {transcription.previewSeconds
-                              ? ` · last ${transcription.previewSeconds}s`
-                              : ''}
-                          </span>
+                            <Server size={20} />
+                          </div>
+                          <div className="text-sm font-semibold tracking-wide text-white">
+                            Inference Server
+                          </div>
                         </div>
-                        {transcription.previewError ? (
-                          <div className="rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-400">
-                            {transcription.previewError}
+                        <div className="flex items-center gap-2.5">
+                          <span className="text-xs font-medium text-slate-400">
+                            {isRemoteMode
+                              ? serverConnection.reachable
+                                ? serverConnection.ready
+                                  ? 'Remote Server Ready'
+                                  : 'Remote Server Loading\u2026'
+                                : 'Remote Server Offline'
+                              : isBareMetal
+                                ? serverRunning
+                                  ? 'Native Process Running'
+                                  : 'Server Offline'
+                                : serverRunning && docker.container.health === 'healthy'
+                                  ? 'Docker Container Running'
+                                  : serverRunning
+                                    ? 'Container Starting\u2026'
+                                    : docker.container.exists
+                                      ? 'Container Stopped'
+                                      : 'Container Missing'}
+                          </span>
+                          {isBareMetal && serverRunning && (
+                            <span className="bg-accent-violet/15 text-accent-violet flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-bold tracking-wide uppercase">
+                              <Zap size={10} />
+                              metal
+                            </span>
+                          )}
+                          {!isBareMetal && serverRunning && serverMode && (
+                            <span
+                              className={`flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-bold tracking-wide uppercase ${serverMode === 'local' ? 'bg-accent-cyan/15 text-accent-cyan' : 'bg-accent-magenta/15 text-accent-magenta'}`}
+                            >
+                              {serverMode === 'local' ? <Laptop size={10} /> : <Radio size={10} />}
+                              {serverMode}
+                            </span>
+                          )}
+                          <StatusLight
+                            status={
+                              isRemoteMode
+                                ? serverConnection.reachable
+                                  ? serverConnection.ready
+                                    ? 'active'
+                                    : 'warning'
+                                  : 'inactive'
+                                : isBareMetal
+                                  ? serverRunning
+                                    ? 'active'
+                                    : 'inactive'
+                                  : serverRunning && docker.container.health === 'healthy'
+                                    ? 'active'
+                                    : docker.container.exists
+                                      ? 'warning'
+                                      : 'inactive'
+                            }
+                            className="h-2 w-2"
+                          />
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        {isBareMetal ? (
+                          <div className="text-accent-violet/80 flex items-center gap-1.5 text-xs">
+                            <Zap size={12} />
+                            Managed by native process — start from Server view
                           </div>
                         ) : (
-                          <div className="selectable-text custom-scrollbar max-h-72 min-h-[8rem] overflow-y-auto rounded-xl border border-white/5 bg-black/20 p-4 font-mono text-sm leading-relaxed text-slate-300">
-                            {transcription.previewLoading && !transcription.previewText
-                              ? 'Transcribing recent audio…'
-                              : transcription.previewText || '(no speech detected)'}
-                          </div>
-                        )}
-                      </div>
-                    )}
-
-                  {/* Transcription Result */}
-                  {transcription.result && (
-                    <div className="space-y-2">
-                      {/* Incomplete transcript: the sidecar failed partway through
-                          long audio, or the user cancelled mid-file. The job is
-                          stored as 'completed', so this banner is the only signal
-                          that the text stops early. Warning tone, not error — the
-                          transcript is usable, just truncated. */}
-                      {transcription.result.partial && (
-                        <div
-                          role="alert"
-                          className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-xs text-amber-300"
-                        >
-                          <span>
-                            This transcript is incomplete and may be missing the end of the
-                            recording
-                            {transcription.result.partialReason
-                              ? ` (${transcription.result.partialReason})`
-                              : ''}
-                            .
-                          </span>
-                          <Button
-                            variant="secondary"
-                            disabled={retryingPartial || !transcription.jobId}
-                            onClick={handleRetryPartial}
-                          >
-                            {retryingPartial ? 'Retrying…' : 'Retry'}
-                          </Button>
-                        </div>
-                      )}
-                      <FindReplaceTextEditor
-                        value={editedResultText}
-                        onChange={setEditedResultText}
-                        ariaLabel="Transcription result"
-                        placeholder="Transcription result"
-                        className="selectable-text rounded-xl border border-white/5 bg-black/20 p-4"
-                        textClassName="custom-scrollbar max-h-72 min-h-[8rem] overflow-y-auto font-mono text-sm leading-relaxed text-slate-300"
-                      />
-                      {transcription.result.language && (
-                        <div className="text-xs text-slate-500">
-                          Detected: {transcription.result.language} &middot;{' '}
-                          {transcription.result.duration?.toFixed(1)}s
-                        </div>
-                      )}
-                      <div className="flex items-center gap-2">
-                        <Button
-                          variant="secondary"
-                          size="sm"
-                          icon={<Copy size={14} />}
-                          onClick={handleCopyTranscription}
-                        >
-                          Copy
-                        </Button>
-                        <Button
-                          variant="secondary"
-                          size="sm"
-                          icon={<Download size={14} />}
-                          onClick={handleDownloadTranscription}
-                        >
-                          Download
-                        </Button>
-                      </div>
-                    </div>
-                  )}
-
-                  {/* Errors */}
-                  {transcription.error && (
-                    <div className="rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-400">
-                      {transcription.error}
-                    </div>
-                  )}
-                </div>
-              </GlassCard>
-
-              {/* Audio Configuration */}
-              <GlassCard title="Audio Configuration" className="flex-none">
-                <div className="space-y-6">
-                  <div>
-                    <label className="mb-2 ml-1 block text-xs font-medium tracking-wider text-slate-400 uppercase">
-                      Active Input Source
-                    </label>
-                    <div className="relative flex rounded-xl border border-white/5 bg-black/60 p-1 shadow-[inset_0_2px_4px_rgba(0,0,0,0.3)]">
-                      <div
-                        className={`absolute top-1 bottom-1 z-0 w-[calc(50%-4px)] rounded-lg border-t border-white/10 bg-slate-700 shadow-[0_2px_8px_rgba(0,0,0,0.4)] transition-all duration-300 ease-[cubic-bezier(0.25,0.1,0.25,1)] ${audioSource === 'system' ? 'translate-x-[calc(100%+4px)]' : 'translate-x-0'}`}
-                      />
-                      <button
-                        onClick={() => handleAudioSourceChange('mic')}
-                        className={`relative z-10 flex flex-1 items-center justify-center space-x-2.5 py-2.5 text-sm font-semibold transition-all duration-300 ${audioSource === 'mic' ? 'text-white' : 'text-slate-500 hover:text-slate-300'}`}
-                      >
-                        <Mic
-                          size={18}
-                          className={`transition-all duration-300 ${audioSource === 'mic' ? 'text-accent-cyan scale-110 drop-shadow-[0_0_8px_rgba(34,211,238,0.6)]' : ''}`}
-                        />
-                        <span>Microphone</span>
-                      </button>
-                      <button
-                        onClick={() => handleAudioSourceChange('system')}
-                        className={`relative z-10 flex flex-1 items-center justify-center space-x-2.5 py-2.5 text-sm font-semibold transition-all duration-300 ${audioSource === 'system' ? 'text-white' : 'text-slate-500 hover:text-slate-300'}`}
-                      >
-                        <Laptop
-                          size={18}
-                          className={`transition-all duration-300 ${audioSource === 'system' ? 'text-accent-cyan scale-110 drop-shadow-[0_0_8px_rgba(34,211,238,0.6)]' : ''}`}
-                        />
-                        <span>System Audio</span>
-                      </button>
-                    </div>
-                  </div>
-                  <div className="h-px w-full bg-white/5"></div>
-                  <div className="space-y-4">
-                    <div
-                      className={`rounded-xl border p-3 transition-all duration-300 ${audioSource === 'mic' ? 'bg-accent-cyan/5 border-accent-cyan/20 shadow-[0_0_10px_rgba(34,211,238,0.05)]' : 'border-transparent bg-transparent hover:bg-white/5'}`}
-                    >
-                      <div className="mb-2 flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                          <Mic
-                            size={14}
-                            className={
-                              audioSource === 'mic' ? 'text-accent-cyan' : 'text-slate-500'
-                            }
-                          />
-                          <label
-                            className={`text-xs font-medium ${audioSource === 'mic' ? 'text-white' : 'text-slate-400'}`}
-                          >
-                            Microphone Device
-                          </label>
-                        </div>
-                        {audioSource === 'mic' && (
-                          <span className="bg-accent-cyan rounded px-1.5 py-0.5 text-[10px] font-bold tracking-wide text-black uppercase">
-                            Live
-                          </span>
-                        )}
-                      </div>
-                      <div className="flex min-w-0 items-center gap-2">
-                        <div className="min-w-0 flex-1">
-                          <CustomSelect
-                            value={micDevice}
-                            onChange={handleMicDeviceChange}
-                            options={micDevices.length > 0 ? micDevices : ['Default Microphone']}
-                            className="focus:ring-accent-cyan w-full min-w-0 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white transition-shadow outline-none hover:border-white/20 focus:ring-1"
-                          />
-                        </div>
-                        <Button
-                          variant="secondary"
-                          size="icon"
-                          className="shrink-0"
-                          icon={<RefreshCw size={14} />}
-                          onClick={enumerateDevices}
-                        />
-                      </div>
-                    </div>
-                    <div
-                      className={`rounded-xl border p-3 transition-all duration-300 ${audioSource === 'system' ? 'bg-accent-cyan/5 border-accent-cyan/20 shadow-[0_0_10px_rgba(34,211,238,0.05)]' : 'border-transparent bg-transparent hover:bg-white/5'}`}
-                    >
-                      <div className="mb-2 flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                          <Laptop
-                            size={14}
-                            className={
-                              audioSource === 'system' ? 'text-accent-cyan' : 'text-slate-500'
-                            }
-                          />
-                          <label
-                            className={`text-xs font-medium ${audioSource === 'system' ? 'text-white' : 'text-slate-400'}`}
-                          >
-                            System Audio
-                          </label>
-                        </div>
-                        {audioSource === 'system' && (
-                          <span className="bg-accent-cyan rounded px-1.5 py-0.5 text-[10px] font-bold tracking-wide text-black uppercase">
-                            Live
-                          </span>
-                        )}
-                      </div>
-                      <div className="flex min-w-0 items-center gap-2">
-                        <div className="min-w-0 flex-1">
-                          {isLinux ? (
-                            <CustomSelect
-                              value={sysDevice}
-                              onChange={handleSystemDeviceChange}
-                              options={sysDevices.length > 0 ? sysDevices : ['Default Output']}
-                              className="focus:ring-accent-cyan w-full min-w-0 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white transition-shadow outline-none hover:border-white/20 focus:ring-1"
-                            />
-                          ) : (
-                            <div className="w-full min-w-0 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/60 select-none">
-                              All System Audio
-                            </div>
-                          )}
-                        </div>
-                        {isLinux && (
-                          <Button
-                            variant="secondary"
-                            size="icon"
-                            className="shrink-0"
-                            icon={<RefreshCw size={14} />}
-                            onClick={fetchSinks}
-                          />
-                        )}
-                      </div>
-                      {/* Capture gain slider — boost or attenuate system audio input */}
-                      {audioSource === 'system' && (
-                        <div className="mt-2.5">
-                          <div className="mb-1 flex items-center justify-between">
-                            <label className="text-[11px] font-medium text-slate-400">
-                              Capture Gain
-                            </label>
-                            <div className="flex items-center gap-1.5">
-                              {monitorVolumePct !== null && (
-                                <span className="rounded bg-white/5 px-1.5 py-0.5 text-[10px] text-slate-500 tabular-nums">
-                                  src {monitorVolumePct}%
-                                </span>
-                              )}
-                              <span className="min-w-[3ch] text-right text-[11px] text-slate-300 tabular-nums">
-                                {captureGain.toFixed(2)}x
-                              </span>
-                            </div>
-                          </div>
-                          <input
-                            type="range"
-                            min={0.25}
-                            max={5}
-                            step={0.25}
-                            value={captureGain}
-                            onChange={(e) => handleCaptureGainChange(parseFloat(e.target.value))}
-                            className="ts-gain-slider h-1 w-full cursor-pointer appearance-none rounded-full bg-white/10 accent-cyan-400"
-                          />
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              </GlassCard>
-            </div>
-          </div>
-
-          {/* Left Bottom Scroll Indicator */}
-          <div
-            className={`pointer-events-none absolute right-3 bottom-0 left-0 z-20 h-6 overflow-hidden rounded-b-2xl transition-opacity duration-300 ${leftScrollState.bottom ? 'opacity-100' : 'opacity-0'}`}
-          >
-            <div
-              className="h-full w-full bg-linear-to-t from-white/10 to-transparent backdrop-blur-sm"
-              style={{
-                maskImage: 'linear-gradient(to top, black 50%, transparent 100%)',
-                WebkitMaskImage: 'linear-gradient(to top, black 50%, transparent 100%)',
-              }}
-            ></div>
-          </div>
-          {/* Left Bottom Corner Mask */}
-          <div
-            className="pointer-events-none absolute right-3 bottom-0 z-20 h-4 w-4 @max-[840px]:hidden"
-            style={{
-              ...maskStyle,
-              maskImage: 'radial-gradient(circle at top left, transparent 1rem, black 1rem)',
-              WebkitMaskImage: 'radial-gradient(circle at top left, transparent 1rem, black 1rem)',
-            }}
-          />
-        </div>
-
-        {/* Right Column: Visualizer & Live Mode (60%) */}
-        {/* @max-[840px]: stacks below the left column as one scrolling grid, and slides in
-            via the reflowStackIn keyframe (motion-safe only — reduced-motion = instant).
-            min-h-0 is gated to @min-[840px] for the same reason as the left column: in
-            stacked mode it would let the grid stretch the rows to equal heights and cause
-            the panels to overlap. */}
-        <div className="relative flex min-w-0 flex-col overflow-hidden rounded-2xl @max-[840px]:overflow-visible @max-[840px]:motion-safe:animate-[reflowStackIn_0.3s_cubic-bezier(0.16,1,0.3,1)] @min-[840px]:min-h-0">
-          {/* Right Top Scroll Indicator */}
-          <div
-            className={`pointer-events-none absolute top-0 right-3 left-0 z-20 h-6 overflow-hidden rounded-t-2xl transition-opacity duration-300 ${rightScrollState.top ? 'opacity-100' : 'opacity-0'}`}
-          >
-            <div
-              className="h-full w-full bg-linear-to-b from-white/10 to-transparent backdrop-blur-sm"
-              style={{
-                maskImage: 'linear-gradient(to bottom, black 50%, transparent 100%)',
-                WebkitMaskImage: 'linear-gradient(to bottom, black 50%, transparent 100%)',
-              }}
-            ></div>
-          </div>
-          {/* Right Top Corner Mask */}
-          <div
-            className="pointer-events-none absolute top-0 right-3 z-20 h-4 w-4 @max-[840px]:hidden"
-            style={{
-              ...maskStyle,
-              maskImage: 'radial-gradient(circle at bottom left, transparent 1rem, black 1rem)',
-              WebkitMaskImage:
-                'radial-gradient(circle at bottom left, transparent 1rem, black 1rem)',
-            }}
-          />
-
-          {/* Right Column Scroll Container */}
-          <div
-            ref={rightScrollRef}
-            className="custom-scrollbar flex-1 overflow-y-auto pt-0 pr-3 pb-0 @max-[840px]:overflow-visible"
-          >
-            {/* Baseline min-height applies in the two-column layout only (see left column);
-                gated behind @min-[840px] so it no-ops when stacked. */}
-            <div
-              ref={rightContentRef}
-              className="flex min-h-full flex-col @min-[840px]:[min-height:var(--ts-col-baseline)]"
-              style={
-                rightColumnBaselineHeight
-                  ? ({
-                      '--ts-col-baseline': `${rightColumnBaselineHeight}px`,
-                    } as React.CSSProperties)
-                  : undefined
-              }
-            >
-              {/* Visualizer Card */}
-              <GlassCard className="relative z-10 mb-6 flex-none overflow-visible">
-                <div className="mb-4 flex shrink-0 items-center justify-between">
-                  <div className="flex items-center gap-3">
-                    <div className="bg-accent-cyan/10 text-accent-cyan rounded-full p-2">
-                      <Activity size={20} className={isLive ? 'animate-pulse' : ''} />
-                    </div>
-                    <div>
-                      <h3 className="font-semibold text-white">Audio Visualizer</h3>
-                      <p className="text-xs text-slate-400">
-                        {activeAnalyser ? 'Live — listening' : 'Idle — awaiting input'}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <div className="flex items-center gap-1 rounded-lg border border-white/5 bg-black/20 p-0.5">
-                      <button
-                        onClick={() =>
-                          setVisualizerAmplitudeScale((s) => Math.max(0.25, +(s - 0.25).toFixed(2)))
-                        }
-                        className="rounded p-1 text-slate-400 transition-colors hover:bg-white/10 hover:text-white"
-                        title="Decrease sensitivity"
-                      >
-                        <Minus size={14} />
-                      </button>
-                      <button
-                        onClick={() =>
-                          setVisualizerAmplitudeScale((s) => Math.min(4, +(s + 0.25).toFixed(2)))
-                        }
-                        className="rounded p-1 text-slate-400 transition-colors hover:bg-white/10 hover:text-white"
-                        title="Increase sensitivity"
-                      >
-                        <Plus size={14} />
-                      </button>
-                    </div>
-                    <button
-                      onClick={() => setIsFullscreenVisualizerOpen(true)}
-                      className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-slate-400 transition-colors hover:bg-white/10 hover:text-white"
-                      title="Fullscreen"
-                    >
-                      <Maximize2 size={14} />
-                    </button>
-                  </div>
-                </div>
-                <AudioVisualizer
-                  analyserNode={activeAnalyser}
-                  amplitudeScale={visualizerAmplitudeScale}
-                  isActive={!!activeAnalyser}
-                />
-              </GlassCard>
-
-              {/* Live Mode (Text + Controls) */}
-              {isLivePoppedOut ? (
-                <>
-                  {/* Greyed-out placeholder while popped out */}
-                  <GlassCard
-                    className="flex min-h-[calc(100vh-30rem)] flex-1 flex-col opacity-40 transition-all duration-300"
-                    title="Live Mode"
-                    action={
-                      <button
-                        onClick={() => setIsLivePoppedOut(false)}
-                        className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-slate-400 transition-colors hover:bg-white/10 hover:text-white"
-                        title="Return Live Mode to this window"
-                      >
-                        <Minimize2 size={14} />
-                      </button>
-                    }
-                  >
-                    <div className="flex min-h-0 flex-1 items-center justify-center rounded-xl border border-white/5 bg-black/20">
-                      <div className="flex flex-col items-center space-y-3 text-center text-slate-500 select-none">
-                        <ExternalLink size={48} strokeWidth={1} />
-                        <p className="text-sm">Live Mode is in a separate window.</p>
-                        <button
-                          onClick={() => setIsLivePoppedOut(false)}
-                          className="mt-1 rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs text-slate-400 transition-colors hover:bg-white/10 hover:text-white"
-                        >
-                          Return here
-                        </button>
-                      </div>
-                    </div>
-                  </GlassCard>
-                  {/* Pop-out window with live content */}
-                  <PopOutWindow
-                    isOpen={isLivePoppedOut}
-                    onClose={() => setIsLivePoppedOut(false)}
-                    title="Live Mode — Transcription Suite"
-                    width={520}
-                    height={650}
-                  >
-                    <div className="flex h-full flex-col bg-[#0f172a] p-4">
-                      {/* Pop-out header bar */}
-                      <div className="mb-4 flex shrink-0 items-center justify-between">
-                        <h2 className="text-sm font-semibold tracking-wide text-white/90">
-                          Live Mode
-                        </h2>
-                        <div className="flex items-center gap-2">
-                          <button
-                            onClick={() => live.toggleMute()}
-                            className={`flex h-7 w-7 items-center justify-center rounded-lg border transition-colors ${live.muted ? 'border-red-500/30 bg-red-500/20 text-red-400 hover:bg-red-500/30' : 'border-white/10 bg-white/5 text-slate-400 hover:bg-white/10 hover:text-white'}`}
-                            title={live.muted ? 'Unmute' : 'Mute'}
-                          >
-                            {live.muted ? <VolumeX size={14} /> : <Volume2 size={14} />}
-                          </button>
-                          <button
-                            onClick={() => setIsLivePoppedOut(false)}
-                            className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-slate-400 transition-colors hover:bg-white/10 hover:text-white"
-                            title="Return to main window"
-                          >
-                            <Minimize2 size={14} />
-                          </button>
-                        </div>
-                      </div>
-                      {/* Controls Toolbar */}
-                      <div className="custom-scrollbar no-scrollbar mb-4 flex shrink-0 flex-nowrap items-center gap-2 overflow-x-auto border-b border-white/5 p-1 pb-4">
-                        <div className="flex h-8 shrink-0 items-center gap-2">
-                          <span
-                            className={`text-xs font-bold tracking-wider uppercase ${isLive ? 'text-green-400' : 'text-slate-500'}`}
-                          >
-                            {live.status === 'starting'
-                              ? 'Loading...'
-                              : isLive
-                                ? 'Active'
-                                : 'Offline'}
-                          </span>
-                          <span
-                            title={
-                              !isLive && liveModeDisabledReason ? liveModeDisabledReason : undefined
-                            }
-                          >
-                            <AppleSwitch
-                              checked={isLive}
-                              onChange={handleLiveToggle}
+                          <div className="flex flex-wrap gap-2">
+                            <Button
+                              variant="secondary"
                               size="sm"
-                              disabled={
-                                !isLive &&
-                                (!clientRunning ||
-                                  !serverConnection.ready ||
-                                  liveModelDisabled ||
-                                  !liveModeWhisperOnlyCompatible)
-                              }
-                            />
-                          </span>
-                        </div>
-                        <div className="mx-0.5 h-5 w-px shrink-0 bg-white/10"></div>
-                        <div className="flex h-8 shrink-0 items-center gap-2">
-                          <div className="bg-accent-magenta/10 text-accent-magenta border-accent-magenta/5 flex aspect-square h-full items-center justify-center rounded-lg border">
-                            <Languages size={15} />
+                              onClick={() => onStartServer('local', runtimeProfile)}
+                              disabled={serverRunning || docker.operating || startupFlowPending}
+                              className="px-3 text-xs"
+                            >
+                              {docker.operating || startupFlowPending ? (
+                                <Loader2 size={14} className="animate-spin" />
+                              ) : (
+                                'Start Local'
+                              )}
+                            </Button>
+                            <Button
+                              variant="secondary"
+                              size="sm"
+                              onClick={() => onStartServer('remote', runtimeProfile)}
+                              disabled={serverRunning || docker.operating || startupFlowPending}
+                              className="px-3 text-xs"
+                            >
+                              Start Remote
+                            </Button>
+                            <Button
+                              variant="danger"
+                              size="sm"
+                              onClick={() => docker.stopContainer()}
+                              disabled={!serverRunning || docker.operating}
+                              className="px-3 text-xs"
+                            >
+                              Stop
+                            </Button>
                           </div>
-                          <CustomSelect
-                            value={liveLanguage}
-                            onChange={handleLiveLanguageChange}
-                            options={liveLanguageOptions}
-                            accentColor="magenta"
-                            className="focus:ring-accent-magenta h-full min-w-32.5 rounded-lg border border-white/10 bg-white/5 px-3 py-1 text-sm text-slate-300 outline-none focus:ring-1"
+                        )}
+                        <div className="ml-auto shrink-0">
+                          <Button
+                            variant={showUnloadModelsState ? 'danger' : 'secondary'}
+                            size="sm"
+                            onClick={isAsrModelsLoaded ? handleUnloadAllModels : handleReloadModels}
+                            disabled={!serverConnection.reachable || modelsOperationPending}
+                            className="px-3 text-xs"
+                          >
+                            {modelsOperationPending ? (
+                              <>
+                                <Loader2 size={14} className="mr-1 animate-spin" />
+                                {modelsOperationType === 'loading' ? 'Loading...' : 'Unloading...'}
+                              </>
+                            ) : showUnloadModelsState ? (
+                              'Unload Models'
+                            ) : (
+                              'Reload Models'
+                            )}
+                          </Button>
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* Client Control */}
+                    <div className="flex flex-col space-y-4 rounded-xl border border-white/5 bg-white/5 p-4 shadow-sm">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-3">
+                          <div className={`bg-accent-cyan/10 text-accent-cyan rounded-lg p-2`}>
+                            <Activity size={20} />
+                          </div>
+                          <div className="text-sm font-semibold tracking-wide text-white">
+                            Client Link
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-2.5">
+                          <span className="text-xs font-medium text-slate-400">
+                            {clientStatusLabel}
+                          </span>
+                          {clientRunning && clientMode && (
+                            <span
+                              className={`flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-bold tracking-wide uppercase ${clientMode === 'local' ? 'bg-accent-cyan/15 text-accent-cyan' : 'bg-accent-magenta/15 text-accent-magenta'}`}
+                            >
+                              {clientMode === 'local' ? <Laptop size={10} /> : <Radio size={10} />}
+                              {clientMode}
+                            </span>
+                          )}
+                          <StatusLight
+                            status={
+                              clientRunning && !serverConnection.reachable
+                                ? 'warning'
+                                : clientRunning
+                                  ? 'active'
+                                  : 'inactive'
+                            }
+                            className="h-2 w-2"
                           />
                         </div>
-                        <div className="mx-0.5 h-5 w-px shrink-0 bg-white/10"></div>
-                        <div
-                          className="flex h-8 shrink-0 items-center gap-2"
-                          title={
-                            canTranslateLive ? '' : 'Current model does not support translation'
-                          }
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          onClick={handleStartClientLocal}
+                          disabled={clientRunning}
+                          className="px-3 text-xs"
                         >
-                          <span
-                            className={`text-[9px] font-bold tracking-widest whitespace-nowrap uppercase ${canTranslateLive ? 'text-slate-500' : 'text-slate-600 line-through'}`}
-                          >
-                            {isCanaryLiveBidi ? 'Translate to' : 'Translate to English'}
-                          </span>
-                          {isCanaryLiveBidi ? (
+                          Start Local
+                        </Button>
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          onClick={handleStartClientRemote}
+                          disabled={clientRunning || isBareMetal}
+                          title={
+                            isBareMetal
+                              ? 'Remote client link is not supported in Metal mode'
+                              : undefined
+                          }
+                          className="px-3 text-xs"
+                        >
+                          Start Remote
+                        </Button>
+                        <Button
+                          variant="danger"
+                          size="sm"
+                          onClick={handleStopClient}
+                          disabled={!clientRunning}
+                          className="px-3 text-xs"
+                        >
+                          Stop
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                </GlassCard>
+
+                {/* Main Transcription */}
+                <GlassCard
+                  title="Main Transcription"
+                  className="flex-none"
+                  action={
+                    <button
+                      onClick={() => live.toggleMute()}
+                      className={`flex h-7 w-7 items-center justify-center rounded-lg border transition-colors ${live.muted ? 'border-red-500/30 bg-red-500/20 text-red-400 hover:bg-red-500/30' : 'border-white/10 bg-white/5 text-slate-400 hover:bg-white/10 hover:text-white'}`}
+                      title={live.muted ? 'Unmute' : 'Mute'}
+                    >
+                      {live.muted ? <VolumeX size={14} /> : <Volume2 size={14} />}
+                    </button>
+                  }
+                >
+                  <div className="space-y-4">
+                    <div className="flex items-center justify-between gap-6 p-1">
+                      <div className="flex min-w-0 flex-1 flex-col">
+                        <label className="mb-2 ml-1 text-[11px] font-semibold tracking-wider text-slate-500 uppercase">
+                          Source Language
+                        </label>
+                        <div className="flex items-center gap-2">
+                          <div className="bg-accent-magenta/10 text-accent-magenta border-accent-magenta/5 rounded-xl border p-2.5 shadow-inner">
+                            <Languages size={18} />
+                          </div>
+                          <CustomSelect
+                            value={mainLanguage}
+                            onChange={handleMainLanguageChange}
+                            options={mainLanguageOptions}
+                            accentColor="magenta"
+                            className="focus:ring-accent-magenta flex-1 rounded-xl border border-white/10 bg-white/5 px-4 py-2.5 text-sm text-white transition-all outline-none hover:border-white/20 focus:ring-1"
+                          />
+                        </div>
+                      </div>
+                      <div className="mb-1 h-12 w-px self-end bg-white/10"></div>
+                      <div
+                        className="flex min-w-25 flex-col items-center"
+                        title={canTranslate ? '' : 'Current model does not support translation'}
+                      >
+                        <label
+                          className={`mt-1 mb-2 text-center text-[9px] font-bold tracking-widest whitespace-nowrap uppercase ${canTranslate ? 'text-slate-500' : 'text-slate-600 line-through'}`}
+                        >
+                          {isCanaryMainBidi ? 'Translate to' : 'Translate to English'}
+                        </label>
+                        <div className="flex h-11.5 items-center justify-center">
+                          {isCanaryMainBidi ? (
                             <CustomSelect
-                              value={liveBidiTarget}
-                              onChange={setLiveBidiTarget}
+                              value={mainBidiTarget}
+                              onChange={setMainBidiTarget}
                               options={['Off', ...CANARY_TRANSLATION_TARGETS]}
                               accentColor="magenta"
                               className="focus:ring-accent-magenta h-full min-w-25 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-sm text-slate-300 outline-none focus:ring-1"
                             />
                           ) : (
                             <AppleSwitch
-                              checked={liveTranslate && canTranslateLive}
-                              onChange={setLiveTranslate}
+                              checked={mainTranslate && canTranslate}
+                              onChange={setMainTranslate}
                               size="sm"
-                              disabled={!canTranslateLive}
+                              disabled={!canTranslate}
                             />
                           )}
                         </div>
-                        <div className="mx-0.5 h-5 w-px shrink-0 bg-white/10"></div>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          icon={<Copy size={14} />}
-                          onClick={handleLiveCopyAndClear}
-                          className="ml-auto h-8 shrink-0 whitespace-nowrap"
-                        >
-                          Copy
-                        </Button>
                       </div>
-                      {/* Transcript Area */}
-                      <LiveTranscriptView
-                        live={live}
-                        isLive={isLive}
-                        hideTimestamps={hideTimestamps}
-                        serverRunning={serverRunning}
-                        isRemoteMode={isRemoteMode}
-                        serverReady={serverConnection.ready}
-                        liveModelDisabled={liveModelDisabled}
-                        liveModeWhisperOnlyCompatible={liveModeWhisperOnlyCompatible}
-                        liveModeUnsupportedMessage={liveModeUnsupportedMessage}
-                        transcriptRef={liveTranscriptRef}
-                        editedLiveText={editedLiveText}
-                        onEditedLiveChange={handleEditedLiveChange}
-                      />
                     </div>
-                  </PopOutWindow>
-                </>
-              ) : (
-                <GlassCard
-                  className="flex min-h-[calc(100vh-30rem)] flex-1 flex-col transition-all duration-300"
-                  title="Live Mode"
-                  action={
-                    <div className="flex items-center gap-1.5">
-                      <button
-                        onClick={() => setIsLivePoppedOut(true)}
-                        className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-slate-400 transition-colors hover:bg-white/10 hover:text-white"
-                        title="Pop out into separate window"
-                      >
-                        <ExternalLink size={14} />
-                      </button>
-                      <button
-                        onClick={() => live.toggleMute()}
-                        className={`flex h-7 w-7 items-center justify-center rounded-lg border transition-colors ${live.muted ? 'border-red-500/30 bg-red-500/20 text-red-400 hover:bg-red-500/30' : 'border-white/10 bg-white/5 text-slate-400 hover:bg-white/10 hover:text-white'}`}
-                        title={live.muted ? 'Unmute' : 'Mute'}
-                      >
-                        {live.muted ? <VolumeX size={14} /> : <Volume2 size={14} />}
-                      </button>
-                    </div>
-                  }
-                >
-                  {/* Live Mode Controls Toolbar */}
-                  <div className="custom-scrollbar no-scrollbar mb-4 flex flex-none flex-nowrap items-center gap-2 overflow-x-auto border-b border-white/5 p-1 pb-4">
-                    <div className="flex h-8 shrink-0 items-center gap-2">
-                      <span
-                        className={`text-xs font-bold tracking-wider uppercase ${isLive ? 'text-green-400' : 'text-slate-500'}`}
-                      >
-                        {live.status === 'starting' ? 'Loading...' : isLive ? 'Active' : 'Offline'}
-                      </span>
-                      <span
-                        title={
-                          !isLive && liveModeDisabledReason ? liveModeDisabledReason : undefined
-                        }
-                      >
-                        <AppleSwitch
-                          checked={isLive}
-                          onChange={handleLiveToggle}
-                          size="sm"
-                          disabled={
-                            !isLive &&
-                            (!clientRunning ||
-                              !serverConnection.ready ||
-                              liveModelDisabled ||
-                              !liveModeWhisperOnlyCompatible)
-                          }
-                        />
-                      </span>
-                    </div>
-                    <div className="mx-0.5 h-5 w-px shrink-0 bg-white/10"></div>
-                    <div className="flex h-8 shrink-0 items-center gap-2">
-                      <div className="bg-accent-magenta/10 text-accent-magenta border-accent-magenta/5 flex aspect-square h-full items-center justify-center rounded-lg border">
-                        <Languages size={15} />
-                      </div>
-                      <CustomSelect
-                        value={liveLanguage}
-                        onChange={handleLiveLanguageChange}
-                        options={liveLanguageOptions}
-                        accentColor="magenta"
-                        className="focus:ring-accent-magenta h-full min-w-32.5 rounded-lg border border-white/10 bg-white/5 px-3 py-1 text-sm text-slate-300 outline-none focus:ring-1"
-                      />
-                    </div>
-                    <div className="mx-0.5 h-5 w-px shrink-0 bg-white/10"></div>
-                    <div
-                      className="flex h-8 shrink-0 items-center gap-2"
-                      title={canTranslateLive ? '' : 'Current model does not support translation'}
-                    >
-                      <span
-                        className={`text-[9px] font-bold tracking-widest whitespace-nowrap uppercase ${canTranslateLive ? 'text-slate-500' : 'text-slate-600 line-through'}`}
-                      >
-                        {isCanaryLiveBidi ? 'Translate to' : 'Translate to English'}
-                      </span>
-                      {isCanaryLiveBidi ? (
-                        <CustomSelect
-                          value={liveBidiTarget}
-                          onChange={setLiveBidiTarget}
-                          options={['Off', ...CANARY_TRANSLATION_TARGETS]}
-                          accentColor="magenta"
-                          className="focus:ring-accent-magenta h-full min-w-25 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-sm text-slate-300 outline-none focus:ring-1"
-                        />
-                      ) : (
-                        <AppleSwitch
-                          checked={liveTranslate && canTranslateLive}
-                          onChange={setLiveTranslate}
-                          size="sm"
-                          disabled={!canTranslateLive}
-                        />
-                      )}
-                    </div>
-                    <div className="mx-0.5 h-5 w-px shrink-0 bg-white/10"></div>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      icon={<Copy size={14} />}
-                      onClick={handleLiveCopyAndClear}
-                      className="ml-auto h-8 shrink-0 whitespace-nowrap"
-                    >
-                      Copy
-                    </Button>
-                  </div>
 
-                  {/* Transcript Area */}
-                  <LiveTranscriptView
-                    live={live}
-                    isLive={isLive}
-                    hideTimestamps={hideTimestamps}
-                    serverRunning={serverRunning}
-                    isRemoteMode={isRemoteMode}
-                    serverReady={serverConnection.ready}
-                    liveModelDisabled={liveModelDisabled}
-                    liveModeWhisperOnlyCompatible={liveModeWhisperOnlyCompatible}
-                    liveModeUnsupportedMessage={liveModeUnsupportedMessage}
-                    transcriptRef={liveTranscriptRef}
-                    editedLiveText={editedLiveText}
-                    onEditedLiveChange={handleEditedLiveChange}
+                    {/* Record / Stop Button */}
+                    <div className="flex flex-col gap-2">
+                      {(serverRunning || isRemoteMode) && serverConnection.details?.gpu_error && (
+                        <div className="flex items-start gap-2 rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-300">
+                          <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+                          <span>
+                            {serverConnection.details.gpu_error_action ??
+                              'GPU unavailable — restart your computer to reset the GPU driver, or switch to CPU mode in Settings > Server.'}
+                          </span>
+                        </div>
+                      )}
+                      {(serverRunning || isRemoteMode) &&
+                        serverConnection.ready &&
+                        mainModelDisabled && (
+                          <div className="rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
+                            Main model not selected.
+                          </div>
+                        )}
+                      {isRemoteMode &&
+                        serverConnection.ready &&
+                        !admin.status &&
+                        !admin.loading && (
+                          <div className="flex items-start gap-2 rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
+                            <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+                            <span>
+                              Auth token not configured — enter the server token in Settings to
+                              enable recording.
+                            </span>
+                          </div>
+                        )}
+                      {/* gh-86 #1: review-cycle patches — drop `!mainModelDisabled`
+                        gate (existing model warning needs `serverConnection.ready`,
+                        so the two warnings are naturally non-overlapping; the prior
+                        gate created a silent-disabled gap when both fired); also
+                        suppress when `gpu_error` is set so the red GPU warning
+                        above owns that surface (the "loading" text would be
+                        misleading when the model can't load at all). */}
+                      {canStartRecording &&
+                        recordingDisabledReason !== '' &&
+                        !serverConnection.details?.gpu_error && (
+                          <div
+                            data-testid="recording-disabled-reason"
+                            className="flex items-start gap-2 rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-300"
+                          >
+                            <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+                            <span>{recordingDisabledReason}</span>
+                          </div>
+                        )}
+                      <div className="flex items-center gap-2">
+                        {canStartRecording ? (
+                          <Button
+                            variant="primary"
+                            className="bg-accent-cyan/20 border-accent-cyan/40 text-accent-cyan hover:bg-accent-cyan/30 w-full"
+                            icon={
+                              isConnecting ? (
+                                <Loader2 size={16} className="animate-spin" />
+                              ) : (
+                                <Mic size={16} />
+                              )
+                            }
+                            onClick={handleStartRecording}
+                            disabled={
+                              isLive ||
+                              !clientRunning ||
+                              !serverConnection.ready ||
+                              mainModelDisabled
+                            }
+                          >
+                            {isConnecting ? 'Connecting...' : 'Start Recording'}
+                          </Button>
+                        ) : (
+                          <>
+                            <Button
+                              variant="danger"
+                              className="w-full"
+                              icon={
+                                isProcessing ? (
+                                  <Loader2 size={16} className="animate-spin" />
+                                ) : (
+                                  <Square size={16} />
+                                )
+                              }
+                              onClick={handleStopRecording}
+                              disabled={isProcessing}
+                            >
+                              {isProcessing
+                                ? transcription.processingProgress?.total
+                                  ? `Processing... ${transcription.processingProgress.current}/${transcription.processingProgress.total}`
+                                  : 'Processing...'
+                                : 'Stop Recording'}
+                            </Button>
+                            {isRecording && (
+                              <Button
+                                variant="secondary"
+                                className="shrink-0"
+                                icon={
+                                  transcription.previewLoading ? (
+                                    <Loader2 size={16} className="animate-spin" />
+                                  ) : (
+                                    <Eye size={16} />
+                                  )
+                                }
+                                onClick={handlePreview}
+                                disabled={transcription.previewLoading}
+                              >
+                                Preview
+                              </Button>
+                            )}
+                            {(isConnecting || isRecording || isProcessing) && (
+                              <Button
+                                variant="secondary"
+                                className="shrink-0"
+                                icon={<X size={16} />}
+                                onClick={handleCancelProcessing}
+                              >
+                                Cancel
+                              </Button>
+                            )}
+                          </>
+                        )}
+                        {transcription.vadActive && (
+                          <span className="animate-pulse font-mono text-xs whitespace-nowrap text-green-400">
+                            VAD Active
+                          </span>
+                        )}
+                      </div>
+                    </div>
+
+                    {/* Preview — ephemeral "last N seconds" reminder during recording */}
+                    {isRecording &&
+                      (transcription.previewLoading ||
+                        transcription.previewText !== null ||
+                        transcription.previewError) && (
+                        <div className="space-y-2">
+                          <div className="flex items-center gap-2 text-xs font-medium text-slate-400">
+                            <Eye size={14} className="text-accent-cyan" />
+                            <span>
+                              Preview
+                              {transcription.previewSeconds
+                                ? ` · last ${transcription.previewSeconds}s`
+                                : ''}
+                            </span>
+                          </div>
+                          {transcription.previewError ? (
+                            <div className="rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+                              {transcription.previewError}
+                            </div>
+                          ) : (
+                            <div className="selectable-text custom-scrollbar max-h-72 min-h-[8rem] overflow-y-auto rounded-xl border border-white/5 bg-black/20 p-4 font-mono text-sm leading-relaxed text-slate-300">
+                              {transcription.previewLoading && !transcription.previewText
+                                ? 'Transcribing recent audio…'
+                                : transcription.previewText || '(no speech detected)'}
+                            </div>
+                          )}
+                        </div>
+                      )}
+
+                    {/* Transcription Result */}
+                    {transcription.result && (
+                      <div className="space-y-2">
+                        {/* Incomplete transcript: the sidecar failed partway through
+                          long audio, or the user cancelled mid-file. The job is
+                          stored as 'completed', so this banner is the only signal
+                          that the text stops early. Warning tone, not error — the
+                          transcript is usable, just truncated. */}
+                        {transcription.result.partial && (
+                          <div
+                            role="alert"
+                            className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-xs text-amber-300"
+                          >
+                            <span>
+                              This transcript is incomplete and may be missing the end of the
+                              recording
+                              {transcription.result.partialReason
+                                ? ` (${transcription.result.partialReason})`
+                                : ''}
+                              .
+                            </span>
+                            <Button
+                              variant="secondary"
+                              disabled={retryingPartial || !transcription.jobId}
+                              onClick={handleRetryPartial}
+                            >
+                              {retryingPartial ? 'Retrying…' : 'Retry'}
+                            </Button>
+                          </div>
+                        )}
+                        <FindReplaceTextEditor
+                          value={editedResultText}
+                          onChange={setEditedResultText}
+                          ariaLabel="Transcription result"
+                          placeholder="Transcription result"
+                          className="selectable-text rounded-xl border border-white/5 bg-black/20 p-4"
+                          textClassName="custom-scrollbar max-h-72 min-h-[8rem] overflow-y-auto font-mono text-sm leading-relaxed text-slate-300"
+                        />
+                        {transcription.result.language && (
+                          <div className="text-xs text-slate-500">
+                            Detected: {transcription.result.language} &middot;{' '}
+                            {transcription.result.duration?.toFixed(1)}s
+                          </div>
+                        )}
+                        <div className="flex items-center gap-2">
+                          <Button
+                            variant="secondary"
+                            size="sm"
+                            icon={<Copy size={14} />}
+                            onClick={handleCopyTranscription}
+                          >
+                            Copy
+                          </Button>
+                          <Button
+                            variant="secondary"
+                            size="sm"
+                            icon={<Download size={14} />}
+                            onClick={handleDownloadTranscription}
+                          >
+                            Download
+                          </Button>
+                        </div>
+                      </div>
+                    )}
+
+                    {/* Errors */}
+                    {transcription.error && (
+                      <div className="rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+                        {transcription.error}
+                      </div>
+                    )}
+                  </div>
+                </GlassCard>
+
+                {/* Audio Configuration */}
+                <GlassCard title="Audio Configuration" className="flex-none">
+                  <div className="space-y-6">
+                    <div>
+                      <label className="mb-2 ml-1 block text-xs font-medium tracking-wider text-slate-400 uppercase">
+                        Active Input Source
+                      </label>
+                      <div className="relative flex rounded-xl border border-white/5 bg-black/60 p-1 shadow-[inset_0_2px_4px_rgba(0,0,0,0.3)]">
+                        <div
+                          className={`absolute top-1 bottom-1 z-0 w-[calc(50%-4px)] rounded-lg border-t border-white/10 bg-slate-700 shadow-[0_2px_8px_rgba(0,0,0,0.4)] transition-all duration-300 ease-[cubic-bezier(0.25,0.1,0.25,1)] ${audioSource === 'system' ? 'translate-x-[calc(100%+4px)]' : 'translate-x-0'}`}
+                        />
+                        <button
+                          onClick={() => handleAudioSourceChange('mic')}
+                          className={`relative z-10 flex flex-1 items-center justify-center space-x-2.5 py-2.5 text-sm font-semibold transition-all duration-300 ${audioSource === 'mic' ? 'text-white' : 'text-slate-500 hover:text-slate-300'}`}
+                        >
+                          <Mic
+                            size={18}
+                            className={`transition-all duration-300 ${audioSource === 'mic' ? 'text-accent-cyan scale-110 drop-shadow-[0_0_8px_rgba(34,211,238,0.6)]' : ''}`}
+                          />
+                          <span>Microphone</span>
+                        </button>
+                        <button
+                          onClick={() => handleAudioSourceChange('system')}
+                          className={`relative z-10 flex flex-1 items-center justify-center space-x-2.5 py-2.5 text-sm font-semibold transition-all duration-300 ${audioSource === 'system' ? 'text-white' : 'text-slate-500 hover:text-slate-300'}`}
+                        >
+                          <Laptop
+                            size={18}
+                            className={`transition-all duration-300 ${audioSource === 'system' ? 'text-accent-cyan scale-110 drop-shadow-[0_0_8px_rgba(34,211,238,0.6)]' : ''}`}
+                          />
+                          <span>System Audio</span>
+                        </button>
+                      </div>
+                    </div>
+                    <div className="h-px w-full bg-white/5"></div>
+                    <div className="space-y-4">
+                      <div
+                        className={`rounded-xl border p-3 transition-all duration-300 ${audioSource === 'mic' ? 'bg-accent-cyan/5 border-accent-cyan/20 shadow-[0_0_10px_rgba(34,211,238,0.05)]' : 'border-transparent bg-transparent hover:bg-white/5'}`}
+                      >
+                        <div className="mb-2 flex items-center justify-between">
+                          <div className="flex items-center gap-2">
+                            <Mic
+                              size={14}
+                              className={
+                                audioSource === 'mic' ? 'text-accent-cyan' : 'text-slate-500'
+                              }
+                            />
+                            <label
+                              className={`text-xs font-medium ${audioSource === 'mic' ? 'text-white' : 'text-slate-400'}`}
+                            >
+                              Microphone Device
+                            </label>
+                          </div>
+                          {audioSource === 'mic' && (
+                            <span className="bg-accent-cyan rounded px-1.5 py-0.5 text-[10px] font-bold tracking-wide text-black uppercase">
+                              Live
+                            </span>
+                          )}
+                        </div>
+                        <div className="flex min-w-0 items-center gap-2">
+                          <div className="min-w-0 flex-1">
+                            <CustomSelect
+                              value={micDevice}
+                              onChange={handleMicDeviceChange}
+                              options={micDevices.length > 0 ? micDevices : ['Default Microphone']}
+                              className="focus:ring-accent-cyan w-full min-w-0 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white transition-shadow outline-none hover:border-white/20 focus:ring-1"
+                            />
+                          </div>
+                          <Button
+                            variant="secondary"
+                            size="icon"
+                            className="shrink-0"
+                            icon={<RefreshCw size={14} />}
+                            onClick={enumerateDevices}
+                          />
+                        </div>
+                      </div>
+                      <div
+                        className={`rounded-xl border p-3 transition-all duration-300 ${audioSource === 'system' ? 'bg-accent-cyan/5 border-accent-cyan/20 shadow-[0_0_10px_rgba(34,211,238,0.05)]' : 'border-transparent bg-transparent hover:bg-white/5'}`}
+                      >
+                        <div className="mb-2 flex items-center justify-between">
+                          <div className="flex items-center gap-2">
+                            <Laptop
+                              size={14}
+                              className={
+                                audioSource === 'system' ? 'text-accent-cyan' : 'text-slate-500'
+                              }
+                            />
+                            <label
+                              className={`text-xs font-medium ${audioSource === 'system' ? 'text-white' : 'text-slate-400'}`}
+                            >
+                              System Audio
+                            </label>
+                          </div>
+                          {audioSource === 'system' && (
+                            <span className="bg-accent-cyan rounded px-1.5 py-0.5 text-[10px] font-bold tracking-wide text-black uppercase">
+                              Live
+                            </span>
+                          )}
+                        </div>
+                        <div className="flex min-w-0 items-center gap-2">
+                          <div className="min-w-0 flex-1">
+                            {isLinux ? (
+                              <CustomSelect
+                                value={sysDevice}
+                                onChange={handleSystemDeviceChange}
+                                options={sysDevices.length > 0 ? sysDevices : ['Default Output']}
+                                className="focus:ring-accent-cyan w-full min-w-0 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white transition-shadow outline-none hover:border-white/20 focus:ring-1"
+                              />
+                            ) : (
+                              <div className="w-full min-w-0 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/60 select-none">
+                                All System Audio
+                              </div>
+                            )}
+                          </div>
+                          {isLinux && (
+                            <Button
+                              variant="secondary"
+                              size="icon"
+                              className="shrink-0"
+                              icon={<RefreshCw size={14} />}
+                              onClick={fetchSinks}
+                            />
+                          )}
+                        </div>
+                        {/* Capture gain slider — boost or attenuate system audio input */}
+                        {audioSource === 'system' && (
+                          <div className="mt-2.5">
+                            <div className="mb-1 flex items-center justify-between">
+                              <label className="text-[11px] font-medium text-slate-400">
+                                Capture Gain
+                              </label>
+                              <div className="flex items-center gap-1.5">
+                                {monitorVolumePct !== null && (
+                                  <span className="rounded bg-white/5 px-1.5 py-0.5 text-[10px] text-slate-500 tabular-nums">
+                                    src {monitorVolumePct}%
+                                  </span>
+                                )}
+                                <span className="min-w-[3ch] text-right text-[11px] text-slate-300 tabular-nums">
+                                  {captureGain.toFixed(2)}x
+                                </span>
+                              </div>
+                            </div>
+                            <input
+                              type="range"
+                              min={0.25}
+                              max={5}
+                              step={0.25}
+                              value={captureGain}
+                              onChange={(e) => handleCaptureGainChange(parseFloat(e.target.value))}
+                              className="ts-gain-slider h-1 w-full cursor-pointer appearance-none rounded-full bg-white/10 accent-cyan-400"
+                            />
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </GlassCard>
+              </div>
+            </div>
+
+            {/* Left Bottom Scroll Indicator */}
+            <div
+              className={`pointer-events-none absolute right-3 bottom-0 left-0 z-20 h-6 overflow-hidden rounded-b-2xl transition-opacity duration-300 ${leftScrollState.bottom ? 'opacity-100' : 'opacity-0'}`}
+            >
+              <div
+                className="h-full w-full bg-linear-to-t from-white/10 to-transparent backdrop-blur-sm"
+                style={{
+                  maskImage: 'linear-gradient(to top, black 50%, transparent 100%)',
+                  WebkitMaskImage: 'linear-gradient(to top, black 50%, transparent 100%)',
+                }}
+              ></div>
+            </div>
+            {/* Left Bottom Corner Mask */}
+            <div
+              className="pointer-events-none absolute right-3 bottom-0 z-20 h-4 w-4 @max-[840px]:hidden"
+              style={{
+                ...maskStyle,
+                maskImage: 'radial-gradient(circle at top left, transparent 1rem, black 1rem)',
+                WebkitMaskImage:
+                  'radial-gradient(circle at top left, transparent 1rem, black 1rem)',
+              }}
+            />
+          </div>
+
+          {/* Right Column: Visualizer & Live Mode (60%) */}
+          {/* @max-[840px]: stacks below the left column as one scrolling grid, and slides in
+            via the reflowStackIn keyframe (motion-safe only — reduced-motion = instant).
+            min-h-0 is gated to @min-[840px] for the same reason as the left column: in
+            stacked mode it would let the grid stretch the rows to equal heights and cause
+            the panels to overlap. */}
+          <div className="relative flex min-w-0 flex-col overflow-hidden rounded-2xl @max-[840px]:overflow-visible @max-[840px]:motion-safe:animate-[reflowStackIn_0.3s_cubic-bezier(0.16,1,0.3,1)] @min-[840px]:min-h-0">
+            {/* Right Top Scroll Indicator */}
+            <div
+              className={`pointer-events-none absolute top-0 right-3 left-0 z-20 h-6 overflow-hidden rounded-t-2xl transition-opacity duration-300 ${rightScrollState.top ? 'opacity-100' : 'opacity-0'}`}
+            >
+              <div
+                className="h-full w-full bg-linear-to-b from-white/10 to-transparent backdrop-blur-sm"
+                style={{
+                  maskImage: 'linear-gradient(to bottom, black 50%, transparent 100%)',
+                  WebkitMaskImage: 'linear-gradient(to bottom, black 50%, transparent 100%)',
+                }}
+              ></div>
+            </div>
+            {/* Right Top Corner Mask */}
+            <div
+              className="pointer-events-none absolute top-0 right-3 z-20 h-4 w-4 @max-[840px]:hidden"
+              style={{
+                ...maskStyle,
+                maskImage: 'radial-gradient(circle at bottom left, transparent 1rem, black 1rem)',
+                WebkitMaskImage:
+                  'radial-gradient(circle at bottom left, transparent 1rem, black 1rem)',
+              }}
+            />
+
+            {/* Right Column Scroll Container */}
+            <div
+              ref={rightScrollRef}
+              className="custom-scrollbar flex-1 overflow-y-auto pt-0 pr-3 pb-0 @max-[840px]:overflow-visible"
+            >
+              {/* Baseline min-height applies in the two-column layout only (see left column);
+                gated behind @min-[840px] so it no-ops when stacked. */}
+              <div
+                ref={rightContentRef}
+                className="flex min-h-full flex-col @min-[840px]:[min-height:var(--ts-col-baseline)]"
+                style={
+                  rightColumnBaselineHeight
+                    ? ({
+                        '--ts-col-baseline': `${rightColumnBaselineHeight}px`,
+                      } as React.CSSProperties)
+                    : undefined
+                }
+              >
+                {/* Visualizer Card */}
+                <GlassCard className="relative z-10 mb-6 flex-none overflow-visible">
+                  <div className="mb-4 flex shrink-0 items-center justify-between">
+                    <div className="flex items-center gap-3">
+                      <div className="bg-accent-cyan/10 text-accent-cyan rounded-full p-2">
+                        <Activity size={20} className={isLive ? 'animate-pulse' : ''} />
+                      </div>
+                      <div>
+                        <h3 className="font-semibold text-white">Audio Visualizer</h3>
+                        <p className="text-xs text-slate-400">
+                          {activeAnalyser ? 'Live — listening' : 'Idle — awaiting input'}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <div className="flex items-center gap-1 rounded-lg border border-white/5 bg-black/20 p-0.5">
+                        <button
+                          onClick={() =>
+                            setVisualizerAmplitudeScale((s) =>
+                              Math.max(0.25, +(s - 0.25).toFixed(2)),
+                            )
+                          }
+                          className="rounded p-1 text-slate-400 transition-colors hover:bg-white/10 hover:text-white"
+                          title="Decrease sensitivity"
+                        >
+                          <Minus size={14} />
+                        </button>
+                        <button
+                          onClick={() =>
+                            setVisualizerAmplitudeScale((s) => Math.min(4, +(s + 0.25).toFixed(2)))
+                          }
+                          className="rounded p-1 text-slate-400 transition-colors hover:bg-white/10 hover:text-white"
+                          title="Increase sensitivity"
+                        >
+                          <Plus size={14} />
+                        </button>
+                      </div>
+                      <button
+                        onClick={() => setIsFullscreenVisualizerOpen(true)}
+                        className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-slate-400 transition-colors hover:bg-white/10 hover:text-white"
+                        title="Fullscreen"
+                      >
+                        <Maximize2 size={14} />
+                      </button>
+                    </div>
+                  </div>
+                  <AudioVisualizer
+                    analyserNode={activeAnalyser}
+                    amplitudeScale={visualizerAmplitudeScale}
+                    isActive={!!activeAnalyser}
                   />
                 </GlassCard>
-              )}
-            </div>
-          </div>
 
-          {/* Right Bottom Scroll Indicator */}
-          <div
-            className={`pointer-events-none absolute right-3 bottom-0 left-0 z-20 h-6 overflow-hidden rounded-b-2xl transition-opacity duration-300 ${rightScrollState.bottom ? 'opacity-100' : 'opacity-0'}`}
-          >
+                {/* Live Mode (Text + Controls) */}
+                {isLivePoppedOut ? (
+                  <>
+                    {/* Greyed-out placeholder while popped out */}
+                    <GlassCard
+                      className="flex min-h-[calc(100vh-30rem)] flex-1 flex-col opacity-40 transition-all duration-300"
+                      title="Live Mode"
+                      action={
+                        <button
+                          onClick={() => setIsLivePoppedOut(false)}
+                          className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-slate-400 transition-colors hover:bg-white/10 hover:text-white"
+                          title="Return Live Mode to this window"
+                        >
+                          <Minimize2 size={14} />
+                        </button>
+                      }
+                    >
+                      <div className="flex min-h-0 flex-1 items-center justify-center rounded-xl border border-white/5 bg-black/20">
+                        <div className="flex flex-col items-center space-y-3 text-center text-slate-500 select-none">
+                          <ExternalLink size={48} strokeWidth={1} />
+                          <p className="text-sm">Live Mode is in a separate window.</p>
+                          <button
+                            onClick={() => setIsLivePoppedOut(false)}
+                            className="mt-1 rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 text-xs text-slate-400 transition-colors hover:bg-white/10 hover:text-white"
+                          >
+                            Return here
+                          </button>
+                        </div>
+                      </div>
+                    </GlassCard>
+                    {/* Pop-out window with live content */}
+                    <PopOutWindow
+                      isOpen={isLivePoppedOut}
+                      onClose={() => setIsLivePoppedOut(false)}
+                      title="Live Mode — Transcription Suite"
+                      width={520}
+                      height={650}
+                    >
+                      <div className="flex h-full flex-col bg-[#0f172a] p-4">
+                        {/* Pop-out header bar */}
+                        <div className="mb-4 flex shrink-0 items-center justify-between">
+                          <h2 className="text-sm font-semibold tracking-wide text-white/90">
+                            Live Mode
+                          </h2>
+                          <div className="flex items-center gap-2">
+                            <button
+                              onClick={() => live.toggleMute()}
+                              className={`flex h-7 w-7 items-center justify-center rounded-lg border transition-colors ${live.muted ? 'border-red-500/30 bg-red-500/20 text-red-400 hover:bg-red-500/30' : 'border-white/10 bg-white/5 text-slate-400 hover:bg-white/10 hover:text-white'}`}
+                              title={live.muted ? 'Unmute' : 'Mute'}
+                            >
+                              {live.muted ? <VolumeX size={14} /> : <Volume2 size={14} />}
+                            </button>
+                            <button
+                              onClick={() => setIsLivePoppedOut(false)}
+                              className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-slate-400 transition-colors hover:bg-white/10 hover:text-white"
+                              title="Return to main window"
+                            >
+                              <Minimize2 size={14} />
+                            </button>
+                          </div>
+                        </div>
+                        {/* Controls Toolbar */}
+                        <div className="custom-scrollbar no-scrollbar mb-4 flex shrink-0 flex-nowrap items-center gap-2 overflow-x-auto border-b border-white/5 p-1 pb-4">
+                          <div className="flex h-8 shrink-0 items-center gap-2">
+                            <span
+                              className={`text-xs font-bold tracking-wider uppercase ${isLive ? 'text-green-400' : 'text-slate-500'}`}
+                            >
+                              {live.status === 'starting'
+                                ? 'Loading...'
+                                : isLive
+                                  ? 'Active'
+                                  : 'Offline'}
+                            </span>
+                            <span
+                              title={
+                                !isLive && liveModeDisabledReason
+                                  ? liveModeDisabledReason
+                                  : undefined
+                              }
+                            >
+                              <AppleSwitch
+                                checked={isLive}
+                                onChange={handleLiveToggle}
+                                size="sm"
+                                disabled={
+                                  !isLive &&
+                                  (!clientRunning ||
+                                    !serverConnection.ready ||
+                                    liveModelDisabled ||
+                                    !liveModeWhisperOnlyCompatible)
+                                }
+                              />
+                            </span>
+                          </div>
+                          <div className="mx-0.5 h-5 w-px shrink-0 bg-white/10"></div>
+                          <div className="flex h-8 shrink-0 items-center gap-2">
+                            <div className="bg-accent-magenta/10 text-accent-magenta border-accent-magenta/5 flex aspect-square h-full items-center justify-center rounded-lg border">
+                              <Languages size={15} />
+                            </div>
+                            <CustomSelect
+                              value={liveLanguage}
+                              onChange={handleLiveLanguageChange}
+                              options={liveLanguageOptions}
+                              accentColor="magenta"
+                              className="focus:ring-accent-magenta h-full min-w-32.5 rounded-lg border border-white/10 bg-white/5 px-3 py-1 text-sm text-slate-300 outline-none focus:ring-1"
+                            />
+                          </div>
+                          <div className="mx-0.5 h-5 w-px shrink-0 bg-white/10"></div>
+                          <div
+                            className="flex h-8 shrink-0 items-center gap-2"
+                            title={
+                              canTranslateLive ? '' : 'Current model does not support translation'
+                            }
+                          >
+                            <span
+                              className={`text-[9px] font-bold tracking-widest whitespace-nowrap uppercase ${canTranslateLive ? 'text-slate-500' : 'text-slate-600 line-through'}`}
+                            >
+                              {isCanaryLiveBidi ? 'Translate to' : 'Translate to English'}
+                            </span>
+                            {isCanaryLiveBidi ? (
+                              <CustomSelect
+                                value={liveBidiTarget}
+                                onChange={setLiveBidiTarget}
+                                options={['Off', ...CANARY_TRANSLATION_TARGETS]}
+                                accentColor="magenta"
+                                className="focus:ring-accent-magenta h-full min-w-25 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-sm text-slate-300 outline-none focus:ring-1"
+                              />
+                            ) : (
+                              <AppleSwitch
+                                checked={liveTranslate && canTranslateLive}
+                                onChange={setLiveTranslate}
+                                size="sm"
+                                disabled={!canTranslateLive}
+                              />
+                            )}
+                          </div>
+                          <div className="mx-0.5 h-5 w-px shrink-0 bg-white/10"></div>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            icon={<Copy size={14} />}
+                            onClick={handleLiveCopyAndClear}
+                            className="ml-auto h-8 shrink-0 whitespace-nowrap"
+                          >
+                            Copy
+                          </Button>
+                        </div>
+                        {/* Transcript Area */}
+                        <LiveTranscriptView
+                          live={live}
+                          isLive={isLive}
+                          hideTimestamps={hideTimestamps}
+                          serverRunning={serverRunning}
+                          isRemoteMode={isRemoteMode}
+                          serverReady={serverConnection.ready}
+                          liveModelDisabled={liveModelDisabled}
+                          liveModeWhisperOnlyCompatible={liveModeWhisperOnlyCompatible}
+                          liveModeUnsupportedMessage={liveModeUnsupportedMessage}
+                          transcriptRef={liveTranscriptRef}
+                          editedLiveText={editedLiveText}
+                          onEditedLiveChange={handleEditedLiveChange}
+                        />
+                      </div>
+                    </PopOutWindow>
+                  </>
+                ) : (
+                  <GlassCard
+                    className="flex min-h-[calc(100vh-30rem)] flex-1 flex-col transition-all duration-300"
+                    title="Live Mode"
+                    action={
+                      <div className="flex items-center gap-1.5">
+                        <button
+                          onClick={() => setIsLivePoppedOut(true)}
+                          className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-slate-400 transition-colors hover:bg-white/10 hover:text-white"
+                          title="Pop out into separate window"
+                        >
+                          <ExternalLink size={14} />
+                        </button>
+                        <button
+                          onClick={() => live.toggleMute()}
+                          className={`flex h-7 w-7 items-center justify-center rounded-lg border transition-colors ${live.muted ? 'border-red-500/30 bg-red-500/20 text-red-400 hover:bg-red-500/30' : 'border-white/10 bg-white/5 text-slate-400 hover:bg-white/10 hover:text-white'}`}
+                          title={live.muted ? 'Unmute' : 'Mute'}
+                        >
+                          {live.muted ? <VolumeX size={14} /> : <Volume2 size={14} />}
+                        </button>
+                      </div>
+                    }
+                  >
+                    {/* Live Mode Controls Toolbar */}
+                    <div className="custom-scrollbar no-scrollbar mb-4 flex flex-none flex-nowrap items-center gap-2 overflow-x-auto border-b border-white/5 p-1 pb-4">
+                      <div className="flex h-8 shrink-0 items-center gap-2">
+                        <span
+                          className={`text-xs font-bold tracking-wider uppercase ${isLive ? 'text-green-400' : 'text-slate-500'}`}
+                        >
+                          {live.status === 'starting'
+                            ? 'Loading...'
+                            : isLive
+                              ? 'Active'
+                              : 'Offline'}
+                        </span>
+                        <span
+                          title={
+                            !isLive && liveModeDisabledReason ? liveModeDisabledReason : undefined
+                          }
+                        >
+                          <AppleSwitch
+                            checked={isLive}
+                            onChange={handleLiveToggle}
+                            size="sm"
+                            disabled={
+                              !isLive &&
+                              (!clientRunning ||
+                                !serverConnection.ready ||
+                                liveModelDisabled ||
+                                !liveModeWhisperOnlyCompatible)
+                            }
+                          />
+                        </span>
+                      </div>
+                      <div className="mx-0.5 h-5 w-px shrink-0 bg-white/10"></div>
+                      <div className="flex h-8 shrink-0 items-center gap-2">
+                        <div className="bg-accent-magenta/10 text-accent-magenta border-accent-magenta/5 flex aspect-square h-full items-center justify-center rounded-lg border">
+                          <Languages size={15} />
+                        </div>
+                        <CustomSelect
+                          value={liveLanguage}
+                          onChange={handleLiveLanguageChange}
+                          options={liveLanguageOptions}
+                          accentColor="magenta"
+                          className="focus:ring-accent-magenta h-full min-w-32.5 rounded-lg border border-white/10 bg-white/5 px-3 py-1 text-sm text-slate-300 outline-none focus:ring-1"
+                        />
+                      </div>
+                      <div className="mx-0.5 h-5 w-px shrink-0 bg-white/10"></div>
+                      <div
+                        className="flex h-8 shrink-0 items-center gap-2"
+                        title={canTranslateLive ? '' : 'Current model does not support translation'}
+                      >
+                        <span
+                          className={`text-[9px] font-bold tracking-widest whitespace-nowrap uppercase ${canTranslateLive ? 'text-slate-500' : 'text-slate-600 line-through'}`}
+                        >
+                          {isCanaryLiveBidi ? 'Translate to' : 'Translate to English'}
+                        </span>
+                        {isCanaryLiveBidi ? (
+                          <CustomSelect
+                            value={liveBidiTarget}
+                            onChange={setLiveBidiTarget}
+                            options={['Off', ...CANARY_TRANSLATION_TARGETS]}
+                            accentColor="magenta"
+                            className="focus:ring-accent-magenta h-full min-w-25 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-sm text-slate-300 outline-none focus:ring-1"
+                          />
+                        ) : (
+                          <AppleSwitch
+                            checked={liveTranslate && canTranslateLive}
+                            onChange={setLiveTranslate}
+                            size="sm"
+                            disabled={!canTranslateLive}
+                          />
+                        )}
+                      </div>
+                      <div className="mx-0.5 h-5 w-px shrink-0 bg-white/10"></div>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        icon={<Copy size={14} />}
+                        onClick={handleLiveCopyAndClear}
+                        className="ml-auto h-8 shrink-0 whitespace-nowrap"
+                      >
+                        Copy
+                      </Button>
+                    </div>
+
+                    {/* Transcript Area */}
+                    <LiveTranscriptView
+                      live={live}
+                      isLive={isLive}
+                      hideTimestamps={hideTimestamps}
+                      serverRunning={serverRunning}
+                      isRemoteMode={isRemoteMode}
+                      serverReady={serverConnection.ready}
+                      liveModelDisabled={liveModelDisabled}
+                      liveModeWhisperOnlyCompatible={liveModeWhisperOnlyCompatible}
+                      liveModeUnsupportedMessage={liveModeUnsupportedMessage}
+                      transcriptRef={liveTranscriptRef}
+                      editedLiveText={editedLiveText}
+                      onEditedLiveChange={handleEditedLiveChange}
+                    />
+                  </GlassCard>
+                )}
+              </div>
+            </div>
+
+            {/* Right Bottom Scroll Indicator */}
             <div
-              className="h-full w-full bg-linear-to-t from-white/10 to-transparent backdrop-blur-sm"
+              className={`pointer-events-none absolute right-3 bottom-0 left-0 z-20 h-6 overflow-hidden rounded-b-2xl transition-opacity duration-300 ${rightScrollState.bottom ? 'opacity-100' : 'opacity-0'}`}
+            >
+              <div
+                className="h-full w-full bg-linear-to-t from-white/10 to-transparent backdrop-blur-sm"
+                style={{
+                  maskImage: 'linear-gradient(to top, black 50%, transparent 100%)',
+                  WebkitMaskImage: 'linear-gradient(to top, black 50%, transparent 100%)',
+                }}
+              ></div>
+            </div>
+            {/* Right Bottom Corner Mask */}
+            <div
+              className="pointer-events-none absolute right-3 bottom-0 z-20 h-4 w-4 @max-[840px]:hidden"
               style={{
-                maskImage: 'linear-gradient(to top, black 50%, transparent 100%)',
-                WebkitMaskImage: 'linear-gradient(to top, black 50%, transparent 100%)',
+                ...maskStyle,
+                maskImage: 'radial-gradient(circle at top left, transparent 1rem, black 1rem)',
+                WebkitMaskImage:
+                  'radial-gradient(circle at top left, transparent 1rem, black 1rem)',
               }}
-            ></div>
+            />
           </div>
-          {/* Right Bottom Corner Mask */}
-          <div
-            className="pointer-events-none absolute right-3 bottom-0 z-20 h-4 w-4 @max-[840px]:hidden"
-            style={{
-              ...maskStyle,
-              maskImage: 'radial-gradient(circle at top left, transparent 1rem, black 1rem)',
-              WebkitMaskImage: 'radial-gradient(circle at top left, transparent 1rem, black 1rem)',
-            }}
-          />
         </div>
+        <ScrollFadeOverlay
+          edge="bottom"
+          visible={stackedScrollState.bottom}
+          className="@min-[840px]:hidden"
+        />
       </div>
 
       {/* Fullscreen Visualizer Modal */}

--- a/dashboard/electron/__tests__/clipboardWayland.test.ts
+++ b/dashboard/electron/__tests__/clipboardWayland.test.ts
@@ -83,9 +83,7 @@ function installExecFileRouter() {
         return state.wlCopyAvailable ? cb(null, { stdout: 'wl-copy 1.0' }) : cb(enoent());
       }
       if (cmd === 'wl-paste') {
-        return state.wlPasteAvailable
-          ? cb(null, { stdout: state.realClipboard })
-          : cb(enoent());
+        return state.wlPasteAvailable ? cb(null, { stdout: state.realClipboard }) : cb(enoent());
       }
       return cb(null, { stdout: '' });
     },

--- a/dashboard/src/hooks/__tests__/useScrollFade.test.tsx
+++ b/dashboard/src/hooks/__tests__/useScrollFade.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * useScrollFade — edge-clipping detection for scroll containers.
+ *
+ * Covers the case that motivated the hook: when the Session/Notebook grids collapse to a
+ * single column, the scroll container migrates from the individual columns to the grid
+ * itself, so the fade state has to be derived from whichever element is actually
+ * scrolling.
+ *
+ * jsdom performs no layout, so scrollHeight/clientHeight are always 0. Every test below
+ * stubs those three metrics explicitly to describe the scroll geometry under test.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useRef } from 'react';
+import { useScrollFade } from '../useScrollFade';
+
+interface Geometry {
+  scrollTop: number;
+  clientHeight: number;
+  scrollHeight: number;
+}
+
+/** Build a detached div whose scroll metrics report the supplied geometry. */
+function makeScroller({ scrollTop, clientHeight, scrollHeight }: Geometry): HTMLDivElement {
+  const el = document.createElement('div');
+  Object.defineProperty(el, 'scrollTop', { value: scrollTop, writable: true });
+  Object.defineProperty(el, 'clientHeight', { value: clientHeight, configurable: true });
+  Object.defineProperty(el, 'scrollHeight', { value: scrollHeight, configurable: true });
+  document.body.appendChild(el);
+  return el;
+}
+
+/** Render the hook against a ref already pointing at `el`. */
+function renderWithElement(el: HTMLDivElement | null) {
+  return renderHook(() => {
+    const ref = useRef<HTMLDivElement | null>(el);
+    return useScrollFade(ref);
+  });
+}
+
+describe('useScrollFade', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('reports no fades when the content fits the container', () => {
+    const el = makeScroller({ scrollTop: 0, clientHeight: 500, scrollHeight: 500 });
+    const { result } = renderWithElement(el);
+
+    expect(result.current).toEqual({ top: false, bottom: false });
+  });
+
+  it('reports only the bottom fade when parked at the top of overflowing content', () => {
+    const el = makeScroller({ scrollTop: 0, clientHeight: 500, scrollHeight: 1200 });
+    const { result } = renderWithElement(el);
+
+    expect(result.current).toEqual({ top: false, bottom: true });
+  });
+
+  it('reports both fades when scrolled to the middle of overflowing content', () => {
+    const el = makeScroller({ scrollTop: 300, clientHeight: 500, scrollHeight: 1200 });
+    const { result } = renderWithElement(el);
+
+    expect(result.current).toEqual({ top: true, bottom: true });
+  });
+
+  it('reports only the top fade when scrolled to the very bottom', () => {
+    const el = makeScroller({ scrollTop: 700, clientHeight: 500, scrollHeight: 1200 });
+    const { result } = renderWithElement(el);
+
+    expect(result.current).toEqual({ top: true, bottom: false });
+  });
+
+  it('recomputes on scroll, so the top fade appears once the user leaves the top', () => {
+    const el = makeScroller({ scrollTop: 0, clientHeight: 500, scrollHeight: 1200 });
+    const { result } = renderWithElement(el);
+
+    expect(result.current).toEqual({ top: false, bottom: true });
+
+    act(() => {
+      el.scrollTop = 40;
+      el.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(result.current).toEqual({ top: true, bottom: true });
+  });
+
+  it('clears the bottom fade when content shrinks to fit under a stationary scroll position', () => {
+    const el = makeScroller({ scrollTop: 0, clientHeight: 500, scrollHeight: 1200 });
+    const { result } = renderWithElement(el);
+    expect(result.current.bottom).toBe(true);
+
+    // A collapsing card shrinks the content without emitting a scroll event. The late
+    // settle pass is what catches this in browsers that lack ResizeObserver.
+    act(() => {
+      Object.defineProperty(el, 'scrollHeight', { value: 400, configurable: true });
+      vi.advanceTimersByTime(600);
+    });
+
+    expect(result.current.bottom).toBe(false);
+  });
+
+  it('treats a sub-pixel overflow as fitting, so the bar does not flicker on fractional heights', () => {
+    const el = makeScroller({ scrollTop: 0, clientHeight: 500.4, scrollHeight: 500.6 });
+    const { result } = renderWithElement(el);
+
+    expect(result.current).toEqual({ top: false, bottom: false });
+  });
+
+  it('stays hidden when the ref is empty', () => {
+    const { result } = renderWithElement(null);
+
+    expect(result.current).toEqual({ top: false, bottom: false });
+  });
+
+  it('detaches its listeners on unmount', () => {
+    const el = makeScroller({ scrollTop: 0, clientHeight: 500, scrollHeight: 1200 });
+    const removeSpy = vi.spyOn(el, 'removeEventListener');
+    const { unmount } = renderWithElement(el);
+
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith('scroll', expect.any(Function));
+  });
+});

--- a/dashboard/src/hooks/useScrollFade.ts
+++ b/dashboard/src/hooks/useScrollFade.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useState, type RefObject } from 'react';
+
+export interface ScrollFadeState {
+  top: boolean;
+  bottom: boolean;
+}
+
+const HIDDEN: ScrollFadeState = { top: false, bottom: false };
+
+/**
+ * Reports whether a scroll container is clipping content above or below its
+ * viewport, so a caller can fade in an edge affordance.
+ *
+ * Observes the container and its direct children, not just scroll events, so the
+ * bottom edge still updates when content grows or collapses under a stationary
+ * scroll position.
+ */
+export function useScrollFade(
+  ref: RefObject<HTMLElement | null>,
+  deps: readonly unknown[] = [],
+): ScrollFadeState {
+  const [state, setState] = useState<ScrollFadeState>(HIDDEN);
+
+  const recalc = useCallback(() => {
+    const el = ref.current;
+    const next: ScrollFadeState = el
+      ? {
+          top: el.scrollTop > 0,
+          bottom: Math.ceil(el.scrollTop + el.clientHeight) < el.scrollHeight,
+        }
+      : HIDDEN;
+    // Keep the previous object when nothing changed, so a scroll frame that does not
+    // cross an edge boundary does not re-render the consumer.
+    setState((prev) => (prev.top === next.top && prev.bottom === next.bottom ? prev : next));
+  }, [ref]);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    el.addEventListener('scroll', recalc, { passive: true });
+    window.addEventListener('resize', recalc);
+
+    // jsdom does not implement ResizeObserver; the view unit tests throw without this guard.
+    const observer = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(recalc);
+    observer?.observe(el);
+    Array.from(el.children).forEach((child) => observer?.observe(child));
+
+    recalc();
+    const raf = requestAnimationFrame(recalc);
+    // Late pass: the stacked-layout reflow animation runs for 300ms, and the column
+    // heights are only final once it settles.
+    const settle = setTimeout(recalc, 575);
+
+    return () => {
+      el.removeEventListener('scroll', recalc);
+      window.removeEventListener('resize', recalc);
+      observer?.disconnect();
+      cancelAnimationFrame(raf);
+      clearTimeout(settle);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ref, recalc, ...deps]);
+
+  return state;
+}

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.2.0",
-  "contract_sha256": "2de9497d7a4b8a5b4159a4749eaae1a86e46fc8bdb9484d75ab12d1829514d2a",
-  "updated_at": "2026-07-14T08:05:49.332Z"
+  "spec_version": "1.3.0",
+  "contract_sha256": "f18b97f1be25bc3e43254e1046fac3a8a1e986b09578209868d0938bb5b48eab",
+  "updated_at": "2026-07-14T11:07:40.255Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.2.0
+  spec_version: 1.3.0
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -52,6 +52,7 @@ meta:
       - components/recording/SpeakerRenameInput.tsx
       - components/Sidebar.tsx
       - components/ui/__tests__/PersistentInfoBanner.test.tsx
+      - components/ui/__tests__/ScrollFadeOverlay.test.tsx
       - components/ui/__tests__/UpdateBanner.test.tsx
       - components/ui/__tests__/UpdateModal.test.tsx
       - components/ui/ActivityNotifications.tsx
@@ -68,6 +69,7 @@ meta:
       - components/ui/LogTerminal.tsx
       - components/ui/PersistentInfoBanner.tsx
       - components/ui/QueuePausedBanner.tsx
+      - components/ui/ScrollFadeOverlay.tsx
       - components/ui/SelectorGroup.tsx
       - components/ui/SelectorTile.tsx
       - components/ui/ShortcutCapture.tsx
@@ -102,7 +104,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-07-14T08:05:41.637Z
+    generated_at: 2026-07-14T11:07:00.722Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -916,6 +918,7 @@ utility_allowlist:
     - my-4
     - opacity-0
     - opacity-10
+    - opacity-100
     - opacity-30
     - opacity-40
     - opacity-45
@@ -2506,6 +2509,23 @@ component_contracts:
         rule: Do not introduce unregistered utility, arbitrary, or inline style values.
   RemoteConnectionCard:
     file: components/views/server/RemoteConnectionCard.tsx
+    required_tokens:
+      - colors
+      - motion
+      - radii
+      - shadows
+    allowed_variants: {}
+    structural_invariants:
+      - id: structure-stable
+        rule: Preserve current structural layout and region hierarchy for this component.
+    behavior_rules:
+      - id: motion-locked
+        rule: Use only approved motion tokens and classes from foundation token registry.
+    state_rules:
+      - id: closed-set-styles
+        rule: Do not introduce unregistered utility, arbitrary, or inline style values.
+  ScrollFadeOverlay:
+    file: components/ui/ScrollFadeOverlay.tsx
     required_tokens:
       - colors
       - motion


### PR DESCRIPTION
## The bug

The fade bars at the top and bottom of the Session tab never appear once the window is narrow enough to collapse the two-column layout into one.

They were not failing to paint. **They were correctly reporting "nothing is clipped."**

The scroll container *moves* between layouts. Above the 840px container breakpoint each column scrolls itself. Below it, the columns flip to `overflow-visible` and the outer grid takes over scrolling. But the fade state was only ever computed from the two column refs, and a non-scrolling element has `scrollHeight === clientHeight` and `scrollTop === 0` - so the state was pinned at `{top: false, bottom: false}` and the bars sat at `opacity-0` forever.

The Notebook tab had no fade system at all, in either layout, so that half is an addition rather than a repair.

## Why this is not a one-line fix

An absolutely positioned child of a scrolling element is laid out against the **scrolled** box, so it slides away with the content. The bars cannot simply move inside the grid - they need a non-scrolling `relative` wrapper that is a *parent* of the scroller. That is the DOM restructure in the diff.

## What changed

- `useScrollFade` (new) - reports whether a container is clipping content above or below. Observes the container **and its children**, not just scroll events, so the bottom bar clears when content shrinks under a stationary scroll position. Keeps the previous state object when nothing changed, so scroll frames that do not cross an edge boundary no longer re-render the view.
- `ScrollFadeOverlay` (new) - the fading blur bar itself.
- `SessionView` / `NotebookView` - wrap the grid in a non-scrolling `relative` parent and hang the bars off it, gated to the stacked layout.

Extracting the bar into its own component was **not** a style preference. The UI contract caps `backdrop-blur` per file, and both views already sat at their max of 4, so an inline bar would have tripped `blur_budget_exceeded`. A new file gets the default budget of 3 and uses 1.

## Testing

`npm run check` (typecheck, lint, prettier, ui-contract) exits 0. Suite is at **1662 passing**, with 16 new cases covering the hook and the overlay.

The large `SessionView.tsx` diff is almost entirely prettier re-wrapping caused by the one extra indent level - review with `?w=1`.

## Test plan

- [ ] Narrow the window on the **Session** tab until it stacks; confirm the fade appears at the top and bottom when content is clipped, and disappears when it is not.
- [ ] Same on the **Notebook** tab.
- [ ] Confirm the two-column layout still fades per-column as before (no regression).

## Note

`electron/__tests__/clipboardWayland.test.ts` is reformatted here. That is **pre-existing prettier drift on `main`**, unrelated to this change, but `npm run check` cannot go green without it.