### PR TITLE
  fix(dashboard): point Windows Vulkan whisper-server pull to whisper-cpp-windows GHCR repo

### DIFF
--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -3702,7 +3702,7 @@ function ensureWhisperDirectories(): void {
  * GHCR OCI repo that hosts the whisper-server.exe Windows binary as a package
  * blob, pushed with:
  *
- *   oras push ghcr.io/homelab-00/whisper-server:latest \
+ *   oras push ghcr.io/homelab-00/whisper-cpp-windows:latest \
  *     --artifact-type application/vnd.transcriptionsuite.whisper-server \
  *     --annotation "org.opencontainers.image.source=https://github.com/homelab-00/TranscriptionSuite" \
  *     whisper-server/whisper-server.exe:application/vnd.microsoft.portable-executable
@@ -3711,7 +3711,7 @@ function ensureWhisperDirectories(): void {
  * image-source annotation and must be a *public* package so the app can pull
  * it anonymously.
  */
-const WHISPER_SERVER_BLOB_REPO = 'ghcr.io/homelab-00/whisper-server';
+const WHISPER_SERVER_BLOB_REPO = 'ghcr.io/homelab-00/whisper-cpp-windows';
 /**
  * Tag to pull. Each release is pushed as both `latest` and `vX.Y.Z`, so
  * `latest` always resolves to the newest binary.


### PR DESCRIPTION
  ## Summary

  Updates the GHCR repo that the dashboard pulls the Windows `whisper-server.exe`
  Vulkan binary from, moving it from `ghcr.io/homelab-00/whisper-server` to
  `ghcr.io/homelab-00/whisper-cpp-windows`.

  ## Changes

  - Renamed `WHISPER_SERVER_BLOB_REPO` in `dashboard/electron/dockerManager.ts`
    to the new `whisper-cpp-windows` repo path.
  - Updated the `oras push` example in the accompanying doc comment to match.

  ## Why

  The binary now lives under the `whisper-cpp-windows` package on GHCR. Without
  this change, the Windows Vulkan path pulls from a stale repo path.

  ## Notes

  - The target package must remain **public** so the app can pull it anonymously.
  - No functional/logic change beyond the repo path constant.