### PR TITLE
fix(dashboard): gate the WS start re-send so reconnects don't spawn zombie sessions (GH-237)

### DIFF
--- a/dashboard/src/hooks/useLiveMode.test.ts
+++ b/dashboard/src/hooks/useLiveMode.test.ts
@@ -674,4 +674,106 @@ describe('[P1] useLiveMode', () => {
       );
     });
   });
+
+  // ── GH-237: WS reconnect must not resurrect a dead live session ───────
+  //
+  // Same root cause as the longform hook: the server cannot resume a dropped
+  // session, so re-sending `start` on an auto-reconnect used to silently
+  // resurrect the session in the background (reconnect → start → LISTENING
+  // flipped the UI back to active after it had already gone idle).
+
+  describe('GH-237: reconnect start-gate + fail-loudly', () => {
+    /** Count the `start` messages sent over a given socket instance. */
+    const startSends = (s: typeof lastSocket = lastSocket): number =>
+      s.sendJSON.mock.calls.filter((c) => (c[0] as { type?: string })?.type === 'start').length;
+
+    it('does not re-send start when auth_ok fires again after LISTENING', async () => {
+      const { result } = renderHook(() => useLiveMode());
+      await driveToListening(result);
+      expect(startSends()).toBe(1);
+
+      act(() => {
+        lastSocketCbs.onMessage!({ type: 'auth_ok' });
+      });
+
+      expect(startSends()).toBe(1);
+    });
+
+    it('re-sends start on a reconnect before the engine acknowledged (still starting)', () => {
+      const { result } = renderHook(() => useLiveMode());
+      act(() => {
+        result.current.start();
+      });
+      act(() => {
+        lastSocketCbs.onMessage!({ type: 'auth_ok' });
+      });
+      expect(startSends()).toBe(1);
+
+      // Dropped during the model swap, before any `state` arrived.
+      act(() => {
+        lastSocketCbs.onClose!(1001, 'drop while starting');
+      });
+      act(() => {
+        lastSocketCbs.onMessage!({ type: 'auth_ok' });
+      });
+
+      expect(startSends()).toBe(2);
+    });
+
+    it('fails loudly when the socket closes unexpectedly while listening', async () => {
+      const { result } = renderHook(() => useLiveMode());
+      await driveToListening(result);
+      lastSocket.disconnect.mockClear();
+      lastCapture.stop.mockClear();
+
+      act(() => {
+        lastSocketCbs.onClose!(1001, 'server going away');
+      });
+
+      expect(result.current.status).toBe('error');
+      expect(result.current.error).toMatch(/connection.*lost/i);
+      expect(lastCapture.stop).toHaveBeenCalled();
+      expect(lastSocket.disconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('a server STOPPED followed by an unintentional close stays idle and does not resurrect', async () => {
+      const { result } = renderHook(() => useLiveMode());
+      await driveToListening(result);
+      expect(startSends()).toBe(1);
+
+      // Server stops the engine (grace-period expiry / client link stop).
+      act(() => {
+        lastSocketCbs.onMessage!({ type: 'state', data: { state: 'STOPPED' } });
+      });
+      expect(result.current.status).toBe('idle');
+
+      // The socket then drops and auto-reconnects.
+      act(() => {
+        lastSocketCbs.onClose!(1001, 'closed after stop');
+      });
+      // Nothing was capturing, so this is not a loud failure.
+      expect(result.current.status).toBe('idle');
+      act(() => {
+        lastSocketCbs.onMessage!({ type: 'auth_ok' });
+      });
+
+      // Gate still closed — no background resurrection.
+      expect(startSends()).toBe(1);
+      expect(result.current.status).toBe('idle');
+    });
+
+    it('reopens the gate on a fresh start()', async () => {
+      const { result } = renderHook(() => useLiveMode());
+      await driveToListening(result);
+      act(() => {
+        result.current.stop();
+      });
+
+      await driveToListening(result);
+
+      // lastSocket is the second socket instance — it sent its own start.
+      expect(startSends()).toBe(1);
+      expect(result.current.status).toBe('listening');
+    });
+  });
 });

--- a/dashboard/src/hooks/useLiveMode.ts
+++ b/dashboard/src/hooks/useLiveMode.ts
@@ -78,6 +78,20 @@ export function useLiveMode(): LiveModeState {
   // a stale reference. Updated on every render (see the effect below).
   const retargetRef = useRef<(() => void) | null>(null);
   const isRetargetingRef = useRef(false);
+  // Mirror of `status` so the socket callbacks (created once in start()) can
+  // read the CURRENT status without a stale closure — mirrors useTranscription.
+  const statusRef = useRef<LiveStatus>('idle');
+  const setStatusTracked = useCallback((s: LiveStatus) => {
+    statusRef.current = s;
+    setStatus(s);
+  }, []);
+  // GH-237: gate the `start` re-send across auto-reconnects (same rationale as
+  // useTranscription). The server cannot resume a dropped live session, so
+  // re-sending `start` on reconnect resurrects it in the background. Flipped
+  // true on the first `state` message (engine acknowledged our start); stays
+  // true across a server STOPPED + reconnect so nothing resurrects; reopened
+  // only by a user-initiated start()/stop().
+  const sessionEstablishedRef = useRef(false);
 
   // Cleanup on unmount
   useEffect(() => {
@@ -97,115 +111,126 @@ export function useLiveMode(): LiveModeState {
     });
   }, []);
 
-  const handleMessage = useCallback((msg: ServerMessage) => {
-    switch (msg.type) {
-      case 'auth_ok':
-        // Authenticated — send start with config
-        setStatus('starting');
-        socketRef.current?.sendJSON({
-          type: 'start',
-          data: {
-            config: {
-              language: startOptsRef.current.language,
-              model: startOptsRef.current.model,
-              translation_enabled: startOptsRef.current.translate ?? false,
-              translation_target_language: startOptsRef.current.translationTarget ?? 'en',
-              post_speech_silence_duration: startOptsRef.current.gracePeriodSeconds,
+  const handleMessage = useCallback(
+    (msg: ServerMessage) => {
+      switch (msg.type) {
+        case 'auth_ok':
+          // GH-237: only send `start` on the FIRST connect of a user session.
+          // After the engine has acknowledged us, an auth_ok is an auto-reconnect
+          // and re-sending `start` would resurrect the session (see
+          // sessionEstablishedRef).
+          if (sessionEstablishedRef.current) break;
+          // Authenticated — send start with config
+          setStatusTracked('starting');
+          socketRef.current?.sendJSON({
+            type: 'start',
+            data: {
+              config: {
+                language: startOptsRef.current.language,
+                model: startOptsRef.current.model,
+                translation_enabled: startOptsRef.current.translate ?? false,
+                translation_target_language: startOptsRef.current.translationTarget ?? 'en',
+                post_speech_silence_duration: startOptsRef.current.gracePeriodSeconds,
+              },
             },
-          },
-        });
-        break;
+          });
+          break;
 
-      case 'status':
-        // Model loading/swapping progress
-        setStatusMessage((msg.data?.message as string) ?? null);
-        break;
+        case 'status':
+          // Model loading/swapping progress
+          setStatusMessage((msg.data?.message as string) ?? null);
+          break;
 
-      case 'state': {
-        const state = msg.data?.state as string;
-        if (state === 'LISTENING') {
-          setStatus('listening');
-          setStatusMessage(null);
-          // Start audio capture once engine is ready. Stop any previous
-          // instance first — GH-230: replacing a still-starting capture
-          // without stopping it would orphan its loopback hold and stream.
-          if (!captureRef.current?.isCapturing) {
-            captureRef.current?.stop();
-            captureRef.current = new AudioCapture((chunk) => {
-              socketRef.current?.sendAudio(chunk);
-            });
-            captureRef.current
-              .start({
-                deviceId: startOptsRef.current.deviceId,
-                systemAudio: startOptsRef.current.systemAudio,
-                monitorSinkName: startOptsRef.current.monitorSinkName,
-              })
-              .then(() => {
-                setAnalyser(captureRef.current?.analyser ?? null);
-              })
-              .catch((err) => {
-                // A stop() that raced the start — the stop already put the
-                // state machine where it belongs; don't flip to error.
-                if (err instanceof Error && err.name === 'AbortError') return;
-                setError(err instanceof Error ? err.message : 'Audio capture failed');
-                setStatus('error');
-                socketRef.current?.disconnect();
+        case 'state': {
+          // GH-237: the engine has acknowledged our start — close the start-gate
+          // so a later auto-reconnect cannot resurrect the session.
+          sessionEstablishedRef.current = true;
+          const state = msg.data?.state as string;
+          if (state === 'LISTENING') {
+            setStatusTracked('listening');
+            setStatusMessage(null);
+            // Start audio capture once engine is ready. Stop any previous
+            // instance first — GH-230: replacing a still-starting capture
+            // without stopping it would orphan its loopback hold and stream.
+            if (!captureRef.current?.isCapturing) {
+              captureRef.current?.stop();
+              captureRef.current = new AudioCapture((chunk) => {
+                socketRef.current?.sendAudio(chunk);
               });
+              captureRef.current
+                .start({
+                  deviceId: startOptsRef.current.deviceId,
+                  systemAudio: startOptsRef.current.systemAudio,
+                  monitorSinkName: startOptsRef.current.monitorSinkName,
+                })
+                .then(() => {
+                  setAnalyser(captureRef.current?.analyser ?? null);
+                })
+                .catch((err) => {
+                  // A stop() that raced the start — the stop already put the
+                  // state machine where it belongs; don't flip to error.
+                  if (err instanceof Error && err.name === 'AbortError') return;
+                  setError(err instanceof Error ? err.message : 'Audio capture failed');
+                  setStatusTracked('error');
+                  socketRef.current?.disconnect();
+                });
+            }
+          } else if (state === 'PROCESSING') {
+            setStatusTracked('processing');
+          } else if (state === 'STOPPED') {
+            // GH-230: a server-initiated stop must tear down capture too —
+            // leaving it running kept streaming audio into a dead session and
+            // stranded the Linux loopback module (mic indicator stayed lit).
+            captureRef.current?.stop();
+            setAnalyser(null);
+            setStatusTracked('idle');
+            setStatusMessage(null);
           }
-        } else if (state === 'PROCESSING') {
-          setStatus('processing');
-        } else if (state === 'STOPPED') {
-          // GH-230: a server-initiated stop must tear down capture too —
-          // leaving it running kept streaming audio into a dead session and
-          // stranded the Linux loopback module (mic indicator stayed lit).
+          break;
+        }
+
+        case 'sentence':
+          setSentences((prev) => [
+            ...prev,
+            {
+              text: (msg.data?.text as string) ?? '',
+              timestamp: Date.now(),
+            },
+          ]);
+          setPartial(''); // Clear partial when sentence completes
+          break;
+
+        case 'partial':
+          setPartial((msg.data?.text as string) ?? '');
+          break;
+
+        case 'history':
+          // Restore history from server
+          if (Array.isArray(msg.data?.sentences)) {
+            setSentences(
+              (msg.data.sentences as string[]).map((text) => ({
+                text,
+                timestamp: Date.now(),
+              })),
+            );
+          }
+          break;
+
+        case 'history_cleared':
+          setSentences([]);
+          break;
+
+        case 'error':
+          setError((msg.data?.message as string) ?? 'Live mode error');
+          setStatusTracked('error');
           captureRef.current?.stop();
           setAnalyser(null);
-          setStatus('idle');
           setStatusMessage(null);
-        }
-        break;
+          break;
       }
-
-      case 'sentence':
-        setSentences((prev) => [
-          ...prev,
-          {
-            text: (msg.data?.text as string) ?? '',
-            timestamp: Date.now(),
-          },
-        ]);
-        setPartial(''); // Clear partial when sentence completes
-        break;
-
-      case 'partial':
-        setPartial((msg.data?.text as string) ?? '');
-        break;
-
-      case 'history':
-        // Restore history from server
-        if (Array.isArray(msg.data?.sentences)) {
-          setSentences(
-            (msg.data.sentences as string[]).map((text) => ({
-              text,
-              timestamp: Date.now(),
-            })),
-          );
-        }
-        break;
-
-      case 'history_cleared':
-        setSentences([]);
-        break;
-
-      case 'error':
-        setError((msg.data?.message as string) ?? 'Live mode error');
-        setStatus('error');
-        captureRef.current?.stop();
-        setAnalyser(null);
-        setStatusMessage(null);
-        break;
-    }
-  }, []);
+    },
+    [setStatusTracked],
+  );
 
   const start = useCallback(
     (options?: LiveStartOptions) => {
@@ -220,15 +245,17 @@ export function useLiveMode(): LiveModeState {
       }
       setStatusMessage(null);
       startOptsRef.current = options ?? {};
+      // GH-237: a user-initiated session reopens the start-gate.
+      sessionEstablishedRef.current = false;
 
-      setStatus('connecting');
+      setStatusTracked('connecting');
 
       socketRef.current?.disconnect();
       socketRef.current = new TranscriptionSocket('/ws/live', {
         onMessage: handleMessage,
         onError: (err) => {
           setError(err);
-          setStatus('error');
+          setStatusTracked('error');
           captureRef.current?.stop();
           setAnalyser(null);
         },
@@ -240,7 +267,19 @@ export function useLiveMode(): LiveModeState {
           captureRef.current?.stop();
           setAnalyser(null);
           setStatusMessage(null);
-          setStatus('idle');
+          // GH-237: if the drop happened while a session was actively running
+          // (listening/processing), it is an unrecoverable interruption — the
+          // server cannot resume, and the start-gate now blocks the reconnect
+          // from resurrecting it. Fail loudly and halt the reconnect. A drop
+          // before the engine acknowledged us (connecting/starting) or after a
+          // clean STOPPED (idle) is not fatal: let the reconnect re-establish.
+          if (statusRef.current === 'listening' || statusRef.current === 'processing') {
+            setError('Connection to the server was lost. Live mode stopped.');
+            setStatusTracked('error');
+            socketRef.current?.disconnect();
+            return;
+          }
+          setStatusTracked('idle');
         },
         onHostMismatch: () => {
           // Drain + retarget for EC-6: the user changed hosts while live mode
@@ -270,7 +309,7 @@ export function useLiveMode(): LiveModeState {
       });
       socketRef.current.connect();
     },
-    [handleMessage],
+    [handleMessage, setStatusTracked],
   );
 
   // Keep the retarget ref pointed at the latest `start` closure. Updated every
@@ -286,8 +325,10 @@ export function useLiveMode(): LiveModeState {
     captureRef.current?.stop();
     setAnalyser(null);
     setStatusMessage(null);
-    setStatus('idle');
-  }, []);
+    // GH-237: user stop reopens the start-gate for the next session.
+    sessionEstablishedRef.current = false;
+    setStatusTracked('idle');
+  }, [setStatusTracked]);
 
   const toggleMute = useCallback(() => {
     setMuted((prev) => {

--- a/dashboard/src/hooks/useTranscription.test.ts
+++ b/dashboard/src/hooks/useTranscription.test.ts
@@ -927,4 +927,112 @@ describe('[P1] useTranscription', () => {
       expect(lastSocket.disconnect).not.toHaveBeenCalled();
     });
   });
+
+  // ── GH-237: WS reconnect must not spawn zombie server sessions ────────
+  //
+  // The server assigns a NEW session_id + job_id per WS connection and cannot
+  // resume a dropped session. The socket auto-reconnects unintentional closes,
+  // so a `start` re-sent on every reconnect used to silently abandon the
+  // original job and spin up a fresh one for a new slice of audio — a
+  // truncated transcript passed off as complete (data-loss invariant breach).
+
+  describe('GH-237: reconnect start-gate + fail-loudly', () => {
+    /** Count the `start` messages sent over a given socket instance. */
+    const startSends = (s: typeof lastSocket = lastSocket): number =>
+      s.sendJSON.mock.calls.filter((c) => (c[0] as { type?: string })?.type === 'start').length;
+
+    it('does not re-send start when auth_ok fires again after the session is established', async () => {
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+      expect(startSends()).toBe(1);
+
+      // A reconnect re-runs the auth handshake on the same socket instance.
+      act(() => {
+        lastSocketCbs.onMessage!({ type: 'auth_ok' });
+      });
+
+      // Gate held — otherwise the server would have spawned a second job.
+      expect(startSends()).toBe(1);
+    });
+
+    it('re-sends start on a reconnect that lands before the session was established', () => {
+      const { result } = renderHook(() => useTranscription());
+      act(() => {
+        result.current.start();
+      });
+      act(() => {
+        lastSocketCbs.onMessage!({ type: 'auth_ok' });
+      });
+      expect(startSends()).toBe(1);
+
+      // Dropped mid-handshake (still 'connecting', no session_started yet).
+      act(() => {
+        lastSocketCbs.onClose!(1001, 'drop before session');
+      });
+      act(() => {
+        lastSocketCbs.onMessage!({ type: 'auth_ok' });
+      });
+
+      // No job existed yet, so re-establishing the first session is correct.
+      expect(startSends()).toBe(2);
+      expect(result.current.status).not.toBe('error');
+    });
+
+    it('fails loudly when the socket closes unexpectedly while recording', async () => {
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+      lastSocket.disconnect.mockClear();
+      lastCapture.stop.mockClear();
+
+      act(() => {
+        lastSocketCbs.onClose!(1001, 'server going away');
+      });
+
+      expect(result.current.status).toBe('error');
+      expect(result.current.error).toMatch(/connection.*lost/i);
+      expect(lastCapture.stop).toHaveBeenCalled();
+      // Auto-reconnect is halted so no zombie session is created.
+      expect(lastSocket.disconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not re-send start on a reconnect during processing (poll owns recovery)', async () => {
+      (apiClient.fetchTranscriptionResult as Mock).mockResolvedValue({ status: 202 });
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+      act(() => {
+        result.current.stop();
+      });
+      expect(result.current.status).toBe('processing');
+      expect(startSends()).toBe(1);
+
+      // Socket drops mid-processing, then auto-reconnects and re-authenticates.
+      await act(async () => {
+        lastSocketCbs.onClose!(1001, 'drop during processing');
+        await Promise.resolve();
+      });
+      act(() => {
+        lastSocketCbs.onMessage!({ type: 'auth_ok' });
+      });
+
+      // No phantom job: the poll-for-result fallback recovers the real one.
+      expect(startSends()).toBe(1);
+      expect(result.current.status).toBe('processing');
+    });
+
+    it('reopens the gate on a fresh start() so the next session sends its own start', async () => {
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+      act(() => {
+        lastSocketCbs.onMessage!({ type: 'final', data: { text: 'one', words: [] } });
+      });
+      expect(result.current.status).toBe('complete');
+
+      // A brand-new user-initiated session builds a fresh socket instance.
+      await driveToRecording(result);
+
+      // lastSocket is now the second socket — it sent exactly one start.
+      expect(startSends()).toBe(1);
+      expect(result.current.status).toBe('recording');
+    });
+  });
 });

--- a/dashboard/src/hooks/useTranscription.ts
+++ b/dashboard/src/hooks/useTranscription.ts
@@ -127,6 +127,16 @@ export function useTranscription(): TranscriptionState {
   const [jobId, setJobId] = useState<string | null>(null);
   const jobIdRef = useRef<string | null>(null);
   const statusRef = useRef<TranscriptionStatus>('idle');
+  // GH-237: gate the `start` re-send. The socket auto-reconnects unintentional
+  // closes and re-runs the auth handshake, but the server assigns a NEW
+  // session_id + job_id per connection and cannot resume — so re-sending
+  // `start` after a session already exists spawns a zombie job for a fresh
+  // slice of audio. Flipped true on `session_started`; reopened only by a
+  // user-initiated start()/reset(). Deliberately NOT reset on stop(): the
+  // processing phase still needs the gate closed so a drop-during-processing
+  // reconnect can't spawn a phantom job while the poll-for-result fallback
+  // recovers the real one.
+  const sessionEstablishedRef = useRef(false);
   // Ref-based cancel flag for the disconnect poll loop — accessible from the
   // useEffect cleanup on unmount (a plain `let cancelled` in the onClose closure
   // cannot be reached from the cleanup function).
@@ -250,6 +260,10 @@ export function useTranscription(): TranscriptionState {
     (msg: ServerMessage) => {
       switch (msg.type) {
         case 'auth_ok':
+          // GH-237: only send `start` on the FIRST connect of a user session.
+          // Once a session is established, an auth_ok is an auto-reconnect —
+          // re-sending `start` would spawn a zombie job (see sessionEstablishedRef).
+          if (sessionEstablishedRef.current) break;
           // Auth succeeded — now send start
           socketRef.current?.sendJSON({
             type: 'start',
@@ -266,6 +280,9 @@ export function useTranscription(): TranscriptionState {
           break;
 
         case 'session_started':
+          // GH-237: a real job now exists — close the start-gate so any later
+          // auto-reconnect cannot spawn a second one.
+          sessionEstablishedRef.current = true;
           if (msg.data?.job_id) {
             const id = msg.data.job_id as string;
             jobIdRef.current = id;
@@ -463,6 +480,8 @@ export function useTranscription(): TranscriptionState {
       setMuted(false);
       jobIdRef.current = null;
       setJobId(null);
+      // GH-237: a user-initiated session reopens the start-gate.
+      sessionEstablishedRef.current = false;
       stopPreview();
       // The old socket is being replaced — any in-flight preview response is
       // lost with it, so the wire flag must not carry into the new session.
@@ -492,6 +511,19 @@ export function useTranscription(): TranscriptionState {
           // guard would block every future refresh — even across a reconnect.
           stopPreview();
           previewLoadingRef.current = false;
+
+          // GH-237: a drop WHILE recording is an unrecoverable interruption.
+          // The server cannot resume a dropped session, and the start-gate now
+          // stops the auto-reconnect from spawning a fresh job — which would
+          // leave the UI frozen in a false 'recording' state. Fail loudly
+          // instead of silently truncating: surface the interruption and halt
+          // the reconnect so no zombie session is created. (Data-loss invariant.)
+          if (statusRef.current === 'recording') {
+            setError('Connection to the server was lost. The recording was interrupted.');
+            setStatusTracked('error');
+            socketRef.current?.disconnect();
+            return;
+          }
 
           // If we were processing when the socket closed, poll for the result
           const currentJobId = jobIdRef.current;
@@ -584,6 +616,8 @@ export function useTranscription(): TranscriptionState {
     setProcessingProgress(null);
     jobIdRef.current = null;
     setJobId(null);
+    // GH-237: back to idle — reopen the start-gate for the next session.
+    sessionEstablishedRef.current = false;
     stopPreview();
     // reset() disconnects the socket — the in-flight response (if any) is lost.
     previewLoadingRef.current = false;


### PR DESCRIPTION
Fixes the zombie-session behavior found during the GH #230 RCA (deliberately deferred there) and filed as #237.

## Root cause

`TranscriptionSocket` auto-reconnects unintentional closes with unlimited attempts, and on every successful reconnect the `auth_ok` handler in **both** hooks unconditionally re-sent `start`. But the server (`api/routes/websocket.py`) assigns a **new `session_id` + `job_id` per WS connection and has no resume primitive** — on disconnect it flips `_client_disconnected`, releases the job slot, and tears the session down in `cleanup()` (the buffered head audio is **discarded**, never finalized). So a reconnected `start` could only ever mean a *new* job, never a continued one.

Consequences of the old behavior:
- **Longform:** a transient drop mid-recording silently abandoned the original job and started a fresh one at the reconnect point. The user saw one continuous recording but got a transcript that started partway through — a truncated result passed off as complete, which collides head-on with the project's data-loss invariant.
- **Longform, during processing:** a reconnect could yank the UI out of `processing` back into a phantom `recording` (new job) *while* the poll-for-result fallback was still recovering the real one.
- **Live:** a drop after the UI had gone idle could resurrect the session in the background (reconnect → `start` → `LISTENING` flipped the UI back to active).
- Because the job tracker is single-slot and the old session's `cleanup()` runs async, a fast reconnect could also hit a spurious `session_busy` before the old slot was released.

## The fix (client-side, both hooks)

**1. Start-gate (`sessionEstablishedRef`).** `auth_ok` sends `start` only on the first connect of a user session. The gate flips true on `session_started` (longform) / the first `state` (live), and reopens **only** on a user-initiated `start()` / `reset()` / `stop()`. Keying it on *session-established* (not start-*sent*) means a drop during the initial connecting handshake — where no job exists yet — still legitimately re-establishes the first session; only a reconnect *after* a real job exists is blocked.

- It deliberately does **not** reset on longform `stop()`: the processing phase must keep the gate closed so a drop-during-processing reconnect can't spawn a phantom job while the poll fallback recovers the real one.
- It stays true across a clean live `STOPPED` + reconnect, so nothing resurrects.

**2. Fail loudly on unrecoverable mid-recording drops.** The gate alone would freeze the UI in a false `recording` state (dead capture, no result path), so `onClose` now surfaces the interruption when the drop lands while actively capturing (`recording` / `listening` / `processing`): it sets an error ("Connection to the server was lost…") and calls `disconnect()` to halt the auto-reconnect so no zombie session is created. Non-fatal cases are unchanged: a drop during `connecting`/`starting` lets the reconnect re-establish, a longform drop during `processing` still runs the poll-for-result fallback, and a clean live `STOPPED` stays idle.

`useLiveMode` gained a `statusRef` mirror (mirroring `useTranscription`) so its once-created socket callbacks can read the current status without a stale closure. The live host-change **retarget** path is unaffected — it calls `start()` afresh, which reopens the gate.

## Not in scope (follow-up filed)

The server still **discards** the already-streamed head audio on a mid-recording drop. Making it durably finalize/salvage that buffer so the head can be recovered via the existing poll path is a separate, server-side change (with its own junk-job risk) — filed as a follow-up issue.

## Test plan

**Automated (done):** `dashboard/` full suite green — 128 files / 1871 tests. New coverage in both hooks:
- gate holds when `auth_ok` re-fires after establishment (no second `start`)
- a reconnect *before* establishment still re-sends `start` (connecting-phase resilience)
- fail-loudly (error + `disconnect`) on an unintentional close while recording/listening
- no phantom `start` on a reconnect during processing (poll owns recovery)
- a live `STOPPED` followed by an unintentional close stays idle and does not resurrect
- a fresh `start()`/`stop()` reopens the gate

**Manual smoke (needs your desktop — jsdom can't exercise a real WS drop):**
1. Start a longform recording, then briefly interrupt the connection (e.g. `docker stop` the server / drop the network) → UI fails loudly with the "connection lost" error, does **not** silently start a new job, and no second job appears in history.
2. Repeat during the **processing** phase (after Stop) → the poll-for-result fallback still recovers the transcript; no phantom recording appears.
3. Live mode: interrupt the connection while listening → UI stops with the error and the accumulated sentences remain; on reconnect it does **not** resurrect in the background.
4. Sanity: a normal record → stop → result still works end to end, and the live host-change retarget still preserves sentences.

Refs #237