### PR TITLE
docs(readme): full rewrite for approachability and current UI

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,24 +5,17 @@
 <table width="100%">
   <tr>
     <td valign="top">
-      <table>
-        <tr>
-          <td width="375px">
-<pre>
-A fully local and private Speech-To-Text
-app with cross-platform support, speaker
-diarization, Audio Notebook mode,
-AI assistant (OpenAI-compatible), and
-both longform and live transcription. Electron
-dashboard + Python backend with
-multi-backend STT (Whisper, NVIDIA NeMo,
-VibeVoice-ASR, SenseVoice, whisper.cpp),
-NVIDIA GPU acceleration, AMD/Intel Vulkan
-support, or CPU mode. Dockerized for fast setup.
-</pre>
-          </td>
-        </tr>
-      </table>
+      <strong>Turn speech into text - on your own computer.</strong>
+      <br><br>
+      TranscriptionSuite is a free, open-source transcription app. Record a lecture,
+      dictate a document, or import an audio file, and get an accurate transcript with
+      speaker labels in minutes. Everything runs locally: your audio never leaves your
+      machine.
+      <br><br>
+      Under the hood: an Electron dashboard + Python backend with multi-backend
+      speech-to-text (Whisper, NVIDIA NeMo, VibeVoice-ASR, SenseVoice, whisper.cpp,
+      MLX), accelerated by NVIDIA CUDA, Apple Metal, or AMD/Intel Vulkan - or plain
+      CPU. Dockerized for fast setup.
     </td>
     <td align="left" valign="top" width="280px">
       <strong>OS Support:</strong><br>
@@ -82,38 +75,51 @@ https://github.com/user-attachments/assets/f63ee730-de9a-4a55-b0ab-e342b30905a4
 
 ## 1. Introduction
 
