### PR TITLE
feat(dashboard): Docker image variant selector in the Server tab

### DIFF
--- a/dashboard/components/__tests__/ServerView.test.tsx
+++ b/dashboard/components/__tests__/ServerView.test.tsx
@@ -38,8 +38,12 @@ const mockDocker = {
   startLogStream: vi.fn(),
   stopLogStream: vi.fn(),
   clearLogs: vi.fn(),
-  remoteTags: [] as string[],
+  remoteTags: [] as Array<{ tag: string; created: string | null }>,
   remoteTagsStatus: 'ok' as 'ok' | 'not-published' | 'error' | null,
+  variantTags: null as Record<
+    'cuda' | 'cuda-legacy' | 'vulkan-wsl2' | 'vulkan-linux',
+    string[]
+  > | null,
   refreshImages: vi.fn(),
   refreshRemoteTags: vi.fn(),
   clearRemoteTags: vi.fn(),
@@ -781,5 +785,136 @@ describe('Server tab matrix redesign', () => {
         'openai/whisper-large-v3-turbo',
       );
     });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Docker image variant selector — the Image Variant tile row in the Docker
+// Image card. Replaces the Legacy GPU toggle that used to live in Instance
+// Settings: cuda ↔ cuda-legacy switching goes through the same confirmation
+// dialog, the vulkan variants are implied by the Runtime selector, and
+// per-version availability comes from the four GHCR tag lists (fail-open
+// when the probe is unavailable).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Docker image variant selector', () => {
+  function setupVariantAPI(configMap: Record<string, unknown>) {
+    const setSpy = vi.fn().mockResolvedValue(undefined);
+    (window as any).electronAPI = {
+      config: {
+        get: vi.fn().mockImplementation(async (key: string) => configMap[key]),
+        set: setSpy,
+      },
+      docker: {
+        readComposeEnvValue: vi.fn().mockResolvedValue('false'),
+        checkModelCache: vi.fn().mockResolvedValue({}),
+      },
+      app: {
+        getArch: vi.fn().mockReturnValue('x64'),
+        getConfigDir: vi.fn().mockResolvedValue('/mock/config'),
+      },
+      mlx: {
+        getStatus: vi.fn().mockResolvedValue('stopped'),
+        onStatusChanged: vi.fn().mockReturnValue(vi.fn()),
+      },
+      tailscale: {
+        getHostname: vi.fn().mockResolvedValue('my-server.tail1234.ts.net'),
+      },
+      server: {
+        checkFirewallPort: vi.fn().mockResolvedValue(null),
+        checkGpu: vi.fn().mockResolvedValue({ gpu: false, toolkit: false, vulkan: false }),
+      },
+    };
+    return { setSpy };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDocker.available = true;
+    mockDocker.images = [];
+    mockDocker.remoteTags = [];
+    mockDocker.variantTags = null;
+    mockDocker.container = { exists: false, running: false, status: 'unknown', health: undefined };
+    mockDocker.operationError = null;
+    mockDocker.operating = false;
+    mockDocker.composeAvailable = true;
+    mockAdminStatus.status = { models: {} };
+  });
+
+  it('renders the four variant tiles and drops the Legacy GPU toggle', async () => {
+    setupVariantAPI({ 'server.runtimeProfile': 'gpu' });
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    expect(screen.getByText('Image Variant')).toBeDefined();
+    // Label text nodes are exact-matched, so the variant tiles don't collide
+    // with the runtime tiles ('GPU (CUDA)', 'GPU (Vulkan Windows)', …).
+    expect(screen.getByText('CUDA').closest('button')).not.toBeNull();
+    expect(screen.getByText('CUDA Legacy').closest('button')).not.toBeNull();
+    expect(screen.getByText('Vulkan Windows').closest('button')).not.toBeNull();
+    expect(screen.getByText('Vulkan Linux').closest('button')).not.toBeNull();
+    expect(screen.queryByText('Legacy GPU image')).toBeNull();
+  });
+
+  it('clicking CUDA Legacy on the CUDA runtime opens the variant confirmation dialog', async () => {
+    setupVariantAPI({ 'server.runtimeProfile': 'gpu' });
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    const legacyTile = screen.getByText('CUDA Legacy').closest('button') as HTMLButtonElement;
+    // Enabled only after the persisted gpu profile hydrates (initial state is cpu).
+    await waitFor(() => {
+      expect(legacyTile.disabled).toBe(false);
+    });
+    fireEvent.click(legacyTile);
+    expect(screen.getByText('Switch to the CUDA Legacy image?')).toBeDefined();
+  });
+
+  it('gates CUDA Legacy to the GPU (CUDA) runtime', async () => {
+    setupVariantAPI({ 'server.runtimeProfile': 'cpu' });
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    const legacyTile = screen.getByText('CUDA Legacy').closest('button') as HTMLButtonElement;
+    expect(legacyTile.disabled).toBe(true);
+    expect(screen.getByText('Requires CUDA runtime')).toBeDefined();
+  });
+
+  it('blocks variant switching while a container exists (volume-wipe rule)', async () => {
+    mockDocker.container = { exists: true, running: false, status: 'exited', health: undefined };
+    setupVariantAPI({ 'server.runtimeProfile': 'gpu' });
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    // Badge flips from the runtime reason to the container reason once the
+    // persisted gpu profile hydrates.
+    await waitFor(() => {
+      expect(screen.getByText('Remove container to switch')).toBeDefined();
+    });
+    const legacyTile = screen.getByText('CUDA Legacy').closest('button') as HTMLButtonElement;
+    expect(legacyTile.disabled).toBe(true);
+  });
+
+  it('shows "Not published" for variants missing the selected version tag', async () => {
+    mockDocker.remoteTags = [{ tag: 'v1.3.7', created: null }];
+    mockDocker.variantTags = {
+      cuda: ['v1.3.7'],
+      'cuda-legacy': [],
+      'vulkan-wsl2': ['v1.3.7'],
+      'vulkan-linux': [],
+    };
+    setupVariantAPI({ 'server.runtimeProfile': 'gpu' });
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    // cuda-legacy and vulkan-linux lack v1.3.7 → "Not published" wins over
+    // their runtime badges; vulkan-wsl2 has the tag → keeps its runtime badge.
+    await waitFor(() => {
+      expect(screen.getAllByText('Not published').length).toBe(2);
+    });
+    expect(screen.getByText('Requires Vulkan Windows runtime')).toBeDefined();
+    expect(screen.queryByText('Requires Vulkan Linux runtime')).toBeNull();
+  });
+
+  it('fails open when the variant probe is unavailable (variantTags null)', async () => {
+    mockDocker.remoteTags = [{ tag: 'v1.3.7', created: null }];
+    mockDocker.variantTags = null;
+    setupVariantAPI({ 'server.runtimeProfile': 'gpu' });
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    const legacyTile = screen.getByText('CUDA Legacy').closest('button') as HTMLButtonElement;
+    await waitFor(() => {
+      expect(legacyTile.disabled).toBe(false);
+    });
+    expect(screen.queryByText('Not published')).toBeNull();
   });
 });

