### PR TITLE
feat(ci, dashboard): bundle static FFmpeg into the mac-metal DMG (GH #255)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,6 +296,84 @@ jobs:
           fi
           echo "✓ Bundled MLX venv verified (uvicorn + fastapi present and importable)"
 
+      - name: Bundle static ffmpeg + ffprobe into app bundle
+        # GH #255: macOS ships no ffmpeg, and the Metal backend shells out to
+        # ffmpeg/ffprobe for every non-WAV decode (imports, multitrack probing,
+        # duration, notebook MP3). Bundle a self-contained static pair so the
+        # native build works without Homebrew. mlxServerManager appends this
+        # directory to the spawned server's PATH after the Homebrew bins, so a
+        # user-installed FFmpeg still takes precedence.
+        #
+        # Binaries: FFmpeg GPL static arm64 builds from
+        # https://ffmpeg.martin-riedl.de (build script published at
+        # https://git.martin-riedl.de/ffmpeg/build-script). Pinned to an
+        # immutable versioned path with hardcoded SHA256s of the zips — a
+        # changed or compromised upstream fails the build instead of shipping
+        # silently. To bump: pick a new versioned path from the site, update
+        # FFMPEG_BUILD and both hashes from the published .zip.sha256 files.
+        #
+        # ORDERING (GH #154): this step mutates Contents/Resources, so it MUST
+        # run before the re-sign step below. The re-sign's `-perm /111` pass
+        # signs these binaries automatically, and the seal gate then covers
+        # them.
+        env:
+          FFMPEG_BUILD: "1783011502_8.1.2"
+          FFMPEG_ZIP_SHA256: "ef1aa60006c7b77ce170c1608c08d8e4ba1c30c5746f2ac986ded932d0ac2c3c"
+          FFPROBE_ZIP_SHA256: "c39787f4af7a3932502d2d48db6f6feaaa836b48a73ef78c32cc3285df61dfaf"
+        run: |
+          APP_BUNDLE="$(pwd)/dashboard/release/mac-arm64/TranscriptionSuite.app"
+          FFMPEG_DIR="$APP_BUNDLE/Contents/Resources/ffmpeg"
+          BASE_URL="https://ffmpeg.martin-riedl.de/download/macos/arm64/${FFMPEG_BUILD}"
+          mkdir -p "$FFMPEG_DIR"
+
+          fetch_tool() {
+            local tool="$1" sha="$2"
+            curl -fsSL --retry 3 -o "$tool.zip" "$BASE_URL/$tool.zip"
+            echo "$sha  $tool.zip" | shasum -a 256 -c -
+            unzip -o -q "$tool.zip" -d "$FFMPEG_DIR"
+            chmod 755 "$FFMPEG_DIR/$tool"
+            rm "$tool.zip"
+          }
+          fetch_tool ffmpeg "$FFMPEG_ZIP_SHA256"
+          fetch_tool ffprobe "$FFPROBE_ZIP_SHA256"
+
+          # Smoke-run on the arm64 runner: the binaries must execute and carry
+          # the codecs the backend depends on (aac/mp3/flac/vorbis/opus decode
+          # for imports, libmp3lame encode for notebook MP3 conversion).
+          "$FFMPEG_DIR/ffmpeg" -version | head -1
+          "$FFMPEG_DIR/ffprobe" -version | head -1
+          DECODERS="$("$FFMPEG_DIR/ffmpeg" -hide_banner -decoders)"
+          for codec in aac mp3 flac vorbis opus; do
+            if ! echo "$DECODERS" | grep -qw "$codec"; then
+              echo "::error::Bundled ffmpeg is missing the $codec decoder"
+              exit 1
+            fi
+          done
+          if ! "$FFMPEG_DIR/ffmpeg" -hide_banner -encoders | grep -qw libmp3lame; then
+            echo "::error::Bundled ffmpeg is missing the libmp3lame encoder"
+            exit 1
+          fi
+
+          # GPL compliance: record what ships and where its source and build
+          # script live, next to the binaries.
+          cat > "$FFMPEG_DIR/NOTICE.txt" <<EOF
+          FFmpeg static binaries (ffmpeg, ffprobe) for macOS arm64
+          Build: ${FFMPEG_BUILD} from https://ffmpeg.martin-riedl.de
+          Build script (Apache-2.0): https://git.martin-riedl.de/ffmpeg/build-script
+          FFmpeg source code: https://ffmpeg.org/download.html
+
+          These binaries are compiled with --enable-gpl (includes libx264 and
+          libx265) and are distributed under the GNU General Public License.
+          Run "./ffmpeg -L" for the full license text and "./ffmpeg -buildconf"
+          for the exact configure flags. TranscriptionSuite itself is licensed
+          under GPL-3.0 (see the LICENSE file in the repository).
+
+          The bundled binaries are a fallback used only when no ffmpeg is found
+          on PATH; a Homebrew-installed FFmpeg takes precedence.
+          EOF
+
+          echo "✓ Bundled static ffmpeg/ffprobe (${FFMPEG_BUILD}) into Resources/ffmpeg"
+
       - name: Re-sign app bundle after backend injection
         # electron-builder builds with hardenedRuntime=true, signing the Electron
         # binaries.  Adding the Python venv (with many unsigned .so files) breaks

--- a/dashboard/electron/__tests__/mlxServerManager.test.ts
+++ b/dashboard/electron/__tests__/mlxServerManager.test.ts
@@ -524,3 +524,82 @@ describe('[GH #136] MLXServerManager native model cache', () => {
     });
   });
 });