+TranscriptionSuite is two parts working as one app:
+
+- the **Dashboard** - the desktop program you install, and
+- the **server** - the transcription engine, which the Dashboard downloads and manages for you (in [Docker](https://www.docker.com/) on most platforms, natively on Apple Silicon Macs). Docker is a free program that runs the server in its own self-contained box; you install it once during setup and the Dashboard drives it for you.
+
+Day-to-day use is entirely point-and-click; a terminal is only needed for a few one-time setup steps on some platforms. Want to get going right away? Jump to [Installation](#2-installation) and pick your platform. Wondering whether your computer can run it? Check the [Compatibility Matrix](#12-compatibility-matrix).
+
 ### 1.1 Features
 
-- **100% Local**: *Everything* runs on your own computer, the app doesn't need internet beyond the initial setup*
-- **Multiple Models available**: On **Docker/Linux/Windows**: *WhisperX* ([`faster-whisper`](https://huggingface.co/Systran/faster-whisper-large-v3) models), NVIDIA NeMo [*Parakeet v3*](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3)/[*Canary v2*](https://huggingface.co/nvidia/canary-1b-v2), [*VibeVoice-ASR*](https://huggingface.co/microsoft/VibeVoice-ASR), [*SenseVoice*](https://huggingface.co/FunAudioLLM/SenseVoiceSmall) (FunASR), and [*whisper.cpp*](https://github.com/ggerganov/whisper.cpp) (GGML models for AMD/Intel GPU via Vulkan — Linux via Docker sidecar; Windows via native `whisper-server.exe` auto-downloaded by the app, see §2.7). On **Apple Silicon (Metal)**: [*MLX Whisper*](https://huggingface.co/mlx-community/whisper-large-v3-turbo-asr-fp16) (tiny → large-v3-turbo), [*MLX Parakeet v3*](https://huggingface.co/mlx-community/parakeet-tdt-0.6b-v3), [*MLX Canary v2*](https://huggingface.co/mlx-community/canary-1b-v2), and [*MLX VibeVoice-ASR*](https://huggingface.co/mlx-community/VibeVoice-ASR-bf16) - all running natively without Docker
-- **Speaker Diarization**: Speaker identification & diarization (subtitling) for Whisper, NeMo, SenseVoice, and VibeVoice models; Whisper and NeMo use PyAnnote (HuggingFace token required), SenseVoice ships a built-in CAM++ single-pass diarizer (no token needed, with PyAnnote as an optional override), and VibeVoice does it by itself (not available for whisper.cpp models). On Apple Silicon, [*Sortformer*](https://huggingface.co/mlx-community/diar_sortformer_4spk-v1-fp32) provides Metal-native diarization for up to 4 speakers - no HuggingFace token required
-- **Parallel Processing**: If your VRAM budget allows it, transcribe & diarize a recording at the same time - speeding up processing time significantly
-- **Truly Multilingual**: Whisper supports [90+ languages](https://github.com/openai/whisper/blob/main/whisper/tokenizer.py); NeMo Parakeet/Canary support [25 European languages](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3); VibeVoice supports [51 languages](https://huggingface.co/microsoft/VibeVoice-ASR); SenseVoice supports 5 languages (Chinese, English, Cantonese, Japanese, Korean)
-- **Longform Transcription**: Record as long as you want and have it transcribed in seconds; either using your mic or the system audio
-- **Session File Import**: Import existing audio files from the Session tab; transcription results are saved directly as `.txt` or `.srt` to a folder of your choice - no Notebook entry created
-- **Live Mode**: Real-time sentence-by-sentence transcription for continuous dictation workflows (available for Whisper and whisper.cpp/GGML models; not available for NeMo or VibeVoice models)
-- **Global Keyboard Shortcuts**: System-wide shortcuts & paste-at-cursor functionality
-- **Remote Access**: Securely access your desktop at home running the model from anywhere (utilizing Tailscale) or share it on your local network via LAN
-- **Audio Notebook**: An Audio Notebook mode, with a calendar-based view, full-text search, and AI assistant (chat with any OpenAI-compatible provider about your notes - LM Studio, Ollama, OpenAI, Groq, OpenRouter, and others)
-
+- **100% local and private** - *everything* runs on your own computer. Internet is only needed to download the app and the model weights on first use*; after that it works fully offline. Your audio and transcripts never leave your machine.
+- **Longform transcription** - record for as long as you want, from your microphone or the system audio, and get the full transcript seconds after you stop. While you record, a rolling preview shows the latest ~20 seconds of transcription so you can watch it work.
+- **Live Mode** - real-time, sentence-by-sentence transcription for continuous dictation workflows. Runs on Whisper (faster-whisper) and whisper.cpp models; other model families don't serve Live Mode.
+- **Speaker diarization** - automatic "who said what" labels for Whisper, NeMo, SenseVoice, and VibeVoice models. Whisper and NeMo use PyAnnote (needs a free HuggingFace account token; the app walks you through it during setup); SenseVoice ships a built-in CAM++ diarizer and VibeVoice diarizes by itself (no token for either). On Apple Silicon, [Sortformer](https://huggingface.co/mlx-community/diar_sortformer_4spk-v1-fp32) provides Metal-native diarization for up to 4 speakers, no token needed.
+- **File import** - drop existing audio or video files into the Session tab and save the result as plain text (`.txt`), subtitles (`.srt`/`.ass`), or both, straight to a folder of your choice (no Notebook entry is created).
+- **Your choice of speech models** - on the Docker platforms (Linux / Windows / Intel Mac): *WhisperX* ([faster-whisper](https://huggingface.co/Systran/faster-whisper-large-v3) models), NVIDIA NeMo [Parakeet v3](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3) / [Canary v2](https://huggingface.co/nvidia/canary-1b-v2), [VibeVoice-ASR](https://huggingface.co/microsoft/VibeVoice-ASR), [SenseVoice](https://huggingface.co/FunAudioLLM/SenseVoiceSmall) (FunASR), and [whisper.cpp](https://github.com/ggerganov/whisper.cpp) (GGML models, whisper.cpp's compact model format, for AMD/Intel GPUs via Vulkan; see [§2.7](#27-amd--intel-gpu-support-vulkan)). On Apple Silicon: [MLX Whisper](https://huggingface.co/mlx-community/whisper-large-v3-turbo-asr-fp16) (tiny → large-v3-turbo), [MLX Parakeet v3](https://huggingface.co/mlx-community/parakeet-tdt-0.6b-v3), [MLX Canary v2](https://huggingface.co/mlx-community/canary-1b-v2), and [MLX VibeVoice-ASR](https://huggingface.co/mlx-community/VibeVoice-ASR-bf16), all running natively on the GPU without Docker.
+- **Truly multilingual** - Whisper transcribes [90+ languages](https://github.com/openai/whisper/blob/main/whisper/tokenizer.py) and can translate foreign audio to English; Canary v2 additionally translates in both directions across [25 European languages](https://huggingface.co/nvidia/canary-1b-v2); Parakeet covers 25 European languages; VibeVoice [51 languages](https://huggingface.co/microsoft/VibeVoice-ASR); SenseVoice 5 (Chinese, English, Cantonese, Japanese, Korean).
+- **Parallel processing** - if your GPU has enough memory (VRAM), transcription and diarization run at the same time, cutting processing time significantly.
+- **Audio Notebook** - every recording can be kept in a notebook with a calendar view, full-text search, and an AI assistant: chat about your notes with any OpenAI-compatible provider (LM Studio, Ollama, OpenAI, Groq, OpenRouter, and others).
+- **Global keyboard shortcuts** - system-wide start/stop shortcuts and paste-at-cursor, so you can dictate into any app.
+- **Remote access** - run the server on your desktop at home and transcribe from anywhere via [Tailscale](https://tailscale.com/), or share it on your local network via LAN ([§3](#3-remote-connection)).
+- **Stays out of your way** - a **Notifications** entry at the bottom of the sidebar keeps a session log of downloads, server events, and errors (with toast popups for the important ones), and the app checks for new versions weekly so you don't have to.
+- **Plays well with others** - an OpenAI-compatible API ([§4](#4-openai-compatible-api-endpoints)) lets tools like Open-WebUI and LM Studio use TranscriptionSuite as their transcription engine, and outgoing webhooks ([§5](#5-outgoing-webhooks)) push finished transcripts into your own automations.
 
 📌*Half an hour of audio transcribed in under a minute with Whisper (RTX 3060)!*
 
-**All transcription processing runs entirely on your own computer - your audio never leaves your machine. Internet is only needed to download model weights on first use (STT models, PyAnnote diarization, and wav2vec2 alignment models); all weights are cached locally in a Docker volume and no further internet access is required after that.*
+\**What downloads on first use: the STT model weights themselves, plus the PyAnnote diarization and wav2vec2 alignment models if you use them. Everything is cached locally and nothing further is fetched after that.*
 
 ### 1.2 Compatibility Matrix
 
-Not every model runs on every machine. The tables below show which **runtime** fits your hardware, and what each **model family** can do on it. The Server tab's Instance Settings selectors enforce the same rules — incompatible choices are greyed out with the reason.
+Not every model runs on every machine. **Not sure what any of this means? You can skip this section** - the app detects your hardware, pre-selects working defaults, and greys out incompatible choices with the reason shown.
 
-**Where each runtime runs:**
+A **runtime** is the engine mode the app uses to run the models, and it maps to your hardware: NVIDIA GPU = CUDA, Apple Silicon = Metal, AMD/Intel GPU = Vulkan, any machine = CPU. The tables below show which runtime fits your computer, and what each **model family** can do on it.
+
+**Where each runtime runs** (runtime names as shown in the app):
 
 | Runtime | Linux NVIDIA | Linux AMD/Intel | Windows NVIDIA | Windows AMD/Intel | macOS Apple Silicon | macOS Intel |
 |---------|--------------|-----------------|----------------|-------------------|---------------------|-------------|
-| **NVIDIA CUDA** (Docker) | Yes | No | Yes | No | No | No |
-| **CPU** (Docker) | Yes | Yes | Yes | Yes | No | Yes |
-| **Vulkan Linux** (Docker + sidecar, experimental) | Yes | Yes | No | No | No | No |
-| **Vulkan Windows** (WSL2 + native whisper-server) | No | No | Yes | Yes | No | No |
-| **Apple Metal** (native, no Docker) | No | No | No | No | Yes | No |
+| **CUDA** (Docker) | Yes | No | Yes | No | No | No |
+| **CPU Only** (Docker) | Yes | Yes | Yes | Yes | Yes¹ | Yes |
+| **Vulkan Linux** (Docker + sidecar helper container) | No² | Yes | No | No | No | No |
+| **Vulkan Windows** (Docker + native whisper-server) | No | No | No² | Yes | No | No |
+| **Metal** (native, no Docker) | No | No | No | No | Yes | No |
+
+> ¹ Possible, but Apple Silicon Macs should use Metal instead - it's native and much faster.
+> ² When an NVIDIA GPU is detected, the app greys out the Vulkan runtimes ("NVIDIA detected" badge) and steers you to CUDA.
 
 **Models × runtimes × features:**
 
@@ -121,22 +127,25 @@ Not every model runs on every machine. The tables below show which **runtime** f
 |--------------|------------|-----------|-------------|-------------|
 | **Faster-Whisper** (WhisperX) | CUDA, CPU | Yes | To English (not turbo/`.en` variants) | PyAnnote (token) |
 | **Parakeet v3** (NeMo) | CUDA | No | No | PyAnnote (token) |
-| **Canary v2** (NeMo) | CUDA | No | Yes — bidirectional, 25 languages | PyAnnote (token) |
+| **Canary v2** (NeMo) | CUDA | No | Yes - bidirectional, 25 languages | PyAnnote (token) |
 | **SenseVoice** (FunASR) | CUDA, CPU (slow) | No | No | CAM++ built-in (no token) or PyAnnote |
 | **VibeVoice-ASR** | CUDA, CPU (very slow) | No | No | Built-in |
 | **Whisper.cpp** (GGML) | Vulkan Linux/Windows | Yes | To English (not turbo/`.en` variants) | No |
-| **MLX Whisper** | Metal | Via faster-whisper (CPU) | To English | Sortformer (≤ 4 speakers) or PyAnnote |
+| **MLX Whisper** | Metal | Via faster-whisper (CPU) | To English (not turbo/`.en` variants) | Sortformer (≤ 4 speakers) or PyAnnote |
 | **MLX Parakeet v3** | Metal | Via faster-whisper (CPU) | No | Sortformer or PyAnnote |
 | **MLX Canary v2** | Metal | Via faster-whisper (CPU) | No (MLX port) | Sortformer or PyAnnote |
 | **MLX VibeVoice-ASR** | Metal | Via faster-whisper (CPU) | No | Built-in |
 
 > **Notes:**
 >
-> - **Live Mode** always runs on faster-whisper or whisper.cpp models. On Apple Silicon the Metal server bundles faster-whisper for exactly this — Live Mode works, but decodes on the CPU rather than the GPU.
-> - **PyAnnote** diarization needs a free HuggingFace token and accepting the [model's terms](https://huggingface.co/pyannote/speaker-diarization-community-1). **CAM++** (SenseVoice), **Sortformer** (Apple Silicon) and VibeVoice's **built-in** diarization need no token.
+> - **Live Mode** always runs on faster-whisper or whisper.cpp models. On Apple Silicon the Metal server bundles faster-whisper for exactly this - Live Mode works, but decodes on the CPU rather than the GPU.
+> - **PyAnnote** diarization needs a free HuggingFace token and accepting the [model's terms](https://huggingface.co/pyannote/speaker-diarization-community-1); the app asks for the token during first-start setup. **CAM++** (SenseVoice), **Sortformer** (Apple Silicon), and VibeVoice's **built-in** diarization need no token.
 > - **Sortformer** handles up to 4 speakers; pick PyAnnote on Apple Silicon for larger groups.
-> - NeMo models (Parakeet/Canary) are unavailable on the CPU runtime — the app substitutes a faster-whisper model instead.
-> - Older NVIDIA cards (GTX 10-series and earlier) use the same CUDA runtime with the legacy image toggle — see [§2.6](#26-setting-up-the-server).
+> - NeMo models (Parakeet/Canary) are unavailable on the CPU runtime - the app substitutes a faster-whisper model instead.
+> - NeMo models can't output the Greek final sigma (ς), so Greek word endings may be truncated; the app shows a warning when this applies.
+> - **VibeVoice-ASR** is a 9-billion-parameter model (~16 GB download) - it wants a GPU with plenty of VRAM and is very slow on CPU.
+> - Model weights that are missing get downloaded automatically when the server starts - there is no separate download step.
+> - Older NVIDIA cards (GTX 10-series and earlier) use the same CUDA runtime with the **CUDA Legacy** image variant - see [§2.6](#26-setting-up-the-server).
 
 ### 1.3 Screenshots
 
@@ -164,18 +173,11 @@ https://github.com/user-attachments/assets/688fd4b2-230b-4e2f-bfed-7f92aa769010
 
 ## 2. Installation
 
-The app is comprised of two parts:
-* The **UI frontend** (Dashboard)
-* The **server backend** (Docker image / bare metal depending on deployment)
-
-The [*Releases*](https://github.com/homelab-00/TranscriptionSuite/releases) page contains the Dashboard only; the server is downloaded from inside the Dashboard app.
-
-
-Pick the section for your platform:
+The [Releases](https://github.com/homelab-00/TranscriptionSuite/releases) page contains the **Dashboard** only - the server is downloaded from inside the app. Pick the section for your platform:
 
 | Your computer | Section | How the server runs |
 |---|---|---|
-| **Apple Silicon Mac (M1+)** | [§ 2.1](#21-macos-apple-silicon) | Natively on the Mac — no Docker |
+| **Apple Silicon Mac (M1+)** | [§ 2.1](#21-macos-apple-silicon) | Natively on the Mac - no Docker |
 | **Intel Mac (pre-M1)** | [§ 2.2](#22-macos-intel) | Docker / Podman (CPU only) |
 | **Windows** | [§ 2.3](#23-windows) | Docker / Podman |
 | **Linux** | [§ 2.4](#24-linux) | Docker / Podman |
@@ -184,57 +186,55 @@ Pick the section for your platform:
 
 ### 2.1 macOS Apple Silicon
 
-*For Macs with an Apple chip (M1 and later). This is the easiest setup: the server runs **natively on your Mac's GPU** — no Docker, no Python, no separate server install.*
+*For Macs with an Apple chip (M1 and later). This is the easiest setup: the server runs **natively on your Mac's GPU** - no Docker, no Python, no separate server install.*
 
 Apple Silicon transcription runs on Apple's **Metal + MLX** GPU stack, bundled right inside the app. You download one file, drag it to Applications, and click **Start Metal Server**.
 
-> *Naming note: wherever the app says "Metal server" or "Start Metal Server", what actually runs is **MLX** — Apple's machine-learning framework, which uses Metal as its GPU layer. MLX only exists on Apple Silicon, which is why Intel Macs ([§2.2](#22-macos-intel)) can't use this path.*
-
-**Which file to download** (from the [Releases](https://github.com/homelab-00/TranscriptionSuite/releases) page):
-
-- **`TranscriptionSuite-<version>-arm64-mac-metal.dmg`** (~3–5 GB) — the **bundled** build. It contains the dashboard **and** the Python/MLX server pre-installed, so there's nothing else to set up.
+> *Naming note: wherever the app says "Metal server", what actually runs is **MLX** - Apple's machine-learning framework, which uses Metal as its GPU layer. MLX only exists on Apple Silicon, which is why Intel Macs ([§2.2](#22-macos-intel)) can't use this path.*
 
 **Install steps:**
 
-1. Download the `arm64-mac-metal.dmg` from the Releases page.
-2. Open it and drag **TranscriptionSuite.app** into your **Applications** folder.
-3. Open **Terminal** and run this once to clear the macOS "unverified app" quarantine (details are in `Installation Instructions.txt` on the DMG):
-   ```bash
-   xattr -dr com.apple.quarantine /Applications/TranscriptionSuite.app
-   ```
-4. Launch the app, open **Settings → Runtime Profile**, choose **Metal (Apple Silicon)**, and click **Start Metal Server**. That's it — you're ready to transcribe.
+1. From the [Releases](https://github.com/homelab-00/TranscriptionSuite/releases) page, download **`TranscriptionSuite-<version>-arm64-mac-metal.dmg`** (~3-5 GB) - the **bundled** build with the dashboard **and** the Python/MLX server pre-installed. (Careful: there is also a thin `arm64-mac.dmg` without the server - see the tip below.)
+2. Open the DMG and drag **TranscriptionSuite.app** into **Applications**.
+3. The app is unsigned, so macOS will refuse to open it at first (as "unverified" or even "damaged"). Fix it either way:
+   - **Terminal:** run once:
+     ```bash
+     xattr -dr com.apple.quarantine /Applications/TranscriptionSuite.app
+     ```
+   - **Or System Settings:** try to open the app, then go to **System Settings → Privacy & Security** and click **Open Anyway**.
+4. Launch the app, open the **Server** tab, click the **Metal** tile in the **1. Runtime Settings** card, then click **Start Metal Server**. The first start downloads your selected model (a multi-GB download), so give it a few minutes - after that you're ready to transcribe.
 
-> **Want to run the server somewhere else instead?** If you'd rather use this Mac only as a remote control for a server on another machine (e.g. a Windows/Linux PC with an NVIDIA GPU), or run the server locally in Docker, download the **thin** `arm64-mac.dmg` (~200 MB, dashboard only) instead. Then set up a local Docker server via [§2.5](#25-download-the-dashboard-app)–[§2.6](#26-setting-up-the-server), or connect to another machine via [§3 Remote Connection](#3-remote-connection).
+> **Want to run the server somewhere else instead?** If you'd rather use this Mac only as a remote control for a server on another machine (e.g. a PC with an NVIDIA GPU), or run the server locally in Docker, download the **thin** `arm64-mac.dmg` (~200 MB, dashboard only) instead. Then set up a Docker server via [§2.5](#25-download-the-dashboard-app)-[§2.6](#26-setting-up-the-server), or connect to another machine via [§3 Remote Connection](#3-remote-connection).
 
 ---
 
 ### 2.2 macOS Intel
 
-*For older Intel-based Macs (pre-M1). The server runs in **Docker on the CPU** — it works, but expect it to be slow. Intel Macs get no GPU acceleration here, because Apple's MLX is Apple-Silicon-only.*
+*For older Intel-based Macs (pre-M1). The server runs in **Docker on the CPU** - it works, but expect it to be slow. Intel Macs get no GPU acceleration here, because Apple's MLX is Apple-Silicon-only.*
 
-1. **Install Docker.** Install [Docker Desktop for Mac](https://www.docker.com/products/docker-desktop/) (or [Podman Desktop](https://podman-desktop.io/)). The server will run in **CPU mode** — GPU acceleration isn't available through Docker on macOS.
-2. **Download the thin dashboard and set up the server**, following the two shared sections below:
-   - [§2.5 Download the Dashboard app](#25-download-the-dashboard-app) — use the `x64-mac.dmg` build
-   - [§2.6 Set Up the Server](#26-setting-up-the-server)
+1. **Install Docker.** Install [Docker Desktop for Mac](https://www.docker.com/products/docker-desktop/) (or [Podman Desktop](https://podman-desktop.io/)). The server will run in **CPU mode** - GPU acceleration isn't available through Docker on macOS.
+2. **Download the thin dashboard and set up the server** using the shared sections below:
+   - [§2.5 Download the Dashboard app](#25-download-the-dashboard-app) - use the `x64-mac.dmg` build
+   - [§2.6 Setting Up the Server](#26-setting-up-the-server)
 
 ---
 
 ### 2.3 Windows
 
-*Windows 11 runs the server in Docker (or Podman). With an **NVIDIA** GPU you get full acceleration; with an **AMD or Intel** GPU you can use the Vulkan path ([§2.7](#27-amd--intel-gpu-support-vulkan)), which works well on Windows; otherwise the server runs on **CPU**.*
+*Windows runs the server in Docker (or Podman). With an **NVIDIA** GPU you get full acceleration; with an **AMD or Intel** GPU use the Vulkan path ([§2.7](#27-amd--intel-gpu-support-vulkan)); otherwise the server runs on **CPU**.*
 
-1. **Install Docker Desktop** with the **WSL 2** backend. During installation, if you're given the choice, tick **"Use WSL 2 instead of Hyper-V"**. Once it's installed, you can confirm WSL 2 is active by running `wsl --list --verbose` in a terminal — the version column should read **2**.
+1. **Install Docker Desktop** with the **WSL 2** backend. During installation, if you're given the choice, tick **"Use WSL 2 instead of Hyper-V"**. You can confirm WSL 2 is active by running `wsl --list --verbose` in a terminal - the version column should read **2**.
 2. **NVIDIA GPU:** install the NVIDIA GPU driver with WSL support (the standard NVIDIA gaming drivers work fine). Skip this if you'll run on CPU.
-3. **AMD or Intel GPU:** see [§2.7 AMD / Intel GPU Support (Vulkan)](#27-amd--intel-gpu-support-vulkan) — the Windows Vulkan path is the recommended route for these cards.
-4. **Then continue with the shared steps:** [§2.5 Download the Dashboard app](#25-download-the-dashboard-app) and [§2.6 Set Up the Server](#26-setting-up-the-server).
+3. **AMD or Intel GPU:** see [§2.7 AMD / Intel GPU Support (Vulkan)](#27-amd--intel-gpu-support-vulkan) - the recommended route for these cards.
+4. **Then continue with the shared steps:** [§2.5 Download the Dashboard app](#25-download-the-dashboard-app) and [§2.6 Setting Up the Server](#26-setting-up-the-server).
 
 ---
 
 ### 2.4 Linux
 
-*Linux runs the server in Docker (or Podman). With an **NVIDIA** GPU you get full acceleration; otherwise the server runs on **CPU**. AMD/Intel GPU acceleration (Vulkan) exists but is **experimental and not working correctly yet** — see [§2.7](#27-amd--intel-gpu-support-vulkan).*
+*Linux runs the server in Docker (or Podman). With an **NVIDIA** GPU you get full acceleration; with an **AMD or Intel** GPU use the Vulkan path ([§2.7](#27-amd--intel-gpu-support-vulkan)); otherwise the server runs on **CPU**.*
 
-Pick **Docker** or **Podman** — the app auto-detects whichever is installed (Docker is checked first).
+Pick **Docker** or **Podman** - the app auto-detects whichever is installed (Docker is checked first).
 
 **Docker:**
 
@@ -251,7 +251,7 @@ Pick **Docker** or **Podman** — the app auto-detects whichever is installed (D
    sudo nvidia-ctk runtime configure --runtime=docker
    sudo systemctl restart docker
    ```
-   Skip this for CPU mode. (If a later driver update breaks GPU access, switch Docker to CDI mode — see [GPU not working after a system update](#gpu-not-working-after-a-system-update-linux).)
+   Skip this for CPU mode. (The app automatically prefers CDI when a CDI spec exists; if a later driver update breaks GPU access, see [GPU not working after a system update](#gpu-not-working-after-a-system-update-linux).)
 
 **Podman** (4.7+ required for `podman compose`):
 
@@ -268,23 +268,27 @@ Pick **Docker** or **Podman** — the app auto-detects whichever is installed (D
    ```bash
    sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
    ```
-   The `nvidia-ctk` command is provided by the toolkit, so it must be installed first. Skip this for CPU mode.
+   Skip this for CPU mode.
 
-Then continue with the shared steps: [§2.5 Download the Dashboard app](#25-download-the-dashboard-app) and [§2.6 Set Up the Server](#26-setting-up-the-server).
+Then continue with the shared steps: [§2.5 Download the Dashboard app](#25-download-the-dashboard-app) and [§2.6 Setting Up the Server](#26-setting-up-the-server).
 
 ---
 
 ### 2.5 Download the Dashboard app
 
-Download **and install** the Dashboard for your platform from the [Releases](https://github.com/homelab-00/TranscriptionSuite/releases) page. This is just the frontend — no models or packages are downloaded yet — but it must be installed before you set up the server in [§2.6](#26-setting-up-the-server).
+Download **and install** the Dashboard for your platform from the [Releases](https://github.com/homelab-00/TranscriptionSuite/releases) page. This is just the frontend - no models or packages are downloaded yet - but it must be installed before you set up the server in [§2.6](#26-setting-up-the-server).
 
 **Which file to download:**
 
-- **Linux:** the `.AppImage` (x64)
-- **Windows:** the `.exe` installer (x64)
-- **macOS:** the `.dmg` — `arm64-mac` for Apple Silicon ([§2.1](#21-macos-apple-silicon)), `x64-mac` for Intel ([§2.2](#22-macos-intel))
+| Platform | File |
+|---|---|
+| **Linux** (x64) | `TranscriptionSuite-<version>.AppImage` |
+| **Windows** (x64) | `TranscriptionSuite Setup <version>.exe` |
+| **Mac - Apple Silicon, bundled server** | `TranscriptionSuite-<version>-arm64-mac-metal.dmg` ([§2.1](#21-macos-apple-silicon)) |
+| **Mac - Apple Silicon, thin (dashboard only)** | `TranscriptionSuite-<version>-arm64-mac.dmg` |
+| **Mac - Intel** | `TranscriptionSuite-<version>-x64-mac.dmg` ([§2.2](#22-macos-intel)) |
 
-> *Each release file is signed with my GPG key (the matching `.asc` file). Verifying is optional — see [§2.5.2](#252-verify-download-with-kleopatra-optional).*
+> *Only x64 builds exist for Linux and Windows - there are no ARM builds for those platforms. Each release file is signed with my GPG key (the matching `.asc` file); verifying is optional - see [§2.5.2](#252-verify-download-with-kleopatra-optional).*
 
 > **macOS only:** after dragging the app into Applications, clear the "unverified app" quarantine once in Terminal:
 > ```bash
@@ -306,6 +310,9 @@ AppImages need **FUSE 2** (`libfuse.so.2`), which isn't installed by default on 
 
 #### 2.5.2 Verify Download with Kleopatra (optional)
 
+<details>
+<summary><strong>Verification steps</strong></summary>
+
 1. Download both files from the same release:
    - the installer/app (`.AppImage`, `.exe`, or `.dmg`)
    - the matching signature file (`.asc`)
@@ -315,21 +322,24 @@ AppImages need **FUSE 2** (`libfuse.so.2`), which isn't installed by default on 
 4. In Kleopatra, use `File` → `Decrypt/Verify Files...` and select the downloaded `.asc` signature.
 5. If prompted, select the matching app file. Verification should report a valid signature.
 
+</details>
+
 ---
 
 ### 2.6 Setting Up the Server
 
-*This section covers the Docker/Podman platforms — **Intel Mac, Windows, and Linux**. (Apple Silicon Macs already have the server bundled in the app — see [§2.1](#21-macos-apple-silicon).)*
+*This section covers the Docker/Podman platforms - **Intel Mac, Windows, and Linux**. (Apple Silicon Macs already have the server bundled in the app - see [§2.1](#21-macos-apple-silicon).)*
 
-Setting up the server has two parts: downloading the Docker image, then starting a container from it.
+The **Server** tab is laid out as a numbered wizard - just work through the cards from top to bottom:
 
-> **Windows:** make sure Docker Desktop is **already running** before you start — server setup fails if it isn't started first.
+> **Windows:** make sure Docker Desktop is **already running** before you start - server setup fails if it isn't.
 
-1. **Download the image.** In the left sidebar, open the **Server** tab and click **Fetch Fresh Image**.
-2. **Pick your runtime, models & diarization.** The **Instance Settings** card (box **#2**) holds the selectors — runtime, main model, Live Mode model, diarization engine. Incompatible combinations are greyed out with the reason (see the [Compatibility Matrix](#12-compatibility-matrix)).
-3. **Start the container.** Click **Start Local** in the **#1** box. Prompts confirm which models to download and whether to enable diarization. A free HuggingFace token is needed only for **PyAnnote** diarization (plus accepting the [model's terms](https://huggingface.co/pyannote/speaker-diarization-community-1)) — SenseVoice's CAM++ and Apple Silicon's Sortformer diarizers need no token. To create a token, go to your [HuggingFace token settings](https://huggingface.co/settings/tokens), click *Create new token*, and choose **Read** as the access type (Write / Fine-grained aren't needed).
-4. **Wait.** The first startup can take a while, even on newer hardware and fast internet — think **10–20 minutes** with reasonable specs, not hours. You'll know it's done when the server status light turns **green**.
-5. **Start the client.** Go to the **Session** tab and click **Start Local** in the **Client Link** box — when it turns green, you're ready to roll!
+1. **Pick your runtime** - in the **1. Runtime Settings** card, click a tile: **CUDA** (NVIDIA GPUs), **Vulkan Windows** / **Vulkan Linux** (AMD/Intel GPUs, [§2.7](#27-amd--intel-gpu-support-vulkan)), **Metal** (Apple Silicon), or **CPU Only** (any machine). Incompatible tiles are greyed out with the reason; on machines with an NVIDIA GPU the app disables the other GPU runtimes with an "NVIDIA detected" badge (CPU Only stays available).
+2. **Fetch the image** - in the **2. Docker Image** card, click **Fetch Fresh Image**. The *Image Variant* row switches automatically to match your runtime; the only choice you'd ever make there yourself is **CUDA Legacy** for older NVIDIA cards (see below).
+3. **Choose your models** - in the **3. Instance Settings** card, pick a **Main Transcriber**, a **Live Mode Model**, and a **Diarization** engine by clicking their cards. Badges show what's *Downloaded* or *Missing* - anything missing is downloaded automatically when the server starts. Invalid combinations are greyed out with the reason (see the [Compatibility Matrix](#12-compatibility-matrix)).
+4. **Start it** - click **Start Local** at the bottom of the Instance Settings card. On the very first start the app walks you through a few quick prompts: confirming your model choices, approving the dependency download, and an **Optional Diarization Setup** step that asks for a HuggingFace token. The token is only needed for **PyAnnote** diarization - it's free ([create one here](https://huggingface.co/settings/tokens) with **Read** access) and you must also accept the [model's terms](https://huggingface.co/pyannote/speaker-diarization-community-1). Skipping this just disables PyAnnote; CAM++ and Sortformer need no token.
+5. **Wait for green.** The first start downloads several GB and can take **10-20 minutes** on reasonable hardware - later starts are fast. The status light turning **green** means the server is running and healthy.
+6. **Start the client** - go to the **Session** tab and click **Start Local** in the **Client Link** box. When it turns green, you're ready to roll!
 
 <br>
 
@@ -339,83 +349,87 @@ Setting up the server has two parts: downloading the Docker image, then starting
   * *Linux: `~/.config/TranscriptionSuite/`*
   * *Windows: `%APPDATA%\TranscriptionSuite\`*
   * *macOS: `~/Library/Application Support/TranscriptionSuite/`*
+* *Model selection is locked while the server is running - stop it first to switch models.*
 * *GNOME: the [AppIndicator](https://extensions.gnome.org/extension/615/appindicator-support/) extension is required for system-tray support.*
-* *Docker vs Podman: both are supported and auto-detected (Docker first). For GPU mode with Podman, make sure CDI is configured (`sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml`). Podman 4.7+ is required for `podman compose`.*
+* *Docker vs Podman: both are supported and auto-detected (Docker first). If detection failed and you've since fixed the cause, use the **Retry** button in the Server tab's setup checklist. For GPU mode with Podman, make sure CDI is configured (`sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml`). Podman 4.7+ is required for `podman compose`.*
 
-#### Older NVIDIA GPUs (GTX 10-series and earlier — Pascal / Maxwell)
+#### Older NVIDIA GPUs (GTX 10-series and earlier - Pascal / Maxwell)
 
-The default Docker image ships PyTorch built for **Volta and newer** GPUs (RTX 20-series and up). If your card is Pascal- or Maxwell-generation, PyTorch rejects it and the container crash-loops with an error like *"NVIDIA GeForce GTX 1070 with CUDA capability sm_61 is not compatible with the current PyTorch installation"*. Affected cards include:
+The default Docker image ships PyTorch built for **Volta and newer** GPUs (RTX 20-series and up). On a Pascal- or Maxwell-generation card the container crash-loops with an error like *"NVIDIA GeForce GTX 1070 with CUDA capability sm_61 is not compatible with the current PyTorch installation"*.
 
-- GeForce GTX 10-series — 1050 / 1060 / 1070 / 1080 (and Ti variants)
+<details>
+<summary><strong>Affected cards</strong></summary>
+
+- GeForce GTX 10-series - 1050 / 1060 / 1070 / 1080 (and Ti variants)
 - GeForce GTX 900-series and GTX 750 / 750 Ti
 - Tesla P4 / P40 / P100 / M40
 - Quadro P-series and M-series
 
-**Fix — switch to the legacy-GPU image** (a separate image built from the same Dockerfile but pinned to the cu126 PyTorch wheels, which still cover sm_50..sm_90):
+</details>
 
-1. In the Server tab, set the runtime to **GPU (CUDA)** (the legacy-GPU toggle only appears under this runtime).
-2. If the container already exists, stop the server and remove it via the cleanup controls.
-3. Flip the **Use legacy-GPU image (GTX 10-series / 900-series and older)** toggle. Confirm the dialog and leave **"Wipe runtime volume now (recommended)"** checked, so the next bootstrap re-syncs the cu126 wheels cleanly.
-4. Click **Fetch Fresh Image** to pull the legacy image, then **Start Local**. The first start re-downloads PyTorch and dependencies (10–20 minutes on reasonable hardware); later starts are normal speed.
+**Fix - switch to the CUDA Legacy image** (built from the same Dockerfile but pinned to the cu126 PyTorch wheels, which still support these cards):
 
-Once running, the legacy image behaves identically to the default. If you later move to a Volta-or-newer card, flip the toggle back off — leaving it on a modern GPU just gives you older PyTorch wheels for no benefit.
+1. In the **1. Runtime Settings** card, make sure the runtime is **CUDA**.
+2. If the container already exists, stop the server and remove the container first.
+3. In the **2. Docker Image** card, click the **CUDA Legacy** tile (*"GTX 10-series / 900-series and older"*) in the *Image Variant* row. Confirm the **"Switch to the CUDA Legacy image?"** dialog and leave **"Wipe runtime volume now (recommended)"** checked, so the next bootstrap re-syncs the cu126 wheels cleanly.
+4. Click **Fetch Fresh Image** to pull the legacy image, then **Start Local**. The first start re-downloads PyTorch and dependencies (10-20 minutes); later starts are normal speed.
+
+Once running, the legacy image behaves identically to the default. If you later move to a newer card, click the **CUDA / CPU Only** tile to switch back - staying on the legacy image with a modern GPU just gives you older PyTorch wheels for no benefit.
 
 ---
 
 ### 2.7 AMD / Intel GPU Support (Vulkan)
 
-If you have an **AMD or Intel GPU** (instead of NVIDIA), you can get GPU-accelerated transcription with [whisper.cpp](https://github.com/ggerganov/whisper.cpp) and Vulkan. There are two separate paths, and they're in very different shape right now:
+If you have an **AMD or Intel GPU** (instead of NVIDIA), you can get GPU-accelerated transcription with [whisper.cpp](https://github.com/ggerganov/whisper.cpp) and Vulkan. The setup differs per OS:
 
-- ✅ **Windows — works well.** The app runs a native `whisper-server.exe` on your PC and manages it for you. See [§2.7.1](#271-windows-working).
-- ⚠️ **Linux — experimental, not working correctly yet.** A helper Docker container (sidecar) runs alongside the main one. See the warning in [§2.7.2](#272-linux-experimental-not-working-yet).
+- **Windows** - the app runs a native `whisper-server.exe` on your PC and manages it for you. See [§2.7.1](#271-windows).
+- **Linux** - a helper Docker container (sidecar) runs alongside the main one. See [§2.7.2](#272-linux).
 
-Either way, you use **GGML models** (not the CUDA models) — see the [model table below](#available-ggml-models).
+Either way, you use **GGML models** (not the CUDA models) - see the [model table below](#available-ggml-models). Diarization is not available for GGML models. Note that on machines with an NVIDIA GPU, the app disables both Vulkan runtimes ("NVIDIA detected") and steers you to CUDA.
 
-#### 2.7.1 Windows (working)
+#### 2.7.1 Windows
 
 **What you need:**
 
 - An AMD or Intel GPU with current Windows drivers
-- Docker Desktop with the **WSL 2 backend** enabled (Settings → General → "Use the WSL 2 based engine")
+- Docker Desktop with the **WSL 2 backend** enabled (Settings → General → "Use the WSL 2 based engine") - without WSL 2 GPU passthrough the runtime tile is disabled with *"Requires WSL2 GPU"*
 
-**How it works:** the app downloads a native `whisper-server.exe`, runs it directly on Windows (not inside Docker), and the Docker backend talks to it at `http://host.docker.internal:8080`. Running it natively avoids the AVX2 CPU requirement that the containerised Vulkan build has, so it works on a wider range of CPUs.
+**How it works:** the app downloads a native `whisper-server.exe`, runs it directly on Windows (not inside Docker), and the Docker backend talks to it at `http://host.docker.internal:8080`. Running it natively avoids the AVX2 CPU requirement of the containerized Vulkan build, so it works on a wider range of CPUs. Docker Desktop is still needed for the main backend container - only the whisper engine runs natively.
 
 **How to set it up:**
 
-1. In the **Server tab**, open **Instance Settings** and select **GPU (Vulkan Windows)** as the runtime profile.
-2. In the image selector, choose the latest image tag (e.g. `v1.3.5`) and click **Fetch Fresh Image**. The Vulkan Windows profile uses its own dedicated image, so wait for the download to finish.
-3. Click **Start Local**. The app automatically downloads `whisper-server.exe` (if it isn't already present), then starts the Docker backend.
-4. In the setup prompts, pick a **GGML model** as your **Main Transcriber** and (optionally) one for **Live Mode**. Diarization isn't supported on this path — skip it.
+1. In the **Server** tab's **1. Runtime Settings** card, click the **Vulkan Windows** tile. (It's marked *Experimental* in the app, but for AMD/Intel GPUs on Windows it's the recommended GPU path.)
+2. In the **2. Docker Image** card, the *Image Variant* switches to Vulkan Windows automatically - this profile uses its own dedicated image. Click **Fetch Fresh Image** and wait for the download to finish.
+3. In the **3. Instance Settings** card, select **Whisper.cpp** as your **Main Transcriber** and pick a **GGML model** from the row below it; optionally do the same for **Live Mode**. (Diarization isn't offered for GGML models - the selector says so itself.)
+4. Click **Start Local**. The app downloads `whisper-server.exe` automatically if it isn't already present, then starts the Docker backend; missing GGML weights download during startup.
 5. Wait for the server status to turn green. You're ready to transcribe.
 
 > **Where the file lives:** `whisper-server.exe` is stored at `%APPDATA%\TranscriptionSuite\whisper-server\whisper-server.exe` and managed automatically by the app. You don't need to install or configure it yourself.
 
-#### 2.7.2 Linux (experimental, not working yet)
-
-> ⚠️ **Heads-up:** the Linux Vulkan path is **not working correctly yet**. The steps below are kept for reference and for anyone who wants to experiment, but expect problems. If you're on Linux with an AMD/Intel GPU and just want reliable transcription, use **CPU mode** for now (or an NVIDIA GPU if you have one). The Windows Vulkan path does work — see [§2.7.1](#271-windows-working).
+#### 2.7.2 Linux
 
 **What you need:**
 
-- An AMD GPU with Vulkan support (RDNA1 or newer — e.g. RX 5500 XT, RX 6600, RX 7800 XT), **or** an Intel GPU with Vulkan support (Arc A-series or integrated Xe graphics)
+- An AMD GPU with Vulkan support (RDNA1 or newer - e.g. RX 5500 XT, RX 6600, RX 7800 XT), **or** an Intel GPU with Vulkan support (Arc A-series or integrated Xe graphics)
 - Docker installed (Podman isn't supported for Vulkan mode yet)
 - A Linux host with `/dev/dri/renderD128` (a real DRI render node from the AMD/Intel kernel driver)
 
 **How to set it up:**
 
-1. In the **1. Runtime Settings** card, select **Vulkan Linux** as the runtime profile.
-2. In the **2. Docker Image** card, select the **Vulkan Linux** image variant and click **Fetch Fresh Image**. This profile uses its own dedicated image, so wait for the download to finish.
-3. In the **3. Instance Settings** card, under **Main Transcriber** select **whisper.cpp**, then pick the GGML model you want from the dropdown below it — e.g. `ggml-large-v3-turbo-q8_0.bin` (see the [model table below](#available-ggml-models)).
-4. Under **Live Mode Model**, select **whisper.cpp** again, then pick the GGML model you want for Live Mode from the dropdown below it.
-5. Click **Start Local**.
-6. In the setup prompts, when it gets to diarization, click **Skip** for now — diarization isn't available for whisper.cpp (GGML) models yet.
+1. In the **1. Runtime Settings** card, click the **Vulkan Linux** tile.
+2. In the **2. Docker Image** card, the *Image Variant* switches to Vulkan Linux automatically - this profile uses its own dedicated image. Click **Fetch Fresh Image** and wait for the download to finish.
+3. In the **3. Instance Settings** card, under **Main Transcriber** select **Whisper.cpp**, then pick the GGML model you want from the row below it - e.g. `ggml-large-v3-turbo-q8_0.bin` (see the [model table below](#available-ggml-models)).
+4. Under **Live Mode Model**, select **Whisper.cpp** again and pick a GGML model. **Use the same model for Main and Live Mode** - mixing different GGML models currently has issues we're still working on. (The "Same as main" shortcut isn't available for GGML models, so pick the same model manually in both selectors.)
+5. Click **Start Local**. Missing GGML weights download during startup; diarization isn't offered for GGML models.
 
-> **Use the same model for Main and Live Mode.** Picking different GGML models for the main transcriber and Live Mode currently has some issues we're still working on — stick to the same model for both until that's resolved.
-
-> **Switching models:** model selection is locked while the server is running. To switch, stop the server, pick the new model in Instance Settings, then start again.
+> **Switching models:** model selection is locked while the server is running. To switch, stop the server, pick the new model, then start again.
 
 #### Available GGML models
 
-**Recommended:** `ggml-large-v3-turbo-q8_0.bin` (~1.4 GB) — best balance of speed, quality, and VRAM use for most AMD/Intel GPUs.
+**Recommended:** `ggml-large-v3-turbo-q8_0.bin` (~1.4 GB) - best balance of speed, quality, and VRAM use for most AMD/Intel GPUs.
+
+<details>
+<summary><strong>Full model table</strong></summary>
 
 | Model | Size | Languages | Translation | Notes |
 |-------|------|-----------|-------------|-------|
@@ -431,52 +445,31 @@ Either way, you use **GGML models** (not the CUDA models) — see the [model tab
 | `ggml-small-q5_1.bin` | ~370 MB | 99 | Yes | Smallest multilingual |
 | `ggml-small.en.bin` | ~465 MB | English | No | Smallest English-only |
 
-#### What works on Vulkan
+Translation (to English) is available on the non-turbo, non-`.en` models. GGML weights download over HTTPS from [huggingface.co/ggerganov/whisper.cpp](https://huggingface.co/ggerganov/whisper.cpp).
 
-> **Note:** the full picture across all runtimes and models lives in the [Compatibility Matrix](#12-compatibility-matrix) (§1.2).
-
-| Feature | Vulkan (AMD/Intel) | NVIDIA (CUDA) |
-|---------|-------------------|---------------|
-| Longform transcription | Yes | Yes |
-| Translation (to English) | Yes (except turbo models) | Yes |
-| Speaker diarization | No | Yes |
-| Live mode | Yes | Yes |
-| Multiple concurrent jobs | One at a time | One at a time |
+</details>
 
 #### Vulkan troubleshooting
 
-- **_"Requires CUDA" badge on a model_** — you're in Vulkan mode; use a GGML model instead (the CUDA models won't work with the Vulkan sidecar).
-- **_Download fails_** — make sure the server container is running before downloading models (the download runs inside the container).
-- **_Sidecar health-check timeout_** — the model is still loading; large GGML files can take 30–60 seconds to initialise on first start.
-
-> **Older AMD GPUs (RDNA1):** if you hit Vulkan initialization errors on an RX 5500 XT or similar RDNA1 card, try adding `iommu=soft` to your kernel boot parameters.
-
-> **Windows feels slow?** Make sure Docker Desktop is using the WSL 2 backend (Settings → General → "Use the WSL 2 based engine"). A CPU-only fallback can't be detected automatically from the dashboard.
+- **_A model is greyed out with a "Requires CUDA" badge_** - you're on a Vulkan runtime; use a GGML model instead (the CUDA models won't run through whisper.cpp).
+- **_Sidecar health-check timeout_** - the model is still loading; large GGML files can take 30-60 seconds to initialize on first start.
+- **_Older AMD GPUs (RDNA1):_** if you hit Vulkan initialization errors on an RX 5500 XT or similar RDNA1 card, try adding `iommu=soft` to your kernel boot parameters.
+- **_Windows feels slow?_** Make sure Docker Desktop is using the WSL 2 backend (Settings → General → "Use the WSL 2 based engine").
 
 ---
 
 ## 3. Remote Connection
 
-TranscriptionSuite supports remote transcription where a **server machine** (with a
-GPU) runs the Docker container and a **client machine** connects to it via the
-Dashboard app. Two connection profiles are available:
+TranscriptionSuite supports remote transcription: a **server machine** (with a GPU) runs the container, and a **client machine** connects to it through the Dashboard app. Two connection profiles are available:
 
 | Profile | Use Case | Network Requirement |
 |---------|----------|---------------------|
 | **Tailscale** | Cross-network / internet (recommended) | Both machines on the same [Tailnet](https://tailscale.com/) |
 | **LAN** | Same local network, no Tailscale needed | Both machines on the same LAN / subnet |
 
-Both profiles use **HTTPS + token authentication**. The only difference is *how* the
-client reaches the server and *where* the TLS certificates come from.
+Both profiles use **HTTPS + token authentication** on port **9786**. The only difference is *how* the client reaches the server and *where* the TLS certificates come from.
 
-> **Remote profile chooser:** When you click **Start Remote** without Tailscale
-> certificates configured, a dialog asks you to choose between **LAN** and **Tailscale**.
-> Pick **LAN** if both machines are on the same local network - no extra setup is needed
-> (a self-signed certificate is generated automatically). Pick **Tailscale** if you need
-> cross-network access (requires Tailscale certificates - see Section 3.1 below).
-> You can change this later in **Settings → Client → Remote Profile**.
-
-**Architecture overview:**
+> **Remote profile chooser:** the first time you click **Start Remote** without Tailscale certificates configured, a dialog asks you to choose between **LAN** and **Tailscale**. Pick **LAN** if both machines are on the same local network - no extra setup is needed (a self-signed certificate is generated automatically). Pick **Tailscale** for cross-network access. You can change this later in **Settings → Client → Remote Profile**.
 
 ```
 ┌─────────────────────────┐         HTTPS (port 9786)        ┌─────────────────────────┐
@@ -489,19 +482,11 @@ client reaches the server and *where* the TLS certificates come from.
 └─────────────────────────┘                                  └─────────────────────────┘
 ```
 
-**Security model:**
-
-| Layer | Protection |
-|-------|------------|
-| **Tailscale Network** *(Tailscale profile)* | Only devices on your Tailnet can reach the server |
-| **TLS/HTTPS** | All traffic encrypted with certificates |
-| **Token Authentication** | Required for all API requests in remote mode |
+**Security model:** Tailscale-profile traffic is reachable only from devices on your Tailnet; all traffic is TLS-encrypted; and every API request in remote mode requires a Bearer token. The Settings → Client tab also has a **Manage Tokens** panel to mint extra per-client tokens and revoke old ones.
 
 ### 3.1 Option A: Tailscale (recommended)
 
-Use this when the server and client are on **different networks** (e.g., home
-server ↔ work laptop), or when you want Tailscale's zero-config networking
-and automatic DNS.
+Use this when the server and client are on **different networks** (e.g., home server ↔ work laptop), or when you want Tailscale's zero-config networking and automatic DNS.
 
 #### Server Machine Setup
 
@@ -509,7 +494,7 @@ and automatic DNS.
 
 1. Install Tailscale: [tailscale.com/download](https://tailscale.com/download)
 2. Authenticate: `sudo tailscale up` (Linux) or via the Tailscale app (Windows/macOS)
-3. Go to [Tailscale Admin Console](https://login.tailscale.com/admin) → **DNS** tab
+3. Go to the [Tailscale Admin Console](https://login.tailscale.com/admin) → **DNS** tab
 4. Enable **MagicDNS** and **HTTPS Certificates**
 
 Your DNS settings should look like this:
@@ -523,12 +508,7 @@ Your DNS settings should look like this:
 sudo tailscale cert your-machine.your-tailnet.ts.net
 ```
 
-This produces two files: `your-machine.your-tailnet.ts.net.crt` and
-`your-machine.your-tailnet.ts.net.key`. Move and rename them to the standard
-location so the app can find them without config changes:
-
-*(To change the default location, edit `remote_server.tls.host_cert_path` and
-`host_key_path` in `config.yaml`.)*
+This produces a `.crt` and a `.key` file. Move and rename them to the standard location so the app finds them without config changes *(to change the location, edit `remote_server.tls.host_cert_path` / `host_key_path` in `config.yaml`)*:
 
 **Linux:**
 ```bash
@@ -554,147 +534,67 @@ remote_server:
     host_key_path: "~/Documents/Tailscale/my-machine.key"
 ```
 
-> **Note:** Tailscale HTTPS certificates are issued for `.ts.net` hostnames, so
-> MagicDNS must be enabled in your Tailnet.
+> **Note:** Tailscale HTTPS certificates are issued for `.ts.net` hostnames, so MagicDNS must be enabled in your Tailnet.
 >
-> **Certificate expiry:** These certificates expire after **90 days**. When they expire the app will attempt to auto-renew via `tailscale cert` before starting the server. If auto-renewal fails, renew manually:
-> ```bash
-> sudo tailscale cert your-machine.your-tailnet.ts.net
-> mv your-machine.your-tailnet.ts.net.crt ~/.config/Tailscale/my-machine.crt
-> mv your-machine.your-tailnet.ts.net.key ~/.config/Tailscale/my-machine.key
-> ```
+> **Certificate expiry:** these certificates expire after **90 days**. The app attempts to auto-renew via `tailscale cert` before starting the server; if that fails, re-run the `tailscale cert` + `mv` commands above.
 
 **Step 3 - Start the Server in Remote Mode**
 
-1. Open the Dashboard on the server machine
-2. Navigate to the **Server** view
-3. Click **Start Remote**
-4. Wait for the container to become healthy (green status)
+1. Open the Dashboard on the server machine, go to the **Server** tab, and click **Start Remote**.
+2. Wait for the container to become healthy (green status).
+3. On the first remote start an admin **auth token** is generated automatically. Copy it from the Server tab's "Auth Token" field (or from the container logs: `docker compose logs | grep "Admin Token:"`) - you'll need it on the client machine.
 
-On the first remote start, an admin **auth token** is generated automatically.
-You can find it in the Server view's "Auth Token" field, or in the container logs:
-```bash
-docker compose logs | grep "Admin Token:"
-```
-
-Copy this token - you'll need it on the client machine.
-
-> **Tailscale hostname:** Once the server is running, the Server view displays the
-> machine's Tailscale FQDN (e.g., `desktop.tail1234.ts.net`) with a copy button.
-> Use this exact hostname when configuring clients - don't enter just the tailnet
-> suffix (e.g., `tail1234.ts.net`).
+> **Tailscale hostname:** once the server is running, the Server tab displays the machine's full Tailscale FQDN (e.g., `desktop.tail1234.ts.net`) with a copy button. Use this exact hostname when configuring clients - not just the tailnet suffix.
 
 **Step 4 - Open the Firewall Port (Linux)**
 
-If the server machine runs a firewall, port 9786 must be open for
-remote clients to reach the server. Without this, connections silently time out.
+If the server machine runs a firewall, port 9786 must be open or connections will silently time out. The dashboard shows a warning banner on the Server tab if it detects the port may be blocked.
 
 | Distribution | Command |
 |---|---|
 | **Ubuntu / Debian** (`ufw`) | `sudo ufw allow 9786/tcp comment 'TranscriptionSuite Server'` |
-| **Fedora GNOME / Fedora KDE** (`firewalld`) | `sudo firewall-cmd --permanent --add-port=9786/tcp && sudo firewall-cmd --reload` |
-
-The dashboard will show a firewall warning banner on the Server view if it
-detects the port may be blocked.
-
-> **Note:** This step is only needed on Linux with an active firewall. Windows and
-> macOS do not typically block Docker ports by default.
+| **Fedora** (`firewalld`) | `sudo firewall-cmd --permanent --add-port=9786/tcp && sudo firewall-cmd --reload` |
 
 #### Client Machine Setup
 
-1. Install Tailscale on the client machine and sign in with the **same account**
-   as the server machine (so both devices are on the same Tailnet)
-2. Open the Dashboard on the client machine
-3. Go to **Settings** → **Client** tab
-4. Enable **"Use remote server instead of local"**
-5. Select **Tailscale** as the remote profile
-6. Enter the server's **full Tailscale hostname** in the host field
-   (e.g., `my-machine.tail1234.ts.net`) - copy it from the Server view on the
-   server machine
-7. Set port to **`9786`**
-8. **Use HTTPS** will be automatically enabled
-9. Paste the **auth token** from the server into the Auth Token field
-10. Close the Settings modal - the client now connects to the remote server
+1. Install Tailscale on the client machine and sign in with the **same account** as the server machine (so both devices are on the same Tailnet).
+2. Open the Dashboard, go to **Settings → Client**, and enable **"Use remote server instead of local"**.
+3. Select **Tailscale** as the remote profile.
+4. Enter the server's **full Tailscale hostname** (e.g., `my-machine.tail1234.ts.net`) - copy it from the Server tab on the server machine. The Settings modal warns you if you enter a bare tailnet name without the machine prefix.
+5. Set port to **`9786`** (**Use HTTPS** enables automatically).
+6. Paste the **auth token** from the server, then close Settings - the client now connects to the remote server.
 
-> **Tip:** The client machine does *not* need certificates, Docker, or a GPU.
-> It only needs Tailscale running and a valid auth token.
-
-> **Common mistake:** Enter the **full machine hostname** (e.g.,
-> `desktop.tail1234.ts.net`), not just the tailnet name (`tail1234.ts.net`).
-> The Settings modal will warn you if it detects a bare tailnet name without a
-> machine prefix.
+> **Tip:** the client machine does *not* need certificates, Docker, or a GPU. It only needs Tailscale running and a valid auth token.
 
 ### 3.2 Option B: LAN (same local network)
 
-Use this when both machines are on the **same local network** and you don't want
-to use Tailscale. This is common for home-lab setups or office environments.
-
-LAN mode uses the same HTTPS + token authentication as Tailscale mode - the only
-differences are the hostname (LAN IP or local DNS name instead of a `.ts.net`
-address) and the certificate source (self-signed, local CA, or other locally
-trusted certificate instead of a Tailscale-issued one).
+Use this when both machines are on the **same local network** and you don't want Tailscale - common for home-lab or office setups. LAN mode uses the same HTTPS + token authentication; only the hostname (a LAN IP instead of a `.ts.net` address) and the certificate source differ.
 
 #### Server Machine Setup
 
-**Step 1 - TLS Certificate**
-
-LAN mode requires a TLS certificate. The dashboard **auto-generates** a
-self-signed certificate on the first remote start if none exists, covering
-`localhost` and all detected LAN IP addresses. No manual steps are needed in
-most cases.
-
-> **Custom certificate (optional):** If you prefer to use your own certificate
-> (e.g., from an internal CA), place it at the paths in `config.yaml` under
-> `remote_server.tls.lan_host_cert_path` / `lan_host_key_path`
-> (defaults: `~/.config/TranscriptionSuite/lan-server.crt` / `.key` on Linux,
-> `~/Documents/TranscriptionSuite/lan-server.crt` / `.key` on Windows).
-
-**Step 2 - Start the Server in Remote Mode**
-
-Same as Tailscale above:
-1. Open the Dashboard, go to **Server** view, click **Start Remote**
-2. Copy the auth token once the container is healthy
-
-**Step 3 - Open the Firewall Port (Linux)**
-
-Same as Tailscale above - if a firewall is active:
-
-| Distribution | Command |
-|---|---|
-| **Ubuntu / Debian** (`ufw`) | `sudo ufw allow 9786/tcp` |
-| **Fedora GNOME / Fedora KDE** (`firewalld`) | `sudo firewall-cmd --permanent --add-port=9786/tcp && sudo firewall-cmd --reload` |
+1. **TLS certificate:** the dashboard **auto-generates** a self-signed certificate on the first remote start if none exists, covering `localhost` and all detected LAN IPs. No manual steps are needed in most cases.
+   - Certificate generation uses the `openssl` command-line tool, which is preinstalled on Linux and macOS. On **Windows**, `openssl.exe` is usually *not* on PATH - if generation fails, install OpenSSL for Windows, make sure `openssl.exe` is on your PATH, and try again.
+   - *Custom certificate (optional):* to use your own (e.g. from an internal CA), place it at the paths in `config.yaml` under `remote_server.tls.lan_host_cert_path` / `lan_host_key_path` (defaults: `~/.config/TranscriptionSuite/lan-server.crt` / `.key` on Linux, `~/Documents/TranscriptionSuite/lan-server.crt` / `.key` on Windows).
+2. **Start Remote:** open the **Server** tab, click **Start Remote**, and copy the auth token once the container is healthy (same as Tailscale above).
+3. **Firewall (Linux):** if a firewall is active, open port 9786: `sudo ufw allow 9786/tcp` (Ubuntu/Debian) or `sudo firewall-cmd --permanent --add-port=9786/tcp && sudo firewall-cmd --reload` (Fedora).
 
 #### Client Machine Setup
 
-1. Open the Dashboard on the client machine
-2. Go to **Settings** → **Client** tab
-3. Enable **"Use remote server instead of local"**
-4. Select **LAN** as the remote profile
-5. Enter the server's **LAN IP or hostname** (e.g., `192.168.1.100`)
-6. Set port to **`9786`**
-7. **Use HTTPS** will be automatically enabled
-8. Paste the **auth token** from the server
-9. Close Settings - the client now connects over your local network
+Same as the Tailscale client setup, except: select **LAN** as the remote profile and enter the server's **LAN IP or hostname** (e.g., `192.168.1.100`) as the host.
 
-> **Note on Kubernetes / custom deployments:** If you run the server container
-> directly (e.g., via Kubernetes or your own Docker setup), you can still use the
-> LAN profile on the client. Just point the LAN host at your load balancer or
-> service IP. The server image is available at
-> `ghcr.io/homelab-00/transcriptionsuite-server`. Ensure `TLS_ENABLED=true` and
-> the certificate/key are mounted at `/certs/cert.crt` and `/certs/cert.key`
-> inside the container.
+> **Note on Kubernetes / custom deployments:** if you run the server container directly (e.g., via Kubernetes or your own Docker setup), you can still use the LAN profile on the client - point the LAN host at your load balancer or service IP. The server image is at `ghcr.io/homelab-00/transcriptionsuite-server`. Ensure `TLS_ENABLED=true` and mount the certificate/key at `/certs/cert.crt` and `/certs/cert.key` inside the container.
 
 ---
 
 ## 4. OpenAI-compatible API Endpoints
 
-*Note: This is a summary. For more info about API endpoints, see section 7 of README_DEV.*
+*This is a summary - for more detail see [README_DEV](README_DEV.md).*
 
 Mounted at `/v1/audio/`. These endpoints follow the [OpenAI Audio API spec](https://platform.openai.com/docs/api-reference/audio) so that OpenAI-compatible clients (Open-WebUI, LM Studio, etc.) can point at TranscriptionSuite as a drop-in STT backend.
 
-**Auth:** Same rules as all other API routes - Bearer token required in TLS mode; open to localhost in local mode.
+**Auth:** same rules as all other API routes - Bearer token required in TLS mode; open to localhost in local mode.
 
-**Error shape:** All errors follow the OpenAI error envelope:
+**Error shape:** errors follow the OpenAI error envelope:
 ```json
 {"error": {"message": "...", "type": "...", "param": null, "code": null}}
 ```
@@ -703,7 +603,8 @@ Mounted at `/v1/audio/`. These endpoints follow the [OpenAI Audio API spec](http
 
 Transcribe an audio or video file. Language auto-detected when `language` is omitted.
 
-**Form fields:**
+<details>
+<summary><strong>Form fields</strong></summary>
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -718,31 +619,38 @@ Transcribe an audio or video file. Language auto-detected when `language` is omi
 | `expected_speakers` | `int (1-10)` | `null` | Exact speaker count hint; out-of-range values return `400` |
 | `parallel_diarization` | `bool` | server config | Override parallel vs sequential diarize + transcribe for this call |
 
+</details>
+
 **Response formats:**
 
 | `response_format` | Content-Type | Shape |
 |-------------------|--------------|-------|
-| `json` | `application/json` | `{"text": "..."}` — minimal OpenAI body; never leaks speaker labels |
+| `json` | `application/json` | `{"text": "..."}` - minimal OpenAI body; never leaks speaker labels |
 | `text` | `text/plain` | Raw transcript string |
 | `verbose_json` | `application/json` | Full OpenAI object (`task`, `language`, `duration`, `text`, `segments`, optional `words`); gains per-segment `speaker` and top-level `num_speakers` when diarization ran |
 | `srt` | `text/plain` | SRT subtitle file; cues prefixed `Speaker 1:`, `Speaker 2:` when diarization ran |
 | `vtt` | `text/plain` | WebVTT subtitle file; same speaker prefix as SRT |
 | `diarized_json` | `application/json` | Compact `{task, language, duration, text, num_speakers, segments}` with `speaker`, `start`, `end`, `text` per segment (raw `SPEAKER_00` form for programmatic use) |
 
-**Speaker labels:** JSON bodies (`verbose_json`, `diarized_json`) use raw `SPEAKER_00`/`SPEAKER_01` form for stable programmatic identifiers. Subtitle formats (`srt`, `vtt`) normalize to `Speaker 1`/`Speaker 2` — same convention the dashboard's longform export uses.
+**Speaker labels:** JSON bodies (`verbose_json`, `diarized_json`) use raw `SPEAKER_00`/`SPEAKER_01` form for stable programmatic identifiers. Subtitle formats (`srt`, `vtt`) normalize to `Speaker 1`/`Speaker 2` - the same convention the dashboard's longform export uses.
 
-**Diarization failure tolerance:** If `diarization=true` is requested but the diarization engine fails (no HF token, OOM, merge error), the endpoint returns 200 with a plain transcript (`num_speakers=0`, no `speaker` keys) and logs a WARNING server-side. Diarization hiccups never 5xx the call.
+**Diarization failure tolerance:** if `diarization=true` is requested but the diarization engine fails (no HF token, OOM, merge error), the endpoint returns 200 with a plain transcript (`num_speakers=0`, no `speaker` keys) and logs a WARNING server-side. Diarization hiccups never 5xx the call. Whenever diarization was requested, the response carries an `X-Diarization-Status` header (`ready` or `unavailable`) so clients can detect this.
 
 **Error codes:**
 
 | Status | `type` | Cause |
 |--------|--------|-------|
-| `400` | `invalid_request_error` | Unknown `response_format`, missing/empty `file`, `expected_speakers` out of 1–10 |
-| `429` | `rate_limit_error` | Another transcription job is already running |
-| `503` | `server_error` | No transcription model is configured |
-| `500` | `server_error` | Internal engine error |
+| `400` | `invalid_request_error` | Unknown `response_format`, empty `file` field, `expected_speakers` out of 1-10 |
+| `429` | `rate_limit_error` | Another transcription job is already running - the job slot is shared with the dashboard, so a longform, import, or notebook job in progress also triggers this (Live Mode uses a separate path and doesn't occupy the slot) |
+| `503` | `server_error` | No transcription model configured, or a backend dependency is unavailable |
+| `500` | `server_error` | Internal engine error, or the job was cancelled |
 
-**Example — diarized verbose transcript (curl):**
+> A completely *missing* `file` field is rejected by FastAPI's own validation as a `422` with a different (non-OpenAI) error shape.
+
+<details>
+<summary><strong>curl examples</strong></summary>
+
+Diarized verbose transcript:
 ```bash
 curl -X POST http://localhost:9786/v1/audio/transcriptions \
   -H "Authorization: Bearer <token>" \
@@ -752,7 +660,7 @@ curl -X POST http://localhost:9786/v1/audio/transcriptions \
   -F "response_format=diarized_json"
 ```
 
-**Example — word-level verbose (curl):**
+Word-level verbose:
 ```bash
 curl -X POST http://localhost:9786/v1/audio/transcriptions \
   -H "Authorization: Bearer <token>" \
@@ -761,32 +669,20 @@ curl -X POST http://localhost:9786/v1/audio/transcriptions \
   -F "timestamp_granularities[]=word"
 ```
 
+</details>
+
 #### `POST /v1/audio/translations`
 
-Transcribe **and translate** an audio or video file to English. Identical to `/transcriptions` except:
+Transcribe **and translate** an audio or video file to English. Identical to `/transcriptions` (same fields, formats, and error codes) except:
 - `language` is not accepted (source language is always auto-detected)
 - Translation target is always English
 - The `task` field in `verbose_json` responses is `"translate"` instead of `"transcribe"`
 
-**Form fields:**
+> **Backend note:** translation requires a model with translation capability - a multilingual Whisper model (to English) or Canary v2 (bidirectional). Backends without translation support (Parakeet, SenseVoice, VibeVoice, turbo/`.en` Whisper variants) return a `400` or `500` from the engine layer.
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `file` | `UploadFile` | required | Audio or video file |
-| `model` | `string` | `"whisper-1"` | Accepted but ignored |
-| `prompt` | `string` | `null` | Initial prompt passed to the transcription engine |
-| `response_format` | `string` | `"json"` | One of `json`, `text`, `verbose_json`, `srt`, `vtt`, `diarized_json` |
-| `temperature` | `float` | `null` | Accepted but ignored |
-| `timestamp_granularities[]` | `list[string]` | `null` | Include `"word"` to enable word-level timestamps |
-| `diarization` | `bool` | `false` | Same semantics as `/transcriptions` — speaker labels attach to the translated segments |
-| `expected_speakers` | `int (1-10)` | `null` | Exact speaker count hint |
-| `parallel_diarization` | `bool` | server config | Override parallel vs sequential orchestration |
+<details>
+<summary><strong>curl examples</strong></summary>
 
-**Error codes:** Same as `/transcriptions`.
-
-> **Backend note:** Translation requires a model with translation capability — a multilingual Whisper model (to English) or Canary v2 (bidirectional). Backends without `task="translate"` support (Parakeet, SenseVoice, VibeVoice, turbo/`.en` Whisper variants) will return a `400` or `500` from the engine layer.
-
-**Example (curl):**
 ```bash
 curl -X POST http://localhost:9786/v1/audio/translations \
   -H "Authorization: Bearer <token>" \
@@ -794,7 +690,7 @@ curl -X POST http://localhost:9786/v1/audio/translations \
   -F "response_format=text"
 ```
 
-**Example — diarized translation (curl):**
+Diarized translation:
 ```bash
 curl -X POST http://localhost:9786/v1/audio/translations \
   -H "Authorization: Bearer <token>" \
@@ -803,18 +699,18 @@ curl -X POST http://localhost:9786/v1/audio/translations \
   -F "response_format=diarized_json"
 ```
 
+</details>
+
 ---
 
 ## 5. Outgoing Webhooks
 
-TranscriptionSuite can send HTTP POST requests to an external URL whenever a transcription event occurs. This lets you pipe transcription results into your own applications, automation pipelines, or logging services.
-
-Two event types are supported:
+TranscriptionSuite can send HTTP POST requests to an external URL whenever a transcription event occurs, so you can pipe results into your own applications, automation pipelines, or logging services.
 
 | Event | Fires when |
 |-------|------------|
 | `live_sentence` | A sentence is completed during Live Mode |
-| `longform_complete` | A file/import/notebook transcription job finishes |
+| `longform_complete` | A transcription job finishes (file, import, notebook, or OpenAI-API job) |
 
 ### Setup
 
@@ -823,7 +719,7 @@ Open **Settings → Server** tab. In the **Outgoing Webhook** section:
 1. **Enable** the webhook toggle
 2. Enter the **URL** to receive POST requests
 3. *(Optional)* Enter a **Secret** - sent as `Authorization: Bearer <secret>` on every request
-4. Click **Send Test Webhook** to verify your endpoint receives the request
+4. Save the server config (webhook fields are applied with the save button, not instantly), then click **Send Test Webhook** to verify your endpoint receives the request
 
 These settings are also editable directly in `config.yaml`:
 
@@ -846,7 +742,10 @@ Every webhook POST has `Content-Type: application/json` with this envelope:
 }
 ```
 
-**Live sentence payload:**
+<details>
+<summary><strong>Payload shapes per event</strong></summary>
+
+**Live sentence:**
 
 ```json
 {
@@ -855,7 +754,7 @@ Every webhook POST has `Content-Type: application/json` with this envelope:
 }
 ```
 
-**Longform completion payload:**
+**Longform completion:**
 
 ```json
 {
@@ -868,21 +767,35 @@ Every webhook POST has `Content-Type: application/json` with this envelope:
 }
 ```
 
-> **Note:** Delivery is fire-and-forget - the server sends each webhook once and does not retry on failure. Failed deliveries are logged on the server side.
+**Test webhook** (from the Send Test Webhook button): `{"event": "test", ..., "payload": {"message": "Test webhook from TranscriptionSuite.", "source": "test"}}`
+
+</details>
+
+**Delivery notes:**
+
+- Delivery is fire-and-forget: each webhook is sent once with a **10-second timeout** and is not retried on failure. Failed deliveries are logged server-side.
+- For safety, URLs pointing at private or internal addresses (localhost, LAN IPs, `.local`/`.internal` hostnames, non-http(s) schemes) are **blocked** - the test button reports *"URL blocked: targets a private or internal address"*. Use a publicly resolvable endpoint.
 
 ---
 
 ## 6. Troubleshooting
 
-As with most things, the first thing to try is turning them off and on again. Stop the server/client, quit the app and then try again.
+As with most things, the first thing to try is turning it off and on again: stop the server/client, quit the app, and try again.
 
-The next step is to start deleting things. The safest choice is deleting *everything*, but that means having to redownload everything and losing whatever recordings you've saved in the Notebook (unless you create a backup). Volumes 'data' & 'models' don't usually need to be removed for example.
+The next step is deleting things and letting the app re-fetch them. All the controls are in the **Server** tab:
 
-Controls for all these actions can be found in the Server tab. Here you can remove the container, image, and volumes individually or use the big red button at the bottom (that can also remove your config folder).
+- **Remove Image** - in the *2. Docker Image* card
+- **Remove Container** - in the *3. Instance Settings* card
+- **Clear Data** / **Clear Models** / **Clear Runtime** - per-volume buttons in the *5. Persistent Volumes* card
+- **Clean All** - the big red button in the *6. Clean Up* card. Its dialog has checkboxes to keep the data volume, the models volume, and the config folder; everything unchecked means a full wipe.
+
+What the volumes hold: **data** is your database and Notebook recordings (the irreplaceable one - back it up before clearing!), **models** is downloaded model weights (safe to clear, they re-download), and **runtime** is scratch space (always safe to clear; Clean All always wipes it). On Apple Silicon (Metal) there are no Docker volumes - the Persistent Volumes card lists the local directories instead.
+
+Server logs live in the **Logs** tab in the sidebar - the first place to look when something misbehaves.
 
 ### GPU not working after a system update (Linux)
 
-If the server crashes with `CUDA failed with error unknown error` after a system update (common on rolling-release distros like Arch), your NVIDIA driver likely updated past what the legacy Docker GPU hook supports. The fix is to switch to CDI mode:
+If the server crashes with `CUDA failed with error unknown error` after a system update (common on rolling-release distros like Arch), your NVIDIA driver likely updated past what the legacy Docker GPU hook supports. Switch to CDI mode:
 
 ```bash
 sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
@@ -890,11 +803,11 @@ sudo nvidia-ctk config --in-place --set nvidia-container-runtime.mode=cdi
 sudo systemctl restart docker
 ```
 
-The dashboard detects CDI automatically and uses the correct GPU configuration. No image rebuild or reinstall needed.
+The dashboard detects CDI automatically and uses the correct GPU configuration - no image rebuild or reinstall needed. Note that the CDI spec describes your current driver, so re-run the `cdi generate` command after future driver updates too (the dashboard warns when the spec looks stale).
 
 ### Dashboard shows GPU error / red status
 
-**Symptom:** The dashboard shows a red error state with "GPU unavailable" in the Session view and red dots in the sidebar.
+**Symptom:** the dashboard shows a red error state with "GPU unavailable" in the Session tab.
 
 **Steps:**
 
@@ -903,23 +816,23 @@ The dashboard detects CDI automatically and uses the correct GPU configuration. 
    ```bash
    sudo nvidia-smi -pm 1
    ```
-3. If the error persists after a reboot, check the server logs for the CUDA diagnostic line (logged at startup). It contains the torch version, CUDA version, and device nodes - useful for reporting the issue.
+3. If the error persists after a reboot, check the **Logs** tab for the CUDA diagnostic line (logged at startup). It contains the torch version, CUDA version, and device nodes - useful for reporting the issue.
 4. **Advanced:** `sudo nvidia-smi --gpu-reset` can reset the GPU without a full reboot, but this affects all processes using the GPU on the host.
-5. **Workaround:** Switch to CPU mode in **Settings > Server** while you investigate.
+5. **Workaround:** switch to the **CPU Only** runtime in the Server tab while you investigate (expect slower transcription).
 
 ### GPU errors persist across container restarts
 
 **Symptom:** `nvidia-smi` shows a healthy GPU, but the server logs report CUDA error 999 every time the container starts.
 
-**Cause:** The NVIDIA driver can enter a degraded context when a container exits uncleanly. Without Persistence Mode, the driver resets incompletely on the next attach.
+**Cause:** the NVIDIA driver can enter a degraded context when a container exits uncleanly. Without Persistence Mode, the driver resets incompletely on the next attach.
 
-**Solution:** Enable NVIDIA Persistence Mode on the host:
+**Solution:** enable NVIDIA Persistence Mode on the host:
 
 ```bash
 sudo nvidia-smi -pm 1
 ```
 
-This keeps the driver context warm across container lifecycle events. The setting persists until the next reboot. To make it permanent, install the included systemd unit:
+This persists until the next reboot. To make it permanent, install the included systemd unit (run from the repo root):
 
 ```bash
 sudo cp build/nvidia-persistence.service /etc/systemd/system/
@@ -927,17 +840,15 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now nvidia-persistence.service
 ```
 
-**Alternative:** Reboot the host to fully reset the driver state.
-
 ### Windows / CPU-only: local start fails
 
-**Symptom:** On a CPU-only machine (no NVIDIA GPU), first start fails during dependency install — either with `invalid peer certificate: UnknownIssuer` while downloading packages, or later with `UnicodeEncodeError: 'latin-1' codec can't encode ...` when loading the model.
+**Symptom:** on a CPU-only machine (no NVIDIA GPU), first start fails during dependency install - either with `invalid peer certificate: UnknownIssuer` while downloading packages, or later with `UnicodeEncodeError: 'latin-1' codec can't encode ...` when loading the model.
 
 **Steps:**
 
-1. **Use the CPU profile.** In **Settings > Server**, select the **CPU** profile before starting. CPU-only hosts no longer download the multi-GB NVIDIA CUDA wheels and default to a lighter faster-whisper model instead of the GPU-only NeMo model.
-2. **`UnknownIssuer` / certificate errors** mean something (antivirus HTTPS scanning, or a corporate proxy) is intercepting HTTPS and re-signing it, so the container can't verify the package index. Turn off your antivirus's HTTPS-scanning setting, or point `EXTRA_CA_CERTS_DIR` at a folder holding the intercepting root CA — see the [deployment guide](deployment-guide.md#tls-interception--corporate-network-unknownissuer).
-3. **`UnicodeEncodeError` on model load** means a HuggingFace token containing a non-ASCII character was provided. Clear the token (most models don't need one); the server now also ignores non-ASCII tokens automatically and downloads anonymously.
+1. **Use the CPU runtime.** In the Server tab's Runtime Settings, select **CPU Only** before starting. CPU-only hosts then skip the multi-GB NVIDIA CUDA wheels and default to a lighter faster-whisper model.
+2. **`UnknownIssuer` / certificate errors** mean something (antivirus HTTPS scanning, or a corporate proxy) is intercepting HTTPS and re-signing it, so the container can't verify the package index. Turn off your antivirus's HTTPS-scanning setting, or point `EXTRA_CA_CERTS_DIR` at a folder holding the intercepting root CA - see the [deployment guide](deployment-guide.md#tls-interception--corporate-network-unknownissuer).
+3. **`UnicodeEncodeError` on model load** means a HuggingFace token containing a non-ASCII character was provided. Clear the token (most models don't need one); the server also ignores non-ASCII tokens automatically and downloads anonymously.
 
 ### Advanced Troubleshooting
 


### PR DESCRIPTION
## Summary

Complete rewrite of `docs/README.md`: friendlier for new and non-technical users, shorter (977 → 888 source lines, with reference tables collapsed into `<details>` blocks so the rendered page is much shorter still), and every claim re-verified against the current code. Section 9 is kept byte-identical. Screenshots and demo videos are untouched (handled separately).

## What changed

**Introduction (main focus)**
* Plain-language header and intro: what the app is, the Dashboard/server split, a one-line Docker gloss, and where to go first
* Jargon glossed at first use (runtime, VRAM, GGML, sidecar, HuggingFace token) plus a "you can skip this section" note before the compatibility matrix

**Stale UI instructions corrected (post Server-tab redesign, PRs #228-#240)**
* §2.6 rewritten around the numbered card wizard; Start Local located correctly; the removed legacy-GPU toggle replaced by the CUDA Legacy image-variant tile flow
* §2.1 Mac steps point at the Metal runtime tile + Start Metal Server (old "Settings → Runtime Profile" path removed), with the System Settings "Open Anyway" alternative
* §2.7 Vulkan steps match the current UI (variant auto-derives from runtime, no wizard/Skip prompts, "Same as main" caveat for GGML live models)
* Compatibility matrix uses the actual runtime tile names and documents the NVIDIA-detected gating

**Previously undocumented features added**
* Rolling ~20s preview during longform recording, notification center, weekly update checks, `.ass` subtitle export and the "Both" import option, click-to-select model cards with auto-download at server start, Manage Tokens panel, NeMo Greek final-sigma warning, exact release artifact filenames (incl. disambiguating the `arm64-mac-metal` DMG from the thin one)

**Factual corrections**
* OpenAI API error table (shared 429 job slot, extra 503/500 causes, 422 for a missing file part) and the `X-Diarization-Status` header
* Webhook delivery notes: 10s timeout, private/internal URL blocking, test payload shape
* LAN remote mode: openssl dependency (esp. Windows), firewall commands inlined
* Troubleshooting uses the exact current button/card labels and explains what each Docker volume holds

**Removed**
* The "Linux Vulkan not working correctly yet" warning; both Vulkan paths are now presented neutrally

## Test plan
- [x] All internal anchor links verified resolving (64/64)
- [x] Section 9 byte-identical to previous version
- [x] Every named UI string checked against dashboard source
- [ ] Visual once-over of the rendered page on GitHub