### PR TITLE
Title: fix(dashboard): skip multi-GB CUDA PyTorch wheels on the Vulkan runtime profiles

### DIFF
--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -2357,7 +2357,16 @@ async function startContainer(options: StartContainerOptions): Promise<string> {
   // and select the cpu PyTorch wheels so the bootstrap skips the multi-GB CUDA
   // wheels a CPU-only host can't use (GH-125). Set on composeEnv only (not
   // persisted to .env) so a later GPU launch is unaffected.
-  if (runtimeProfile === 'cpu') {
+  //
+  // Vulkan (Linux) and vulkan-wsl2 (Windows) get the same treatment:
+  // composeFileArgs() only attaches the NVIDIA device-passthrough overlay
+  // (docker-compose.gpu.yml) for the 'gpu' profile, so the main container never
+  // has CUDA device access on either Vulkan profile regardless of wheel variant
+  // — GPU-accelerated ASR runs through the whisper.cpp/Vulkan sidecar instead
+  // (containerised on Linux via /dev/dri, a native whisper-server.exe on
+  // Windows). The cu129 wheels (~3.9GB of nvidia-* packages, see uv.lock) buy
+  // nothing on either profile.
+  if (runtimeProfile === 'cpu' || runtimeProfile === 'vulkan' || runtimeProfile === 'vulkan-wsl2') {
     composeEnv['CUDA_VISIBLE_DEVICES'] = '';
     composeEnv['PYTORCH_VARIANT'] = 'cpu';
   }


### PR DESCRIPTION
## Summary
- Skip the multi-GB CUDA PyTorch wheel set (torch + ~14 nvidia-* packages, ~3.9GB per `uv.lock`) when bootstrapping the main server container on either Vulkan runtime profile — Linux
(`vulkan`) and Windows (`vulkan-wsl2`).
- Neither profile ever grants the main container NVIDIA device passthrough (`docker-compose.gpu.yml` is only attached for the `gpu` profile), so those wheels could never actually reach a
CUDA device on this profile in the first place — they were pure download/disk bloat on every first-boot and structural rebuild.
- GPU-accelerated ASR is unaffected: it runs through the whisper.cpp/Vulkan sidecar (containerised via `/dev/dri` on Linux, a native `whisper-server.exe` on Windows), never through
PyTorch.
- Mirrors the existing GH-125 treatment already applied to the `cpu` runtime profile (`CUDA_VISIBLE_DEVICES=''` + `PYTORCH_VARIANT=cpu`).

## Test plan
- [ ] `npx tsc --noEmit` passes (verified)
- [ ] Start the server on the Linux `vulkan` profile from a clean `/runtime` volume; confirm bootstrap logs show `pytorch_variant=cpu` and no `nvidia-*` packages in the sync
- [ ] Start the server on the Windows `vulkan-wsl2` profile from a clean `/runtime` volume; same check
- [ ] Confirm transcription still works via the whisper.cpp sidecar on both profiles
- [ ] Confirm diarization still works (CPU-only torch, expected to be slower but functional)