+
+// ── GH #255 — bundled ffmpeg PATH fallback ────────────────────────────────
+
+describe('[GH #255] MLXServerManager bundled ffmpeg on spawn PATH', () => {
+  const proc = process as unknown as { resourcesPath?: string };
+  const originalResourcesPath = proc.resourcesPath;
+  let mockWindow: ReturnType<typeof makeMockWindow>;
+
+  /** Make the uvicorn/python/symlink probes succeed, plus any extra paths. */
+  function stubExists(extra: (p: string) => boolean = () => false) {
+    mockExistsSync.mockImplementation((p: string) => {
+      if (typeof p !== 'string') return false;
+      if (p.includes('uvicorn') || p.includes('python3') || p.endsWith('/server')) return true;
+      return extra(p);
+    });
+  }
+
+  /** Drive start() to running and return the env passed to spawn(). */
+  async function startAndCaptureSpawnEnv(): Promise<Record<string, string>> {
+    const child = makeChildProcess();
+    mockSpawn.mockReturnValue(child);
+    const manager = new MLXServerManager(() => mockWindow as never);
+    const startPromise = manager.start({ port: 8000 });
+    child.stderr.emit('data', Buffer.from('Application startup complete\n'));
+    await startPromise;
+    const [, , spawnOptions] = mockSpawn.mock.calls[0] as [
+      string,
+      string[],
+      { env: Record<string, string> },
+    ];
+    return spawnOptions.env;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWindow = makeMockWindow();
+    mockApp.isPackaged = false;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    proc.resourcesPath = originalResourcesPath;
+  });
+
+  it('packaged with Resources/ffmpeg/ffmpeg present: appends the bundled dir after the Homebrew bins', async () => {
+    mockApp.isPackaged = true;
+    proc.resourcesPath = '/mock/Resources';
+    stubExists((p) => p === '/mock/Resources/ffmpeg/ffmpeg');
+
+    const env = await startAndCaptureSpawnEnv();
+
+    const dirs = env.PATH.split(':');
+    expect(dirs).toContain('/mock/Resources/ffmpeg');
+    // A user-installed Homebrew FFmpeg must still win over the bundled one.
+    expect(dirs.indexOf('/mock/Resources/ffmpeg')).toBeGreaterThan(
+      dirs.indexOf('/opt/homebrew/bin'),
+    );
+  });
+
+  it('packaged without the bundled binary (e.g. thin DMG): PATH does not gain the dir', async () => {
+    mockApp.isPackaged = true;
+    proc.resourcesPath = '/mock/Resources';
+    stubExists();
+
+    const env = await startAndCaptureSpawnEnv();
+
+    expect(env.PATH.split(':')).not.toContain('/mock/Resources/ffmpeg');
+  });
+
+  it('development (not packaged): PATH is untouched even if a Resources/ffmpeg exists', async () => {
+    mockApp.isPackaged = false;
+    proc.resourcesPath = '/mock/Resources';
+    stubExists((p) => p === '/mock/Resources/ffmpeg/ffmpeg');
+
+    const env = await startAndCaptureSpawnEnv();
+
+    expect(env.PATH.split(':')).not.toContain('/mock/Resources/ffmpeg');
+  });
+});

