### PR TITLE
fix(stt): restore Greek final sigma (ς) in NeMo Canary output and warn on Parakeet

### DIFF
--- a/dashboard/components/__tests__/SessionView.greek-sigma.test.tsx
+++ b/dashboard/components/__tests__/SessionView.greek-sigma.test.tsx
@@ -1,0 +1,313 @@
+/**
+ * SessionView - Greek final-sigma warning for Parakeet-family models.
+ *
+ * NVIDIA's NeMo models were trained with SentencePiece vocabularies that lack
+ * ς (U+03C2). Parakeet models silently truncate Greek word endings ("σας"
+ * becomes "σα") with no recoverable trace, so the UI must warn when Greek is
+ * selected with a Parakeet model. Canary models carry the same tokenizer
+ * defect but the server repairs their output automatically - no warning.
+ *
+ * Upstream defect: https://huggingface.co/nvidia/canary-1b-v2/discussions/26
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const PARAKEET_MODEL = 'nvidia/parakeet-tdt-0.6b-v3';
+const CANARY_MODEL = 'nvidia/canary-1b-v2';
+
+// ── Hoisted mock state ────────────────────────────────────────────────────
+
+const mockModels = {
+  main: PARAKEET_MODEL,
+  live: PARAKEET_MODEL,
+};
+
+const mockTranscription = {
+  status: 'idle' as string,
+  result: null,
+  error: null as string | null,
+  analyser: null,
+  start: vi.fn(),
+  stop: vi.fn(),
+  reset: vi.fn(),
+  vadActive: false,
+  processingProgress: null,
+  muted: false,
+  toggleMute: vi.fn(),
+  setGain: vi.fn(),
+  jobId: null,
+  loadResult: vi.fn(),
+};
+
+const mockGetConfig = vi.fn();
+
+vi.mock('../../src/hooks/useTranscription', () => ({
+  useTranscription: () => mockTranscription,
+}));
+
+vi.mock('../../src/hooks/useLanguages', () => ({
+  useLanguages: () => ({
+    languages: [
+      { code: 'auto', name: 'Auto Detect' },
+      { code: 'en', name: 'English' },
+      { code: 'el', name: 'Greek' },
+      { code: 'es', name: 'Spanish' },
+    ],
+    backendType: 'parakeet',
+    loading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('../../src/hooks/useAdminStatus', () => ({
+  useAdminStatus: () => ({
+    status: {
+      models_loaded: true,
+      config: {
+        main_transcriber: { model: mockModels.main },
+        live_transcriber: { model: mockModels.live },
+      },
+    },
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/hooks/DockerContext', () => ({
+  useDockerContext: () => ({
+    available: true,
+    loading: false,
+    runtimeKind: 'Docker',
+    detectionGuidance: null,
+    composeAvailable: true,
+    images: [],
+    container: { exists: true, running: true, status: 'running', health: 'healthy' },
+    volumes: [],
+    operating: false,
+    operationError: null,
+    pulling: false,
+    sidecarPulling: false,
+    logLines: [],
+    logStreaming: false,
+    hasSidecarImage: vi.fn().mockResolvedValue(false),
+    startLogStream: vi.fn(),
+    stopLogStream: vi.fn(),
+    clearLogs: vi.fn(),
+    refreshImages: vi.fn(),
+    refreshVolumes: vi.fn(),
+    pullImage: vi.fn(),
+    cancelPull: vi.fn(),
+    pullSidecarImage: vi.fn(),
+    cancelSidecarPull: vi.fn(),
+    removeImage: vi.fn(),
+    startContainer: vi.fn(),
+    stopContainer: vi.fn(),
+    removeContainer: vi.fn(),
+    removeVolume: vi.fn(),
+    cleanAll: vi.fn(),
+    retryDetection: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/hooks/useTraySync', () => ({ useTraySync: vi.fn() }));
+
+vi.mock('../../src/stores/importQueueStore', () => ({
+  useImportQueueStore: (selector: (s: Record<string, unknown>) => unknown) => {
+    const state = {
+      jobs: [],
+      isPaused: false,
+      sessionConfig: { outputDir: '', diarizedFormat: 'srt', hideTimestamps: false },
+      sessionWatchPath: '',
+      sessionWatchActive: false,
+    };
+    return typeof selector === 'function' ? selector(state) : state;
+  },
+}));
+
+vi.mock('../../src/api/client', () => ({
+  apiClient: {
+    checkConnection: vi.fn().mockResolvedValue({ reachable: true, ready: true }),
+    getAdminStatus: vi.fn().mockResolvedValue({}),
+    cancelTranscription: vi.fn(),
+    getAuthToken: vi.fn().mockReturnValue(null),
+    setAuthToken: vi.fn(),
+    getBaseUrl: vi.fn().mockReturnValue('http://localhost:7239'),
+    syncFromConfig: vi.fn().mockResolvedValue(undefined),
+    unloadModels: vi.fn().mockResolvedValue(undefined),
+    unloadLLMModel: vi.fn().mockResolvedValue(undefined),
+    loadModelsStream: vi.fn().mockReturnValue(vi.fn()),
+    fetchRecentUndelivered: vi.fn().mockResolvedValue({ json: async () => [] }),
+    fetchTranscriptionResult: vi.fn().mockResolvedValue({ status: 404, json: async () => ({}) }),
+    dismissTranscriptionResult: vi.fn().mockResolvedValue({ status: 200 }),
+  },
+}));
+
+vi.mock('../../src/config/store', () => ({
+  getConfig: (...args: unknown[]) => mockGetConfig(...args),
+  setConfig: vi.fn().mockResolvedValue(undefined),
+  getAuthToken: vi.fn().mockResolvedValue(null),
+  DEFAULT_SERVER_PORT: 7239,
+}));
+
+vi.mock('../../src/services/modelCapabilities', async () => {
+  const actual = await vi.importActual<typeof import('../../src/services/modelCapabilities')>(
+    '../../src/services/modelCapabilities',
+  );
+  return actual;
+});
+
+vi.mock('../../src/services/modelSelection', () => ({
+  isModelDisabled: () => false,
+}));
+
+vi.mock('../../src/hooks/useClipboard', () => ({ writeToClipboard: vi.fn() }));
+vi.mock('../../src/services/clientDebugLog', () => ({ logClientEvent: vi.fn() }));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../views/SessionImportTab', () => ({
+  SessionImportTab: () => React.createElement('div', { 'data-testid': 'session-import-tab' }),
+}));
+vi.mock('../PopOutWindow', () => ({ PopOutWindow: () => null }));
+vi.mock('../views/FullscreenVisualizer', () => ({ FullscreenVisualizer: () => null }));
+vi.mock('../AudioVisualizer', () => ({
+  AudioVisualizer: () => React.createElement('div', { 'data-testid': 'audio-visualizer' }),
+}));
+
+vi.mock('../../src/types/runtime', () => ({
+  isRuntimeProfile: (v: unknown) =>
+    ['gpu', 'cpu', 'vulkan', 'vulkan-wsl2', 'metal'].includes(v as string),
+}));
+
+import { SessionView } from '../views/SessionView';
+import { SessionTab } from '../../types';
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+}
+
+const baseLiveState = {
+  status: 'idle' as const,
+  sentences: [],
+  partial: '',
+  statusMessage: null,
+  error: null,
+  analyser: null,
+  muted: false,
+  start: vi.fn(),
+  stop: vi.fn(),
+  toggleMute: vi.fn(),
+  setGain: vi.fn(),
+  clearHistory: vi.fn(),
+  getText: vi.fn().mockReturnValue(''),
+};
+
+const baseProps = {
+  serverConnection: {
+    serverStatus: 'active' as const,
+    clientStatus: 'active' as const,
+    details: null,
+    serverLabel: 'Server ready',
+    reachable: true,
+    ready: true,
+    error: null,
+    gpuError: null,
+    gpuErrorRecoveryHint: null,
+    refresh: vi.fn(),
+  },
+  clientRunning: true,
+  setClientRunning: vi.fn(),
+  onStartServer: vi.fn().mockResolvedValue(undefined),
+  startupFlowPending: false,
+  isUploading: false,
+  live: baseLiveState,
+  sessionTab: SessionTab.MAIN,
+  onChangeSessionTab: vi.fn(),
+};
+
+function setPersistedLanguages(main: string | undefined, live?: string | undefined) {
+  mockGetConfig.mockImplementation((key: unknown) => {
+    if (key === 'session.mainLanguage') return Promise.resolve(main);
+    if (key === 'session.liveLanguage') return Promise.resolve(live);
+    return Promise.resolve(undefined);
+  });
+}
+
+function renderSessionView() {
+  return render(React.createElement(SessionView, baseProps), { wrapper: createWrapper() });
+}
+
+describe('SessionView - Greek final-sigma warning', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockModels.main = PARAKEET_MODEL;
+    mockModels.live = PARAKEET_MODEL;
+    setPersistedLanguages(undefined, undefined);
+
+    (window as any).electronAPI = {
+      config: {
+        get: vi.fn().mockResolvedValue(undefined),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+      docker: { readComposeEnvValue: vi.fn().mockResolvedValue('false') },
+      audio: {
+        listSinks: vi.fn().mockResolvedValue([]),
+        removeMonitorLoopback: vi.fn().mockResolvedValue(undefined),
+        disableSystemAudioLoopback: vi.fn().mockResolvedValue(undefined),
+      },
+      tray: { onAction: vi.fn().mockReturnValue(vi.fn()) },
+      notifications: { show: vi.fn() },
+    };
+  });
+
+  it('shows the warning when Greek is selected with a Parakeet main model', async () => {
+    setPersistedLanguages('Greek');
+
+    renderSessionView();
+
+    const warning = await screen.findByTestId('greek-sigma-warning-main');
+    expect(warning.textContent).toMatch(/final sigma|ς/);
+  });
+
+  it('does not warn for a Canary main model with Greek selected', async () => {
+    mockModels.main = CANARY_MODEL;
+    mockModels.live = CANARY_MODEL;
+    setPersistedLanguages('Greek');
+
+    renderSessionView();
+
+    // Wait for the persisted language to be applied, then assert absence.
+    await waitFor(() => {
+      expect(mockGetConfig).toHaveBeenCalledWith('session.mainLanguage');
+    });
+    expect(screen.queryByTestId('greek-sigma-warning-main')).toBeNull();
+  });
+
+  it('does not warn when a non-Greek language is selected', async () => {
+    setPersistedLanguages('English');
+
+    renderSessionView();
+
+    await waitFor(() => {
+      expect(mockGetConfig).toHaveBeenCalledWith('session.mainLanguage');
+    });
+    expect(screen.queryByTestId('greek-sigma-warning-main')).toBeNull();
+  });
+
+  it('shows the live warning when the live language is Greek on a Parakeet live model', async () => {
+    setPersistedLanguages('English', 'Greek');
+
+    renderSessionView();
+
+    const warning = await screen.findByTestId('greek-sigma-warning-live');
+    expect(warning.textContent).toMatch(/final sigma|ς/);
+  });
+});

--- a/dashboard/components/__tests__/SessionView.test.tsx
+++ b/dashboard/components/__tests__/SessionView.test.tsx
@@ -151,6 +151,8 @@ vi.mock('../../src/services/modelCapabilities', () => ({
   supportsAutoDetect: () => true,
   pickDefaultLanguage: (options: string[]) =>
     options.includes('English') ? 'English' : (options[0] ?? 'Auto Detect'),
+  // Whisper models have full Greek support - no final-sigma warning surface.
+  truncatesGreekFinalSigma: () => false,
   CANARY_TRANSLATION_TARGETS: [],
 }));
 

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -58,6 +58,7 @@ import {
   isWhisperCppModel,
   pickDefaultLanguage,
   supportsAutoDetect,
+  truncatesGreekFinalSigma,
   CANARY_TRANSLATION_TARGETS,
 } from '../../src/services/modelCapabilities';
 import { isModelDisabled } from '../../src/services/modelSelection';
@@ -1805,6 +1806,35 @@ export const SessionView: React.FC<SessionViewProps> = ({
                             <span>{recordingDisabledReason}</span>
                           </div>
                         )}
+                      {/* NeMo Parakeet tokenizers lack ς (U+03C2) and silently
+                        truncate Greek word endings; Canary is auto-repaired
+                        server-side. See modelCapabilities.truncatesGreekFinalSigma. */}
+                      {truncatesGreekFinalSigma(activeModel) && mainLanguage === 'Greek' && (
+                        <div
+                          data-testid="greek-sigma-warning-main"
+                          className="flex items-start gap-2 rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-300"
+                        >
+                          <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+                          <span>
+                            This model cannot write the Greek final sigma (ς): word endings will be
+                            truncated ("σας" becomes "σα"). Prefer a Canary or Whisper model for
+                            Greek.
+                          </span>
+                        </div>
+                      )}
+                      {truncatesGreekFinalSigma(activeLiveModel) && liveLanguage === 'Greek' && (
+                        <div
+                          data-testid="greek-sigma-warning-live"
+                          className="flex items-start gap-2 rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-300"
+                        >
+                          <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+                          <span>
+                            The live model cannot write the Greek final sigma (ς): live Greek
+                            transcripts will have truncated word endings. Prefer a Whisper live
+                            model for Greek.
+                          </span>
+                        </div>
+                      )}
                       <div className="flex items-center gap-2">
                         {canStartRecording ? (
                           <Button

--- a/dashboard/src/services/modelCapabilities.test.ts
+++ b/dashboard/src/services/modelCapabilities.test.ts
@@ -13,6 +13,7 @@ import {
   supportsAutoDetect,
   supportsTranslation,
   supportsDiarization,
+  truncatesGreekFinalSigma,
   NEMO_LANGUAGES,
   CANARY_TRANSLATION_TARGETS,
   SENSEVOICE_LANGUAGES,
@@ -547,5 +548,30 @@ describe('supportsAutoDetect', () => {
     expect(supportsAutoDetect(null)).toBe(true);
     expect(supportsAutoDetect(undefined)).toBe(true);
     expect(supportsAutoDetect('')).toBe(true);
+  });
+});
+
+describe('truncatesGreekFinalSigma', () => {
+  it('returns true for NVIDIA Parakeet models (silent final-sigma drop)', () => {
+    expect(truncatesGreekFinalSigma('nvidia/parakeet-tdt-0.6b-v3')).toBe(true);
+  });
+
+  it('returns true for nemotron-speech models (same NeMo tokenizer defect)', () => {
+    expect(truncatesGreekFinalSigma('nvidia/nemotron-speech-streaming-en-0.6b')).toBe(true);
+  });
+
+  it('returns true for MLX Parakeet ports', () => {
+    expect(truncatesGreekFinalSigma('mlx-community/parakeet-tdt-0.6b-v3')).toBe(true);
+  });
+
+  it('returns false for Canary models (server repairs their unk marker)', () => {
+    expect(truncatesGreekFinalSigma('nvidia/canary-1b-v2')).toBe(false);
+    expect(truncatesGreekFinalSigma('Mediform/canary-1b-v2-mlx-q8')).toBe(false);
+  });
+
+  it('returns false for Whisper models and empty values', () => {
+    expect(truncatesGreekFinalSigma('large-v3')).toBe(false);
+    expect(truncatesGreekFinalSigma(null)).toBe(false);
+    expect(truncatesGreekFinalSigma(undefined)).toBe(false);
   });
 });

--- a/dashboard/src/services/modelCapabilities.ts
+++ b/dashboard/src/services/modelCapabilities.ts
@@ -140,6 +140,22 @@ export function isMLXCanaryModel(modelName: string | null | undefined): boolean 
 }
 
 /**
+ * Returns true when the model visibly truncates the Greek final sigma (ς).
+ *
+ * NVIDIA's NeMo models were trained with SentencePiece vocabularies that lack
+ * U+03C2 entirely (upstream defect, unacknowledged:
+ * https://huggingface.co/nvidia/canary-1b-v2/discussions/26). Parakeet-family
+ * models (including nemotron-speech and the MLX Parakeet ports) silently drop
+ * the character with no recoverable trace, so Greek word endings come out
+ * truncated ("σας" becomes "σα"). Canary models share the tokenizer defect but
+ * emit a recoverable unk marker that the server repairs automatically, so they
+ * are excluded here.
+ */
+export function truncatesGreekFinalSigma(modelName: string | null | undefined): boolean {
+  return isParakeetModel(modelName) || isMLXParakeetModel(modelName);
+}
+
+/**
  * Returns true if the model should run on the faster-whisper/Whisper backend.
  * Unknown or empty values are treated as Whisper-compatible defaults.
  */

