### PR TITLE
feat(ui): replace the one-shot Preview with a rolling auto-refreshing preview

### DIFF
--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -7,6 +7,7 @@ import {
   Languages,
   Copy,
   Eye,
+  EyeOff,
   Volume2,
   VolumeX,
   Maximize2,
@@ -876,13 +877,18 @@ export const SessionView: React.FC<SessionViewProps> = ({
     }
   }, [transcription, isLinux]);
 
-  // Preview: transcribe the last N seconds (user-configurable, default 20)
-  // so the user can recover their train of thought without stopping. The
-  // duration is clamped to the supported 10–60s range defensively.
-  const handlePreview = useCallback(async () => {
+  // Preview: rolling transcription of the last N seconds (user-configurable,
+  // default 20) so the user can follow their train of thought without
+  // stopping. Toggled on it auto-refreshes; toggled off it clears the pane.
+  // The duration is clamped to the supported 10–60s range defensively.
+  const handlePreviewToggle = useCallback(async () => {
+    if (transcription.previewActive) {
+      transcription.stopPreview();
+      return;
+    }
     const raw = await getConfig<number>('audio.previewDurationSeconds');
     const seconds = Math.min(60, Math.max(10, raw ?? 20));
-    transcription.preview(seconds);
+    transcription.startPreview(seconds);
   }, [transcription]);
 
   // Re-transcribe a truncated result from the job's saved audio. The server
@@ -1768,16 +1774,15 @@ export const SessionView: React.FC<SessionViewProps> = ({
                                 variant="secondary"
                                 className="shrink-0"
                                 icon={
-                                  transcription.previewLoading ? (
-                                    <Loader2 size={16} className="animate-spin" />
+                                  transcription.previewActive ? (
+                                    <EyeOff size={16} />
                                   ) : (
                                     <Eye size={16} />
                                   )
                                 }
-                                onClick={handlePreview}
-                                disabled={transcription.previewLoading}
+                                onClick={handlePreviewToggle}
                               >
-                                Preview
+                                {transcription.previewActive ? 'Stop Preview' : 'Preview'}
                               </Button>
                             )}
                             {(isConnecting || isRecording || isProcessing) && (
@@ -1800,34 +1805,34 @@ export const SessionView: React.FC<SessionViewProps> = ({
                       </div>
                     </div>
 
-                    {/* Preview — ephemeral "last N seconds" reminder during recording */}
-                    {isRecording &&
-                      (transcription.previewLoading ||
-                        transcription.previewText !== null ||
-                        transcription.previewError) && (
-                        <div className="space-y-2">
-                          <div className="flex items-center gap-2 text-xs font-medium text-slate-400">
-                            <Eye size={14} className="text-accent-cyan" />
-                            <span>
-                              Preview
-                              {transcription.previewSeconds
-                                ? ` · last ${transcription.previewSeconds}s`
-                                : ''}
-                            </span>
-                          </div>
-                          {transcription.previewError ? (
-                            <div className="rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-400">
-                              {transcription.previewError}
-                            </div>
-                          ) : (
-                            <div className="selectable-text custom-scrollbar max-h-72 min-h-[8rem] overflow-y-auto rounded-xl border border-white/5 bg-black/20 p-4 font-mono text-sm leading-relaxed text-slate-300">
-                              {transcription.previewLoading && !transcription.previewText
-                                ? 'Transcribing recent audio…'
-                                : transcription.previewText || '(no speech detected)'}
-                            </div>
+                    {/* Preview — rolling "last N seconds" pane during recording */}
+                    {isRecording && (transcription.previewActive || transcription.previewError) && (
+                      <div className="space-y-2">
+                        <div className="flex items-center gap-2 text-xs font-medium text-slate-400">
+                          <Eye size={14} className="text-accent-cyan" />
+                          <span>
+                            Preview
+                            {transcription.previewSeconds
+                              ? ` · last ${transcription.previewSeconds}s`
+                              : ''}
+                          </span>
+                          {transcription.previewLoading && (
+                            <Loader2 size={12} className="animate-spin" />
                           )}
                         </div>
-                      )}
+                        {transcription.previewError ? (
+                          <div className="rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+                            {transcription.previewError}
+                          </div>
+                        ) : (
+                          <div className="selectable-text custom-scrollbar max-h-72 min-h-[8rem] overflow-y-auto rounded-xl border border-white/5 bg-black/20 p-4 font-mono text-sm leading-relaxed text-slate-300">
+                            {transcription.previewLoading && !transcription.previewText
+                              ? 'Transcribing recent audio…'
+                              : transcription.previewText || '(no speech detected)'}
+                          </div>
+                        )}
+                      </div>
+                    )}
 
                     {/* Transcription Result */}
                     {transcription.result && (

--- a/dashboard/src/hooks/useTranscription.test.ts
+++ b/dashboard/src/hooks/useTranscription.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 
 import { useTranscription } from './useTranscription';
 import { apiClient } from '../api/client';
@@ -517,21 +517,48 @@ describe('[P1] useTranscription', () => {
     });
   });
 
-  // ── Preview (ephemeral last-N-seconds reminder) ─────────────────────
-  describe('preview', () => {
-    it('sends a preview message with the requested duration while recording', async () => {
+  // ── Rolling preview (auto-refreshing last-N-seconds pane) ───────────
+  describe('rolling preview', () => {
+    beforeEach(() => {
+      // Explicit toFake so Date.now() advances with the timers — the adaptive
+      // refresh delay is computed from Date.now() deltas.
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    /** Count sendJSON calls that were preview requests. */
+    function previewSends(): Array<Record<string, unknown>> {
+      return (lastSocket?.sendJSON.mock.calls ?? [])
+        .map((c) => c[0] as { type: string; data?: Record<string, unknown> })
+        .filter((m) => m.type === 'preview');
+    }
+
+    function deliverPreviewResult(text = 'recent words', actualSeconds = 20): void {
+      act(() => {
+        lastSocketCbs.onMessage!({
+          type: 'preview_result',
+          data: { text, language: 'en', actual_seconds: actualSeconds },
+        });
+      });
+    }
+
+    it('startPreview sends the first request immediately with the requested duration', async () => {
       const { result } = renderHook(() => useTranscription());
       await driveToRecording(result);
       lastSocket.sendJSON.mockClear();
 
       act(() => {
-        result.current.preview(30);
+        result.current.startPreview(30);
       });
 
       expect(lastSocket.sendJSON).toHaveBeenCalledWith({
         type: 'preview',
         data: { duration_seconds: 30 },
       });
+      expect(result.current.previewActive).toBe(true);
       expect(result.current.previewLoading).toBe(true);
     });
 
@@ -539,57 +566,152 @@ describe('[P1] useTranscription', () => {
       const { result } = renderHook(() => useTranscription());
 
       act(() => {
-        result.current.preview(20);
+        result.current.startPreview(20);
       });
 
-      const previewCalls = (lastSocket?.sendJSON.mock.calls ?? []).filter(
-        (c) => (c[0] as { type: string }).type === 'preview',
-      );
-      expect(previewCalls).toHaveLength(0);
+      expect(previewSends()).toHaveLength(0);
+      expect(result.current.previewActive).toBe(false);
       expect(result.current.previewLoading).toBe(false);
     });
 
-    it('ignores an overlapping request while one is in flight', async () => {
+    it('ignores startPreview while already active', async () => {
       const { result } = renderHook(() => useTranscription());
       await driveToRecording(result);
       lastSocket.sendJSON.mockClear();
 
       act(() => {
-        result.current.preview(20);
-        result.current.preview(20);
+        result.current.startPreview(20);
+        result.current.startPreview(20);
       });
 
-      expect(lastSocket.sendJSON).toHaveBeenCalledTimes(1);
+      expect(previewSends()).toHaveLength(1);
     });
 
-    it('populates preview state on preview_result', async () => {
+    it('populates preview state on preview_result and stays active', async () => {
       const { result } = renderHook(() => useTranscription());
       await driveToRecording(result);
       act(() => {
-        result.current.preview(20);
+        result.current.startPreview(20);
       });
 
-      act(() => {
-        lastSocketCbs.onMessage!({
-          type: 'preview_result',
-          data: { text: 'the last words I said', language: 'en', actual_seconds: 20 },
-        });
-      });
+      deliverPreviewResult('the last words I said', 20);
 
       expect(result.current.previewText).toBe('the last words I said');
       expect(result.current.previewSeconds).toBe(20);
       expect(result.current.previewLanguage).toBe('en');
       expect(result.current.previewLoading).toBe(false);
       expect(result.current.previewError).toBeNull();
+      expect(result.current.previewActive).toBe(true);
     });
 
-    it('surfaces preview_error and clears loading', async () => {
+    it('schedules the next refresh 5s after a fast result', async () => {
       const { result } = renderHook(() => useTranscription());
       await driveToRecording(result);
+      lastSocket.sendJSON.mockClear();
+
       act(() => {
-        result.current.preview(20);
+        result.current.startPreview(20);
+      });
+      deliverPreviewResult();
+      expect(previewSends()).toHaveLength(1);
+
+      act(() => {
+        vi.advanceTimersByTime(4999);
+      });
+      expect(previewSends()).toHaveLength(1);
+
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(previewSends()).toHaveLength(2);
+      expect(previewSends()[1]).toEqual({
+        type: 'preview',
+        data: { duration_seconds: 20 },
+      });
+    });
+
+    it('backs off to the transcription duration when a result is slow (50% duty cycle)', async () => {
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+      lastSocket.sendJSON.mockClear();
+
+      act(() => {
+        result.current.startPreview(20);
+      });
+      // The request takes 8s to come back — longer than the 5s base cadence.
+      act(() => {
+        vi.advanceTimersByTime(8000);
+      });
+      deliverPreviewResult();
+      expect(previewSends()).toHaveLength(1);
+
+      // Next refresh must wait a further 8s (not 5s - 8s = immediate).
+      act(() => {
+        vi.advanceTimersByTime(7999);
+      });
+      expect(previewSends()).toHaveLength(1);
+
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(previewSends()).toHaveLength(2);
+    });
+
+    it('stopPreview cancels the pending refresh and clears the pane state', async () => {
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+      lastSocket.sendJSON.mockClear();
+
+      act(() => {
+        result.current.startPreview(20);
+      });
+      deliverPreviewResult('something');
+      expect(result.current.previewText).toBe('something');
+
+      act(() => {
+        result.current.stopPreview();
       });
 
+      expect(result.current.previewActive).toBe(false);
+      expect(result.current.previewText).toBeNull();
+      expect(result.current.previewError).toBeNull();
+      expect(result.current.previewLoading).toBe(false);
+
+      act(() => {
+        vi.advanceTimersByTime(60000);
+      });
+      expect(previewSends()).toHaveLength(1);
+    });
+
+    it('ignores a late preview_result that lands after stopPreview', async () => {
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+
+      act(() => {
+        result.current.startPreview(20);
+      });
+      act(() => {
+        result.current.stopPreview();
+      });
+      deliverPreviewResult('late text');
+
+      expect(result.current.previewText).toBeNull();
+      expect(result.current.previewLoading).toBe(false);
+
+      act(() => {
+        vi.advanceTimersByTime(60000);
+      });
+      expect(previewSends()).toHaveLength(1);
+    });
+
+    it('stops the loop on preview_error and surfaces the message', async () => {
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+      lastSocket.sendJSON.mockClear();
+
+      act(() => {
+        result.current.startPreview(20);
+      });
       act(() => {
         lastSocketCbs.onMessage!({
           type: 'preview_error',
@@ -598,21 +720,144 @@ describe('[P1] useTranscription', () => {
       });
 
       expect(result.current.previewError).toBe('No audio captured yet');
+      expect(result.current.previewActive).toBe(false);
       expect(result.current.previewLoading).toBe(false);
+
+      act(() => {
+        vi.advanceTimersByTime(60000);
+      });
+      expect(previewSends()).toHaveLength(1);
+    });
+
+    it('stops the loop when the recording stops', async () => {
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+      lastSocket.sendJSON.mockClear();
+
+      act(() => {
+        result.current.startPreview(20);
+      });
+      deliverPreviewResult();
+
+      act(() => {
+        result.current.stop();
+      });
+      act(() => {
+        vi.advanceTimersByTime(60000);
+      });
+
+      expect(result.current.previewActive).toBe(false);
+      expect(previewSends()).toHaveLength(1);
+    });
+
+    it('halts the loop when the socket closes unexpectedly (server restart)', async () => {
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+      lastSocket.sendJSON.mockClear();
+
+      act(() => {
+        result.current.startPreview(20);
+      });
+      expect(result.current.previewLoading).toBe(true);
+
+      // Unintentional close — intentional disconnects never invoke onClose.
+      act(() => {
+        lastSocketCbs.onClose!(1001, 'server going away');
+      });
+
+      expect(result.current.previewActive).toBe(false);
+      expect(result.current.previewLoading).toBe(false);
+
+      act(() => {
+        vi.advanceTimersByTime(60000);
+      });
+      expect(previewSends()).toHaveLength(1);
+    });
+
+    it('halts the loop on a socket error', async () => {
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+      lastSocket.sendJSON.mockClear();
+
+      act(() => {
+        result.current.startPreview(20);
+      });
+      deliverPreviewResult();
+
+      act(() => {
+        lastSocketCbs.onError!('Connection lost');
+      });
+      act(() => {
+        vi.advanceTimersByTime(60000);
+      });
+
+      expect(result.current.previewActive).toBe(false);
+      expect(result.current.previewLoading).toBe(false);
+      expect(previewSends()).toHaveLength(1);
+    });
+
+    it('reuses an in-flight response after a quick off/on toggle instead of double-sending', async () => {
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+      lastSocket.sendJSON.mockClear();
+
+      // R1 goes out, then the user toggles off and immediately back on
+      // before R1 returns. A second 'preview' now would be rejected by the
+      // server ('Preview already in progress') and kill the loop.
+      act(() => {
+        result.current.startPreview(20);
+      });
+      act(() => {
+        result.current.stopPreview();
+      });
+      act(() => {
+        result.current.startPreview(20);
+      });
+
+      expect(previewSends()).toHaveLength(1);
+      expect(result.current.previewActive).toBe(true);
+      expect(result.current.previewLoading).toBe(true);
+
+      // R1's response arrives and is adopted by the restarted loop.
+      deliverPreviewResult('carried over');
+      expect(result.current.previewText).toBe('carried over');
+      expect(result.current.previewLoading).toBe(false);
+
+      // ...and the loop keeps rolling from it.
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+      expect(previewSends()).toHaveLength(2);
+    });
+
+    it('stops the loop on a server error', async () => {
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+      lastSocket.sendJSON.mockClear();
+
+      act(() => {
+        result.current.startPreview(20);
+      });
+      deliverPreviewResult();
+
+      act(() => {
+        lastSocketCbs.onMessage!({ type: 'error', data: { message: 'Backend OOM' } });
+      });
+      act(() => {
+        vi.advanceTimersByTime(60000);
+      });
+
+      expect(result.current.previewActive).toBe(false);
+      expect(previewSends()).toHaveLength(1);
     });
 
     it('clears preview state on a new start()', async () => {
       const { result } = renderHook(() => useTranscription());
       await driveToRecording(result);
       act(() => {
-        result.current.preview(20);
+        result.current.startPreview(20);
       });
-      act(() => {
-        lastSocketCbs.onMessage!({
-          type: 'preview_result',
-          data: { text: 'something', actual_seconds: 20 },
-        });
-      });
+      deliverPreviewResult('something');
       expect(result.current.previewText).toBe('something');
 
       act(() => {
@@ -622,6 +867,7 @@ describe('[P1] useTranscription', () => {
       expect(result.current.previewText).toBeNull();
       expect(result.current.previewError).toBeNull();
       expect(result.current.previewLoading).toBe(false);
+      expect(result.current.previewActive).toBe(false);
     });
   });
 });

--- a/dashboard/src/hooks/useTranscription.ts
+++ b/dashboard/src/hooks/useTranscription.ts
@@ -71,19 +71,28 @@ export interface TranscriptionState {
   jobId: string | null;
   /** Load an externally-fetched result into the hook (e.g. recovered from DB) */
   loadResult: (result: TranscriptionResult) => void;
-  /** Ephemeral "last N seconds" preview text (null until a preview is requested) */
+  /** Ephemeral "last N seconds" preview text (null until a preview has run) */
   previewText: string | null;
   /** Detected language of the most recent preview */
   previewLanguage?: string;
   /** Actual seconds of audio transcribed by the most recent preview */
   previewSeconds: number | null;
-  /** Whether a preview request is currently in flight */
+  /** Whether a preview refresh is currently in flight */
   previewLoading: boolean;
   /** Error message from the most recent preview attempt */
   previewError: string | null;
-  /** Request an ephemeral preview of the last `durationSeconds` of audio */
-  preview: (durationSeconds: number) => void;
+  /** Whether the rolling preview loop is running */
+  previewActive: boolean;
+  /** Start the rolling preview of the last `durationSeconds` of audio */
+  startPreview: (durationSeconds: number) => void;
+  /** Stop the rolling preview and clear its pane state */
+  stopPreview: () => void;
 }
+
+// Rolling-preview cadence: refresh every 5s measured send-to-send. The
+// adaptive delay in the preview_result handler stretches this for slow
+// models so transcription never exceeds a ~50% duty cycle.
+const PREVIEW_REFRESH_BASE_MS = 5000;
 
 export function useTranscription(): TranscriptionState {
   const [status, setStatus] = useState<TranscriptionStatus>('idle');
@@ -101,9 +110,17 @@ export function useTranscription(): TranscriptionState {
   const [previewSeconds, setPreviewSeconds] = useState<number | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
-  // Ref guard so the preview() callback can reject overlapping requests without
+  const [previewActive, setPreviewActive] = useState(false);
+  // Ref guard so refresh scheduling can reject overlapping requests without
   // a stale-closure read of previewLoading.
   const previewLoadingRef = useRef(false);
+  // Ref mirror of previewActive for the WS message handler and timer callbacks.
+  const previewActiveRef = useRef(false);
+  // Window length the active rolling preview was started with.
+  const previewDurationRef = useRef(20);
+  // Date.now() when the in-flight refresh was sent — drives the adaptive delay.
+  const previewSentAtRef = useRef(0);
+  const previewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const socketRef = useRef<TranscriptionSocket | null>(null);
   const captureRef = useRef<AudioCapture | null>(null);
@@ -139,6 +156,13 @@ export function useTranscription(): TranscriptionState {
   // so the server can finish and the poll-for-result fallback can recover
   useEffect(() => {
     return () => {
+      // Always kill a pending preview refresh — nothing is listening for the
+      // result after unmount, and previews are trivially reproducible.
+      if (previewTimerRef.current !== null) {
+        clearTimeout(previewTimerRef.current);
+        previewTimerRef.current = null;
+      }
+      previewActiveRef.current = false;
       const active = statusRef.current === 'recording' || statusRef.current === 'processing';
       if (!active) {
         pollCancelledRef.current = true;
@@ -161,6 +185,66 @@ export function useTranscription(): TranscriptionState {
       socketRef.current?.handleConfigChanged(apiClient.isBaseUrlConfigured());
     });
   }, []);
+
+  // Halt the rolling preview loop (flag + pending timer) without touching the
+  // pane state — preview_error keeps its message visible after the loop dies.
+  const haltPreviewLoop = useCallback(() => {
+    previewActiveRef.current = false;
+    setPreviewActive(false);
+    if (previewTimerRef.current !== null) {
+      clearTimeout(previewTimerRef.current);
+      previewTimerRef.current = null;
+    }
+  }, []);
+
+  const sendPreviewRequest = useCallback(() => {
+    if (!previewActiveRef.current || statusRef.current !== 'recording') return;
+    // Reject overlapping requests (server also guards, this avoids spamming).
+    if (previewLoadingRef.current) return;
+    previewLoadingRef.current = true;
+    setPreviewLoading(true);
+    previewSentAtRef.current = Date.now();
+    socketRef.current?.sendJSON({
+      type: 'preview',
+      data: { duration_seconds: previewDurationRef.current },
+    });
+  }, []);
+
+  const stopPreview = useCallback(() => {
+    haltPreviewLoop();
+    // previewLoadingRef is intentionally NOT cleared: it tracks whether a
+    // request is still on the wire. The socket stays open, so the server's
+    // response WILL arrive and clear it — and until then a new startPreview
+    // must not send a second 'preview' (the server rejects overlaps).
+    setPreviewLoading(false);
+    setPreviewText(null);
+    setPreviewLanguage(undefined);
+    setPreviewSeconds(null);
+    setPreviewError(null);
+  }, [haltPreviewLoop]);
+
+  const startPreview = useCallback(
+    (durationSeconds: number) => {
+      // Preview only makes sense during an active recording; ignore otherwise.
+      if (statusRef.current !== 'recording') return;
+      if (previewActiveRef.current) return;
+      previewActiveRef.current = true;
+      setPreviewActive(true);
+      setPreviewError(null);
+      previewDurationRef.current = durationSeconds;
+      if (previewLoadingRef.current) {
+        // A response from before a quick off/on toggle is still on the wire.
+        // Adopt it: the preview_result handler sees the loop active again,
+        // displays it, and schedules the next refresh. Sending now would be
+        // rejected server-side ('Preview already in progress') and the
+        // resulting preview_error would spuriously kill the new loop.
+        setPreviewLoading(true);
+        return;
+      }
+      sendPreviewRequest();
+    },
+    [sendPreviewRequest],
+  );
 
   const handleMessage = useCallback(
     (msg: ServerMessage) => {
@@ -296,19 +380,40 @@ export function useTranscription(): TranscriptionState {
           break;
         }
 
-        case 'preview_result':
+        case 'preview_result': {
           previewLoadingRef.current = false;
           setPreviewLoading(false);
+          // A late result landing after stopPreview() — the pane is already
+          // cleared and hidden; don't resurrect it.
+          if (!previewActiveRef.current) break;
           setPreviewText((msg.data?.text as string) ?? '');
           setPreviewLanguage(msg.data?.language as string | undefined);
           setPreviewSeconds((msg.data?.actual_seconds as number) ?? null);
           setPreviewError(null);
+          if (statusRef.current === 'recording') {
+            // Aim for one refresh every PREVIEW_REFRESH_BASE_MS send-to-send,
+            // but a refresh that took T ms waits at least T ms before the next
+            // one, capping transcription at a ~50% duty cycle on slow models.
+            const elapsedMs = Date.now() - previewSentAtRef.current;
+            const delayMs = Math.max(PREVIEW_REFRESH_BASE_MS - elapsedMs, elapsedMs);
+            // Defensive: never leave two refresh timers alive.
+            if (previewTimerRef.current !== null) {
+              clearTimeout(previewTimerRef.current);
+            }
+            previewTimerRef.current = setTimeout(() => {
+              previewTimerRef.current = null;
+              sendPreviewRequest();
+            }, delayMs);
+          }
           break;
+        }
 
         case 'preview_error':
           previewLoadingRef.current = false;
           setPreviewLoading(false);
           setPreviewError((msg.data?.message as string) ?? 'Preview failed');
+          // A failed refresh ends the loop; the user re-toggles to retry.
+          haltPreviewLoop();
           break;
 
         case 'vad_start':
@@ -323,6 +428,7 @@ export function useTranscription(): TranscriptionState {
         case 'error':
           setError((msg.data?.message as string) ?? 'Transcription error');
           setStatusTracked('error');
+          haltPreviewLoop();
           previewLoadingRef.current = false;
           setPreviewLoading(false);
           captureRef.current?.stop();
@@ -330,7 +436,7 @@ export function useTranscription(): TranscriptionState {
           break;
       }
     },
-    [setStatusTracked],
+    [setStatusTracked, haltPreviewLoop, sendPreviewRequest],
   );
 
   const start = useCallback(
@@ -351,11 +457,9 @@ export function useTranscription(): TranscriptionState {
       setMuted(false);
       jobIdRef.current = null;
       setJobId(null);
-      setPreviewText(null);
-      setPreviewLanguage(undefined);
-      setPreviewSeconds(null);
-      setPreviewError(null);
-      setPreviewLoading(false);
+      stopPreview();
+      // The old socket is being replaced — any in-flight preview response is
+      // lost with it, so the wire flag must not carry into the new session.
       previewLoadingRef.current = false;
       startOptsRef.current = options ?? {};
 
@@ -367,6 +471,7 @@ export function useTranscription(): TranscriptionState {
         onError: (err) => {
           setError(err);
           setStatusTracked('error');
+          haltPreviewLoop();
           previewLoadingRef.current = false;
           setPreviewLoading(false);
           captureRef.current?.stop();
@@ -375,6 +480,12 @@ export function useTranscription(): TranscriptionState {
         onClose: () => {
           captureRef.current?.stop();
           setAnalyser(null);
+          // onClose only fires for UNINTENTIONAL closes (disconnect() detaches
+          // it), so the socket is gone: an in-flight preview response can never
+          // arrive. Kill the loop and the wire flag, or the stuck previewLoading
+          // guard would block every future refresh — even across a reconnect.
+          stopPreview();
+          previewLoadingRef.current = false;
 
           // If we were processing when the socket closed, poll for the result
           const currentJobId = jobIdRef.current;
@@ -438,11 +549,14 @@ export function useTranscription(): TranscriptionState {
       });
       socketRef.current.connect();
     },
-    [handleMessage, setStatusTracked],
+    [handleMessage, setStatusTracked, stopPreview, haltPreviewLoop],
   );
 
   const stop = useCallback(() => {
     if (status === 'recording') {
+      // The rolling preview only exists during recording — halt it so no
+      // refresh fires into the processing phase.
+      haltPreviewLoop();
       // Tell the server to stop and produce the final result
       socketRef.current?.sendJSON({ type: 'stop' });
       // Stop audio capture immediately
@@ -450,7 +564,7 @@ export function useTranscription(): TranscriptionState {
       setAnalyser(null);
       setStatusTracked('processing');
     }
-  }, [status, setStatusTracked]);
+  }, [status, setStatusTracked, haltPreviewLoop]);
 
   const reset = useCallback(() => {
     captureRef.current?.stop();
@@ -464,27 +578,10 @@ export function useTranscription(): TranscriptionState {
     setProcessingProgress(null);
     jobIdRef.current = null;
     setJobId(null);
-    setPreviewText(null);
-    setPreviewLanguage(undefined);
-    setPreviewSeconds(null);
-    setPreviewError(null);
-    setPreviewLoading(false);
+    stopPreview();
+    // reset() disconnects the socket — the in-flight response (if any) is lost.
     previewLoadingRef.current = false;
-  }, [setStatusTracked]);
-
-  const preview = useCallback((durationSeconds: number) => {
-    // Preview only makes sense during an active recording; ignore otherwise.
-    if (statusRef.current !== 'recording') return;
-    // Reject overlapping requests (server also guards, this avoids spamming).
-    if (previewLoadingRef.current) return;
-    previewLoadingRef.current = true;
-    setPreviewLoading(true);
-    setPreviewError(null);
-    socketRef.current?.sendJSON({
-      type: 'preview',
-      data: { duration_seconds: durationSeconds },
-    });
-  }, []);
+  }, [setStatusTracked, stopPreview]);
 
   const toggleMute = useCallback(() => {
     setMuted((prev) => {
@@ -530,6 +627,8 @@ export function useTranscription(): TranscriptionState {
     previewSeconds,
     previewLoading,
     previewError,
-    preview,
+    previewActive,
+    startPreview,
+    stopPreview,
   };
 }


### PR DESCRIPTION
## Summary

Replaces the Session tab's one-shot Preview button with a rolling, auto-refreshing preview of the last N seconds (default 20s, configurable 10-60s) of the active recording. The button is now a toggle (Preview / Stop Preview) and the pane refreshes itself until stopped. Client-only change: the backend preview protocol from PR #162 is untouched.

This is Phase 1 of the plan to eventually let Preview supersede Live Mode - unlike Live Mode (whisper-only, model swap), the rolling preview works with every STT backend using the already-loaded main model. Live Mode is left intact for now.

## Changes

* feat(ui): `useTranscription` gains `startPreview`/`stopPreview`/`previewActive`, replacing the one-shot `preview()`
  * chained `setTimeout` loop (never `setInterval`), next refresh scheduled after `max(5000 - elapsedMs, elapsedMs)` so slow models cap at ~50% transcription duty cycle
  * `previewLoadingRef` tracks "request on the wire"; a quick Stop/Start toggle adopts the in-flight response instead of double-sending, avoiding the server's "Preview already in progress" rejection killing the fresh loop
  * loop halts on preview_error, recording stop, reset, session start, server error, socket error, unexpected socket close, and unmount; late results after stop are ignored
* feat(ui): SessionView Preview button becomes a toggle (Eye/EyeOff), pane gated on `previewActive || previewError`, per-refresh spinner moved into the pane header
* test(ui): preview tests rewritten for the rolling behavior (16 tests, fake timers with explicit `toFake`) covering adaptive delay, halt paths, late-result guard, in-flight adoption, and socket-close handling

## Test plan

- [x] Full dashboard suite green (1770 tests), tsc and eslint clean, ui-contract check passed
- [x] Adversarial review confirmed and fixed 3 lifecycle bugs pre-merge (socket close stranding the loop, stale in-flight result bleed, double-send loop-kill)
- [x] Manual smoke test: live recording with rolling preview refreshing every ~5s, quick toggle off/on, stop recording mid-preview