### PR TITLE
fix(ui): stack instance status badge under Running/Stopped text

### DIFF
--- a/dashboard/components/views/ServerView.tsx
+++ b/dashboard/components/views/ServerView.tsx
@@ -2343,7 +2343,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                 <div className="border-b border-white/5 pb-4">
                   <div className="flex flex-wrap items-center gap-5">
                     {!isMetal && (
-                      <div className="flex h-6 shrink-0 items-center space-x-3 border-r border-white/10 pr-5">
+                      <div className="flex shrink-0 items-center space-x-3 border-r border-white/10 pr-5">
                         <StatusLight
                           status={
                             isRunningAndHealthy
@@ -2354,25 +2354,31 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                           }
                           animate={isRunningAndHealthy}
                         />
-                        <span
-                          className={`font-mono text-sm transition-colors ${
-                            isRunning
-                              ? 'text-slate-300'
-                              : containerStatus.exists
-                                ? 'text-accent-orange'
-                                : 'text-slate-500'
-                          }`}
-                        >
-                          {statusLabel}
-                        </span>
-                        {isRunning && serverMode && (
+                        {/* Status label and the LOCAL/REMOTE mode badge stack
+                            vertically so the badge sits directly under the
+                            Running/Stopped text instead of widening this block
+                            and pushing the action buttons into an overflow. */}
+                        <div className="flex flex-col items-start gap-1">
                           <span
-                            className={`flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-bold tracking-wide uppercase ${serverMode === 'local' ? 'bg-accent-cyan/15 text-accent-cyan' : 'bg-accent-magenta/15 text-accent-magenta'}`}
+                            className={`font-mono text-sm transition-colors ${
+                              isRunning
+                                ? 'text-slate-300'
+                                : containerStatus.exists
+                                  ? 'text-accent-orange'
+                                  : 'text-slate-500'
+                            }`}
                           >
-                            {serverMode === 'local' ? <Laptop size={10} /> : <Radio size={10} />}
-                            {serverMode}
+                            {statusLabel}
                           </span>
-                        )}
+                          {isRunning && serverMode && (
+                            <span
+                              className={`flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-bold tracking-wide uppercase ${serverMode === 'local' ? 'bg-accent-cyan/15 text-accent-cyan' : 'bg-accent-magenta/15 text-accent-magenta'}`}
+                            >
+                              {serverMode === 'local' ? <Laptop size={10} /> : <Radio size={10} />}
+                              {serverMode}
+                            </span>
+                          )}
+                        </div>
                       </div>
                     )}
                     <div className="flex min-w-0 flex-1 flex-wrap items-center justify-between gap-4">


### PR DESCRIPTION
## Summary

In the **Instance Settings** card, the `LOCAL` / `REMOTE` mode badge rendered **inline** to the right of the container status label (`Running` / `Stopped` / `Exited`). Because that status block shares the header row's spacing with the action-buttons block, the extra inline width stole horizontal space and pushed the action buttons (`Unload Models` / `Remove Container`) into an overflow/wrap.

This moves the badge onto its **own line directly beneath** the status text, shrinking the status block back to the text width and freeing space for the buttons.

## Changes

- `dashboard/components/views/ServerView.tsx`:
  - Wrapped the status label + mode badge in a `flex flex-col items-start gap-1` column so the badge stacks under the `Running`/`Stopped` text.
  - Removed the fixed `h-6` on the status container so it can grow to two lines; the status dot stays vertically centered against the block (parent row keeps `items-center`).
  - `items-start` keeps the badge (itself `display:flex`) hugging its content instead of stretching full width.

## Test plan

- [x] `npm run ui:contract:check` — passes (16 checks), no baseline change required
- [x] `ServerView.test.tsx` — 31/31 pass (Node 22)
- [x] Manual smoke: confirm on a running local instance that `LOCAL` sits under `Running` and the action buttons no longer overflow (KDE Wayland)