--- a/dashboard/components/views/ServerView.tsx
+++ b/dashboard/components/views/ServerView.tsx
@@ -18,6 +18,7 @@ import {
   Check,
   FolderOpen,
   Laptop,
+  Layers,
   Radio,
   SlidersHorizontal,
   Zap,
@@ -27,7 +28,6 @@ import { GlassCard } from '../ui/GlassCard';
 import { Button } from '../ui/Button';
 import { StatusLight } from '../ui/StatusLight';
 import { ImageTagChips } from '../ui/ImageTagChips';
-import { AppleSwitch } from '../ui/AppleSwitch';
 import { SelectorGroup } from '../ui/SelectorGroup';
 import { SelectorTile } from '../ui/SelectorTile';
 import { NvidiaIcon } from '../ui/icons/NvidiaIcon';
@@ -84,6 +84,7 @@ import {
   modelsForFamilyChoice,
 } from '../../src/services/instanceMatrix';
 import { isRuntimeProfile, type RuntimeProfile } from '../../src/types/runtime';
+import type { ImageVariant } from '../../src/hooks/useDocker';
 
 interface ServerViewProps {
   onStartServer: (
@@ -1190,6 +1191,66 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
   const selectedTagForActions = selectedImage;
   const selectedTagForStart = docker.images.length > 0 ? selectedTagForActions : undefined;
 
+  // ─── Image variant selection (Docker Image card) ──────────────────────────
+  // The active variant is a pure projection of existing settings — the
+  // runtime profile implies the vulkan repos, `useLegacyGpu` picks legacy vs
+  // default — so the selector adds no new persisted state or pull wiring:
+  // images are still only downloaded via "Fetch Fresh Image" or when the
+  // server starts. Note: the Vulkan Linux runtime is WIP; its tile mirrors
+  // the intended repo mapping, while actual pulls for that runtime keep
+  // targeting the default repo until the vulkan-linux wiring lands.
+
+  const activeImageVariant: ImageVariant =
+    runtimeProfile === 'vulkan-wsl2'
+      ? 'vulkan-wsl2'
+      : runtimeProfile === 'vulkan'
+        ? 'vulkan-linux'
+        : useLegacyGpu
+          ? 'cuda-legacy'
+          : 'cuda';
+
+  // Per-version availability from the four GHCR tag lists. Fail open: the
+  // default repo has been published since v0.4.4, so an empty `cuda` list
+  // means the probe itself failed (offline, GHCR down) — treat availability
+  // as unknown instead of disabling every tile.
+  const variantAvailability = useMemo(() => {
+    const vt = docker.variantTags;
+    if (!vt || (vt.cuda?.length ?? 0) === 0) return null;
+    return vt;
+  }, [docker.variantTags]);
+
+  const isVariantPublished = useCallback(
+    (variant: ImageVariant): boolean => {
+      if (!variantAvailability || !selectedImage) return true;
+      if (variantAvailability[variant]?.includes(selectedImage)) return true;
+      // A locally built/pulled tag counts for the active variant even when
+      // GHCR does not (or no longer) lists it — e.g. local dev builds.
+      return variant === activeImageVariant && localTagSet.has(selectedImage);
+    },
+    [variantAvailability, selectedImage, activeImageVariant, localTagSet],
+  );
+
+  // Switching image repos is blocked while a container exists — even a
+  // stopped container pins the runtime volume that the cuda ↔ cuda-legacy
+  // switch has to wipe (same rule as the retired Legacy GPU toggle).
+  const containerBlocksVariantSwitch = isRunning || containerStatus.exists;
+
+  // Variant tile click → the same confirmation flow the Legacy GPU toggle
+  // used (GH-83): the user acknowledges the restart + runtime-volume wipe
+  // before `server.useLegacyGpu` flips. The vulkan variants are implied by
+  // the Runtime selector, so their tiles never reach this handler.
+  const handleImageVariantSelect = useCallback(
+    (variant: ImageVariant) => {
+      if (variant !== 'cuda' && variant !== 'cuda-legacy') return;
+      const next = variant === 'cuda-legacy';
+      if (next === useLegacyGpu) return;
+      setPendingLegacyGpuValue(next);
+      setLegacyGpuWipeVolume(true);
+      setLegacyGpuDialogOpen(true);
+    },
+    [useLegacyGpu],
+  );
+
   // ─── Setup Checklist ────────────────────────────────────────────────────────
 
   const [setupDismissed, setSetupDismissed] = useState(true); // hide until loaded
@@ -1868,8 +1929,8 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                       */}
                       {docker.remoteTagsStatus === 'not-published' && useLegacyGpu ? (
                         <div className="border-accent-amber/30 bg-accent-amber/5 rounded-lg border px-3 py-2 text-xs text-slate-400">
-                          Legacy image not yet published for this release. Pull a default image and
-                          toggle legacy mode off, or wait for the next release.
+                          Legacy image not yet published for this release. Switch the image variant
+                          below back to CUDA, or wait for the next release.
                         </div>
                       ) : (
                         <ImageTagChips
@@ -1931,6 +1992,119 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                       </Button>
                     </div>
                   </div>
+                </div>
+                {/*
+                  Image variant selector — same visual language as the
+                  Instance Settings matrix (SelectorGroup + SelectorTile).
+                  Only cuda ↔ cuda-legacy is user-switchable here (this
+                  replaces the retired Legacy GPU toggle); the vulkan
+                  variants are implied by the Runtime selector and render
+                  locked (active) or disabled (inactive) so the whole
+                  variant matrix stays readable at a glance. Availability
+                  is per selected version tag: a variant whose GHCR package
+                  has no such tag shows a "Not published" badge.
+                */}
+                <div className="mt-6 border-t border-white/5 pt-4">
+                  <SelectorGroup
+                    icon={<Layers size={16} className="text-accent-cyan" />}
+                    title="Image Variant"
+                    hint="Which server image build this version uses"
+                    columnsClass="grid-cols-2 lg:grid-cols-4"
+                  >
+                    {(
+                      [
+                        {
+                          variant: 'cuda',
+                          label: 'CUDA',
+                          sublabel: 'Standard image',
+                          accent: 'green',
+                          icon: <NvidiaIcon size={16} />,
+                          runtimeOk: runtimeProfile === 'gpu' || runtimeProfile === 'cpu',
+                          runtimeBadge: 'Requires CUDA or CPU runtime',
+                        },
+                        {
+                          variant: 'cuda-legacy',
+                          label: 'CUDA Legacy',
+                          sublabel: 'GTX 10-series / 900-series and older',
+                          accent: 'amber',
+                          icon: <NvidiaIcon size={16} />,
+                          runtimeOk: runtimeProfile === 'gpu',
+                          runtimeBadge: 'Requires CUDA runtime',
+                        },
+                        {
+                          variant: 'vulkan-wsl2',
+                          label: 'Vulkan Windows',
+                          sublabel: 'AMD / Intel · WSL2',
+                          accent: 'red',
+                          icon: (
+                            <span className="flex h-5 w-10 flex-col items-center justify-center -space-y-1">
+                              <AmdIcon size={30} />
+                              <IntelIcon size={30} />
+                            </span>
+                          ),
+                          runtimeOk: runtimeProfile === 'vulkan-wsl2',
+                          runtimeBadge: 'Requires Vulkan Windows runtime',
+                        },
+                        {
+                          variant: 'vulkan-linux',
+                          label: 'Vulkan Linux',
+                          sublabel: 'AMD / Intel',
+                          accent: 'red',
+                          icon: (
+                            <span className="flex h-5 w-10 flex-col items-center justify-center -space-y-1">
+                              <AmdIcon size={30} />
+                              <IntelIcon size={30} />
+                            </span>
+                          ),
+                          runtimeOk: runtimeProfile === 'vulkan',
+                          runtimeBadge: 'Requires Vulkan Linux runtime',
+                        },
+                      ] satisfies Array<{
+                        variant: ImageVariant;
+                        label: string;
+                        sublabel: string;
+                        accent: 'green' | 'amber' | 'red';
+                        icon: React.ReactNode;
+                        runtimeOk: boolean;
+                        runtimeBadge: string;
+                      }>
+                    ).map((t) => {
+                      const isActiveTile = activeImageVariant === t.variant;
+                      const published = isVariantPublished(t.variant);
+                      const vulkanVariant =
+                        t.variant === 'vulkan-wsl2' || t.variant === 'vulkan-linux';
+                      const disabled =
+                        !isActiveTile &&
+                        (vulkanVariant ||
+                          !t.runtimeOk ||
+                          !published ||
+                          containerBlocksVariantSwitch);
+                      // Badge priority: version availability is the most
+                      // version-specific signal, then the runtime constraint,
+                      // then the container-pins-the-volume rule.
+                      const badge = disabled
+                        ? !published
+                          ? 'Not published'
+                          : vulkanVariant || !t.runtimeOk
+                            ? t.runtimeBadge
+                            : 'Remove container to switch'
+                        : undefined;
+                      return (
+                        <SelectorTile
+                          key={t.variant}
+                          icon={t.icon}
+                          label={t.label}
+                          sublabel={t.sublabel}
+                          accent={t.accent}
+                          selected={isActiveTile}
+                          disabled={disabled}
+                          locked={isActiveTile && vulkanVariant}
+                          badge={badge}
+                          onSelect={() => handleImageVariantSelect(t.variant)}
+                        />
+                      );
+                    })}
+                  </SelectorGroup>
                 </div>
                 {docker.operationError && (
                   <div className="mt-3 flex items-center justify-between gap-3 rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-400">
@@ -2264,43 +2438,10 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                   )}
                 </div>
 
-                {/*
-                  Legacy-GPU image toggle (Issue #83 — Pascal/Maxwell support).
-                  Gated to GPU (CUDA) runtime only: the cu126 wheels are
-                  pointless on Vulkan, CPU, or Metal, and surfacing the toggle
-                  there would invite confusion. Pascal/Maxwell users must
-                  pick GPU (CUDA) first — the README's §2.4 note tells them so.
-                  Switching repos requires a container restart and clears the
-                  runtime volume so the next bootstrap re-syncs wheels from the
-                  new PyTorch index — this is handled via a confirmation dialog.
-                */}
-                {runtimeProfile === 'gpu' && (
-                  <div className="border-b border-white/5 pb-4">
-                    <AppleSwitch
-                      checked={useLegacyGpu}
-                      // Disabled when the container exists at all — even stopped
-                      // containers still hold a reference to the runtime volume,
-                      // so the wipe-on-toggle would silently fail. User must
-                      // remove the container (Stop + cleanup) before switching.
-                      disabled={isRunning || containerStatus.exists}
-                      onChange={(next) => {
-                        // Don't apply immediately — show the confirmation
-                        // dialog so the user acknowledges the restart
-                        // requirement and chooses the wipe-volume option.
-                        setPendingLegacyGpuValue(next);
-                        setLegacyGpuWipeVolume(true);
-                        setLegacyGpuDialogOpen(true);
-                      }}
-                      size="sm"
-                      label="Legacy GPU image"
-                      description={
-                        containerStatus.exists && !isRunning
-                          ? 'Remove the existing container to switch image variants'
-                          : 'Installs cu126 wheels for GTX 10-series / 900-series and older NVIDIA cards (Pascal / Maxwell, Tesla and Quadro P/M)'
-                      }
-                    />
-                  </div>
-                )}
+                {/* The Legacy GPU image toggle used to live here (GH-83) —
+                    it is now the CUDA Legacy tile in the Docker Image card's
+                    Image Variant selector, which reuses the same confirmation
+                    dialog + runtime-volume wipe flow below. */}
                 {runtimeProfile === 'vulkan' && !isRunning && sidecarNeeded && (
                   <div className="border-accent-rose/20 bg-accent-rose/5 flex items-center gap-3 rounded-lg border px-4 py-3">
                     {docker.sidecarPulling ? (
@@ -2688,7 +2829,9 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
           <DialogPanel className="border-accent-orange/25 blur-panel w-full max-w-lg overflow-hidden rounded-3xl border bg-black/75 shadow-2xl backdrop-blur-xl">
             <div className="border-accent-orange/20 bg-accent-orange/10 border-b px-6 py-4">
               <DialogTitle className="text-accent-orange text-lg font-semibold">
-                {pendingLegacyGpuValue ? 'Enable legacy-GPU image?' : 'Disable legacy-GPU image?'}
+                {pendingLegacyGpuValue
+                  ? 'Switch to the CUDA Legacy image?'
+                  : 'Switch to the standard CUDA image?'}
               </DialogTitle>
               <p className="mt-1 text-sm text-slate-300">
                 {pendingLegacyGpuValue
@@ -2768,7 +2911,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                         // GHCR repo. Fire-and-forget — refresh errors surface
                         // through the existing `remoteTagsStatus` channel.
                         void docker.refreshRemoteTags?.();
-                        const base = `${next ? 'Enabled' : 'Disabled'} legacy-GPU image. `;
+                        const base = `Switched to the ${next ? 'CUDA Legacy' : 'standard CUDA'} image. `;
                         if (legacyGpuWipeVolume && !result.runtimeVolumeWiped) {
                           // Wipe was requested but failed — tell the user so
                           // they know the runtime volume still holds old wheels.

--- a/dashboard/electron/__tests__/dockerManagerVariantTags.test.ts
+++ b/dashboard/electron/__tests__/dockerManagerVariantTags.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment node
+
+/**
+ * Image variant selector — per-variant GHCR tag listing.
+ *
+ * Covers `IMAGE_VARIANT_REPOS` (the variant → repo map the Docker Image
+ * card's selector is built on) and `listVariantTags` (the parallel four-repo
+ * tag probe that powers per-version variant availability). Failure isolation
+ * matters most here: one unpublished/private/unreachable variant must never
+ * blank out the availability data of the others.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+// Mock `electron` before importing dockerManager — the module imports `app`
+// at the top level and needs a usable path for `getPath('userData')`.
+const userDataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ts-variant-tags-test-'));
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: (_name: string) => userDataRoot,
+    setPath: vi.fn(),
+  },
+}));
+
+// Mock electron-store (imported transitively by config readers)
+vi.mock('electron-store', () => ({
+  default: class MockStore {
+    get() {
+      return undefined;
+    }
+    set() {}
+  },
+}));
+
+import {
+  IMAGE_REPO,
+  LEGACY_IMAGE_REPO,
+  VULKAN_WSL2_IMAGE_REPO,
+  VULKAN_LINUX_IMAGE_REPO,
+  IMAGE_VARIANT_REPOS,
+  listVariantTags,
+} from '../dockerManager.js';
+
+function mockFetch(
+  impl: (url: string | URL | Request) => Promise<Response>,
+): ReturnType<typeof vi.fn> {
+  const fn = vi.fn(impl);
+  vi.stubGlobal('fetch', fn);
+  return fn;
+}
+
+function tagsResponse(tags: string[]): Response {
+  return new Response(JSON.stringify({ tags }), { status: 200 });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('[P1] IMAGE_VARIANT_REPOS', () => {
+  it('maps each variant to its canonical GHCR repo', () => {
+    expect(IMAGE_VARIANT_REPOS).toEqual({
+      cuda: IMAGE_REPO,
+      'cuda-legacy': LEGACY_IMAGE_REPO,
+      'vulkan-wsl2': VULKAN_WSL2_IMAGE_REPO,
+      'vulkan-linux': VULKAN_LINUX_IMAGE_REPO,
+    });
+  });
+
+  it('vulkan-linux repo follows the shared naming scheme', () => {
+    expect(VULKAN_LINUX_IMAGE_REPO).toBe(
+      'ghcr.io/homelab-00/transcriptionsuite-server-vulkan-linux',
+    );
+  });
+
+  it('all four repos are distinct — variant tag lists can never mix', () => {
+    expect(new Set(Object.values(IMAGE_VARIANT_REPOS)).size).toBe(4);
+  });
+});
+
+describe('[P1] listVariantTags', () => {
+  it('returns per-variant tag lists keyed by variant', async () => {
+    // Dispatch by repo suffix. The default repo path is a prefix of the
+    // other three, so suffixed repos must be matched first.
+    mockFetch(async (url) => {
+      const s = String(url);
+      if (s.includes('/token')) {
+        return new Response(JSON.stringify({ token: 'fake-bearer' }), { status: 200 });
+      }
+      if (s.includes('transcriptionsuite-server-legacy/')) {
+        return tagsResponse(['v1.3.7', 'v1.3.3']);
+      }
+      if (s.includes('transcriptionsuite-server-vulkan-wsl2/')) {
+        return tagsResponse(['v1.3.7', 'v1.3.6']);
+      }
+      if (s.includes('transcriptionsuite-server-vulkan-linux/')) {
+        return tagsResponse(['v1.3.7']);
+      }
+      return tagsResponse(['v1.3.7', 'v1.3.6', 'v1.3.5']);
+    });
+
+    const result = await listVariantTags();
+    expect(result.cuda).toEqual(['v1.3.7', 'v1.3.6', 'v1.3.5']);
+    expect(result['cuda-legacy']).toEqual(['v1.3.7', 'v1.3.3']);
+    expect(result['vulkan-wsl2']).toEqual(['v1.3.7', 'v1.3.6']);
+    expect(result['vulkan-linux']).toEqual(['v1.3.7']);
+  });
+
+  it('filters non-version tags (latest, sha-…) like listRemoteTags does', async () => {
+    mockFetch(async (url) => {
+      const s = String(url);
+      if (s.includes('/token')) {
+        return new Response(JSON.stringify({ token: 'fake-bearer' }), { status: 200 });
+      }
+      return tagsResponse(['latest', 'v1.3.7', 'sha-deadbeef', 'v1.3.7rc1']);
+    });
+
+    const result = await listVariantTags();
+    expect(result.cuda).toEqual(['v1.3.7', 'v1.3.7rc1']);
+  });
+
+  it('isolates failures per variant — one 404 never blanks the others', async () => {
+    mockFetch(async (url) => {
+      const s = String(url);
+      if (s.includes('/token')) {
+        // Private-package simulation: token 401 for vulkan-linux only.
+        if (s.includes('transcriptionsuite-server-vulkan-linux')) {
+          return new Response('Unauthorized', { status: 401 });
+        }
+        return new Response(JSON.stringify({ token: 'fake-bearer' }), { status: 200 });
+      }
+      if (s.includes('transcriptionsuite-server-vulkan-wsl2/')) {
+        return new Response('Not Found', { status: 404 });
+      }
+      return tagsResponse(['v1.3.7']);
+    });
+
+    const result = await listVariantTags();
+    expect(result.cuda).toEqual(['v1.3.7']);
+    expect(result['cuda-legacy']).toEqual(['v1.3.7']);
+    expect(result['vulkan-wsl2']).toEqual([]);
+    expect(result['vulkan-linux']).toEqual([]);
+  });
+
+  it('resolves with all-empty lists instead of rejecting when fetch throws', async () => {
+    mockFetch(async () => {
+      throw new Error('network down');
+    });
+
+    const result = await listVariantTags();
+    expect(result).toEqual({
+      cuda: [],
+      'cuda-legacy': [],
+      'vulkan-wsl2': [],
+      'vulkan-linux': [],
+    });
+  });
+});

--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -54,6 +54,24 @@ const __dirname = path.dirname(__filename);
 export const IMAGE_REPO = 'ghcr.io/homelab-00/transcriptionsuite-server';
 export const LEGACY_IMAGE_REPO = 'ghcr.io/homelab-00/transcriptionsuite-server-legacy';
 export const VULKAN_WSL2_IMAGE_REPO = 'ghcr.io/homelab-00/transcriptionsuite-server-vulkan-wsl2';
+export const VULKAN_LINUX_IMAGE_REPO = 'ghcr.io/homelab-00/transcriptionsuite-server-vulkan-linux';
+
+/**
+ * Server image variants selectable from the Docker Image card. The active
+ * variant is a projection of existing settings — the runtime profile implies
+ * the vulkan repos, `server.useLegacyGpu` picks legacy vs default — so this
+ * type introduces no new persisted state. Pull/start wiring for the
+ * `vulkan-linux` repo is intentionally not hooked up yet (the Vulkan Linux
+ * runtime is WIP); the variant only participates in the availability display.
+ */
+export type ImageVariant = 'cuda' | 'cuda-legacy' | 'vulkan-wsl2' | 'vulkan-linux';
+
+export const IMAGE_VARIANT_REPOS: Record<ImageVariant, string> = {
+  cuda: IMAGE_REPO,
+  'cuda-legacy': LEGACY_IMAGE_REPO,
+  'vulkan-wsl2': VULKAN_WSL2_IMAGE_REPO,
+  'vulkan-linux': VULKAN_LINUX_IMAGE_REPO,
+};
 
 /**
  * Select the GHCR image repo for this session based on the persisted
@@ -4230,6 +4248,52 @@ export async function listRemoteTags(): Promise<RemoteTagsResult> {
 }
 
 /**
+ * Version-tag lists per image variant, keyed by `ImageVariant`. An empty
+ * array means unpublished, private, or unreachable — callers treat the three
+ * identically (the variant cannot be pulled for any tag right now).
+ */
+export type VariantTags = Record<ImageVariant, string[]>;
+
+/**
+ * Fetch the tag lists of all four server image variants in parallel.
+ *
+ * Powers the per-version variant availability display in the Docker Image
+ * card: a variant tile renders as "Not published" when the selected version
+ * tag is missing from that variant's GHCR package. Read-only — pulling and
+ * starting still target the single repo resolved by `resolveImageRepo`.
+ *
+ * Failures are per-variant and non-fatal: a variant whose token or tags/list
+ * request fails simply reports an empty list. The renderer fails open when
+ * even the default repo comes back empty (that signals network trouble, not
+ * "nothing published" — the default repo has had tags since v0.4.4).
+ */
+export async function listVariantTags(): Promise<VariantTags> {
+  const variants = Object.keys(IMAGE_VARIANT_REPOS) as ImageVariant[];
+  const entries = await Promise.all(
+    variants.map(async (variant): Promise<[ImageVariant, string[]]> => {
+      try {
+        const { tokenUrl, tagsUrl } = buildGhcrUrlsForRepo(IMAGE_VARIANT_REPOS[variant]);
+        const signal = AbortSignal.timeout(5000);
+        const tokenResp = await fetch(tokenUrl, { signal });
+        if (!tokenResp.ok) return [variant, []];
+        const { token } = (await tokenResp.json()) as { token?: string };
+        if (!token) return [variant, []];
+        const resp = await fetch(tagsUrl, {
+          signal,
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!resp.ok) return [variant, []];
+        const data = (await resp.json()) as { tags?: string[] };
+        return [variant, (data.tags ?? []).filter((t) => TAG_RE.test(t))];
+      } catch {
+        return [variant, []];
+      }
+    }),
+  );
+  return Object.fromEntries(entries) as VariantTags;
+}
+
+/**
  * Fetch creation dates for the given tags from GHCR OCI manifests.
  * Called separately from listRemoteTags so the tag list appears instantly.
  * Returns a map of tag → ISO date string.
@@ -4324,5 +4388,6 @@ export const dockerManager = {
   CONTAINER_NAME,
   IMAGE_REPO,
   listRemoteTags,
+  listVariantTags,
   fetchRemoteTagDates,
 };

--- a/dashboard/electron/main.ts
+++ b/dashboard/electron/main.ts
@@ -1210,6 +1210,10 @@ ipcMain.handle('docker:listRemoteTags', async () => {
   return dockerManager.listRemoteTags();
 });
 
+ipcMain.handle('docker:listVariantTags', async () => {
+  return dockerManager.listVariantTags();
+});
+
 ipcMain.handle('docker:fetchRemoteTagDates', async (_event, tags: string[]) => {
   return dockerManager.fetchRemoteTagDates(tags);
 });

--- a/dashboard/electron/preload.ts
+++ b/dashboard/electron/preload.ts
@@ -194,6 +194,9 @@ export interface ElectronAPI {
       | { status: 'error'; tags: [] }
     >;
     fetchRemoteTagDates: (tags: string[]) => Promise<Record<string, string | null>>;
+    listVariantTags: () => Promise<
+      Record<'cuda' | 'cuda-legacy' | 'vulkan-wsl2' | 'vulkan-linux', string[]>
+    >;
     pullImage: (tag: string) => Promise<string>;
     cancelPull: () => Promise<boolean>;
     isPulling: () => Promise<boolean>;
@@ -560,6 +563,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     fetchRemoteTagDates: (tags: string[]) =>
       ipcRenderer.invoke('docker:fetchRemoteTagDates', tags) as Promise<
         Record<string, string | null>
+      >,
+    listVariantTags: () =>
+      ipcRenderer.invoke('docker:listVariantTags') as Promise<
+        Record<'cuda' | 'cuda-legacy' | 'vulkan-wsl2' | 'vulkan-linux', string[]>
       >,
     pullImage: (tag: string) => ipcRenderer.invoke('docker:pullImage', tag),
     cancelPull: () => ipcRenderer.invoke('docker:cancelPull'),

--- a/dashboard/src/hooks/useDocker.ts
+++ b/dashboard/src/hooks/useDocker.ts
@@ -18,6 +18,21 @@ export interface RemoteTag {
   created: string | null;
 }
 
+/**
+ * Server image variants shown in the Docker Image card. Mirrors the
+ * `ImageVariant` type in `electron/dockerManager.ts` — the active variant is
+ * a projection of the runtime profile + `server.useLegacyGpu`, not a new
+ * persisted setting.
+ */
+export type ImageVariant = 'cuda' | 'cuda-legacy' | 'vulkan-wsl2' | 'vulkan-linux';
+
+/**
+ * Version-tag lists per image variant from GHCR. An empty array means the
+ * variant is unpublished, private, or unreachable — either way it cannot be
+ * pulled right now.
+ */
+export type VariantTags = Record<ImageVariant, string[]>;
+
 export interface DockerImage {
   tag: string;
   fullName: string;
@@ -100,6 +115,12 @@ export interface UseDockerReturn {
   remoteTagsStatus: 'ok' | 'not-published' | 'error' | null;
   refreshRemoteTags: () => Promise<void>;
   /**
+   * Per-variant GHCR tag lists for the Docker Image card's variant selector,
+   * or null while loading / when the probe is unavailable (non-Electron).
+   * Fetched once on mount alongside the remote tags.
+   */
+  variantTags: VariantTags | null;
+  /**
    * GH-99: reset `remoteTags` / `remoteTagsStatus` to their initial empty
    * state. Called by `ServerView` on legacy-GPU toggle flip so stale chips
    * from the previous variant don't linger during the ~1-2s refetch window.
@@ -168,6 +189,7 @@ export function useDocker(): UseDockerReturn {
   const [remoteTagsStatus, setRemoteTagsStatus] = useState<'ok' | 'not-published' | 'error' | null>(
     null,
   );
+  const [variantTags, setVariantTags] = useState<VariantTags | null>(null);
 
   const pollRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
   const volumeRefreshedOnHealthyRef = useRef(false);
@@ -290,6 +312,18 @@ export function useDocker(): UseDockerReturn {
   useEffect(() => {
     refreshRemoteTags();
   }, [refreshRemoteTags]);
+
+  // Fetch the per-variant tag lists once on mount. Purely informational
+  // (variant availability display) — a failure just leaves the selector
+  // failing open, so best-effort is fine here.
+  useEffect(() => {
+    const docker = api();
+    if (!docker?.listVariantTags) return;
+    docker
+      .listVariantTags()
+      .then(setVariantTags)
+      .catch(() => {});
+  }, []);
 
   /**
    * GH-99: clear cached remote tag state so the UI doesn't show stale chips
@@ -602,6 +636,7 @@ export function useDocker(): UseDockerReturn {
     remoteTags,
     remoteTagsStatus,
     refreshRemoteTags,
+    variantTags,
     clearRemoteTags,
     hasSidecarImage,
     pullSidecarImage,

--- a/dashboard/src/types/electron.d.ts
+++ b/dashboard/src/types/electron.d.ts
@@ -144,6 +144,9 @@ interface ElectronAPI {
       | { status: 'error'; tags: [] }
     >;
     fetchRemoteTagDates: (tags: string[]) => Promise<Record<string, string | null>>;
+    listVariantTags: () => Promise<
+      Record<'cuda' | 'cuda-legacy' | 'vulkan-wsl2' | 'vulkan-linux', string[]>
+    >;
     pullImage: (tag: string) => Promise<string>;
     cancelPull: () => Promise<boolean>;
     isPulling: () => Promise<boolean>;

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.11.0",
-  "contract_sha256": "920a2a88c27e950119a1758551a6a830e676f6bef1b38cb593f28eadef8b27a9",
-  "updated_at": "2026-07-16T14:28:54.663Z"
+  "spec_version": "1.11.1",
+  "contract_sha256": "2551a3d6846da1225987342ffae5540cb341eced728f0075b3f95ac56b5fef32",
+  "updated_at": "2026-07-16T22:13:06.436Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.11.0
+  spec_version: 1.11.1
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -121,7 +121,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-07-16T14:28:13.681Z
+    generated_at: 2026-07-16T22:12:55.890Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -574,7 +574,6 @@ utility_allowlist:
     - bg-blue-400
     - bg-blue-400/10
     - bg-blue-400/20
-    - bg-blue-500
     - bg-blue-500/10
     - bg-cyan-400/10
     - bg-cyan-400/20
@@ -597,10 +596,8 @@ utility_allowlist:
     - bg-neutral-700
     - bg-neutral-900
     - bg-orange-400/10
-    - bg-orange-500
     - bg-orange-500/10
     - bg-purple-400/10
-    - bg-purple-500
     - bg-red-400/10
     - bg-red-500
     - bg-red-500/10
@@ -640,8 +637,6 @@ utility_allowlist:
     - border-accent-magenta/5
     - border-accent-magenta/60
     - border-accent-orange/20
-    - border-accent-orange/25
-    - border-accent-rose/20
     - border-amber-400/20
     - border-amber-400/25
     - border-amber-400/30
@@ -859,6 +854,7 @@ utility_allowlist:
     - left-8
     - lg:flex
     - lg:grid-cols-2
+    - lg:grid-cols-4
     - lg:grid-cols-5
     - lg:p-10
     - line-clamp-2
@@ -897,7 +893,6 @@ utility_allowlist:
     - md:grid-cols-4
     - md:items-center
     - md:items-end
-    - md:justify-between
     - min-h-0
     - min-h-20
     - min-h-32
@@ -1122,7 +1117,6 @@ utility_allowlist:
     - text-purple-400
     - text-red-100
     - text-red-200
-    - text-red-200/90
     - text-red-300
     - text-red-400
     - text-red-400/80


### PR DESCRIPTION
## Summary

Adds an **Image Variant** selector to the `1. Docker Image` card in the Server tab, using the same visual language as the Instance Settings matrix (`SelectorGroup` + `SelectorTile`). The four variants map to the GHCR server packages:

| Tile | GHCR package |
|------|--------------|
| CUDA | `transcriptionsuite-server` |
| CUDA Legacy | `transcriptionsuite-server-legacy` |
| Vulkan Windows | `transcriptionsuite-server-vulkan-wsl2` |
| Vulkan Linux | `transcriptionsuite-server-vulkan-linux` |

The **Legacy GPU image toggle is removed** from Instance Settings — switching to/from the legacy image is now done by clicking the CUDA / CUDA Legacy tiles, which reuse the exact same confirmation dialog + runtime-volume wipe flow (`server:setUseLegacyGpu` IPC unchanged).

## Design notes

- **The active variant is derived, not stored.** Runtime `vulkan-wsl2` → Vulkan Windows, runtime `vulkan` → Vulkan Linux, otherwise `server.useLegacyGpu` picks CUDA Legacy vs CUDA. No new persisted key, no migration.
- **No new pull wiring.** Selecting a variant never downloads anything — images are still pulled only via Fetch Fresh Image or on server start, through the untouched `resolveImageRepo()` funnel. In particular the `vulkan-linux` repo is *not* wired into pulls yet (the Vulkan Linux runtime is WIP); its tile reflects the intended mapping only.
- **Per-version availability.** A new read-only IPC (`docker:listVariantTags`) fetches all four repos' tag lists in parallel. For the selected version tag, variants whose package lacks that tag show a dimmed tile with a `Not published` badge (e.g. v1.3.6 → Vulkan Linux not published; v1.3.4 → only CUDA + CUDA Legacy). Fails open when the probe itself fails (offline), so tiles are never wrongly disabled.
- **Gating carried over from the toggle:** CUDA Legacy requires the GPU (CUDA) runtime, and cuda ↔ cuda-legacy switching is blocked while a container exists (`Remove container to switch` badge) because the switch wipes the runtime volume.
- Vulkan tiles are runtime-implied: locked (with lock glyph) when their runtime is active, disabled with a `Requires … runtime` badge otherwise.

## Verification

- `npm run typecheck` + `npm run lint` clean
- Full vitest suite: **125 files / 1830 tests passed** (incl. 6 new ServerView tests + 7 new `listVariantTags` tests)
- UI contract updated to **1.11.1** (extract → build → bump → update-baseline → check, 16 checks pass)
- GitNexus `detect_changes`: 13 touched symbols, risk **low**, no affected execution flows

## Manual smoke checklist

- [ ] Server tab shows the Image Variant row under the tag chips in the Docker Image card
- [ ] On CUDA runtime with no container: clicking CUDA Legacy opens the "Switch to the CUDA Legacy image?" dialog; confirming refreshes the tag chips against the legacy repo
- [ ] With a container present (running or stopped): CUDA/CUDA Legacy tiles disabled with "Remove container to switch"
- [ ] Select v1.3.6 → Vulkan Linux tile shows "Not published"; select v1.3.7 → badge disappears
- [ ] Switch runtime to GPU (Vulkan Linux) → Vulkan Linux tile becomes the locked active tile
- [ ] Instance Settings no longer shows the Legacy GPU image toggle