### PR TITLE
fix(tests): restore whisper.cpp backend test speed - stub the sidecar /health poll (backend job ~24m -> ~3m)

### DIFF
--- a/server/backend/tests/test_whispercpp_backend.py
+++ b/server/backend/tests/test_whispercpp_backend.py
@@ -133,6 +133,14 @@ def mock_httpx():
     ):
         # Reachable via _inf(); keeps the 70-odd existing call sites unchanged.
         mock_client.post_inference = mock_post_inference
+        # /load polls GET /health via this same client BEFORE the /load POST
+        # (WhisperCppBackend._wait_for_sidecar_ready). Model a sidecar that is
+        # already ready so the poll returns on its first attempt. WITHOUT this,
+        # client.get() returns a bare MagicMock whose .status_code is never 200,
+        # so every load() burns the full _SIDECAR_READY_TIMEOUT_WARM (~16s) — the
+        # gap that once blew this file's suite from seconds to ~21 minutes on CI.
+        # test_healthy_sidecar_load_does_not_block_on_health_poll pins this seam.
+        mock_client.get.return_value = MagicMock(status_code=200)
         yield mock_client
 
 
@@ -593,6 +601,40 @@ class TestLifecycle:
             with pytest.raises(RuntimeError):
                 backend.load("ggml-base.bin", "cpu")
         assert backend._client is None
+
+    def test_healthy_sidecar_load_does_not_block_on_health_poll(
+        self, backend: WhisperCppBackend, mock_httpx: MagicMock
+    ):
+        """Regression guard (perf): a healthy /health poll returns on the first
+        attempt and load() must never sleep.
+
+        ``load()`` calls ``_wait_for_sidecar_ready()``, which polls
+        ``GET /health`` via the sync client until it returns 200 or the warm
+        deadline (``_SIDECAR_READY_TIMEOUT_WARM``) elapses, sleeping
+        ``_SIDECAR_HEALTH_POLL_INTERVAL`` between attempts. If the ``mock_httpx``
+        fixture stops stubbing ``.get`` healthy — or a refactor adds an
+        un-stubbed poll seam — ``client.get()`` returns a bare MagicMock whose
+        ``.status_code`` is never 200, so every ``load()`` burns the full ~16s
+        warm budget. That single gap once turned this file's suite from seconds
+        into ~21 minutes on CI (the whole backend job went 3m -> 24m). Pin both
+        the seam (poll goes through the mocked .get, hitting /health) and the
+        no-sleep fast path so the regression fails loudly and instantly.
+        """
+        mock_httpx.post.return_value = MagicMock(status_code=200)
+        with (
+            patch.dict("os.environ", {"WHISPERCPP_SERVER_URL": "http://test:8080"}),
+            patch("server.core.stt.backends.whispercpp_backend.time.sleep") as mock_sleep,
+        ):
+            backend.load("ggml-base.bin", "cpu")
+
+        assert backend.is_loaded()
+        # The readiness poll must have gone through the mocked .get seam.
+        mock_httpx.get.assert_called_once()
+        health_call = mock_httpx.get.call_args
+        health_url = health_call.args[0] if health_call.args else health_call.kwargs.get("url", "")
+        assert health_url.endswith("/health")
+        # A ready sidecar answers on the first poll, so load() must never sleep.
+        mock_sleep.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The **Backend Tests** CI job jumped from **~3 min to ~24 min**. The regression is entirely in test *execution* (install/lint/`uv sync` are ~1 min); the `Run tests` step alone took **23m07s** in [run 29599698308](https://github.com/homelab-00/TranscriptionSuite/actions/runs/29599698308).

### Root cause

Mining the timestamped CI log, **`tests/test_whispercpp_backend.py` accounted for 1281s (21.4 min)** of the run - 80 of its tests each took **exactly 16.0s**; every other test file was sub-second.

PR #235 (feat/vulkan-on-linux) added `WhisperCppBackend._wait_for_sidecar_ready()`, which polls `GET /health` via the sync client **before** the `/load` POST, sleeping `_SIDECAR_HEALTH_POLL_INTERVAL` (2s) between attempts until 200 or the warm deadline `_SIDECAR_READY_TIMEOUT_WARM` (15s) elapses.

The `mock_httpx` fixture only stubbed `.post` (that `.get`/`/health` seam did not exist when it was written). So `client.get()` returned a bare `MagicMock` whose `.status_code` is never `200`, and **every `load()`-calling test burned the full 15s warm deadline** (~16s wall: the deadline is checked before the sleep, so the last poll interval overshoots). ~80 parametrized `load()` tests x 16s ≈ 21 min.

The bug is in the **test harness, not production** - the 15s warm wait is deliberate and correct for a real deployment (it stops `/load` racing a still-starting sidecar). `tests/test_whispercpp_self_download.py` already dodged this by stubbing `_wait_for_sidecar_ready` directly; the big fixture was simply never updated for the new seam.

## Fix (test-only, +42 lines, one file)

1. **`mock_httpx` fixture** now stubs `mock_client.get.return_value = MagicMock(status_code=200)` - models a *ready* sidecar so the poll returns on its first attempt.
2. **New regression guard** `test_healthy_sidecar_load_does_not_block_on_health_poll` pins both the seam (the poll must reach `/health` through the mocked `.get`) and the no-sleep fast path (a ready sidecar answers on the first poll, so `time.sleep` is never called). It fails loudly and instantly if the fixture ever stops covering `.get` or a refactor adds another un-stubbed poll seam.

No production code changed.

## Verification

| Check | Before | After |
|-------|--------|-------|
| Guard test | FAIL 21.17s (`.get` called 9x; `sidecar not healthy after 15s` logged) | PASS 0.23s |
| `test_whispercpp_backend.py` (whole file) | ~1281s (~21 min) | **164 passed in 0.52s** |
| Full backend suite | ~24 min on CI | **2176 passed, 4 skipped in 36s** (local) |
| `ruff check tests/` (CI gate) | - | All checks passed |

## Test plan

- [x] Full backend suite green locally (build venv, from `server/backend/`)
- [x] ruff banned-API gate clean
- [x] CI **Backend Tests** job back to ~3 min