### PR TITLE
fix(dashboard): own the Linux loopback module lifecycle so the mic indicator always clears

### DIFF
--- a/dashboard/components/__tests__/SessionView.canary-language.test.tsx
+++ b/dashboard/components/__tests__/SessionView.canary-language.test.tsx
@@ -478,14 +478,18 @@ describe('SessionView — Canary language guards (gh-102)', () => {
 
   // ── Tray Stop / Cancel routed through their handlers (gh-102 followup #2) ──
   //
-  // Pre-fix the tray callbacks bypassed handleStopRecording (skipping Linux
-  // loopback / Win+Mac system-audio cleanup) and handleCancelProcessing
-  // (leaving orphan transcription jobs running on the server during
-  // `processing` — a CLAUDE.md data-loss-class regression). The fix routes
-  // them through the existing handlers via wrapped arrows (TDZ — same
-  // pattern as the gh-102 Start Recording fix at SessionView.tsx:633).
+  // Pre-fix the tray callbacks bypassed handleStopRecording (skipping Win+Mac
+  // system-audio cleanup) and handleCancelProcessing (leaving orphan
+  // transcription jobs running on the server during `processing` — a
+  // CLAUDE.md data-loss-class regression). The fix routes them through the
+  // existing handlers via wrapped arrows (TDZ — same pattern as the gh-102
+  // Start Recording fix at SessionView.tsx:633).
+  //
+  // GH-230: the Linux loopback module is no longer removed by SessionView —
+  // AudioCapture releases it via loopbackOwner on every capture teardown, so
+  // these tests pin that the handlers DON'T call removeMonitorLoopback.
 
-  it('tray Stop on Linux while recording calls handleStopRecording (transcription.stop + removeMonitorLoopback)', async () => {
+  it('tray Stop on Linux while recording calls handleStopRecording (transcription.stop; loopback owned by loopbackOwner)', async () => {
     Object.defineProperty(navigator, 'platform', { value: 'Linux x86_64', configurable: true });
     mockTranscription.status = 'recording';
 
@@ -506,7 +510,8 @@ describe('SessionView — Canary language guards (gh-102)', () => {
     const audio = (
       window as unknown as { electronAPI: { audio: Record<string, ReturnType<typeof vi.fn>> } }
     ).electronAPI.audio;
-    expect(audio.removeMonitorLoopback).toHaveBeenCalledTimes(1);
+    // GH-230: module release is loopbackOwner's job (via capture.stop()).
+    expect(audio.removeMonitorLoopback).not.toHaveBeenCalled();
     expect(audio.disableSystemAudioLoopback).not.toHaveBeenCalled();
   });
 
@@ -560,7 +565,9 @@ describe('SessionView — Canary language guards (gh-102)', () => {
     const audio = (
       window as unknown as { electronAPI: { audio: Record<string, ReturnType<typeof vi.fn>> } }
     ).electronAPI.audio;
-    expect(audio.removeMonitorLoopback).toHaveBeenCalledTimes(1);
+    // GH-230: module release happens inside reset() → capture.stop() →
+    // loopbackOwner, not in the SessionView handler.
+    expect(audio.removeMonitorLoopback).not.toHaveBeenCalled();
   });
 
   it('tray Cancel during recording skips apiClient.cancelTranscription but still runs reset and loopback cleanup', async () => {
@@ -585,6 +592,8 @@ describe('SessionView — Canary language guards (gh-102)', () => {
     const audio = (
       window as unknown as { electronAPI: { audio: Record<string, ReturnType<typeof vi.fn>> } }
     ).electronAPI.audio;
-    expect(audio.removeMonitorLoopback).toHaveBeenCalledTimes(1);
+    // GH-230: module release happens inside reset() → capture.stop() →
+    // loopbackOwner, not in the SessionView handler.
+    expect(audio.removeMonitorLoopback).not.toHaveBeenCalled();
   });
 });

--- a/dashboard/components/__tests__/SessionView.client-link-stop.test.tsx
+++ b/dashboard/components/__tests__/SessionView.client-link-stop.test.tsx
@@ -1,0 +1,321 @@
+/**
+ * GH-230: stopping the Client Link must terminate active sessions.
+ *
+ * Pre-fix, handleStopClient only flipped clientRunning=false — an active
+ * recording kept streaming invisibly (status read "Disconnected" while the
+ * OS microphone indicator stayed lit). These tests pin the new contract:
+ *  - recording   → handleStopRecording() (stop-and-transcribe)
+ *  - connecting  → transcription.reset()
+ *  - processing  → untouched (server holds the audio; poll fallback recovers)
+ *  - live active → handleLiveToggle(false)
+ * and in every case the clientRunning flag still flips.
+ */
+
+import React from 'react';
+import { render, screen, within, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockTranscription = {
+  status: 'idle' as string,
+  result: null,
+  error: null as string | null,
+  analyser: null,
+  start: vi.fn(),
+  stop: vi.fn(),
+  reset: vi.fn(),
+  vadActive: false,
+  processingProgress: null,
+  muted: false,
+  toggleMute: vi.fn(),
+  setGain: vi.fn(),
+  jobId: null,
+  loadResult: vi.fn(),
+};
+
+vi.mock('../../src/hooks/useTranscription', () => ({
+  useTranscription: () => mockTranscription,
+}));
+
+vi.mock('../../src/hooks/useLanguages', () => ({
+  useLanguages: () => ({
+    languages: [{ code: 'auto', name: 'Auto Detect' }],
+    backendType: 'whisper',
+    loading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('../../src/hooks/useAdminStatus', () => ({
+  useAdminStatus: () => ({
+    status: {
+      models_loaded: true,
+      config: {
+        main_transcriber: { model: 'large-v3' },
+        live_transcriber: { model: 'large-v3' },
+      },
+    },
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/hooks/DockerContext', () => ({
+  useDockerContext: () => ({
+    available: true,
+    loading: false,
+    runtimeKind: 'Docker',
+    detectionGuidance: null,
+    composeAvailable: true,
+    images: [],
+    container: { exists: true, running: true, status: 'running', health: 'healthy' },
+    volumes: [],
+    operating: false,
+    operationError: null,
+    pulling: false,
+    sidecarPulling: false,
+    logLines: [],
+    logStreaming: false,
+    hasSidecarImage: vi.fn().mockResolvedValue(false),
+    startLogStream: vi.fn(),
+    stopLogStream: vi.fn(),
+    clearLogs: vi.fn(),
+    refreshImages: vi.fn(),
+    refreshVolumes: vi.fn(),
+    pullImage: vi.fn(),
+    cancelPull: vi.fn(),
+    pullSidecarImage: vi.fn(),
+    cancelSidecarPull: vi.fn(),
+    removeImage: vi.fn(),
+    startContainer: vi.fn(),
+    stopContainer: vi.fn(),
+    removeContainer: vi.fn(),
+    removeVolume: vi.fn(),
+    cleanAll: vi.fn(),
+    retryDetection: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/hooks/useTraySync', () => ({ useTraySync: vi.fn() }));
+
+vi.mock('../../src/stores/importQueueStore', () => ({
+  useImportQueueStore: (selector: (s: Record<string, unknown>) => unknown) => {
+    const state = {
+      jobs: [],
+      isPaused: false,
+      sessionConfig: { outputDir: '', diarizedFormat: 'srt', hideTimestamps: false },
+      sessionWatchPath: '',
+      sessionWatchActive: false,
+    };
+    return typeof selector === 'function' ? selector(state) : state;
+  },
+}));
+
+vi.mock('../../src/api/client', () => ({
+  apiClient: {
+    checkConnection: vi.fn().mockResolvedValue({ reachable: true, ready: true }),
+    getAdminStatus: vi.fn().mockResolvedValue({}),
+    cancelTranscription: vi.fn(),
+    getAuthToken: vi.fn().mockReturnValue(null),
+    setAuthToken: vi.fn(),
+    getBaseUrl: vi.fn().mockReturnValue('http://localhost:7239'),
+    syncFromConfig: vi.fn().mockResolvedValue(undefined),
+    unloadModels: vi.fn().mockResolvedValue(undefined),
+    unloadLLMModel: vi.fn().mockResolvedValue(undefined),
+    loadModelsStream: vi.fn().mockReturnValue(vi.fn()),
+    fetchRecentUndelivered: vi.fn().mockResolvedValue({ json: async () => [] }),
+    fetchTranscriptionResult: vi.fn().mockResolvedValue({ status: 404, json: async () => ({}) }),
+    dismissTranscriptionResult: vi.fn().mockResolvedValue({ status: 200 }),
+  },
+}));
+
+vi.mock('../../src/config/store', () => ({
+  getConfig: vi.fn().mockResolvedValue(undefined),
+  setConfig: vi.fn().mockResolvedValue(undefined),
+  getAuthToken: vi.fn().mockResolvedValue(null),
+  DEFAULT_SERVER_PORT: 7239,
+}));
+
+vi.mock('../../src/services/modelSelection', () => ({
+  isModelDisabled: () => false,
+}));
+
+vi.mock('../../src/hooks/useClipboard', () => ({ writeToClipboard: vi.fn() }));
+vi.mock('../../src/services/clientDebugLog', () => ({ logClientEvent: vi.fn() }));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../views/SessionImportTab', () => ({
+  SessionImportTab: () => React.createElement('div', { 'data-testid': 'session-import-tab' }),
+}));
+vi.mock('../PopOutWindow', () => ({ PopOutWindow: () => null }));
+vi.mock('../views/FullscreenVisualizer', () => ({ FullscreenVisualizer: () => null }));
+vi.mock('../AudioVisualizer', () => ({
+  AudioVisualizer: () => React.createElement('div', { 'data-testid': 'audio-visualizer' }),
+}));
+
+vi.mock('../../src/types/runtime', () => ({
+  isRuntimeProfile: (v: unknown) =>
+    ['gpu', 'cpu', 'vulkan', 'vulkan-wsl2', 'metal'].includes(v as string),
+}));
+
+import { SessionView } from '../views/SessionView';
+import { SessionTab } from '../../types';
+import type { LiveModeState } from '../../src/hooks/useLiveMode';
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+}
+
+const baseLiveState = {
+  status: 'idle' as LiveModeState['status'],
+  sentences: [],
+  partial: '',
+  statusMessage: null,
+  error: null,
+  analyser: null,
+  muted: false,
+  start: vi.fn(),
+  stop: vi.fn(),
+  toggleMute: vi.fn(),
+  setGain: vi.fn(),
+  clearHistory: vi.fn(),
+  getText: vi.fn().mockReturnValue(''),
+};
+
+const baseProps = {
+  serverConnection: {
+    serverStatus: 'active' as const,
+    clientStatus: 'active' as const,
+    details: null,
+    serverLabel: 'Server ready',
+    reachable: true,
+    ready: true,
+    error: null,
+    gpuError: null,
+    gpuErrorRecoveryHint: null,
+    refresh: vi.fn(),
+  },
+  clientRunning: true,
+  setClientRunning: vi.fn(),
+  onStartServer: vi.fn().mockResolvedValue(undefined),
+  startupFlowPending: false,
+  isUploading: false,
+  live: baseLiveState,
+  sessionTab: SessionTab.MAIN,
+  onChangeSessionTab: vi.fn(),
+};
+
+const ORIGINAL_NAVIGATOR_PLATFORM = navigator.platform;
+
+/** Render SessionView and click the Client Link card's Stop button. */
+async function clickClientLinkStop(
+  props: typeof baseProps & { live?: typeof baseLiveState },
+): Promise<void> {
+  render(React.createElement(SessionView, props), { wrapper: createWrapper() });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  const clientCard = screen
+    .getByText('Client Link')
+    .closest('div[class*="rounded-xl"]') as HTMLElement;
+  expect(clientCard).not.toBeNull();
+  const stopButton = within(clientCard).getByRole('button', { name: 'Stop' });
+  await act(async () => {
+    fireEvent.click(stopButton);
+  });
+}
+
+describe('SessionView — Client Link Stop terminates active sessions (GH-230)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTranscription.status = 'idle';
+    // Linux platform: pins that the Linux loopback module is NOT touched by
+    // SessionView (loopbackOwner owns it via capture teardown).
+    Object.defineProperty(navigator, 'platform', { value: 'Linux x86_64', configurable: true });
+    (window as unknown as { electronAPI: unknown }).electronAPI = {
+      config: {
+        get: vi.fn().mockResolvedValue(undefined),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+      docker: { readComposeEnvValue: vi.fn().mockResolvedValue('false') },
+      audio: {
+        listSinks: vi.fn().mockResolvedValue([]),
+        removeMonitorLoopback: vi.fn().mockResolvedValue(undefined),
+        disableSystemAudioLoopback: vi.fn().mockResolvedValue(undefined),
+      },
+      tray: { onAction: vi.fn().mockReturnValue(vi.fn()) },
+      notifications: { show: vi.fn() },
+    };
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'platform', {
+      value: ORIGINAL_NAVIGATOR_PLATFORM,
+      configurable: true,
+    });
+  });
+
+  it('while recording: stops the recording (stop-and-transcribe) and drops the link', async () => {
+    mockTranscription.status = 'recording';
+    const setClientRunning = vi.fn();
+    await clickClientLinkStop({ ...baseProps, setClientRunning });
+
+    expect(mockTranscription.stop).toHaveBeenCalledTimes(1);
+    expect(mockTranscription.reset).not.toHaveBeenCalled();
+    expect(setClientRunning).toHaveBeenCalledWith(false);
+    // GH-230: no manual loopback IPC from the view — loopbackOwner owns it.
+    const audio = (
+      window as unknown as { electronAPI: { audio: Record<string, ReturnType<typeof vi.fn>> } }
+    ).electronAPI.audio;
+    expect(audio.removeMonitorLoopback).not.toHaveBeenCalled();
+  });
+
+  it('while connecting: resets the session and drops the link', async () => {
+    mockTranscription.status = 'connecting';
+    const setClientRunning = vi.fn();
+    await clickClientLinkStop({ ...baseProps, setClientRunning });
+
+    expect(mockTranscription.reset).toHaveBeenCalledTimes(1);
+    expect(mockTranscription.stop).not.toHaveBeenCalled();
+    expect(setClientRunning).toHaveBeenCalledWith(false);
+  });
+
+  it('while processing: leaves the job alone (durability) and drops the link', async () => {
+    mockTranscription.status = 'processing';
+    const setClientRunning = vi.fn();
+    await clickClientLinkStop({ ...baseProps, setClientRunning });
+
+    expect(mockTranscription.stop).not.toHaveBeenCalled();
+    expect(mockTranscription.reset).not.toHaveBeenCalled();
+    expect(setClientRunning).toHaveBeenCalledWith(false);
+  });
+
+  it('while live mode is active: stops live mode and drops the link', async () => {
+    const liveStop = vi.fn();
+    const setClientRunning = vi.fn();
+    await clickClientLinkStop({
+      ...baseProps,
+      setClientRunning,
+      live: { ...baseLiveState, status: 'listening', stop: liveStop },
+    });
+
+    expect(liveStop).toHaveBeenCalledTimes(1);
+    expect(setClientRunning).toHaveBeenCalledWith(false);
+  });
+
+  it('while idle: just drops the link', async () => {
+    const setClientRunning = vi.fn();
+    await clickClientLinkStop({ ...baseProps, setClientRunning });
+
+    expect(mockTranscription.stop).not.toHaveBeenCalled();
+    expect(mockTranscription.reset).not.toHaveBeenCalled();
+    expect(baseProps.live.stop).not.toHaveBeenCalled();
+    expect(setClientRunning).toHaveBeenCalledWith(false);
+  });
+});

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -49,6 +49,7 @@ import { useScrollFade } from '../../src/hooks/useScrollFade';
 import { apiClient } from '../../src/api/client';
 import { getAuthToken, getConfig, setConfig } from '../../src/config/store';
 import { logClientEvent } from '../../src/services/clientDebugLog';
+import { loopbackOwner } from '../../src/services/loopbackOwner';
 import {
   supportsTranslation,
   filterLanguagesForModel,
@@ -108,8 +109,11 @@ export const SessionView: React.FC<SessionViewProps> = ({
   // Capture gain — boosts quiet system audio sources via Web Audio GainNode.
   // Persisted per-sink in config store. Also drives live mode gain.
   const [captureGain, setCaptureGain] = useState(1.0);
-  // Diagnostic: effective monitor source volume after loopback creation (Linux)
+  // Diagnostic: effective monitor source volume after loopback creation (Linux).
+  // Fed by loopbackOwner (GH-230): pct when the module is created, null when
+  // the deferred removal actually executes.
   const [monitorVolumePct, setMonitorVolumePct] = useState<number | null>(null);
+  useEffect(() => loopbackOwner.subscribeVolumePct(setMonitorVolumePct), []);
 
   // Runtime profile (read from persisted config)
   const [runtimeProfile, setRuntimeProfile] = useState<RuntimeProfile>('cpu');
@@ -648,10 +652,8 @@ export const SessionView: React.FC<SessionViewProps> = ({
     serverConnection.refresh();
   }, [serverConnection]);
 
-  const handleStopClient = useCallback(() => {
-    setClientRunning(false);
-    logClientEvent('Client', 'Client link stopped', 'warning');
-  }, []);
+  // handleStopClient is defined below handleLiveToggle — it now terminates
+  // active sessions (GH-230) and therefore depends on the stop handlers.
 
   const handleUnloadAllModels = useCallback(async () => {
     setModelsOperationPending(true);
@@ -793,20 +795,9 @@ export const SessionView: React.FC<SessionViewProps> = ({
     const mainTranslateTarget = isCanaryMainBidi ? (resolveLanguage(mainBidiTarget) ?? 'en') : 'en';
 
     void (async () => {
-      let monitorLabel: string | undefined;
-      if (isSystemAudio) {
-        if (isLinux) {
-          // Linux: create a virtual mic from the selected sink's monitor source
-          const selectedSink = sinkNameMap[sysDevice];
-          if (selectedSink) {
-            const result = await window.electronAPI?.audio?.createMonitorLoopback(selectedSink);
-            monitorLabel = 'TranscriptionSuite_Loopback';
-            setMonitorVolumePct(result?.volumePct ?? null);
-          }
-        } else {
-          // Windows / macOS: register getDisplayMedia loopback handler
-          await window.electronAPI?.audio?.enableSystemAudioLoopback?.();
-        }
+      if (isSystemAudio && !isLinux) {
+        // Windows / macOS: register getDisplayMedia loopback handler
+        await window.electronAPI?.audio?.enableSystemAudioLoopback?.();
       }
       // GH-199: read at start so the server knows whether to promote this
       // recording into the Audio Notebook when it finishes.
@@ -818,7 +809,10 @@ export const SessionView: React.FC<SessionViewProps> = ({
         translate: mainTranslateActive,
         translationTarget: mainTranslateTarget,
         systemAudio: isSystemAudio,
-        monitorDeviceLabel: monitorLabel,
+        // Linux system audio: pass the selected sink through — AudioCapture
+        // acquires/releases the pactl loopback module via loopbackOwner, so
+        // every teardown path releases it (GH-230).
+        monitorSinkName: isSystemAudio && isLinux ? sinkNameMap[sysDevice] : undefined,
         autoAddToNotebook,
       });
       // Apply persisted capture gain after capture starts
@@ -847,10 +841,10 @@ export const SessionView: React.FC<SessionViewProps> = ({
   ]);
 
   const handleStopRecording = useCallback(() => {
+    // Linux loopback-module cleanup is owned by AudioCapture/loopbackOwner
+    // (GH-230) — no manual removeMonitorLoopback here.
     transcription.stop();
-    if (isLinux) {
-      window.electronAPI?.audio?.removeMonitorLoopback?.();
-    } else {
+    if (!isLinux) {
       window.electronAPI?.audio?.disableSystemAudioLoopback?.();
     }
   }, [transcription, isLinux]);
@@ -868,9 +862,9 @@ export const SessionView: React.FC<SessionViewProps> = ({
     } catch (err) {
       console.error('Failed to cancel transcription:', err);
     } finally {
-      if (isLinux) {
-        window.electronAPI?.audio?.removeMonitorLoopback?.();
-      } else {
+      // Loopback module release happens inside transcription.reset() →
+      // capture.stop() → loopbackOwner (GH-230).
+      if (!isLinux) {
         window.electronAPI?.audio?.disableSystemAudioLoopback?.();
       }
       transcription.reset();
@@ -966,18 +960,8 @@ export const SessionView: React.FC<SessionViewProps> = ({
               ? rawGracePeriod
               : 1.0;
 
-          let monitorLabel: string | undefined;
-          if (isSystemAudio) {
-            if (isLinux) {
-              const selectedSink = sinkNameMap[sysDevice];
-              if (selectedSink) {
-                const result = await window.electronAPI?.audio?.createMonitorLoopback(selectedSink);
-                monitorLabel = 'TranscriptionSuite_Loopback';
-                setMonitorVolumePct(result?.volumePct ?? null);
-              }
-            } else {
-              await window.electronAPI?.audio?.enableSystemAudioLoopback?.();
-            }
+          if (isSystemAudio && !isLinux) {
+            await window.electronAPI?.audio?.enableSystemAudioLoopback?.();
           }
 
           live.start({
@@ -987,7 +971,9 @@ export const SessionView: React.FC<SessionViewProps> = ({
             translationTarget: liveTranslateTarget,
             gracePeriodSeconds,
             systemAudio: isSystemAudio,
-            monitorDeviceLabel: monitorLabel,
+            // Linux system audio: AudioCapture owns the loopback module
+            // lifecycle via loopbackOwner (GH-230).
+            monitorSinkName: isSystemAudio && isLinux ? sinkNameMap[sysDevice] : undefined,
           });
           // Apply persisted capture gain after capture starts
           if (isSystemAudio) {
@@ -995,10 +981,9 @@ export const SessionView: React.FC<SessionViewProps> = ({
           }
         })();
       } else {
+        // live.stop() → capture.stop() → loopbackOwner release (GH-230).
         live.stop();
-        if (isLinux) {
-          window.electronAPI?.audio?.removeMonitorLoopback?.();
-        } else {
+        if (!isLinux) {
           window.electronAPI?.audio?.disableSystemAudioLoopback?.();
         }
       }
@@ -1023,6 +1008,27 @@ export const SessionView: React.FC<SessionViewProps> = ({
       languagesLoading,
     ],
   );
+
+  // GH-230: stopping the client link used to only flip the UI flag while an
+  // active session kept recording invisibly — the status read "Disconnected"
+  // but audio kept streaming and the OS microphone indicator stayed lit
+  // (v0.5.6's ClientControlMixin disconnected the session; the port lost
+  // that). End active sessions before dropping the link.
+  const handleStopClient = useCallback(() => {
+    if (transcription.status === 'recording') {
+      // Stop-and-transcribe: the buffered audio is sent to the server now.
+      handleStopRecording();
+    } else if (transcription.status === 'connecting') {
+      transcription.reset();
+    }
+    // 'processing' is deliberately left alone — the server already holds the
+    // audio and the poll-for-result fallback can still deliver the transcript.
+    if (isLive) {
+      handleLiveToggle(false);
+    }
+    setClientRunning(false);
+    logClientEvent('Client', 'Client link stopped', 'warning');
+  }, [transcription, handleStopRecording, isLive, handleLiveToggle, setClientRunning]);
 
   const prevClientConnectedRef = useRef(clientConnected);
   useEffect(() => {

--- a/dashboard/electron/main.ts
+++ b/dashboard/electron/main.ts
@@ -888,6 +888,18 @@ function createWindow(): void {
     mlxLogSink.flush();
   });
 
+  // GH-230: the renderer owns the loopback module lifecycle (loopbackOwner),
+  // so a renderer crash or reload (Ctrl+R) orphans any held module — nothing
+  // on the new page knows it exists. Sweep it here.
+  mainWindow.webContents.on('render-process-gone', () => {
+    if (process.platform === 'linux') void enqueueLoopbackOp(sweepStaleLoopbackModules);
+  });
+  mainWindow.webContents.on('did-start-navigation', (details) => {
+    if (details.isMainFrame && !details.isSameDocument && process.platform === 'linux') {
+      void enqueueLoopbackOp(sweepStaleLoopbackModules);
+    }
+  });
+
   // M6 stable-launch confirmation is handled by the
   // `updates:rendererReady` ipcMain.on handler — the renderer emits the
   // signal after its initial mount completes, which is the only signal
@@ -1463,76 +1475,138 @@ ipcMain.handle(
   },
 );
 
+// GH-230: serialize create/remove so overlapping IPC (or a removal racing a
+// re-create) can never interleave pactl subprocesses.
+let loopbackIpcChain: Promise<unknown> = Promise.resolve();
+function enqueueLoopbackOp<T>(op: () => Promise<T>): Promise<T> {
+  const run = loopbackIpcChain.then(op, op);
+  loopbackIpcChain = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+/**
+ * Unload any module-remap-source named tsuite_loopback, including strays a
+ * crashed previous run left behind (GH-230). Without the sweep a stale module
+ * keeps the OS microphone indicator lit from boot AND makes the next
+ * load-module fail because the source name is already taken.
+ */
+async function sweepStaleLoopbackModules(): Promise<void> {
+  try {
+    // NOTE: `pactl -f json list modules` is useless here — on PipeWire the
+    // JSON objects carry NO index field (empirically verified: keys are
+    // name/argument/usage_counter/properties). Parse the tab-separated short
+    // listing instead: entry lines are `<index>\tmodule-remap-source\t<args>`
+    // and our remap-source argument is always single-line (brace-style
+    // multi-line arguments only occur for other module types).
+    const { stdout } = await execFileAsync('pactl', ['list', 'short', 'modules']);
+    for (const line of stdout.split('\n')) {
+      const m = /^(\d+)\tmodule-remap-source\t(.*)$/.exec(line);
+      if (m !== null && m[2].includes('source_name=tsuite_loopback')) {
+        try {
+          await execFileAsync('pactl', ['unload-module', m[1]]);
+        } catch {
+          /* already gone */
+        }
+      }
+    }
+    loopbackModuleId = null;
+  } catch {
+    // Listing failed (pactl missing or transient exec failure) — degrade to
+    // the tracked-id unload rather than silently dropping the id, which
+    // would turn the remove/quit safety nets into no-ops for a live module.
+    if (loopbackModuleId !== null) {
+      try {
+        await execFileAsync('pactl', ['unload-module', String(loopbackModuleId)]);
+      } catch {
+        /* already gone */
+      }
+      loopbackModuleId = null;
+    }
+  }
+}
+
 /** Create a virtual mic from a sink's monitor source. */
-ipcMain.handle('audio:createMonitorLoopback', async (_e, sinkName: string) => {
-  // Clean up any previous loopback first
-  if (loopbackModuleId !== null) {
+ipcMain.handle('audio:createMonitorLoopback', async (_e, sinkName: string) =>
+  enqueueLoopbackOp(async () => {
+    // GH-230: a create queued behind the chain can otherwise run AFTER
+    // gracefulShutdown() already unloaded the module, re-loading one that
+    // then leaks past app.exit(0).
+    if (isQuitting) {
+      throw new Error('App is shutting down — refusing to create the loopback module');
+    }
+    // Clean up any previous loopback first — ours or a stale one from a
+    // crashed run (the sweep covers the tracked id too).
+    await sweepStaleLoopbackModules();
+    const { stdout } = await execFileAsync('pactl', [
+      'load-module',
+      'module-remap-source',
+      `master=${sinkName}.monitor`,
+      'source_name=tsuite_loopback',
+      'source_properties=device.description=TranscriptionSuite_Loopback',
+    ]);
+    loopbackModuleId = parseInt(stdout.trim(), 10);
+
+    // Ensure both the master monitor source and the virtual remap source are at
+    // 100 % (0 dB).  PipeWire/PulseAudio may inherit a lower volume from the
+    // sink, causing very faint capture on some devices (e.g. headphone outputs
+    // whose sink volume is low).  65536 = 100 % in PulseAudio volume units.
+    try {
+      await execFileAsync('pactl', ['set-source-volume', `${sinkName}.monitor`, '65536']);
+    } catch {
+      /* best-effort — some sinks may not allow volume changes */
+    }
+    try {
+      await execFileAsync('pactl', ['set-source-volume', 'tsuite_loopback', '65536']);
+    } catch {
+      /* best-effort */
+    }
+
+    // Read back the effective volume to return as a diagnostic percentage.
+    let volumePct: number | null = null;
+    try {
+      const { stdout: srcJson } = await execFileAsync('pactl', ['-f', 'json', 'list', 'sources']);
+      const sources = JSON.parse(srcJson) as Array<{
+        name: string;
+        volume: Record<string, { value_percent: string }>;
+      }>;
+      const loopSrc = sources.find((s) => s.name === 'tsuite_loopback');
+      if (loopSrc?.volume) {
+        const firstCh = Object.values(loopSrc.volume)[0];
+        if (firstCh?.value_percent) {
+          volumePct = parseInt(firstCh.value_percent, 10);
+        }
+      }
+    } catch {
+      /* diagnostic only — non-fatal */
+    }
+
+    return { moduleId: loopbackModuleId, volumePct };
+  }),
+);
+
+/** Remove the virtual mic. */
+ipcMain.handle('audio:removeMonitorLoopback', async () =>
+  enqueueLoopbackOp(async () => {
+    if (loopbackModuleId === null) return;
     try {
       await execFileAsync('pactl', ['unload-module', String(loopbackModuleId)]);
     } catch {
       /* already gone */
     }
     loopbackModuleId = null;
-  }
-  const { stdout } = await execFileAsync('pactl', [
-    'load-module',
-    'module-remap-source',
-    `master=${sinkName}.monitor`,
-    'source_name=tsuite_loopback',
-    'source_properties=device.description=TranscriptionSuite_Loopback',
-  ]);
-  loopbackModuleId = parseInt(stdout.trim(), 10);
+  }),
+);
 
-  // Ensure both the master monitor source and the virtual remap source are at
-  // 100 % (0 dB).  PipeWire/PulseAudio may inherit a lower volume from the
-  // sink, causing very faint capture on some devices (e.g. headphone outputs
-  // whose sink volume is low).  65536 = 100 % in PulseAudio volume units.
-  try {
-    await execFileAsync('pactl', ['set-source-volume', `${sinkName}.monitor`, '65536']);
-  } catch {
-    /* best-effort — some sinks may not allow volume changes */
-  }
-  try {
-    await execFileAsync('pactl', ['set-source-volume', 'tsuite_loopback', '65536']);
-  } catch {
-    /* best-effort */
-  }
-
-  // Read back the effective volume to return as a diagnostic percentage.
-  let volumePct: number | null = null;
-  try {
-    const { stdout: srcJson } = await execFileAsync('pactl', ['-f', 'json', 'list', 'sources']);
-    const sources = JSON.parse(srcJson) as Array<{
-      name: string;
-      volume: Record<string, { value_percent: string }>;
-    }>;
-    const loopSrc = sources.find((s) => s.name === 'tsuite_loopback');
-    if (loopSrc?.volume) {
-      const firstCh = Object.values(loopSrc.volume)[0];
-      if (firstCh?.value_percent) {
-        volumePct = parseInt(firstCh.value_percent, 10);
-      }
-    }
-  } catch {
-    /* diagnostic only — non-fatal */
-  }
-
-  return { moduleId: loopbackModuleId, volumePct };
-});
-
-/** Remove the virtual mic. */
-ipcMain.handle('audio:removeMonitorLoopback', async () => {
-  if (loopbackModuleId === null) return;
-  try {
-    await execFileAsync('pactl', ['unload-module', String(loopbackModuleId)]);
-  } catch {
-    /* already gone */
-  }
-  loopbackModuleId = null;
-});
-
-// Safety-net: clean up the loopback module on quit so it doesn't linger.
-app.on('will-quit', () => {
+/**
+ * Synchronous unload for shutdown paths (GH-230). Registered on will-quit AND
+ * called from gracefulShutdown(): every real quit path (before-quit handler,
+ * SIGINT/SIGTERM/SIGHUP) funnels through gracefulShutdown() and ends in
+ * app.exit(0), which SKIPS will-quit — so will-quit alone never fired.
+ */
+function unloadLoopbackModuleSync(): void {
   if (loopbackModuleId !== null && process.platform === 'linux') {
     try {
       execFileSync('pactl', ['unload-module', String(loopbackModuleId)]);
@@ -1541,7 +1615,10 @@ app.on('will-quit', () => {
     }
     loopbackModuleId = null;
   }
-});
+}
+
+// Safety-net: clean up the loopback module on quit so it doesn't linger.
+app.on('will-quit', unloadLoopbackModuleSync);
 
 // Kill any lingering wl-copy child on quit.
 app.on('will-quit', cleanupClipboard);
@@ -2155,6 +2232,9 @@ function gracefulShutdown(): Promise<void> {
   isQuitting = true;
 
   shutdownPromise = (async () => {
+    // GH-230: unload the Linux loopback module first — every real quit path
+    // funnels through here and then app.exit(0), which skips will-quit.
+    unloadLoopbackModuleSync();
     flushMainProcessLogRemainders();
     // Kill the container sentinel before we stop the container ourselves —
     // prevents both racing to docker-stop.
@@ -2298,6 +2378,11 @@ if (!gotLock) {
 }
 
 app.whenReady().then(async () => {
+  // GH-230: a crashed previous run can leave a tsuite_loopback module behind,
+  // keeping the OS microphone indicator lit from boot and blocking the next
+  // load-module (source name taken). Sweep it before anything records.
+  if (process.platform === 'linux') void enqueueLoopbackOp(sweepStaleLoopbackModules);
+
   // Fresh app session: drop any notification log a crashed session left behind.
   notificationLog.clear();
   ipcMain.handle('notificationLog:load', async () => notificationLog.load());

--- a/dashboard/src/hooks/useLiveMode.test.ts
+++ b/dashboard/src/hooks/useLiveMode.test.ts
@@ -633,4 +633,45 @@ describe('[P1] useLiveMode', () => {
       });
     });
   });
+
+  // ── GH-230: capture teardown + system-audio pass-through ─────────────
+
+  describe('GH-230: server STOPPED state and monitorSinkName', () => {
+    it("'state' STOPPED stops the capture and clears the analyser", async () => {
+      // Pre-fix the STOPPED branch only reset the status: the capture kept
+      // streaming into a dead session and the Linux loopback module stayed
+      // held (OS mic indicator lit forever).
+      const { result } = renderHook(() => useLiveMode());
+      await driveToListening(result);
+      expect(lastCapture.stop).not.toHaveBeenCalled();
+
+      act(() => {
+        lastSocketCbs.onMessage!({ type: 'state', data: { state: 'STOPPED' } });
+      });
+
+      expect(lastCapture.stop).toHaveBeenCalledTimes(1);
+      expect(result.current.status).toBe('idle');
+      expect(result.current.analyser).toBeNull();
+    });
+
+    it('passes systemAudio + monitorSinkName to AudioCapture.start on LISTENING', async () => {
+      const { result } = renderHook(() => useLiveMode());
+      act(() => {
+        result.current.start({ systemAudio: true, monitorSinkName: 'alsa_output.sink' });
+      });
+      act(() => {
+        lastSocketCbs.onMessage!({ type: 'auth_ok' });
+      });
+      await act(async () => {
+        lastSocketCbs.onMessage!({ type: 'state', data: { state: 'LISTENING' } });
+      });
+
+      expect(lastCapture.start).toHaveBeenCalledWith(
+        expect.objectContaining({
+          systemAudio: true,
+          monitorSinkName: 'alsa_output.sink',
+        }),
+      );
+    });
+  });
 });

--- a/dashboard/src/hooks/useLiveMode.ts
+++ b/dashboard/src/hooks/useLiveMode.ts
@@ -58,7 +58,7 @@ export interface LiveStartOptions {
   gracePeriodSeconds?: number;
   model?: string;
   systemAudio?: boolean;
-  monitorDeviceLabel?: string;
+  monitorSinkName?: string;
 }
 
 export function useLiveMode(): LiveModeState {
@@ -126,8 +126,11 @@ export function useLiveMode(): LiveModeState {
         if (state === 'LISTENING') {
           setStatus('listening');
           setStatusMessage(null);
-          // Start audio capture once engine is ready
+          // Start audio capture once engine is ready. Stop any previous
+          // instance first — GH-230: replacing a still-starting capture
+          // without stopping it would orphan its loopback hold and stream.
           if (!captureRef.current?.isCapturing) {
+            captureRef.current?.stop();
             captureRef.current = new AudioCapture((chunk) => {
               socketRef.current?.sendAudio(chunk);
             });
@@ -135,12 +138,15 @@ export function useLiveMode(): LiveModeState {
               .start({
                 deviceId: startOptsRef.current.deviceId,
                 systemAudio: startOptsRef.current.systemAudio,
-                monitorDeviceLabel: startOptsRef.current.monitorDeviceLabel,
+                monitorSinkName: startOptsRef.current.monitorSinkName,
               })
               .then(() => {
                 setAnalyser(captureRef.current?.analyser ?? null);
               })
               .catch((err) => {
+                // A stop() that raced the start — the stop already put the
+                // state machine where it belongs; don't flip to error.
+                if (err instanceof Error && err.name === 'AbortError') return;
                 setError(err instanceof Error ? err.message : 'Audio capture failed');
                 setStatus('error');
                 socketRef.current?.disconnect();
@@ -149,6 +155,11 @@ export function useLiveMode(): LiveModeState {
         } else if (state === 'PROCESSING') {
           setStatus('processing');
         } else if (state === 'STOPPED') {
+          // GH-230: a server-initiated stop must tear down capture too —
+          // leaving it running kept streaming audio into a dead session and
+          // stranded the Linux loopback module (mic indicator stayed lit).
+          captureRef.current?.stop();
+          setAnalyser(null);
           setStatus('idle');
           setStatusMessage(null);
         }

--- a/dashboard/src/hooks/useTranscription.test.ts
+++ b/dashboard/src/hooks/useTranscription.test.ts
@@ -49,10 +49,22 @@ let lastCapture: {
   isCapturing: boolean;
 };
 
+// When set, the NEXT AudioCapture instance's start() rejects with this error
+// (consumed once). Lets tests exercise the capture-start failure paths even
+// though instances are created inside the session_started handler.
+let nextCaptureStartRejection: Error | null = null;
+
 vi.mock('../services/audioCapture', () => ({
   AudioCapture: vi.fn().mockImplementation(function () {
     lastCapture = {
-      start: vi.fn().mockResolvedValue(undefined),
+      start: vi.fn().mockImplementation(() => {
+        if (nextCaptureStartRejection !== null) {
+          const err = nextCaptureStartRejection;
+          nextCaptureStartRejection = null;
+          return Promise.reject(err);
+        }
+        return Promise.resolve(undefined);
+      }),
       stop: vi.fn(),
       mute: vi.fn(),
       unmute: vi.fn(),
@@ -868,6 +880,51 @@ describe('[P1] useTranscription', () => {
       expect(result.current.previewError).toBeNull();
       expect(result.current.previewLoading).toBe(false);
       expect(result.current.previewActive).toBe(false);
+    });
+  });
+
+  // ── GH-230: system-audio option pass-through ─────────────────────────
+  //
+  // The Linux loopback module lifecycle is owned by AudioCapture/loopbackOwner;
+  // the hook's only responsibility is to hand the selected sink through to
+  // capture.start() so the capture can acquire the module.
+
+  describe('GH-230: monitorSinkName pass-through', () => {
+    it('passes systemAudio + monitorSinkName to AudioCapture.start on session_started', async () => {
+      const { result } = renderHook(() => useTranscription());
+      act(() => {
+        result.current.start({ systemAudio: true, monitorSinkName: 'alsa_output.sink' });
+      });
+      await act(async () => {
+        lastSocketCbs.onMessage!({ type: 'auth_ok' });
+      });
+      await act(async () => {
+        lastSocketCbs.onMessage!({
+          type: 'session_started',
+          data: { job_id: 'job-sys', capture_sample_rate_hz: 16000 },
+        });
+      });
+
+      expect(lastCapture.start).toHaveBeenCalledWith(
+        expect.objectContaining({
+          systemAudio: true,
+          monitorSinkName: 'alsa_output.sink',
+        }),
+      );
+    });
+
+    it('a capture start aborted by a racing stop() does NOT flip the hook to error', async () => {
+      const abort = new Error('Audio capture start aborted by stop()');
+      abort.name = 'AbortError';
+      nextCaptureStartRejection = abort;
+
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+
+      expect(result.current.status).not.toBe('error');
+      expect(result.current.error).toBeNull();
+      // The socket was NOT torn down by the swallowed abort.
+      expect(lastSocket.disconnect).not.toHaveBeenCalled();
     });
   });
 });

--- a/dashboard/src/hooks/useTranscription.ts
+++ b/dashboard/src/hooks/useTranscription.ts
@@ -49,7 +49,7 @@ export interface TranscriptionState {
     translate?: boolean;
     translationTarget?: string;
     systemAudio?: boolean;
-    monitorDeviceLabel?: string;
+    monitorSinkName?: string;
     /** Save the finished recording to the Audio Notebook (GH-199). */
     autoAddToNotebook?: boolean;
   }) => void;
@@ -145,7 +145,7 @@ export function useTranscription(): TranscriptionState {
     translate?: boolean;
     translationTarget?: string;
     systemAudio?: boolean;
-    monitorDeviceLabel?: string;
+    monitorSinkName?: string;
     /** Active recording-profile id (FR18). Snapshotted server-side at job start. */
     profileId?: number | null;
     /** Save the finished recording to the Audio Notebook (GH-199). */
@@ -281,7 +281,10 @@ export function useTranscription(): TranscriptionState {
                 ? Math.round(rawCaptureRate)
                 : 16000;
             socketRef.current?.setAudioSampleRate(captureSampleRateHz);
-            // Begin audio capture
+            // Begin audio capture. Stop any previous instance first — GH-230:
+            // replacing a still-starting capture without stopping it would
+            // orphan its loopback hold and its stream.
+            captureRef.current?.stop();
             captureRef.current = new AudioCapture((chunk) => {
               socketRef.current?.sendAudio(chunk);
             });
@@ -289,13 +292,16 @@ export function useTranscription(): TranscriptionState {
               .start({
                 deviceId: startOptsRef.current.deviceId,
                 systemAudio: startOptsRef.current.systemAudio,
-                monitorDeviceLabel: startOptsRef.current.monitorDeviceLabel,
+                monitorSinkName: startOptsRef.current.monitorSinkName,
                 targetSampleRateHz: captureSampleRateHz,
               })
               .then(() => {
                 setAnalyser(captureRef.current?.analyser ?? null);
               })
               .catch((err) => {
+                // A stop() that raced the start — the stop already put the
+                // state machine where it belongs; don't flip to error.
+                if (err instanceof Error && err.name === 'AbortError') return;
                 setError(err instanceof Error ? err.message : 'Failed to start audio capture');
                 setStatus('error');
                 socketRef.current?.disconnect();
@@ -446,7 +452,7 @@ export function useTranscription(): TranscriptionState {
       translate?: boolean;
       translationTarget?: string;
       systemAudio?: boolean;
-      monitorDeviceLabel?: string;
+      monitorSinkName?: string;
       profileId?: number | null;
       autoAddToNotebook?: boolean;
     }) => {

--- a/dashboard/src/services/audioCapture.test.ts
+++ b/dashboard/src/services/audioCapture.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+
+import { AudioCapture } from './audioCapture';
+import { loopbackOwner } from './loopbackOwner';
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('./loopbackOwner', () => ({
+  LOOPBACK_DEVICE_LABEL: 'TranscriptionSuite_Loopback',
+  loopbackOwner: {
+    acquire: vi.fn().mockResolvedValue({ label: 'TranscriptionSuite_Loopback', volumePct: 100 }),
+    release: vi.fn(),
+  },
+}));
+
+const acquireMock = loopbackOwner.acquire as unknown as Mock;
+const releaseMock = loopbackOwner.release as unknown as Mock;
+
+function makeTrack(): { stop: Mock; getSettings: Mock } {
+  return { stop: vi.fn(), getSettings: vi.fn().mockReturnValue({ sampleRate: 48000 }) };
+}
+
+function makeStream(): {
+  stream: MediaStream;
+  audioTrack: ReturnType<typeof makeTrack>;
+} {
+  const audioTrack = makeTrack();
+  const stream = {
+    getTracks: () => [audioTrack],
+    getAudioTracks: () => [audioTrack],
+    getVideoTracks: () => [],
+  } as unknown as MediaStream;
+  return { stream, audioTrack };
+}
+
+let getUserMediaMock: Mock;
+let enumerateDevicesMock: Mock;
+let addModuleMock: Mock;
+
+class FakeAudioContext {
+  sampleRate = 48000;
+  state = 'running';
+  audioWorklet = { addModule: (...args: unknown[]) => addModuleMock(...args) };
+  createMediaStreamSource = vi.fn().mockReturnValue({ connect: vi.fn(), disconnect: vi.fn() });
+  createGain = vi
+    .fn()
+    .mockReturnValue({ connect: vi.fn(), disconnect: vi.fn(), gain: { value: 1 } });
+  createAnalyser = vi.fn().mockReturnValue({
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    fftSize: 0,
+    smoothingTimeConstant: 0,
+  });
+  close = vi.fn().mockResolvedValue(undefined);
+}
+
+class FakeAudioWorkletNode {
+  port = { onmessage: null as unknown };
+  connect = vi.fn();
+  disconnect = vi.fn();
+}
+
+describe('[P1] AudioCapture loopback ownership (GH-230)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    acquireMock.mockResolvedValue({ label: 'TranscriptionSuite_Loopback', volumePct: 100 });
+
+    const { stream } = makeStream();
+    getUserMediaMock = vi.fn().mockResolvedValue(stream);
+    enumerateDevicesMock = vi.fn().mockResolvedValue([
+      {
+        kind: 'audioinput',
+        label: 'Remapped TranscriptionSuite_Loopback source',
+        deviceId: 'loopback-dev-1',
+      },
+    ]);
+    addModuleMock = vi.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(globalThis.navigator, 'mediaDevices', {
+      value: {
+        getUserMedia: getUserMediaMock,
+        enumerateDevices: enumerateDevicesMock,
+        getDisplayMedia: vi.fn().mockResolvedValue(makeStream().stream),
+      },
+      configurable: true,
+    });
+    vi.stubGlobal('AudioContext', FakeAudioContext);
+    vi.stubGlobal('AudioWorkletNode', FakeAudioWorkletNode);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('system-audio start acquires the module BEFORE device enumeration; stop releases once', async () => {
+    const capture = new AudioCapture(() => {});
+    await capture.start({ systemAudio: true, monitorSinkName: 'sink-a' });
+
+    expect(acquireMock).toHaveBeenCalledTimes(1);
+    expect(acquireMock).toHaveBeenCalledWith('sink-a');
+    expect(acquireMock.mock.invocationCallOrder[0]).toBeLessThan(
+      enumerateDevicesMock.mock.invocationCallOrder[0],
+    );
+    expect(getUserMediaMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        audio: expect.objectContaining({ deviceId: { exact: 'loopback-dev-1' } }),
+      }),
+    );
+    expect(releaseMock).not.toHaveBeenCalled();
+
+    capture.stop();
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('double stop() releases only once', async () => {
+    const capture = new AudioCapture(() => {});
+    await capture.start({ systemAudio: true, monitorSinkName: 'sink-a' });
+    capture.stop();
+    capture.stop();
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('getUserMedia rejection after acquire → release called, start() rejects', async () => {
+    getUserMediaMock.mockRejectedValueOnce(new Error('NotAllowedError'));
+    const capture = new AudioCapture(() => {});
+    await expect(capture.start({ systemAudio: true, monitorSinkName: 'sink-a' })).rejects.toThrow(
+      'NotAllowedError',
+    );
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('waitForDevice timeout → release called, start() rejects', async () => {
+    vi.useFakeTimers();
+    enumerateDevicesMock.mockResolvedValue([]); // device never appears
+    const capture = new AudioCapture(() => {});
+    const starting = capture.start({ systemAudio: true, monitorSinkName: 'sink-a' });
+    const assertion = expect(starting).rejects.toThrow(/did not appear in time/);
+    await vi.advanceTimersByTimeAsync(8000);
+    await assertion;
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('addModule rejection → release called AND stream tracks stopped', async () => {
+    const { stream, audioTrack } = makeStream();
+    getUserMediaMock.mockResolvedValueOnce(stream);
+    addModuleMock.mockRejectedValueOnce(new Error('worklet load failed'));
+    const capture = new AudioCapture(() => {});
+    await expect(capture.start({ systemAudio: true, monitorSinkName: 'sink-a' })).rejects.toThrow(
+      'worklet load failed',
+    );
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+    expect(audioTrack.stop).toHaveBeenCalled();
+  });
+
+  it('microphone capture never touches loopbackOwner', async () => {
+    const capture = new AudioCapture(() => {});
+    await capture.start({ deviceId: 'mic-1' });
+    capture.stop();
+    expect(acquireMock).not.toHaveBeenCalled();
+    expect(releaseMock).not.toHaveBeenCalled();
+  });
+
+  it('getDisplayMedia system audio (win/mac path) never touches loopbackOwner', async () => {
+    const capture = new AudioCapture(() => {});
+    await capture.start({ systemAudio: true });
+    capture.stop();
+    expect(acquireMock).not.toHaveBeenCalled();
+    expect(releaseMock).not.toHaveBeenCalled();
+  });
+
+  it('the defensive internal stop() at start() never releases a hold it does not have', async () => {
+    const capture = new AudioCapture(() => {});
+    // Fresh instance: the stop() inside start() must not call release.
+    await capture.start({ systemAudio: true, monitorSinkName: 'sink-a' });
+    expect(releaseMock).not.toHaveBeenCalled();
+    // Restart on the same instance: the internal stop() releases the previous
+    // hold exactly once, then re-acquires.
+    await capture.start({ systemAudio: true, monitorSinkName: 'sink-a' });
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+    expect(acquireMock).toHaveBeenCalledTimes(2);
+  });
+
+  // ── stop()-during-start() abort races (GH-230 review finding) ─────────
+  //
+  // An external stop() landing while start() is awaiting used to be a silent
+  // no-op: the orphaned start() ran to completion, held the loopback module
+  // forever (mic indicator lit), and pumped audio into a dead session.
+
+  it('external stop() during the acquire await → hold released exactly once, start rejects with AbortError', async () => {
+    let resolveAcquire!: (v: { label: string; volumePct: number | null }) => void;
+    acquireMock.mockImplementationOnce(
+      () =>
+        new Promise<{ label: string; volumePct: number | null }>((res) => {
+          resolveAcquire = res;
+        }),
+    );
+    const capture = new AudioCapture(() => {});
+    const starting = capture.start({ systemAudio: true, monitorSinkName: 'sink-a' });
+    const assertion = expect(starting).rejects.toMatchObject({ name: 'AbortError' });
+
+    capture.stop(); // lands mid-acquire: nothing to release yet
+    expect(releaseMock).not.toHaveBeenCalled();
+
+    resolveAcquire({ label: 'TranscriptionSuite_Loopback', volumePct: 100 });
+    await assertion;
+    // The just-granted hold was released by the abort path — exactly once.
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+    // The orphaned start never opened the device.
+    expect(getUserMediaMock).not.toHaveBeenCalled();
+  });
+
+  it('external stop() during getUserMedia → stream tracks stopped, hold released exactly once', async () => {
+    const { stream, audioTrack } = makeStream();
+    let resolveGum!: (v: MediaStream) => void;
+    getUserMediaMock.mockImplementationOnce(
+      () =>
+        new Promise<MediaStream>((res) => {
+          resolveGum = res;
+        }),
+    );
+    const capture = new AudioCapture(() => {});
+    const starting = capture.start({ systemAudio: true, monitorSinkName: 'sink-a' });
+    const assertion = expect(starting).rejects.toMatchObject({ name: 'AbortError' });
+    // Let the acquire + waitForDevice settle so start() is inside getUserMedia.
+    await vi.waitFor(() => expect(getUserMediaMock).toHaveBeenCalled());
+
+    capture.stop(); // releases the already-taken hold
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+
+    resolveGum(stream);
+    await assertion;
+    // The catch-path stop() cleaned the late-arriving stream and did NOT
+    // double-release the hold.
+    expect(audioTrack.stop).toHaveBeenCalled();
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/dashboard/src/services/audioCapture.ts
+++ b/dashboard/src/services/audioCapture.ts
@@ -15,7 +15,22 @@
  *   capture.stop();
  */
 
+import { loopbackOwner } from './loopbackOwner';
+
 export type AudioChunkCallback = (pcmInt16: Int16Array) => void;
+
+/**
+ * Thrown when stop() lands while start() is still awaiting (device acquire,
+ * getUserMedia, worklet load). Callers treat it as a clean no-op — the stop
+ * already put the UI in its final state (GH-230). `name` is 'AbortError' so
+ * generic handlers can filter it without importing this class.
+ */
+export class AudioCaptureAbortedError extends Error {
+  constructor() {
+    super('Audio capture start aborted by stop()');
+    this.name = 'AbortError';
+  }
+}
 
 export interface AudioCaptureOptions {
   /** Device ID from navigator.mediaDevices.enumerateDevices() */
@@ -23,14 +38,15 @@ export interface AudioCaptureOptions {
   /** Whether to capture system audio instead of microphone */
   systemAudio?: boolean;
   /**
-   * When set, the Linux monitor-source path is used: enumerate devices, find
-   * the virtual input whose label contains this string, and capture via
+   * When set, the Linux monitor-source path is used: acquire the loopback
+   * module for this sink via loopbackOwner (GH-230 — the capture owns the
+   * module lifetime), find the virtual input by label, and capture via
    * getUserMedia (no xdg-desktop-portal picker).
    *
    * If unset while systemAudio=true, the Windows/macOS getDisplayMedia path
    * is used instead.
    */
-  monitorDeviceLabel?: string;
+  monitorSinkName?: string;
   /** Target PCM sample rate emitted by the worklet (e.g. 16000 or 24000) */
   targetSampleRateHz?: number;
 }
@@ -45,6 +61,20 @@ export class AudioCapture {
   private onChunk: AudioChunkCallback;
   private _muted = false;
   private _gain = 1;
+  /**
+   * True while THIS capture holds a loopbackOwner acquisition (GH-230).
+   * Flag-based so the defensive stop() at the top of start() on a fresh
+   * instance never releases another capture's hold, and double stop() is safe.
+   */
+  private holdsLoopback = false;
+  /**
+   * Bumped by every stop(). start() snapshots it after its own defensive
+   * stop() and re-checks after every await — an external stop() landing
+   * mid-start would otherwise be a silent no-op (nothing built yet), letting
+   * the orphaned start() run to completion holding the loopback module
+   * forever and pumping audio into a dead session (GH-230 review finding).
+   */
+  private stopEpoch = 0;
 
   constructor(onChunk: AudioChunkCallback) {
     this.onChunk = onChunk;
@@ -54,90 +84,119 @@ export class AudioCapture {
   async start(options: AudioCaptureOptions = {}): Promise<void> {
     // Stop any existing capture
     this.stop();
+    // Snapshot AFTER the defensive stop above — any later mismatch means an
+    // external stop() landed while we were awaiting.
+    const epoch = this.stopEpoch;
 
-    // 1. Get media stream — microphone or system audio
-    if (options.systemAudio && options.monitorDeviceLabel) {
-      // Linux path: a virtual input was created from the PulseAudio/PipeWire
-      // monitor source via module-remap-source.  Find it by label and capture
-      // with plain getUserMedia — no xdg-desktop-portal, no screen picker.
-      const deviceId = await AudioCapture.waitForDevice(options.monitorDeviceLabel);
-      this.stream = await navigator.mediaDevices.getUserMedia({
-        audio: {
-          deviceId: { exact: deviceId },
-          echoCancellation: false,
-          noiseSuppression: false,
-          autoGainControl: false,
-          channelCount: 1,
-        },
-      });
-    } else if (options.systemAudio) {
-      // Windows / macOS path: getDisplayMedia with loopback handler.
-      // The main process registers setDisplayMediaRequestHandler with
-      // { audio: 'loopback' } before we reach here.
-      const displayStream = await navigator.mediaDevices.getDisplayMedia({
-        audio: true,
-        video: true, // video required by spec; tracks dropped immediately
-      });
-      displayStream.getVideoTracks().forEach((t) => t.stop());
-      this.stream = displayStream;
-    } else {
-      // Standard microphone capture
-      const constraints: MediaStreamConstraints = {
-        audio: {
-          ...(options.deviceId ? { deviceId: { exact: options.deviceId } } : {}),
-          echoCancellation: false,
-          noiseSuppression: false,
-          autoGainControl: false,
-          sampleRate: options.targetSampleRateHz ?? 16000, // Hint — browser may ignore
-          channelCount: 1,
-        },
-      };
-      this.stream = await navigator.mediaDevices.getUserMedia(constraints);
-    }
-
-    // 2. Create AudioContext
-    this.ctx = new AudioContext({
-      sampleRate: this.stream.getAudioTracks()[0].getSettings().sampleRate || 48000,
-    });
-
-    // 3. Register the AudioWorklet processor
-    await this.ctx.audioWorklet.addModule('./audio-worklet-processor.js');
-
-    // 4. Create nodes
-    this.sourceNode = this.ctx.createMediaStreamSource(this.stream);
-
-    this.gainNode = this.ctx.createGain();
-    this.gainNode.gain.value = this._gain;
-
-    this.analyserNode = this.ctx.createAnalyser();
-    this.analyserNode.fftSize = 2048;
-    this.analyserNode.smoothingTimeConstant = 0.8;
-
-    this.workletNode = new AudioWorkletNode(this.ctx, 'pcm-processor', {
-      processorOptions: {
-        targetSampleRateHz: options.targetSampleRateHz ?? 16000,
-      },
-    });
-
-    // 5. Handle PCM chunks from the worklet
-    this.workletNode.port.onmessage = (ev: MessageEvent) => {
-      if (ev.data?.type === 'audio' && !this._muted) {
-        const int16 = new Int16Array(ev.data.data);
-        this.onChunk(int16);
+    try {
+      // 1. Get media stream — microphone or system audio
+      if (options.systemAudio && options.monitorSinkName) {
+        // Linux path: acquire the virtual input created from the selected
+        // sink's PulseAudio/PipeWire monitor source via module-remap-source
+        // (loopbackOwner owns create/remove — GH-230), then find it by label
+        // and capture with plain getUserMedia — no xdg-desktop-portal, no
+        // screen picker.
+        const { label } = await loopbackOwner.acquire(options.monitorSinkName);
+        // Take the hold BEFORE the abort check so the catch-path stop()
+        // releases it exactly once when an external stop() raced the acquire.
+        this.holdsLoopback = true;
+        this.assertNotStopped(epoch);
+        // The module may have been created just now — allow longer than the
+        // generic default for the virtual device to reach enumerateDevices.
+        const deviceId = await AudioCapture.waitForDevice(label, 7000);
+        this.assertNotStopped(epoch);
+        this.stream = await navigator.mediaDevices.getUserMedia({
+          audio: {
+            deviceId: { exact: deviceId },
+            echoCancellation: false,
+            noiseSuppression: false,
+            autoGainControl: false,
+            channelCount: 1,
+          },
+        });
+      } else if (options.systemAudio) {
+        // Windows / macOS path: getDisplayMedia with loopback handler.
+        // The main process registers setDisplayMediaRequestHandler with
+        // { audio: 'loopback' } before we reach here.
+        const displayStream = await navigator.mediaDevices.getDisplayMedia({
+          audio: true,
+          video: true, // video required by spec; tracks dropped immediately
+        });
+        displayStream.getVideoTracks().forEach((t) => t.stop());
+        this.stream = displayStream;
+      } else {
+        // Standard microphone capture
+        const constraints: MediaStreamConstraints = {
+          audio: {
+            ...(options.deviceId ? { deviceId: { exact: options.deviceId } } : {}),
+            echoCancellation: false,
+            noiseSuppression: false,
+            autoGainControl: false,
+            sampleRate: options.targetSampleRateHz ?? 16000, // Hint — browser may ignore
+            channelCount: 1,
+          },
+        };
+        this.stream = await navigator.mediaDevices.getUserMedia(constraints);
       }
-    };
+      // The stream is assigned before this check so the catch-path stop()
+      // can release its tracks when the start was aborted mid-getUserMedia.
+      this.assertNotStopped(epoch);
 
-    // 6. Wire the graph:
-    //    source → gain → analyser → worklet → (silence — worklet has no output)
-    //    Gain is set to 0 when muted so the visualiser also flatlines.
-    this.sourceNode.connect(this.gainNode);
-    this.gainNode.connect(this.analyserNode);
-    this.analyserNode.connect(this.workletNode);
-    // Don't connect worklet to destination — we don't want to play back the mic
+      // 2. Create AudioContext
+      this.ctx = new AudioContext({
+        sampleRate: this.stream.getAudioTracks()[0].getSettings().sampleRate || 48000,
+      });
+
+      // 3. Register the AudioWorklet processor
+      await this.ctx.audioWorklet.addModule('./audio-worklet-processor.js');
+      this.assertNotStopped(epoch);
+
+      // 4. Create nodes
+      this.sourceNode = this.ctx.createMediaStreamSource(this.stream);
+
+      this.gainNode = this.ctx.createGain();
+      this.gainNode.gain.value = this._gain;
+
+      this.analyserNode = this.ctx.createAnalyser();
+      this.analyserNode.fftSize = 2048;
+      this.analyserNode.smoothingTimeConstant = 0.8;
+
+      this.workletNode = new AudioWorkletNode(this.ctx, 'pcm-processor', {
+        processorOptions: {
+          targetSampleRateHz: options.targetSampleRateHz ?? 16000,
+        },
+      });
+
+      // 5. Handle PCM chunks from the worklet
+      this.workletNode.port.onmessage = (ev: MessageEvent) => {
+        if (ev.data?.type === 'audio' && !this._muted) {
+          const int16 = new Int16Array(ev.data.data);
+          this.onChunk(int16);
+        }
+      };
+
+      // 6. Wire the graph:
+      //    source → gain → analyser → worklet → (silence — worklet has no output)
+      //    Gain is set to 0 when muted so the visualiser also flatlines.
+      this.sourceNode.connect(this.gainNode);
+      this.gainNode.connect(this.analyserNode);
+      this.analyserNode.connect(this.workletNode);
+      // Don't connect worklet to destination — we don't want to play back the mic
+    } catch (err) {
+      // A partial start must not leak: stop() tears down whatever was already
+      // grabbed — stream tracks, the AudioContext, and the loopback hold
+      // (GH-230: waitForDevice timeout / getUserMedia denial / addModule
+      // failure previously stranded the pactl module and kept the KDE
+      // microphone indicator lit).
+      this.stop();
+      throw err;
+    }
   }
 
   /** Stop capturing and release all resources. */
   stop(): void {
+    // Abort any start() still in flight (checked after each of its awaits).
+    this.stopEpoch++;
     if (this.workletNode) {
       this.workletNode.port.onmessage = null;
       this.workletNode.disconnect();
@@ -163,7 +222,23 @@ export class AudioCapture {
       this.ctx.close().catch(() => {});
       this.ctx = null;
     }
+    this.releaseLoopback();
     this._muted = false;
+  }
+
+  /** Drop this capture's loopbackOwner hold exactly once (GH-230). */
+  private releaseLoopback(): void {
+    if (this.holdsLoopback) {
+      this.holdsLoopback = false;
+      loopbackOwner.release();
+    }
+  }
+
+  /** Throw AbortError when an external stop() landed since `epoch`. */
+  private assertNotStopped(epoch: number): void {
+    if (epoch !== this.stopEpoch) {
+      throw new AudioCaptureAbortedError();
+    }
   }
 
   /** Mute — stops sending audio chunks and silences the visualiser. */

--- a/dashboard/src/services/loopbackOwner.test.ts
+++ b/dashboard/src/services/loopbackOwner.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+
+import { loopbackOwner, LOOPBACK_DEVICE_LABEL, LOOPBACK_RELEASE_GRACE_MS } from './loopbackOwner';
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+let createMock: Mock;
+let removeMock: Mock;
+
+function installElectronAudioMock(): void {
+  createMock = vi.fn().mockResolvedValue({ moduleId: 42, volumePct: 100 });
+  removeMock = vi.fn().mockResolvedValue(undefined);
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    audio: {
+      createMonitorLoopback: createMock,
+      removeMonitorLoopback: removeMock,
+    },
+  };
+}
+
+describe('[P1] loopbackOwner', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    installElectronAudioMock();
+    // The singleton carries state between tests — drain any pending hold from
+    // a previous test by releasing until idle and flushing the grace timer.
+    loopbackOwner._resetForTests();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('acquire() creates the module once and returns the device label', async () => {
+    const result = await loopbackOwner.acquire('sink-a');
+    expect(createMock).toHaveBeenCalledTimes(1);
+    expect(createMock).toHaveBeenCalledWith('sink-a');
+    expect(result.label).toBe(LOOPBACK_DEVICE_LABEL);
+    expect(result.volumePct).toBe(100);
+  });
+
+  it('release() does not remove immediately — only after the grace window', async () => {
+    await loopbackOwner.acquire('sink-a');
+    loopbackOwner.release();
+    expect(removeMock).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(LOOPBACK_RELEASE_GRACE_MS - 1);
+    expect(removeMock).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(removeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-acquire within the grace window reuses the module (no remove, no re-create)', async () => {
+    await loopbackOwner.acquire('sink-a');
+    loopbackOwner.release();
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await loopbackOwner.acquire('sink-a');
+    await vi.advanceTimersByTimeAsync(LOOPBACK_RELEASE_GRACE_MS * 2);
+    expect(removeMock).not.toHaveBeenCalled();
+    expect(createMock).toHaveBeenCalledTimes(1);
+    expect(result.label).toBe(LOOPBACK_DEVICE_LABEL);
+  });
+
+  it('re-acquire after grace expiry re-creates (create twice, remove once, in order)', async () => {
+    await loopbackOwner.acquire('sink-a');
+    loopbackOwner.release();
+    await vi.advanceTimersByTimeAsync(LOOPBACK_RELEASE_GRACE_MS + 1);
+    expect(removeMock).toHaveBeenCalledTimes(1);
+    await loopbackOwner.acquire('sink-a');
+    expect(createMock).toHaveBeenCalledTimes(2);
+    // Strict ordering: create → remove → create
+    const order = [
+      createMock.mock.invocationCallOrder[0],
+      removeMock.mock.invocationCallOrder[0],
+      createMock.mock.invocationCallOrder[1],
+    ];
+    expect([...order].sort((a, b) => a - b)).toEqual(order);
+  });
+
+  it('re-acquire with a DIFFERENT sink during grace re-creates against the new sink', async () => {
+    await loopbackOwner.acquire('sink-a');
+    loopbackOwner.release();
+    await loopbackOwner.acquire('sink-b');
+    expect(createMock).toHaveBeenCalledTimes(2);
+    expect(createMock).toHaveBeenLastCalledWith('sink-b');
+    // The stale grace timer from sink-a's release must not remove sink-b's module.
+    await vi.advanceTimersByTimeAsync(LOOPBACK_RELEASE_GRACE_MS * 2);
+    expect(removeMock).not.toHaveBeenCalled();
+  });
+
+  it('overlapping holds: remove only fires after the LAST hold releases', async () => {
+    await loopbackOwner.acquire('sink-a');
+    await loopbackOwner.acquire('sink-a');
+    expect(createMock).toHaveBeenCalledTimes(1);
+    loopbackOwner.release();
+    await vi.advanceTimersByTimeAsync(LOOPBACK_RELEASE_GRACE_MS * 2);
+    expect(removeMock).not.toHaveBeenCalled();
+    loopbackOwner.release();
+    await vi.advanceTimersByTimeAsync(LOOPBACK_RELEASE_GRACE_MS);
+    expect(removeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('double release is idempotent (never double-removes, never goes negative)', async () => {
+    await loopbackOwner.acquire('sink-a');
+    loopbackOwner.release();
+    loopbackOwner.release();
+    loopbackOwner.release();
+    await vi.advanceTimersByTimeAsync(LOOPBACK_RELEASE_GRACE_MS * 2);
+    expect(removeMock).toHaveBeenCalledTimes(1);
+    // A later acquire still works from clean state
+    await loopbackOwner.acquire('sink-a');
+    expect(createMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('release with nothing held is a no-op', async () => {
+    loopbackOwner.release();
+    await vi.advanceTimersByTimeAsync(LOOPBACK_RELEASE_GRACE_MS * 2);
+    expect(removeMock).not.toHaveBeenCalled();
+  });
+
+  it('create IPC rejection → acquire rejects, state stays clean, next acquire retries', async () => {
+    createMock.mockRejectedValueOnce(new Error('pactl failed'));
+    await expect(loopbackOwner.acquire('sink-a')).rejects.toThrow('pactl failed');
+    // State clean: a release after the failed acquire must not schedule a removal
+    loopbackOwner.release();
+    await vi.advanceTimersByTimeAsync(LOOPBACK_RELEASE_GRACE_MS * 2);
+    expect(removeMock).not.toHaveBeenCalled();
+    // Retry works
+    const result = await loopbackOwner.acquire('sink-a');
+    expect(result.volumePct).toBe(100);
+    expect(createMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('missing electronAPI → acquire rejects without corrupting state', async () => {
+    (window as unknown as { electronAPI: unknown }).electronAPI = undefined;
+    await expect(loopbackOwner.acquire('sink-a')).rejects.toThrow();
+    installElectronAudioMock();
+    const result = await loopbackOwner.acquire('sink-a');
+    expect(result.label).toBe(LOOPBACK_DEVICE_LABEL);
+  });
+
+  it('IPC calls are serialized — a post-grace re-acquire queues its create behind an in-flight remove', async () => {
+    await loopbackOwner.acquire('sink-a');
+    // Make the remove hang so it is genuinely in flight when the re-acquire
+    // arrives — without the serialization chain the second create would run
+    // immediately instead of waiting for the remove to settle.
+    let resolveRemove!: () => void;
+    removeMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((res) => {
+          resolveRemove = res;
+        }),
+    );
+    loopbackOwner.release();
+    await vi.advanceTimersByTimeAsync(LOOPBACK_RELEASE_GRACE_MS);
+    expect(removeMock).toHaveBeenCalledTimes(1); // in flight, hanging
+
+    const acquiring = loopbackOwner.acquire('sink-a');
+    await vi.advanceTimersByTimeAsync(0); // flush microtasks
+    // Pins the chain: the second create must NOT have started yet.
+    expect(createMock).toHaveBeenCalledTimes(1);
+
+    resolveRemove();
+    await acquiring;
+    expect(createMock).toHaveBeenCalledTimes(2);
+    expect(createMock.mock.invocationCallOrder[1]).toBeGreaterThan(
+      removeMock.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('subscribeVolumePct fires with pct on create and null when removal executes', async () => {
+    const seen: Array<number | null> = [];
+    const unsubscribe = loopbackOwner.subscribeVolumePct((pct) => seen.push(pct));
+    await loopbackOwner.acquire('sink-a');
+    expect(seen).toEqual([100]);
+    loopbackOwner.release();
+    await vi.advanceTimersByTimeAsync(LOOPBACK_RELEASE_GRACE_MS);
+    expect(seen).toEqual([100, null]);
+    unsubscribe();
+    await loopbackOwner.acquire('sink-a');
+    expect(seen).toEqual([100, null]);
+  });
+});

--- a/dashboard/src/services/loopbackOwner.ts
+++ b/dashboard/src/services/loopbackOwner.ts
@@ -1,0 +1,153 @@
+/**
+ * loopbackOwner — single renderer-side owner of the Linux PulseAudio/PipeWire
+ * loopback module lifecycle (GH-230).
+ *
+ * The pactl `module-remap-source` module that backs system-audio capture holds
+ * an uncorked recording stream ALL BY ITSELF — a leaked module keeps the KDE
+ * "microphone in use" indicator lit forever, even after the getUserMedia
+ * stream is stopped. Before GH-230 the module was created by SessionView ahead
+ * of the session and removed by three UI handlers; every teardown that
+ * bypassed those handlers (WS drop, server error, tray stop, reconnect)
+ * leaked it.
+ *
+ * Ownership inversion: the capture that consumes the module owns its
+ * lifetime. AudioCapture calls acquire() before opening the device and
+ * release() when it stops. Release is deferred by a short grace window so a
+ * quick WebSocket reconnect or a live-mode host retarget reuses the module
+ * instead of racing a pactl unload/reload cycle; a generation token makes any
+ * stale grace timer a no-op after a newer acquire.
+ *
+ * All IPC (create + remove) flows through one internal promise chain so the
+ * two operations can never interleave.
+ */
+
+export const LOOPBACK_DEVICE_LABEL = 'TranscriptionSuite_Loopback';
+export const LOOPBACK_RELEASE_GRACE_MS = 5000;
+
+type VolumeListener = (pct: number | null) => void;
+
+interface AcquireResult {
+  /** Device label AudioCapture polls enumerateDevices for. */
+  label: string;
+  /** Effective source volume (diagnostic), null when unknown. */
+  volumePct: number | null;
+}
+
+class LoopbackOwner {
+  /** Number of captures currently holding the module. */
+  private holdCount = 0;
+  /** Whether the module is believed to exist in the audio server. */
+  private moduleActive = false;
+  private activeSinkName: string | null = null;
+  /** Bumped on every acquire — invalidates stale grace timers. */
+  private generation = 0;
+  private releaseTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Serializes create/remove IPC so pactl operations never interleave. */
+  private ipcChain: Promise<unknown> = Promise.resolve();
+  private lastVolumePct: number | null = null;
+  private volumeListeners = new Set<VolumeListener>();
+
+  /** Hold the loopback module for `sinkName`, creating it if needed. */
+  async acquire(sinkName: string): Promise<AcquireResult> {
+    if (this.releaseTimer !== null) {
+      clearTimeout(this.releaseTimer);
+      this.releaseTimer = null;
+    }
+    this.generation++;
+    const needsCreate = !this.moduleActive || this.activeSinkName !== sinkName;
+    this.holdCount++;
+    if (needsCreate) {
+      const create = window.electronAPI?.audio?.createMonitorLoopback;
+      if (!create) {
+        this.holdCount--;
+        throw new Error('Monitor loopback IPC unavailable');
+      }
+      try {
+        // Main unloads any previous module before loading the new one, so a
+        // sink switch during grace is a plain re-create.
+        const result = await this.enqueue(() => create(sinkName));
+        this.moduleActive = true;
+        this.activeSinkName = sinkName;
+        this.notifyVolume(result?.volumePct ?? null);
+      } catch (err) {
+        // Main nulls its tracked id before loading — a failed load means no
+        // module exists, so the next acquire retries from a clean slate.
+        this.holdCount--;
+        this.moduleActive = false;
+        this.activeSinkName = null;
+        throw err;
+      }
+    }
+    return { label: LOOPBACK_DEVICE_LABEL, volumePct: this.lastVolumePct };
+  }
+
+  /**
+   * Drop one hold. When the last hold drops, schedule the module unload after
+   * the grace window (a re-acquire within the window cancels it).
+   */
+  release(): void {
+    if (this.holdCount === 0) return;
+    this.holdCount--;
+    if (this.holdCount > 0 || !this.moduleActive) return;
+
+    const gen = this.generation;
+    if (this.releaseTimer !== null) clearTimeout(this.releaseTimer);
+    this.releaseTimer = setTimeout(() => {
+      this.releaseTimer = null;
+      // A newer acquire owns the module now — this timer is stale.
+      if (gen !== this.generation) return;
+      this.moduleActive = false;
+      this.activeSinkName = null;
+      const remove = window.electronAPI?.audio?.removeMonitorLoopback;
+      if (remove) {
+        void this.enqueue(() => remove()).catch(() => {
+          // Best-effort: main's handler is idempotent and the will-quit /
+          // shutdown safety nets sweep anything that slips through.
+        });
+      }
+      this.notifyVolume(null);
+    }, LOOPBACK_RELEASE_GRACE_MS);
+  }
+
+  /**
+   * Subscribe to the diagnostic volume readout: pct after a create, null when
+   * a scheduled removal actually executes. Returns an unsubscribe function.
+   */
+  subscribeVolumePct(cb: VolumeListener): () => void {
+    this.volumeListeners.add(cb);
+    return () => {
+      this.volumeListeners.delete(cb);
+    };
+  }
+
+  /** Test-only: reset singleton state between tests. */
+  _resetForTests(): void {
+    if (this.releaseTimer !== null) {
+      clearTimeout(this.releaseTimer);
+      this.releaseTimer = null;
+    }
+    this.holdCount = 0;
+    this.moduleActive = false;
+    this.activeSinkName = null;
+    this.generation = 0;
+    this.ipcChain = Promise.resolve();
+    this.lastVolumePct = null;
+    this.volumeListeners.clear();
+  }
+
+  private enqueue<T>(op: () => Promise<T>): Promise<T> {
+    const run = this.ipcChain.then(op, op);
+    this.ipcChain = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  private notifyVolume(pct: number | null): void {
+    this.lastVolumePct = pct;
+    for (const cb of this.volumeListeners) cb(pct);
+  }
+}
+
+export const loopbackOwner = new LoopbackOwner();


### PR DESCRIPTION
## Summary

Fixes the GH #230 symptom class: on Linux, the KDE "microphone in use" indicator stayed lit after a system-audio recording ended through anything other than the three UI buttons.

**Root cause (empirically verified on KDE/PipeWire):** the pactl `module-remap-source` module holds an *uncorked recording stream all by itself* - a leaked module keeps the mic indicator lit even after Chromium's capture stream is stopped. The module was created by SessionView before the session and removed by exactly 3 UI handlers; an adversarially-verified RCA confirmed ~20 teardown paths that bypassed them (WS close/error mid-recording, server `error` frames, tray Stop Live Mode, live retarget, renderer reload, and every real quit path - `will-quit` is dead code because all quits funnel through `gracefulShutdown()` then `app.exit(0)`).

The literal reported repro was a mental-model mismatch: **Client Link Stop only flipped a UI flag** - the recording kept streaming invisibly ("Disconnected" while capture ran and the icon stayed lit, truthfully).

## Design: ownership inversion

The capture that consumes the module now owns its lifetime - leak-freedom is structural instead of a call-site enumeration (which is the approach that already failed once and caused this bug).

- **`loopbackOwner` (new renderer service):** `acquire(sinkName)`/`release()` around the create/remove IPC, with a **5s release grace window** + generation token so quick WS reconnects and live-mode host retargets *reuse* the module instead of racing a pactl unload/reload; create/remove IPC is serialized through one promise chain.
- **`AudioCapture`** acquires on system-audio start and releases on every `stop()` (option renamed `monitorDeviceLabel` → `monitorSinkName`). Start failures (waitForDevice timeout, getUserMedia denial, worklet load) release the hold and stop partial streams. A `stop()` racing an in-flight `start()` now aborts it deterministically (epoch guard + `AbortError`, swallowed by the hooks) instead of orphaning a running capture that held the module forever.
- **Hooks** are pure pass-through; `useLiveMode`'s server `STOPPED` state now stops the capture (previously kept streaming into a dead session).
- **Client Link Stop terminates active sessions** (v0.5.6 ClientControlMixin parity): recording → stop-and-transcribe, connecting → reset, processing → left alone (durability - the poll-for-result fallback recovers it), live → toggled off.
- **Electron main safety nets:** unload runs first in `gracefulShutdown()` (covers window-close quits AND SIGINT/SIGTERM/SIGHUP); stale `tsuite_loopback` modules from crashed runs are swept at startup, on renderer reload/crash, and before every create (parsed from `pactl list short modules` - on PipeWire the JSON listing carries **no module index**); create refuses to run once shutdown has begun; a failed listing degrades to the tracked-id unload.

The staged diff itself went through a 13-agent adversarial review; all 9 confirmed findings (1 critical, 4 high, 4 medium/low) are fixed in this PR.

## Behavior changes

1. The module unloads ~5s after a session ends (grace window) instead of at the exact Stop click - the icon can linger up to 5s, in exchange for reconnect/retarget robustness.
2. Transient WS drops: a quick reconnect reuses the module; a slow one recreates it - system-audio resume now works in both hooks *without* leaking.
3. pactl load failure at start surfaces as a visible capture error instead of a stranded rejection.
4. Client Link Stop actually ends active sessions.
5. Normal quit and SIGTERM now unload the module (previously never - dead `will-quit`).
6. Known residual: a main-process SIGKILL/crash leaks the module until the next app launch (startup sweep reclaims it) or PipeWire restart.

## Test plan

- [x] `npm run typecheck` (renderer + electron), `npm run lint` (`--max-warnings=0`)
- [x] Full dashboard suite on Node 22: **128 files / 1861 tests green**, including new suites: `loopbackOwner.test.ts` (grace/generation/serialization semantics), `audioCapture.test.ts` (acquire-before-enumerate, release-on-every-failure, stop-during-start abort races), `SessionView.client-link-stop.test.tsx` (all 5 session states), hook pass-through + live `STOPPED` teardown
- [ ] Manual KDE/PipeWire smoke (needs desktop; verify with `pactl list short source-outputs` + tray icon after each):
  - [ ] Literal GH #230: system-audio recording → Client Link Stop → recording stops and transcribes, module gone within ~5s, icon off
  - [ ] `docker stop` the server mid-system-audio recording → module gone after grace; restart → reconnect recreates module and resumes capture
  - [ ] System-audio live mode → tray "Stop Live Mode" → module gone (previously always leaked)
  - [ ] Ctrl+R renderer reload mid-recording → module swept by main
  - [ ] Normal quit and separately SIGTERM mid-recording → module gone after exit
  - [ ] Crash simulation: `kill -9` the app mid-recording → relaunch → module swept at startup

Refs GH #230 (manual close after the smoke test passes).