--- a/docs/project-context.md
+++ b/docs/project-context.md
@@ -275,6 +275,7 @@ durability:
 - **Python 3.13 lhotse patch**: `_patch_sampler_for_python313()` in ParakeetBackend — required for NeMo compatibility
 - **VibeVoice OOM**: `DEFAULT_MAX_CHUNK_DURATION_S = 60` (1 minute) — was 600s, caused CUDA OOM on 12GB GPU. Never increase without GPU memory testing
 - **NeMo requires `INSTALL_NEMO=true`** env var in Docker — not installed by default
+- **NeMo Greek final sigma (ς)**: canary-1b-v2 and parakeet-tdt-0.6b-v3 tokenizers lack U+03C2 entirely (upstream defect, huggingface.co/nvidia/canary-1b-v2/discussions/26). Canary emits a recoverable " ⁇ " unk marker, repaired in `core/stt/greek_sigma.py` when the output language is `el`; Parakeet emits nothing (irrecoverable), so the backend logs a warning and the dashboard warns on Greek + Parakeet. Do NOT try to fix Parakeet by rewriting word-final σ to ς: the model never emits a trailing σ, the letter is simply gone
 - **SenseVoice (FunASR) requires `INSTALL_FUNASR=true`** env var in Docker — not installed by default; Linux/NVIDIA only
 
 #### GPU Crash Resilience