--- a/dashboard/electron/mlxServerManager.ts
+++ b/dashboard/electron/mlxServerManager.ts
@@ -103,6 +103,18 @@ export class MLXServerManager {
       ? inheritedPath
       : `${homebrewBins}:${inheritedPath}`;
 
+    // GH #255: the Metal DMG ships a static ffmpeg/ffprobe pair at
+    // Resources/ffmpeg (injected and code-signed by release.yml). Append that
+    // dir AFTER the Homebrew bins so a user-installed FFmpeg (typically a
+    // fuller build) still wins, while hosts without one fall back to the
+    // bundled binaries instead of failing every non-WAV decode.
+    const bundledFfmpegDir =
+      app.isPackaged && process.resourcesPath ? path.join(process.resourcesPath, 'ffmpeg') : null;
+    const spawnPath =
+      bundledFfmpegDir && fs.existsSync(path.join(bundledFfmpegDir, 'ffmpeg'))
+        ? `${augmentedPath}:${bundledFfmpegDir}`
+        : augmentedPath;
+
     const env: Record<string, string> = {
       ...(process.env as Record<string, string>),
       DATA_DIR: dataDir,
@@ -115,7 +127,7 @@ export class MLXServerManager {
       // Force line-buffered stdout so the Electron parent sees output
       // immediately instead of waiting for the 8KB pipe buffer to fill.
       PYTHONUNBUFFERED: '1',
-      PATH: augmentedPath,
+      PATH: spawnPath,
     };
     if (opts.hfToken) env.HF_TOKEN = opts.hfToken;
     if (opts.mainTranscriberModel) env.MAIN_TRANSCRIBER_MODEL = opts.mainTranscriberModel;


### PR DESCRIPTION
## Summary

Root cause of GH #255: the mac-metal DMG bundles a self-contained Python backend but no FFmpeg, and macOS ships none - so every non-WAV import (M4A from Voice Memos, MP3, FLAC, OGG) fails to decode on a stock Mac. PR #259 (companion, already open) makes that failure loud and actionable; this PR removes the failure entirely: the DMG now ships a static `ffmpeg`/`ffprobe` pair, so compressed-audio imports work out of the box with no Homebrew install.

## What changed

**`release.yml` (`build-macos-metal` job)** - new *Bundle static ffmpeg + ffprobe into app bundle* step:
- Downloads the pinned FFmpeg 8.1.2 GPL static arm64 pair into `Contents/Resources/ffmpeg/`, verifies hardcoded SHA256s (a changed or compromised upstream fails the build instead of shipping silently), smoke-runs both binaries on the arm64 runner, and asserts the aac/mp3/flac/vorbis/opus decoders plus the libmp3lame encoder are present.
- Writes a `NOTICE.txt` with build provenance and GPL pointers next to the binaries.
- **Ordering (GH #154):** the step runs after the venv verify and strictly before the re-sign step, so the existing `-perm /111` codesign pass signs the binaries and the seal-integrity gate covers them. Injecting them any later would reproduce the "damaged DMG" failure.

**`mlxServerManager.ts`** - appends `Resources/ffmpeg` to the spawned Metal server's PATH, gated on `app.isPackaged` + the bundled binary actually existing. The Homebrew bins stay ahead, so a user-installed (fuller) FFmpeg still wins; dev checkouts and the thin dashboard-only DMG are no-ops.

**Tests** - 3 new vitest cases: packaged-with-bundle (appended after Homebrew), packaged-without (thin DMG, no PATH change), and dev (no PATH change).

## Binary provenance and licensing

- Source: https://ffmpeg.martin-riedl.de (build script published at https://git.martin-riedl.de/ffmpeg/build-script), immutable versioned path `1783011502_8.1.2`.
- Verified on the exact pinned bytes: Mach-O arm64, only system dylibs referenced (fully static, no Homebrew paths), `--enable-gpl` with **no** `--enable-nonfree`, `--enable-libmp3lame` present.
- License fit: TranscriptionSuite is GPL-3.0, so redistributing a GPL FFmpeg build alongside it is clean; NOTICE.txt records provenance and points at `ffmpeg -L` / `-buildconf`.
- Rejected alternatives: OSXExperts.net (site carries an "educational purposes only" note), evermeet.cx (Intel-only by explicit maintainer policy), static-ffmpeg / imageio-ffmpeg on PyPI (undocumented re-wraps of the OSXExperts build with no published checksums).

## Size impact

~131 MB uncompressed across the two binaries; roughly +60 MB on the compressed DMG - low single-digit percent of the Metal DMG.

## Test plan

- [x] `mlxServerManager` suite: 25/25 (3 new, written red-first)
- [x] Full dashboard suite: 130 files / 1885 tests green; typecheck, eslint `--max-warnings=0`, ui-contract (16 checks) green
- [x] Workflow YAML parses; step ordering verified (bundle step sits between venv verify and re-sign)
- [x] Download + SHA256 verify + unzip + NOTICE heredoc simulated locally against the live pinned URLs
- [ ] Manual `workflow_dispatch` release run (platform: `macos-metal`) to exercise the job end to end, including the codesign seal gate
- [ ] Hardware smoke on an Apple Silicon Mac without Homebrew FFmpeg: import an `.m4a`, confirm decode succeeds; with Homebrew FFmpeg installed, confirm it still takes precedence

Related: #255. Companion PR: #259 (clear error message + dashboard warning when FFmpeg is missing, still valuable for older releases and edge hosts).