### PR TITLE
fix(ui): themed dropdown for Session Import Output Format

### DIFF
--- a/dashboard/components/__tests__/SessionImportTab.output-format.test.tsx
+++ b/dashboard/components/__tests__/SessionImportTab.output-format.test.tsx
@@ -142,6 +142,63 @@ vi.mock('sonner', () => ({
   },
 }));
 
+// headlessui — the Output Format / Subtitle format controls are CustomSelect
+// (a Listbox). Same render-prop mock convention as ServerView.test.tsx, plus:
+//   * ListboxButton forwards aria-label so getByRole('button', { name }) works.
+//   * ListboxOption is a role="option" that wires its click to the Listbox's
+//     onChange (via context), so selecting an option drives the component.
+vi.mock('@headlessui/react', () => {
+  const renderChildren = (
+    children: React.ReactNode | ((args: any) => React.ReactNode),
+    args: Record<string, unknown> = {},
+  ): React.ReactNode =>
+    typeof children === 'function' ? (children as (a: any) => React.ReactNode)(args) : children;
+  const passthrough = ({ children }: { children?: React.ReactNode }) =>
+    React.createElement('div', null, renderChildren(children));
+  const OnChangeCtx = React.createContext<(value: unknown) => void>(() => {});
+  return {
+    Listbox: ({
+      children,
+      value,
+      onChange,
+    }: {
+      children: React.ReactNode;
+      value: unknown;
+      onChange: (value: unknown) => void;
+    }) =>
+      React.createElement(
+        OnChangeCtx.Provider,
+        { value: onChange },
+        React.createElement(
+          'div',
+          { 'data-value': value },
+          renderChildren(children, { open: true }),
+        ),
+      ),
+    ListboxButton: ({
+      children,
+      ['aria-label']: ariaLabel,
+    }: {
+      children: React.ReactNode;
+      'aria-label'?: string;
+    }) =>
+      React.createElement(
+        'button',
+        { type: 'button', 'aria-label': ariaLabel },
+        renderChildren(children, { open: true, focus: false, hover: false }),
+      ),
+    ListboxOptions: passthrough,
+    ListboxOption: ({ children, value }: { children: React.ReactNode; value: unknown }) => {
+      const onChange = React.useContext(OnChangeCtx);
+      return React.createElement(
+        'div',
+        { role: 'option', 'data-value': value, onClick: () => onChange(value) },
+        renderChildren(children, { selected: false, focus: false, active: false }),
+      );
+    },
+  };
+});
+
 import { SessionImportTab } from '../views/SessionImportTab';
 
 async function renderTab() {
@@ -154,12 +211,23 @@ async function renderTab() {
   return result;
 }
 
-function outputFormatSelect(): HTMLSelectElement {
-  return screen.getByRole('combobox', { name: /output format/i }) as HTMLSelectElement;
+function outputFormatButton(): HTMLElement {
+  return screen.getByRole('button', { name: /output format/i });
 }
 
-function querySubtitleFormatSelect(): HTMLSelectElement | null {
-  return screen.queryByRole('combobox', { name: /subtitle format/i }) as HTMLSelectElement | null;
+function querySubtitleFormatButton(): HTMLElement | null {
+  return screen.queryByRole('button', { name: /subtitle format/i });
+}
+
+// Open the CustomSelect (mock renders options inline) and click the option
+// whose visible label matches `optionName`.
+async function pickOutputFormat(optionName: string): Promise<void> {
+  await act(async () => {
+    fireEvent.click(outputFormatButton());
+  });
+  await act(async () => {
+    fireEvent.click(screen.getByRole('option', { name: optionName }));
+  });
 }
 
 describe('SessionImportTab — explicit output-format selector (GH-212)', () => {
@@ -194,32 +262,26 @@ describe('SessionImportTab — explicit output-format selector (GH-212)', () => 
     });
 
     expect(diarizationSwitch).toHaveAttribute('aria-checked', 'false');
-    expect(outputFormatSelect()).toBeInTheDocument();
+    expect(outputFormatButton()).toBeInTheDocument();
   });
 
   it('hides the Subtitle format select for Plain text and shows it for Both', async () => {
     await renderTab();
 
     // Default 'subtitles' → the subtitle-flavor select is visible.
-    expect(querySubtitleFormatSelect()).not.toBeNull();
+    expect(querySubtitleFormatButton()).not.toBeNull();
 
-    await act(async () => {
-      fireEvent.change(outputFormatSelect(), { target: { value: 'txt' } });
-    });
-    expect(querySubtitleFormatSelect()).toBeNull();
+    await pickOutputFormat('Plain text (.txt)');
+    expect(querySubtitleFormatButton()).toBeNull();
 
-    await act(async () => {
-      fireEvent.change(outputFormatSelect(), { target: { value: 'both' } });
-    });
-    expect(querySubtitleFormatSelect()).not.toBeNull();
+    await pickOutputFormat('Both');
+    expect(querySubtitleFormatButton()).not.toBeNull();
   });
 
   it('persists the selection under sessionImport.outputFormat', async () => {
     await renderTab();
 
-    await act(async () => {
-      fireEvent.change(outputFormatSelect(), { target: { value: 'txt' } });
-    });
+    await pickOutputFormat('Plain text (.txt)');
 
     expect(mockSetConfig).toHaveBeenCalledWith('sessionImport.outputFormat', 'txt');
   });

--- a/dashboard/components/ui/CustomSelect.tsx
+++ b/dashboard/components/ui/CustomSelect.tsx
@@ -25,6 +25,8 @@ interface CustomSelectProps {
   placeholder?: string;
   accentColor?: 'cyan' | 'magenta';
   disabled?: boolean;
+  /** Accessible label forwarded to the trigger button (for screen readers / tests). */
+  'aria-label'?: string;
 }
 
 export const CustomSelect: React.FC<CustomSelectProps> = ({
@@ -38,6 +40,7 @@ export const CustomSelect: React.FC<CustomSelectProps> = ({
   placeholder = 'Select...',
   accentColor = 'cyan',
   disabled = false,
+  'aria-label': ariaLabel,
 }) => {
   // Extract layout classes from className to apply to the container div
   const isFlex = className.includes('flex-1');
@@ -62,6 +65,7 @@ export const CustomSelect: React.FC<CustomSelectProps> = ({
     <Listbox value={value} onChange={onChange} disabled={disabled}>
       <div className={containerClasses}>
         <ListboxButton
+          aria-label={ariaLabel}
           title={value || placeholder}
           className={`flex h-full w-full min-w-0 items-center justify-between text-left ${disabled ? 'cursor-not-allowed opacity-50' : ''} ${className}`}
         >

--- a/dashboard/components/views/SessionImportTab.tsx
+++ b/dashboard/components/views/SessionImportTab.tsx
@@ -20,6 +20,7 @@ import {
 import { GlassCard } from '../ui/GlassCard';
 import { Button } from '../ui/Button';
 import { AppleSwitch } from '../ui/AppleSwitch';
+import { CustomSelect } from '../ui/CustomSelect';
 import { useShallow } from 'zustand/react/shallow';
 import {
   useImportQueueStore,
@@ -872,20 +873,22 @@ export const SessionImportTab: React.FC = () => {
               <p className="text-sm font-medium text-white">Output Format</p>
               <p className="text-xs text-slate-400">Applies to every imported file</p>
             </div>
-            <select
+            <CustomSelect
               aria-label="Output Format"
               value={outputFormat}
-              onChange={(e) => {
-                const v = e.target.value as SessionOutputFormat;
-                setOutputFormat(v);
-                void setConfig('sessionImport.outputFormat', v);
+              onChange={(v) => {
+                const format = v as SessionOutputFormat;
+                setOutputFormat(format);
+                void setConfig('sessionImport.outputFormat', format);
               }}
-              className="focus:border-accent-cyan/50 shrink-0 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 text-sm text-white scheme-dark outline-none"
-            >
-              <option value="txt">Plain text (.txt)</option>
-              <option value="subtitles">Subtitles (.srt/.ass)</option>
-              <option value="both">Both</option>
-            </select>
+              options={['txt', 'subtitles', 'both']}
+              optionLabel={{
+                txt: 'Plain text (.txt)',
+                subtitles: 'Subtitles (.srt/.ass)',
+                both: 'Both',
+              }}
+              className="focus:ring-accent-cyan w-52 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 text-sm text-white transition-all outline-none hover:border-white/20 focus:ring-1"
+            />
           </div>
           {outputFormat !== 'txt' && (
             <div className="flex items-center justify-between gap-4 pl-1">
@@ -893,15 +896,14 @@ export const SessionImportTab: React.FC = () => {
                 <p className="text-sm font-medium text-white">Subtitle format</p>
                 <p className="text-xs text-slate-400">File type for subtitle output</p>
               </div>
-              <select
+              <CustomSelect
                 aria-label="Subtitle format"
                 value={diarizedFormat}
-                onChange={(e) => setDiarizedFormat(e.target.value as 'srt' | 'ass')}
-                className="focus:border-accent-cyan/50 shrink-0 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 text-sm text-white scheme-dark outline-none"
-              >
-                <option value="srt">.srt</option>
-                <option value="ass">.ass</option>
-              </select>
+                onChange={(v) => setDiarizedFormat(v as 'srt' | 'ass')}
+                options={['srt', 'ass']}
+                optionLabel={{ srt: '.srt', ass: '.ass' }}
+                className="focus:ring-accent-cyan w-52 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 text-sm text-white transition-all outline-none hover:border-white/20 focus:ring-1"
+              />
             </div>
           )}
           <div className="h-px bg-white/5"></div>

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.12.1",
-  "contract_sha256": "d27fe1cbf07108af845c5c3df37693f27e6855dc89e83aeb911bfe475231f238",
-  "updated_at": "2026-07-17T15:18:43.075Z"
+  "spec_version": "1.12.2",
+  "contract_sha256": "94f297c326d09348c4665653968d8e2b34fa36351cd2b61b34a1d9b369cc5742",
+  "updated_at": "2026-07-18T06:36:35.094Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.12.1
+  spec_version: 1.12.2
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -24,6 +24,7 @@ meta:
       - components/__tests__/SessionImportTab.output-format.test.tsx
       - components/__tests__/SessionView.canary-language.test.tsx
       - components/__tests__/SessionView.client-link-stop.test.tsx
+      - components/__tests__/SessionView.greek-sigma.test.tsx
       - components/__tests__/SessionView.test.tsx
       - components/__tests__/StartupActivityInline.test.tsx
       - components/AriaLiveRegion.tsx
@@ -122,7 +123,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-07-17T15:18:35.029Z
+    generated_at: 2026-07-18T06:36:20.190Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -783,6 +784,7 @@ utility_allowlist:
     - h-px
     - h-screen
     - hidden
+    - "hover:"
     - hover:-translate-y-1
     - hover:bg-accent-cyan
     - hover:bg-accent-cyan/10
@@ -1194,6 +1196,7 @@ utility_allowlist:
     - w-4.5
     - w-44
     - w-48
+    - w-52
     - w-56
     - w-6
     - w-7
@@ -2487,6 +2490,23 @@ component_contracts:
         rule: Do not introduce unregistered utility, arbitrary, or inline style values.
   NvidiaIcon:
     file: components/ui/icons/NvidiaIcon.tsx
+    required_tokens:
+      - colors
+      - motion
+      - radii
+      - shadows
+    allowed_variants: {}
+    structural_invariants:
+      - id: structure-stable
+        rule: Preserve current structural layout and region hierarchy for this component.
+    behavior_rules:
+      - id: motion-locked
+        rule: Use only approved motion tokens and classes from foundation token registry.
+    state_rules:
+      - id: closed-set-styles
+        rule: Do not introduce unregistered utility, arbitrary, or inline style values.
+  OnChangeCtx:
+    file: components/__tests__/SessionImportTab.output-format.test.tsx
     required_tokens:
       - colors
       - motion


### PR DESCRIPTION
## Problem

On the **Session Import** tab, the *Output Format* dropdown was a native HTML `<select>`. A native select's option popup is drawn by the OS/Chromium and ignores the app's Tailwind theme, so:

- the two unselected options rendered white-on-white and were effectively invisible;
- the popup did not match the app's glassy dark style.

`scheme-dark` (`color-scheme: dark`) only recolors widget chrome and was not enough here.

## Fix

Replace the *Output Format* and *Subtitle format* native `<select>` elements with the app's existing **`CustomSelect`** (a headless-UI `Listbox` already used across `SessionView`/`SettingsModal`). Its popup is real, fully-themed DOM: dark rounded panel, accent-cyan selected row, hover states, and all options visible.

- `CustomSelect` now forwards an optional `aria-label` to its trigger button — purely additive, keeps the controls labelled for screen readers and tests, no change for existing callers.
- Tests updated to drive the control as a `Listbox` (mock `@headlessui/react` per repo convention, open-then-click-option instead of native `fireEvent.change`).
- UI contract baseline regenerated, `spec_version` bumped `1.12.1 -> 1.12.2`.

## Test plan

- [x] `SessionImportTab.output-format.test.tsx` (5) pass
- [x] All `SessionImportTab*.test.tsx` (19) pass
- [x] `CustomSelect.test.tsx` + `ServerView.test.tsx` (34) pass — confirms the additive `aria-label` prop is safe for other callers
- [x] `tsc --noEmit` clean
- [x] `npm run ui:contract:check` clean (16 checks)
- [ ] Manual: open Session Import tab, verify both dropdowns render dark/themed with all options visible and selection works