### PR TITLE
  fix(dashboard, stt): load a distinct Live Mode model on Windows Vulkan (vulkan-wsl2)

### DIFF
--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -972,6 +972,9 @@ export const SessionView: React.FC<SessionViewProps> = ({
             translationTarget: liveTranslateTarget,
             gracePeriodSeconds,
             systemAudio: isSystemAudio,
+            // vulkan-wsl2: relaunch the native whisper-server.exe onto the live
+            // model before connecting (no-op on other profiles / non-GGML models).
+            whisperServerModel: activeLiveModel ?? undefined,
             // Linux system audio: AudioCapture owns the loopback module
             // lifecycle via loopbackOwner (GH-230).
             monitorSinkName: isSystemAudio && isLinux ? sinkNameMap[sysDevice] : undefined,

--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -2461,11 +2461,26 @@ async function startContainer(options: StartContainerOptions): Promise<string> {
       composeEnv['WHISPERCPP_MODEL'] = whispercppModel;
       envUpdates['WHISPERCPP_MODEL'] = whispercppModel;
     }
+
+    // vulkan-wsl2 only: the whisper-server runs natively on the Windows host and
+    // serves a SINGLE model chosen at launch (`--model`). It cannot hot-swap via
+    // the containerised `/load` path — that receives an in-container `/models/...`
+    // path the native exe cannot open (different filesystem namespace), so a
+    // main→live model switch would fail to load. Instead Electron relaunches the
+    // exe with the new model (see `switchWhisperServerModel`), and this flag tells
+    // the backend to SKIP its own `/load` POST + container-side GGML download and
+    // simply wait for the (externally managed) sidecar to be healthy. The Linux
+    // `vulkan` profile keeps the containerised sidecar, whose `/load` works, so it
+    // must NOT get this flag.
+    const externalMgmt = runtimeProfile === 'vulkan-wsl2' ? '1' : '';
+    composeEnv['WHISPERCPP_EXTERNAL_MODEL_MGMT'] = externalMgmt;
+    envUpdates['WHISPERCPP_EXTERNAL_MODEL_MGMT'] = externalMgmt;
   } else {
     // Clear stale vulkan env vars from a previous profile switch so they
     // don't linger in the .env file.
     envUpdates['WHISPERCPP_SERVER_URL'] = '';
     envUpdates['WHISPERCPP_MODEL'] = '';
+    envUpdates['WHISPERCPP_EXTERNAL_MODEL_MGMT'] = '';
   }
   // Always clear MESA_D3D12_DEFAULT_ADAPTER_NAME — it was only used by the
   // now-retired containerised whisper-server sidecar (docker-compose.vulkan-wsl2.yml).
@@ -2537,6 +2552,11 @@ async function startContainer(options: StartContainerOptions): Promise<string> {
       await downloadGgmlModelToHost(ggmlFilename);
     }
     await launchWhisperServerNative(hostModelPath);
+    // Record what the native exe is now serving. `_whisperServerDefaultModel` is
+    // the main-transcription model to restore to after a Live Mode session that
+    // relaunched the exe onto a different live model (see switchWhisperServerModel).
+    _whisperServerDefaultModel = ggmlFilename;
+    _whisperServerCurrentModel = ggmlFilename;
   }
 
   const fileArgs = composeFileArgs(
@@ -2593,6 +2613,10 @@ async function stopContainer(): Promise<string> {
   await killExistingWhisperServer().catch((err) => {
     console.warn('[DockerManager] killExistingWhisperServer on stop failed:', err?.message ?? err);
   });
+  // The exe is gone — forget which model it was serving so a later
+  // switchWhisperServerModel() before the next start doesn't act on stale state.
+  _whisperServerDefaultModel = null;
+  _whisperServerCurrentModel = null;
   try {
     return await exec(await runtimeBin(), ['compose', 'stop'], { cwd: getComposeDir() });
   } catch (composeErr: any) {
@@ -3490,6 +3514,143 @@ async function hasVulkanWsl2SidecarImage(): Promise<boolean> {
 
 // ─── Native whisper-server.exe (vulkan-wsl2) ────────────────────────────────
 
+// The native exe serves ONE model, fixed at launch via `--model`. These track
+// what it is currently serving and what to restore to. `_default` is the
+// main-transcription model set at start; `_current` is whatever a Live Mode
+// switch last relaunched it onto. Both null when no exe is running.
+let _whisperServerDefaultModel: string | null = null;
+let _whisperServerCurrentModel: string | null = null;
+
+/**
+ * How long to wait for a freshly relaunched whisper-server.exe to start
+ * listening on :8080 before returning. This only covers the process/socket
+ * coming up — the backend separately waits for the model to finish loading onto
+ * the GPU (`_wait_for_sidecar_ready`), so we don't need to block that long here.
+ */
+const WHISPER_RELAUNCH_LISTEN_TIMEOUT_MS = 15_000;
+const WHISPER_RELAUNCH_LISTEN_POLL_MS = 250;
+
+// Hard ceiling on a host-side GGML download during a model switch. Generous
+// enough for a large model over a slow link, but bounded so a stalled
+// connection (electron `net.request` has no inactivity timeout of its own)
+// can't wedge the Live Mode start that awaits it.
+const WHISPER_MODEL_DOWNLOAD_TIMEOUT_MS = 10 * 60 * 1000;
+
+/** Reject with a labelled error if `promise` hasn't settled within `ms`. */
+async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out after ${ms}ms: ${label}`)), ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/** Poll until whisper-server.exe is accepting connections on :8080, or timeout. */
+async function waitForWhisperServerListening(): Promise<void> {
+  const deadline = Date.now() + WHISPER_RELAUNCH_LISTEN_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (!(await isPort8080Free())) return; // something is listening → up
+    await new Promise((r) => setTimeout(r, WHISPER_RELAUNCH_LISTEN_POLL_MS));
+  }
+  console.warn(
+    '[DockerManager] whisper-server.exe not listening on :8080 after relaunch wait; ' +
+      'continuing anyway (backend has its own readiness wait).',
+  );
+}
+
+/**
+ * Relaunch the native whisper-server.exe (vulkan-wsl2 only) so it serves a
+ * different GGML model, since it cannot hot-swap models over HTTP the way the
+ * containerised Linux sidecar can (its `/load` receives an in-container
+ * `/models/...` path that the native Windows exe cannot open).
+ *
+ * The dashboard drives this around Live Mode: it switches to the live model
+ * before starting the session and restores the main model (pass `null`) after
+ * stopping. Because the backend's own `/load` is disabled in this mode
+ * (WHISPERCPP_EXTERNAL_MODEL_MGMT), this relaunch is the ONLY thing that changes
+ * the served model — so it must complete before the backend transcribes.
+ *
+ * No-ops (returns `{ switched: false }`) when:
+ *  - the active profile is not `vulkan-wsl2` (no native exe in play);
+ *  - `model` is a non-GGML name (faster-whisper live models don't use the exe);
+ *  - the exe is already serving the requested model (idempotent).
+ *
+ * @param model GGML filename to serve, or `null`/`undefined` to restore the
+ *   main-transcription model captured at container start.
+ */
+export async function switchWhisperServerModel(
+  model: string | null | undefined,
+): Promise<{ switched: boolean; model: string | null }> {
+  const profile = readRuntimeProfileFromStore();
+  if (profile !== 'vulkan-wsl2') {
+    return { switched: false, model: null };
+  }
+
+  // Resolve the target filename. A null/empty request means "restore the main
+  // model"; anything else must be a bare GGML filename the exe can load.
+  let target: string | null;
+  if (model && model.trim()) {
+    const sanitized = path.basename(model.trim().replace(/^\/models\//, ''));
+    if (!isGgmlFileName(sanitized)) {
+      // Not a whisper.cpp model (e.g. a faster-whisper live model) — the native
+      // exe isn't involved, so there is nothing to switch.
+      console.log(
+        `[DockerManager] switchWhisperServerModel: '${model}' is not a GGML model — no switch`,
+      );
+      return { switched: false, model: null };
+    }
+    target = sanitized;
+  } else {
+    target = _whisperServerDefaultModel;
+  }
+
+  console.log(
+    `[DockerManager] switchWhisperServerModel: request=${JSON.stringify(model)} ` +
+      `resolved-target=${target} current=${_whisperServerCurrentModel} default=${_whisperServerDefaultModel}`,
+  );
+
+  if (!target) {
+    // No default recorded (exe not started by us) — nothing safe to do.
+    return { switched: false, model: null };
+  }
+
+  if (target === _whisperServerCurrentModel) {
+    console.log('[DockerManager] switchWhisperServerModel: already serving target — no relaunch');
+    return { switched: false, model: target };
+  }
+
+  console.log(
+    `[DockerManager] Switching native whisper-server.exe model: ${_whisperServerCurrentModel} → ${target}`,
+  );
+
+  const hostModelPath = path.join(getWhisperModelsDir(), target);
+  if (!fs.existsSync(hostModelPath)) {
+    console.log(`[DockerManager] Model not found at ${hostModelPath} — downloading...`);
+    // Bound the download so a stalled connection can never wedge the caller
+    // (the renderer defers the live WebSocket connect on this promise).
+    await withTimeout(
+      downloadGgmlModelToHost(target),
+      WHISPER_MODEL_DOWNLOAD_TIMEOUT_MS,
+      `download ${target}`,
+    );
+    console.log(`[DockerManager] Downloaded ${target} to host`);
+  } else {
+    console.log(`[DockerManager] Model already present at ${hostModelPath} — no download`);
+  }
+
+  await killExistingWhisperServer();
+  await launchWhisperServerNative(hostModelPath);
+  _whisperServerCurrentModel = target;
+  await waitForWhisperServerListening();
+  console.log(`[DockerManager] Native whisper-server.exe now serving ${target}`);
+
+  return { switched: true, model: target };
+}
+
 function getWhisperServerExePath(): string {
   return path.join(
     app.getPath('appData'),
@@ -4324,6 +4485,7 @@ export const dockerManager = {
   removeModelCache,
   isGgmlModelDownloadedOnHost,
   downloadGgmlModelToHost,
+  switchWhisperServerModel,
   ensureWhisperDirectories,
   downloadWhisperServerExe,
   checkTailscaleCertsExist,

--- a/dashboard/electron/main.ts
+++ b/dashboard/electron/main.ts
@@ -1254,6 +1254,14 @@ ipcMain.handle('docker:pullSidecarImage', async () => {
   return dockerManager.pullSidecarImage();
 });
 
+// Relaunch the native whisper-server.exe (vulkan-wsl2) onto a different GGML
+// model. Driven by Live Mode: switch to the live model before starting, restore
+// the main model (model = null) after stopping. No-ops on non-vulkan-wsl2
+// profiles and for non-GGML models. See dockerManager.switchWhisperServerModel.
+ipcMain.handle('whisper:switchModel', async (_event, model: string | null) => {
+  return dockerManager.switchWhisperServerModel(model);
+});
+
 ipcMain.handle('docker:cancelSidecarPull', () => {
   return dockerManager.cancelSidecarPull();
 });

--- a/dashboard/electron/preload.ts
+++ b/dashboard/electron/preload.ts
@@ -227,6 +227,9 @@ export interface ElectronAPI {
     removeModelCache: (modelId: string) => Promise<void>;
     isGgmlModelDownloadedOnHost: (fileName: string) => Promise<boolean>;
     downloadGgmlModelToHost: (fileName: string) => Promise<void>;
+    switchWhisperServerModel: (
+      model: string | null,
+    ) => Promise<{ switched: boolean; model: string | null }>;
     removeVolume: (name: string) => Promise<string>;
     readComposeEnvValue: (key: string) => Promise<string | null>;
     volumeExists: (name: string) => Promise<boolean>;
@@ -594,6 +597,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('docker:isGgmlModelDownloadedOnHost', fileName) as Promise<boolean>,
     downloadGgmlModelToHost: (fileName: string) =>
       ipcRenderer.invoke('docker:downloadGgmlModelToHost', fileName) as Promise<void>,
+    switchWhisperServerModel: (model: string | null) =>
+      ipcRenderer.invoke('whisper:switchModel', model) as Promise<{
+        switched: boolean;
+        model: string | null;
+      }>,
     removeVolume: (name: string) => ipcRenderer.invoke('docker:removeVolume', name),
     readComposeEnvValue: (key: string) =>
       ipcRenderer.invoke('docker:readComposeEnvValue', key) as Promise<string | null>,

--- a/dashboard/src/hooks/useLiveMode.ts
+++ b/dashboard/src/hooks/useLiveMode.ts
@@ -59,6 +59,14 @@ export interface LiveStartOptions {
   model?: string;
   systemAudio?: boolean;
   monitorSinkName?: string;
+  /**
+   * GGML filename of the live model, used ONLY on the Windows `vulkan-wsl2`
+   * profile to relaunch the native whisper-server.exe onto this model before
+   * connecting (it serves one model per launch and cannot hot-swap). Ignored by
+   * the server and a no-op on every other profile / non-GGML model. See
+   * dockerManager.switchWhisperServerModel.
+   */
+  whisperServerModel?: string;
 }
 
 export function useLiveMode(): LiveModeState {
@@ -307,7 +315,37 @@ export function useLiveMode(): LiveModeState {
           });
         },
       });
-      socketRef.current.connect();
+
+      // vulkan-wsl2 (Windows): the native whisper-server.exe serves ONE model
+      // per launch and can't hot-swap, so relaunch it onto the live model BEFORE
+      // connecting — otherwise the backend would transcribe against the main
+      // model. The IPC self-gates (no-op off vulkan-wsl2 / for non-GGML models),
+      // so this only defers the connect when a native switch is actually in play.
+      // When the IPC is absent (web build, or already-correct model), connect
+      // synchronously to preserve existing behaviour.
+      const sock = socketRef.current;
+      const switchModel = window.electronAPI?.docker?.switchWhisperServerModel;
+      if (switchModel) {
+        const requested = startOptsRef.current.whisperServerModel ?? null;
+        console.info('[useLiveMode] requesting whisper-server model switch:', requested);
+        void switchModel(requested)
+          .then((res) => {
+            console.info('[useLiveMode] whisper-server model switch result:', res);
+          })
+          .catch((err) => {
+            // A relaunch failure is not fatal here: the backend has its own
+            // sidecar-readiness wait, and connecting still surfaces a clear
+            // server-side error if the model truly can't serve. Log and proceed.
+            console.warn('[useLiveMode] whisper-server model switch failed:', err);
+          })
+          .finally(() => {
+            // Only connect if this socket is still current — a stop()/retarget
+            // between the switch call and its resolution supersedes it.
+            if (socketRef.current === sock) sock.connect();
+          });
+      } else {
+        sock.connect();
+      }
     },
     [handleMessage, setStatusTracked],
   );
@@ -328,6 +366,14 @@ export function useLiveMode(): LiveModeState {
     // GH-237: user stop reopens the start-gate for the next session.
     sessionEstablishedRef.current = false;
     setStatusTracked('idle');
+    // vulkan-wsl2: restore the native whisper-server.exe to the main model the
+    // live session displaced (pass null → the launch/default model). Best-effort
+    // and self-gating; a no-op off vulkan-wsl2. Runs in the background — the next
+    // main transcription won't begin until the user initiates it, by which time
+    // the (few-second) relaunch has completed.
+    void window.electronAPI?.docker?.switchWhisperServerModel?.(null).catch((err) => {
+      console.warn('[useLiveMode] whisper-server main-model restore failed:', err);
+    });
   }, [setStatusTracked]);
 
   const toggleMute = useCallback(() => {

--- a/dashboard/src/types/electron.d.ts
+++ b/dashboard/src/types/electron.d.ts
@@ -175,6 +175,9 @@ interface ElectronAPI {
       modelIds: string[],
     ) => Promise<Record<string, { exists: boolean; size?: string }>>;
     removeModelCache: (modelId: string) => Promise<void>;
+    switchWhisperServerModel: (
+      model: string | null,
+    ) => Promise<{ switched: boolean; model: string | null }>;
     removeVolume: (name: string) => Promise<string>;
     readComposeEnvValue: (key: string) => Promise<string | null>;
     volumeExists: (name: string) => Promise<boolean>;

--- a/server/backend/core/stt/backends/whispercpp_backend.py
+++ b/server/backend/core/stt/backends/whispercpp_backend.py
@@ -191,6 +191,28 @@ def _read_whispercpp_setting(env_key: str, cfg_key: str) -> str | None:
     return text or None
 
 
+def _external_model_management() -> bool:
+    """True when the whisper-server model is managed OUTSIDE this backend.
+
+    On the Windows ``vulkan-wsl2`` profile the whisper-server runs natively on
+    the host and serves a SINGLE model chosen at launch (``--model``). It cannot
+    hot-swap via ``/load``: that endpoint would receive this container's
+    ``/models/...`` path, which the native exe cannot open (different filesystem
+    namespace), so a main→live model switch fails to load. Instead the dashboard
+    (Electron) relaunches the exe onto the requested model before transcription
+    (see ``dockerManager.switchWhisperServerModel``).
+
+    When this flag is set (``WHISPERCPP_EXTERNAL_MODEL_MGMT=1``, exported by the
+    dashboard for ``vulkan-wsl2`` only), ``load()`` therefore skips BOTH its own
+    ``/load`` POST and the container-side GGML download (the model lives on the
+    host, not in this container's ``/models``), and only waits for the
+    externally managed sidecar to become healthy. The Linux ``vulkan`` profile
+    keeps the containerised sidecar whose ``/load`` works, so it never sets this.
+    """
+    raw = os.environ.get("WHISPERCPP_EXTERNAL_MODEL_MGMT", "").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
 def _resolve_chunk_duration_config() -> int:
     """Max chunk duration (seconds) from env → config → default, floored at 60s."""
     raw = _read_whispercpp_setting("WHISPERCPP_CHUNK_DURATION_S", "chunk_duration_s")
@@ -636,6 +658,23 @@ class WhisperCppBackend(STTBackend):
             self._server_url,
             self._max_chunk_duration_s,
         )
+
+        # vulkan-wsl2: the native host exe owns model loading (relaunched by the
+        # dashboard onto this model before we get here). The GGML lives on the
+        # host, not in this container, and a /load POST would hand the exe an
+        # unopenable /models/... path — so skip both the container download and
+        # the /load, and just wait for the externally managed sidecar to be
+        # healthy. A fresh host-side relaunch is a genuine cold start, so use the
+        # full ready budget rather than the warm one.
+        if _external_model_management():
+            logger.info(
+                "WhisperCppBackend: external model management (vulkan-wsl2) — "
+                "skipping container download and /load; waiting for host sidecar to be ready"
+            )
+            self._wait_for_sidecar_ready(_SIDECAR_READY_TIMEOUT)
+            self._loaded = True
+            logger.info("WhisperCppBackend: model ready (external management)")
+            return
 
         # GGML models are not auto-fetched by the sidecar (it only reads + waits),
         # so download into the shared volume ourselves — this is what breaks the

--- a/server/backend/tests/test_whispercpp_self_download.py
+++ b/server/backend/tests/test_whispercpp_self_download.py
@@ -106,3 +106,40 @@ def test_load_tolerates_remote_protocol_error(monkeypatch) -> None:
 
     backend.load(model_name="ggml-small.en.bin", device="cpu")
     assert backend.is_loaded() is True
+
+
+def test_external_model_management_skips_download_and_load(monkeypatch) -> None:
+    """vulkan-wsl2: load() must NOT download or POST /load — the host exe owns
+    model loading. It should only wait for the sidecar and mark itself loaded."""
+    backend = wb.WhisperCppBackend()
+    monkeypatch.setenv("WHISPERCPP_EXTERNAL_MODEL_MGMT", "1")
+
+    def _fail_download(*_a, **_k):
+        raise AssertionError("must not download the GGML in external management mode")
+
+    def _fail_client(*_a, **_k):
+        raise AssertionError("must not POST /load in external management mode")
+
+    monkeypatch.setattr(wb, "_ensure_ggml_model_present", _fail_download)
+    monkeypatch.setattr(backend, "_ensure_client", _fail_client)
+
+    waited: list[float] = []
+    monkeypatch.setattr(
+        backend, "_wait_for_sidecar_ready", lambda timeout_s: waited.append(timeout_s)
+    )
+
+    backend.load(model_name="ggml-small.en.bin", device="cpu")
+
+    assert backend.is_loaded() is True
+    # Waited exactly once, with the full cold-start budget (host relaunch).
+    assert waited == [wb._SIDECAR_READY_TIMEOUT]
+
+
+def test_external_model_management_disabled_by_default(monkeypatch) -> None:
+    """Absent the env flag, the normal download + /load path runs."""
+    monkeypatch.delenv("WHISPERCPP_EXTERNAL_MODEL_MGMT", raising=False)
+    assert wb._external_model_management() is False
+    monkeypatch.setenv("WHISPERCPP_EXTERNAL_MODEL_MGMT", "1")
+    assert wb._external_model_management() is True
+    monkeypatch.setenv("WHISPERCPP_EXTERNAL_MODEL_MGMT", "0")
+    assert wb._external_model_management() is False


### PR DESCRIPTION
  ## Summary

  On the Windows Vulkan (`vulkan-wsl2`) profile, selecting a **different** model for
  Live Mode than for main transcription failed: the model downloaded fine but never
  loaded. Same-model live sessions worked.

  ## Root cause

  On `vulkan-wsl2` the whisper-server runs **natively on the Windows host**, launched
  once with a fixed `--model` and serving a single model for its lifetime. The backend
  (inside the container) switches models by POSTing `/load` with an in-container
  `/models/...` path — which the native Windows exe cannot open (different filesystem
  namespace), so the switch silently failed. Same-model sessions dodged this because
  they reuse the already-loaded backend and never call `/load`.

  ## Fix

  Electron owns the native exe, so it now owns model switching:

  - **`dockerManager.switchWhisperServerModel(model)`** — kills and relaunches the
    native `whisper-server.exe` onto the requested GGML (downloading to the host
    models dir if missing). Idempotent (no relaunch when already serving the model)
    and self-gating (no-op off `vulkan-wsl2` and for non-GGML models). Exposed via
    the `whisper:switchModel` IPC.
  - **`useLiveMode`** relaunches onto the live model *before* connecting `/ws/live`,
    and restores the main model on stop. `SessionView` passes the active live model
    through.
  - **`whispercpp_backend`** — under `WHISPERCPP_EXTERNAL_MODEL_MGMT` (set for
    `vulkan-wsl2` only), `load()` skips the container-side download and the `/load`
    POST and just waits for the host-managed sidecar to be healthy. The Linux
    `vulkan` sidecar keeps its working `/load` path unchanged.
  - The host download during a switch is now **bounded by a timeout** so a stalled
    connection can't wedge the deferred live connect, with diagnostic logging of the
    resolved model on both the renderer and main-process sides.

  Also included: the whisper-server binary pull now targets
  `ghcr.io/homelab-00/whisper-cpp-windows`.

  ## Behavior

  - Different main/live models → few-second relaunch onto the live model, then
    restore on stop.
  - Same main/live model → no relaunch, no reload (unchanged fast path).
  - Non-`vulkan-wsl2` profiles and non-GGML models → completely unaffected.

  ## Testing

  - Backend: `test_whispercpp_self_download.py` covers the external-management path
    (no download, no `/load`, sidecar-wait only). Full whispercpp suite green.
  - Dashboard: `tsc --noEmit` clean.
  - ⚠️ **Still needs an end-to-end run on real `vulkan-wsl2` hardware** — the
    native-exe relaunch path can't be exercised in CI/WSL. Verify: set main = model A,
    live = model B (both GGML), start Live Mode, confirm the `[DockerManager] Switching
    … A → B` log and that live transcription runs, then confirm restore to A on stop.