--- a/server/backend/core/stt/backends/canary_backend.py
+++ b/server/backend/core/stt/backends/canary_backend.py
@@ -26,6 +26,7 @@ from server.core.stt.backends.parakeet_backend import (
     SAMPLE_RATE,
     ParakeetBackend,
 )
+from server.core.stt.greek_sigma import repair_segments_greek_final_sigma
 
 logger = logging.getLogger(__name__)
 
@@ -139,20 +140,30 @@ class CanaryBackend(ParakeetBackend):
                 source_lang=source_lang,
                 target_lang=target_lang,
             )
-            return self._transcribe_long(
+            segments, info = self._transcribe_long(
                 audio,
                 word_timestamps=word_timestamps,
                 transcribe_fn=canary_fn,
                 language=source_lang,
                 progress_callback=progress_callback,
             )
+        else:
+            segments, info = self._transcribe_short_canary(
+                audio,
+                source_lang=source_lang,
+                target_lang=target_lang,
+                word_timestamps=word_timestamps,
+            )
 
-        return self._transcribe_short_canary(
-            audio,
-            source_lang=source_lang,
-            target_lang=target_lang,
-            word_timestamps=word_timestamps,
-        )
+        # Canary's tokenizer has no ς (U+03C2): the model emits <unk> at every
+        # Greek final-sigma position, rendered as " ⁇ " in the decoded text.
+        # Deterministically restore the sigma whenever Greek is the OUTPUT
+        # language (el transcription, or translation into el). See
+        # greek_sigma.py and https://huggingface.co/nvidia/canary-1b-v2/discussions/26
+        if target_lang == "el":
+            segments = repair_segments_greek_final_sigma(segments)
+
+        return segments, info
 
     def supports_translation(self) -> bool:
         return True

--- a/server/backend/core/stt/backends/mlx_canary_backend.py
+++ b/server/backend/core/stt/backends/mlx_canary_backend.py
@@ -37,6 +37,7 @@ from server.core.stt.backends.base import (
     STTBackend,
 )
 from server.core.stt.backends.mlx_thread_pin import MLXThreadAffinityMixin, mlx_pinned
+from server.core.stt.greek_sigma import repair_greek_final_sigma
 
 SAMPLE_RATE = 16000
 
@@ -436,9 +437,16 @@ class MLXCanaryBackend(MLXThreadAffinityMixin, STTBackend):
                     logger.debug("mlx cache clear failed (non-critical)", exc_info=True)
 
             if isinstance(text, str) and text.strip():
+                chunk_text = text.strip()
+                if lang_code == "el":
+                    # Same canary-1b-v2 weights as the NVIDIA backend: the
+                    # tokenizer has no ς (U+03C2) and renders it as an unk
+                    # marker. No-op when the marker is absent. Unverified on
+                    # Metal hardware - see greek_sigma.py.
+                    chunk_text = repair_greek_final_sigma(chunk_text)
                 segments.append(
                     BackendSegment(
-                        text=text.strip(),
+                        text=chunk_text,
                         start=chunk_start_s,
                         end=chunk_end_s,
                         words=[],

--- a/server/backend/core/stt/backends/parakeet_backend.py
+++ b/server/backend/core/stt/backends/parakeet_backend.py
@@ -99,6 +99,7 @@ class ParakeetBackend(STTBackend):
         self._warmup_complete: bool = False
         self._warmup_thread: threading.Thread | None = None
         self._max_chunk_duration_s: int = MAX_CHUNK_DURATION
+        self._greek_sigma_warning_logged: bool = False
 
     @staticmethod
     def _find_cached_nemo_file(model_name: str) -> str | None:
@@ -464,6 +465,19 @@ class ParakeetBackend(STTBackend):
         del audio_sample_rate
         if self._model is None:
             raise RuntimeError("Parakeet model is not loaded")
+
+        # Parakeet's tokenizer has no ς (U+03C2) and, unlike Canary, the model
+        # emits nothing at Greek final-sigma positions - word endings are
+        # silently truncated ("σας" -> "σα") and cannot be restored from the
+        # token stream. Upstream defect, unacknowledged:
+        # https://huggingface.co/nvidia/canary-1b-v2/discussions/26
+        if language == "el" and not self._greek_sigma_warning_logged:
+            logger.warning(
+                "Parakeet cannot write the Greek final sigma (ς): its tokenizer "
+                "lacks U+03C2, so Greek word endings are silently truncated. "
+                "Prefer a Canary (auto-repaired) or Whisper model for Greek."
+            )
+            self._greek_sigma_warning_logged = True
 
         # Wait for warmup to complete if it's still running
         if not self._warmup_complete:

--- a/server/backend/core/stt/greek_sigma.py
+++ b/server/backend/core/stt/greek_sigma.py
@@ -1,0 +1,119 @@
+"""Repair of the Greek final sigma (ς) in NeMo Canary transcription output.
+
+``nvidia/canary-1b-v2`` and ``nvidia/parakeet-tdt-0.6b-v3`` were trained with
+SentencePiece vocabularies that do not contain U+03C2 (ς) - NVIDIA's Granary
+data pipeline folded every word-final sigma away before the tokenizer was
+trained, so ς encodes to ``<unk>`` (id 0) and the models cannot write it.
+Upstream defect report (open, unanswered):
+https://huggingface.co/nvidia/canary-1b-v2/discussions/26
+
+The two model families fail differently:
+
+* **Canary (AED)** emits the ``<unk>`` token at each final-sigma position and
+  SentencePiece renders it as " ⁇ " (U+2047) in the decoded text. That marker
+  deterministically locates the missing ς, so it can be repaired here.
+* **Parakeet (RNNT/TDT)** emits nothing at those positions - the sigma is
+  unrecoverable, so its backend only logs a warning for Greek requests.
+
+The repair is deliberately conservative: a marker is rewritten to ς only when
+it directly follows a Greek letter (ς is word-final only, so it always follows
+one). Markers in any other position are left untouched.
+"""
+
+from __future__ import annotations
+
+import re
+
+from server.core.stt.backends.base import BackendSegment
+
+# SentencePiece's default unk_surface is " ⁇ " (U+2047), stripped here to the
+# bare marker character.
+_UNK_MARKER = "⁇"
+
+# Greek and Greek Extended letter ranges - a final sigma can only ever follow
+# one of these. U+037E (Greek question mark) and U+0387 (ano teleia) are
+# punctuation inside the Greek block and are excluded.
+_GREEK_LETTER = "Ͱ-ͽͿ-ΆΈ-Ͽἀ-῿"
+
+# A marker after a Greek letter, optionally followed by trailing punctuation
+# that SentencePiece rendered space-separated ("σα ⁇ !" -> "σας!"). When the
+# optional punctuation group does not match, following whitespace is left in
+# place and collapsed afterwards ("Αυτέ ⁇  οι" -> "Αυτές οι").
+_MARKER_AFTER_GREEK = re.compile(rf"(?<=[{_GREEK_LETTER}])\s*{_UNK_MARKER}(?:\s*([.,!;:·»”’)\]]))?")
+_MULTI_SPACE = re.compile(r" {2,}")
+
+# Word-timestamp entries containing only punctuation (the unk token splits
+# canary's word grouping, leaving e.g. "!" as its own entry).
+_PUNCT_ONLY = re.compile(r"^[.,!;:·»”’)\]]+$")
+_ENDS_WITH_GREEK = re.compile(rf"[{_GREEK_LETTER}]$")
+
+
+def repair_greek_final_sigma(text: str) -> str:
+    """Restore final sigmas in Canary text output for Greek.
+
+    Returns the input unchanged when it contains no unk marker.
+    """
+    if _UNK_MARKER not in text:
+        return text
+    repaired = _MARKER_AFTER_GREEK.sub(lambda m: "ς" + (m.group(1) or ""), text)
+    return _MULTI_SPACE.sub(" ", repaired)
+
+
+def _repair_words(words: list[dict]) -> list[dict]:
+    """Merge marker-only word entries into their preceding Greek word.
+
+    A repaired word absorbs the marker entry's end time, plus one directly
+    following punctuation-only entry (matching canary's usual attached-
+    punctuation rendering, e.g. "κόσμο.").
+    """
+    repaired: list[dict] = []
+    absorb_punct = False
+    for entry in words:
+        token = str(entry.get("word", "")).strip()
+
+        if (
+            token == _UNK_MARKER
+            and repaired
+            and _ENDS_WITH_GREEK.search(str(repaired[-1].get("word", "")))
+        ):
+            prev = repaired[-1]
+            repaired[-1] = {
+                **prev,
+                "word": str(prev.get("word", "")) + "ς",
+                "end": entry.get("end", prev.get("end")),
+            }
+            absorb_punct = True
+            continue
+
+        if absorb_punct and _PUNCT_ONLY.match(token):
+            prev = repaired[-1]
+            repaired[-1] = {
+                **prev,
+                "word": str(prev.get("word", "")) + token,
+                "end": entry.get("end", prev.get("end")),
+            }
+            absorb_punct = False
+            continue
+
+        absorb_punct = False
+        repaired.append(dict(entry))
+
+    return repaired
+
+
+def repair_segments_greek_final_sigma(
+    segments: list[BackendSegment],
+) -> list[BackendSegment]:
+    """Return new segments with text and word entries repaired.
+
+    Input segments are not mutated.
+    """
+    return [
+        BackendSegment(
+            text=repair_greek_final_sigma(segment.text),
+            start=segment.start,
+            end=segment.end,
+            words=_repair_words(segment.words),
+        )
+        for segment in segments
+    ]

--- a/server/backend/tests/test_greek_sigma_repair.py
+++ b/server/backend/tests/test_greek_sigma_repair.py
@@ -1,0 +1,259 @@
+"""Tests for the Greek final-sigma (ς) repair applied to NeMo Canary output.
+
+``nvidia/canary-1b-v2`` and ``nvidia/parakeet-tdt-0.6b-v3`` were trained with
+SentencePiece vocabularies that do not contain U+03C2 (ς). Every Greek
+word-final sigma in their training targets became ``<unk>`` (id 0), so the
+models cannot write ς at all (upstream defect, unacknowledged: HF discussion
+https://huggingface.co/nvidia/canary-1b-v2/discussions/26).
+
+Canary (AED) still *emits* that ``<unk>`` token at each final-sigma position
+and SentencePiece renders it as " ⁇ " (U+2047) in the decoded text - a
+deterministic marker we can map back to ς. Parakeet (RNNT/TDT) emits nothing
+recoverable, so it only gets a server-side warning.
+
+Every Greek fixture string below is a verbatim canary-1b-v2 output captured
+from real inference on Greek audio (see PR for the capture methodology).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pytest
+from server.core.stt.backends.base import BackendSegment, BackendTranscriptionInfo
+from server.core.stt.backends.canary_backend import CanaryBackend
+from server.core.stt.backends.parakeet_backend import SAMPLE_RATE, ParakeetBackend
+from server.core.stt.greek_sigma import (
+    repair_greek_final_sigma,
+    repair_segments_greek_final_sigma,
+)
+
+# ---------------------------------------------------------------------------
+# Text-level repair
+# ---------------------------------------------------------------------------
+
+
+class TestRepairGreekFinalSigmaText:
+    def test_marker_before_exclamation(self):
+        assert repair_greek_final_sigma("Καλησπέρα σα ⁇ !") == "Καλησπέρα σας!"
+
+    def test_markers_between_words_double_spaced(self):
+        # Plain hypothesis.text rendering: double space after the marker.
+        raw = "Αυτέ ⁇  οι λέξει ⁇  έχουν πολλέ ⁇  καταλήξει ⁇ ."
+        assert repair_greek_final_sigma(raw) == "Αυτές οι λέξεις έχουν πολλές καταλήξεις."
+
+    def test_marker_before_comma(self):
+        raw = "Τι κάνει ⁇ , που πηγαίνει ⁇ , ίσω ⁇  αύριο"
+        assert repair_greek_final_sigma(raw) == "Τι κάνεις, που πηγαίνεις, ίσως αύριο"
+
+    def test_marker_at_end_of_text(self):
+        assert repair_greek_final_sigma("ο καιρός είναι καλό ⁇") == "ο καιρός είναι καλός"
+
+    def test_single_spaced_segment_timestamp_rendering(self):
+        # Segment-timestamp texts render with single spaces around the marker.
+        raw = "ένα ⁇ καλό ⁇ φίλο ⁇ ."
+        assert repair_greek_final_sigma(raw) == "ένας καλός φίλος."
+
+    def test_greek_without_marker_unchanged(self):
+        assert repair_greek_final_sigma("Καλημέρα σας.") == "Καλημέρα σας."
+
+    def test_english_with_marker_unchanged(self):
+        assert repair_greek_final_sigma("Hello ⁇ world") == "Hello ⁇ world"
+
+    def test_marker_after_digits_unchanged(self):
+        assert repair_greek_final_sigma("123 ⁇") == "123 ⁇"
+
+    def test_empty_string(self):
+        assert repair_greek_final_sigma("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Segment-level repair (text + word timestamp entries)
+# ---------------------------------------------------------------------------
+
+
+def _word(text: str, start: float, end: float, probability: float = 1.0) -> dict:
+    return {"word": text, "start": start, "end": end, "probability": probability}
+
+
+class TestRepairSegments:
+    def test_marker_word_merged_into_previous_word(self):
+        # Verbatim word entries: "σα" [0.96-1.04], "⁇" [1.04-1.12], "!" [1.12-1.2]
+        seg = BackendSegment(
+            text="Καλησπέρα σα ⁇ !",
+            start=0.0,
+            end=1.2,
+            words=[
+                _word("Καλησπέρα", 0.0, 0.96),
+                _word("σα", 0.96, 1.04, probability=0.9),
+                _word("⁇", 1.04, 1.12),
+                _word("!", 1.12, 1.2),
+            ],
+        )
+
+        (repaired,) = repair_segments_greek_final_sigma([seg])
+
+        assert repaired.text == "Καλησπέρα σας!"
+        assert [w["word"] for w in repaired.words] == ["Καλησπέρα", "σας!"]
+        merged = repaired.words[1]
+        assert merged["start"] == 0.96
+        assert merged["end"] == 1.2  # extended over the marker and the "!"
+        assert merged["probability"] == 0.9  # keeps the original word's confidence
+
+    def test_marker_without_following_punctuation(self):
+        # Verbatim pattern: "ένα" "⁇" "καλό" "⁇" "φίλο" "⁇" "."
+        seg = BackendSegment(
+            text="ένα ⁇ καλό ⁇ φίλο ⁇ .",
+            start=7.52,
+            end=8.8,
+            words=[
+                _word("ένα", 7.52, 7.6),
+                _word("⁇", 7.68, 7.76),
+                _word("καλό", 7.76, 7.84),
+                _word("⁇", 8.08, 8.16),
+                _word("φίλο", 8.32, 8.64),
+                _word("⁇", 8.64, 8.72),
+                _word(".", 8.72, 8.8),
+            ],
+        )
+
+        (repaired,) = repair_segments_greek_final_sigma([seg])
+
+        assert repaired.text == "ένας καλός φίλος."
+        assert [w["word"] for w in repaired.words] == ["ένας", "καλός", "φίλος."]
+        assert repaired.words[0]["end"] == 7.76
+        assert repaired.words[2]["end"] == 8.8
+
+    def test_leading_marker_left_untouched(self):
+        # No previous Greek word to attach to - conservative: keep the entry.
+        seg = BackendSegment(
+            text="⁇ καλημέρα",
+            start=0.0,
+            end=1.0,
+            words=[_word("⁇", 0.0, 0.1), _word("καλημέρα", 0.1, 1.0)],
+        )
+
+        (repaired,) = repair_segments_greek_final_sigma([seg])
+
+        assert [w["word"] for w in repaired.words] == ["⁇", "καλημέρα"]
+
+    def test_input_segments_not_mutated(self):
+        seg = BackendSegment(
+            text="σα ⁇ !",
+            start=0.0,
+            end=1.0,
+            words=[_word("σα", 0.0, 0.5), _word("⁇", 0.5, 0.8), _word("!", 0.8, 1.0)],
+        )
+
+        repair_segments_greek_final_sigma([seg])
+
+        assert seg.text == "σα ⁇ !"
+        assert [w["word"] for w in seg.words] == ["σα", "⁇", "!"]
+        assert seg.words[0]["end"] == 0.5
+
+
+# ---------------------------------------------------------------------------
+# CanaryBackend gating: repair only when the OUTPUT language is Greek
+# ---------------------------------------------------------------------------
+
+
+def _fake_short_canary(captured: dict):
+    """Build a _transcribe_short_canary replacement returning marked segments."""
+
+    def fake(self, audio, *, source_lang, target_lang, word_timestamps=True):
+        captured["source_lang"] = source_lang
+        captured["target_lang"] = target_lang
+        segments = [
+            BackendSegment(
+                text="Καλησπέρα σα ⁇ !",
+                start=0.0,
+                end=1.2,
+                words=[
+                    _word("σα", 0.96, 1.04),
+                    _word("⁇", 1.04, 1.12),
+                    _word("!", 1.12, 1.2),
+                ],
+            )
+        ]
+        info = BackendTranscriptionInfo(language=source_lang, language_probability=1.0)
+        return segments, info
+
+    return fake
+
+
+class TestCanaryBackendGreekRepairGating:
+    @pytest.fixture()
+    def backend(self, monkeypatch):
+        b = CanaryBackend()
+        b._model = object()  # bypass the not-loaded guard
+        self.captured: dict = {}
+        monkeypatch.setattr(
+            CanaryBackend, "_transcribe_short_canary", _fake_short_canary(self.captured)
+        )
+        return b
+
+    def _run(self, backend, **kwargs):
+        audio = np.zeros(SAMPLE_RATE, dtype=np.float32)
+        segments, _info = backend.transcribe(audio, **kwargs)
+        return segments
+
+    def test_greek_transcription_is_repaired(self, backend):
+        segments = self._run(backend, language="el", task="transcribe")
+        assert segments[0].text == "Καλησπέρα σας!"
+        assert [w["word"] for w in segments[0].words] == ["σας!"]
+
+    def test_english_transcription_untouched(self, backend):
+        segments = self._run(backend, language="en", task="transcribe")
+        assert segments[0].text == "Καλησπέρα σα ⁇ !"
+
+    def test_translation_into_greek_is_repaired(self, backend):
+        segments = self._run(
+            backend,
+            language="en",
+            task="translate",
+            translation_target_language="el",
+        )
+        assert self.captured["target_lang"] == "el"
+        assert segments[0].text == "Καλησπέρα σας!"
+
+    def test_translation_out_of_greek_untouched(self, backend):
+        segments = self._run(backend, language="el", task="translate")
+        assert self.captured["target_lang"] == "en"
+        assert segments[0].text == "Καλησπέρα σα ⁇ !"
+
+
+# ---------------------------------------------------------------------------
+# ParakeetBackend: unrepairable - must warn once per instance for Greek
+# ---------------------------------------------------------------------------
+
+
+class TestParakeetGreekWarning:
+    @pytest.fixture()
+    def backend(self, monkeypatch):
+        b = ParakeetBackend()
+        b._model = object()
+        b._warmup_complete = True
+
+        def fake_short(self, audio, *, word_timestamps=True, language=None):
+            info = BackendTranscriptionInfo(language=language or "en")
+            return [], info
+
+        monkeypatch.setattr(ParakeetBackend, "_transcribe_short", fake_short)
+        return b
+
+    def test_greek_request_logs_warning_once(self, backend, caplog):
+        audio = np.zeros(SAMPLE_RATE, dtype=np.float32)
+        with caplog.at_level(logging.WARNING):
+            backend.transcribe(audio, language="el")
+            backend.transcribe(audio, language="el")
+
+        sigma_warnings = [r for r in caplog.records if "ς" in r.getMessage()]
+        assert len(sigma_warnings) == 1
+
+    def test_non_greek_request_does_not_warn(self, backend, caplog):
+        audio = np.zeros(SAMPLE_RATE, dtype=np.float32)
+        with caplog.at_level(logging.WARNING):
+            backend.transcribe(audio, language="en")
+
+        assert not [r for r in caplog.records if "ς" in r.getMessage()]

--- a/server/backend/tests/test_mlx_canary_backend.py
+++ b/server/backend/tests/test_mlx_canary_backend.py
@@ -436,3 +436,27 @@ class TestMLXCanaryResampling:
         # First positional arg is a temp file path (str) — audio conversion is
         # implicit before sf.write; no dtype assertion needed on the path itself.
         assert isinstance(segments, list)
+
+
+# ---------------------------------------------------------------------------
+# Greek final-sigma repair (shared canary-1b-v2 tokenizer defect)
+# ---------------------------------------------------------------------------
+
+
+class TestGreekFinalSigmaRepair:
+    """canary-1b-v2 cannot emit ς (U+03C2); its unk marker must be repaired
+    for Greek output. See server/core/stt/greek_sigma.py."""
+
+    def test_greek_output_is_repaired(self) -> None:
+        backend, _, _ = _loaded_backend("Καλησπέρα σα ⁇ !")
+
+        segments, _ = backend.transcribe(np.zeros(16000, dtype=np.float32), language="el")
+
+        assert segments[0].text == "Καλησπέρα σας!"
+
+    def test_non_greek_output_untouched(self) -> None:
+        backend, _, _ = _loaded_backend("Hello ⁇ world.")
+
+        segments, _ = backend.transcribe(np.zeros(16000, dtype=np.float32), language="en")
+
+        assert segments[0].text == "Hello ⁇ world."


### PR DESCRIPTION
## Problem

Greek transcriptions from `nvidia/canary-1b-v2` and `nvidia/parakeet-tdt-0.6b-v3` are missing every word-final sigma: «σας» comes out «σα», «λέξεις» comes out «λέξει». Since ~30% of Greek words end in ς, every Greek transcript is systematically damaged.

## Root cause (verified, upstream)

Both models ship SentencePiece vocabularies that **do not contain U+03C2 (ς) at all** (0 tokens, vs 132/60 tokens containing medial σ). Encoding ς yields `<unk>` (id 0), so NVIDIA's Granary training pipeline turned every Greek final sigma in the training targets into `<unk>` and the models never learned to write the letter. Verified locally by:

1. Extracting the tokenizers from both cached `.nemo` archives and round-tripping Greek text (`sp.encode('ς')` yields unk id 0 in both).
2. Running both models on synthesized Greek audio inside the server image (GPU):
   - **Parakeet** (RNNT/TDT): emits *nothing* at ς positions - `y_sequence` contains no unk, the letter is simply absent. Unrecoverable.
   - **Canary** (AED): emits the `<unk>` token at **every** ς position (12/12 across two test clips), rendered by SentencePiece as ` ⁇ ` (U+2047): `'Καλησπέρα σα ⁇ ! Αυτέ ⁇  οι λέξει ⁇ …'`. Deterministically recoverable.
3. Additional probes: the Greek question mark `;` is substituted with `,` (never unk), missing accented capitals are lowercased (Ίσως → ίσω ⁇), and rare missing mid-word diacritics (ΐ) drop silently - so a word-final marker after a Greek letter means ς with no observed exceptions.

This is a known, open, unanswered upstream report: https://huggingface.co/nvidia/canary-1b-v2/discussions/26 (also affects Nemotron Speech). No official fix or workaround exists.

## Fix

- **`server/core/stt/greek_sigma.py`** (new): conservative, deterministic repair - rewrites `Greek-letter + ⁇` to ς (with spacing/punctuation tightening), and merges marker-only word-timestamp entries into the preceding word (extending its end time, absorbing one trailing punctuation-only entry). No-op on text without the marker; markers not preceded by a Greek letter are left untouched.
- **`CanaryBackend.transcribe`**: applies the repair whenever the *output* language is Greek (el transcription and en→el translation; el→en is untouched).
- **`MLXCanaryBackend`**: same repair for el (same canary-1b-v2 weights; unverified on Metal hardware, but a guaranteed no-op when the marker is absent).
- **`ParakeetBackend`**: nothing to recover, so it logs a once-per-instance warning for Greek requests.
- **Dashboard**: new `truncatesGreekFinalSigma()` in `modelCapabilities` (Parakeet + nemotron-speech + MLX Parakeet; Canary excluded since the server repairs it) and amber warnings in SessionView when Greek is selected with such a main or live model, recommending Canary or Whisper for Greek.
- **Docs**: gotcha entry in `docs/project-context.md` (including why a word-final σ→ς regex can never fix Parakeet: the model emits no σ at all).

Not covered (deliberately): Parakeet output cannot be repaired (no marker, and Greek's most frequent truncations like τις→τι collapse onto valid words, so no dictionary rule is safe); the secondary language pickers (Import tab, Notebook, AddNote) don't show the UI warning - the server-side Canary repair covers those paths automatically and Parakeet logs server-side.

## Tests

- 19 new backend tests (`test_greek_sigma_repair.py`): text repair fixtures taken **verbatim** from captured model output, segment/word-entry merging, immutability, Canary gating across all four language/task combinations, Parakeet warn-once behavior. Full backend suite: **2194 passed, 4 skipped**.
- MLX Canary repair gating tests (skipped on Linux, run where mlx is installed).
- Dashboard: `truncatesGreekFinalSigma` unit tests + `SessionView.greek-sigma.test.tsx` (warning shown for Parakeet+Greek main/live, absent for Canary or non-Greek). Full dashboard suite: **1879 passed** (the single unhandled `scrollIntoView` jsdom error reproduces identically on main). Typecheck, eslint, ruff, and `ui:contract:check` all green.

## Manual smoke test (needs GPU desktop)

1. Start the server with Canary as main transcriber, record Greek speech, and confirm final sigmas are present and no ` ⁇ ` marks remain.
2. Repeat with word timestamps + diarization to confirm merged word entries behave.
3. Select Parakeet + Greek in the Session tab and confirm the amber warning appears (and again for the live model row).
4. Canary en→el translation: confirm sigmas in the Greek output.