### PR TITLE
feat(dashboard, docker): GPU picker for multi-GPU hosts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
       - id: codespell
         args:
           - "--skip=*.lock,*.svg,*.ico,*.icns,*.png,*.woff,*.woff2,*package-lock.json,node_modules,dist-electron,release,.git,dashboard/dist,contract-baseline.json"
-          - "--ignore-words-list=ect,crate,ser,ane"
+          - "--ignore-words-list=ect,crate,ser,ane,renderd"
         exclude: "^(dashboard/release/|dashboard/dist-electron/)"
 
   # ── Dashboard: Prettier format ───────────────────────────────────────────

--- a/dashboard/components/__tests__/ServerView.test.tsx
+++ b/dashboard/components/__tests__/ServerView.test.tsx
@@ -949,10 +949,12 @@ describe('Docker image variant selector', () => {
 // CUDA and CPU Only runtimes stay selectable; the Vulkan and Metal tiles are
 // disabled with an 'NVIDIA detected' badge.
 //
-// MUST STAY THE LAST DESCRIBE IN THIS FILE: ServerView module-caches the
-// checkGpu result (cachedGpuInfo), so the gpu:true probe below leaks into the
-// initial state of every mount that follows it. Earlier describes never
-// provide docker.checkGpu, which keeps the cache unset until this point.
+// MUST STAY AFTER EVERY DESCRIBE THAT OMITS docker.checkGpu: ServerView
+// module-caches the checkGpu result (cachedGpuInfo), so the gpu:true probe
+// below leaks into the initial state of every mount that follows it. Earlier
+// describes never provide docker.checkGpu, which keeps the cache unset until
+// this point. The multi-GPU describe below tolerates the leak by clicking
+// Re-detect, which resets the cache and re-fetches from its own mock.
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('NVIDIA runtime gating', () => {
@@ -1024,5 +1026,221 @@ describe('NVIDIA runtime gating', () => {
     expect(
       (runtimeGroup.getByText('CPU Only').closest('button') as HTMLButtonElement).disabled,
     ).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Multi-GPU picker + mixed-vendor gating.
+//
+// cachedGpuInfo leaks from the describes above, so every test here clicks the
+// Re-detect link first: handleRedetectGpu clears the module cache and
+// re-invokes docker.checkGpu, whose mock carries the per-test gpus inventory.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Multi-GPU selection', () => {
+  type MockGpu = {
+    vendor: 'nvidia' | 'amd' | 'intel' | 'unknown';
+    kind: 'discrete' | 'integrated' | 'virtual' | 'unknown';
+    index: number | null;
+    name: string;
+    memoryMiB: number | null;
+    uuid: string | null;
+  };
+
+  const RTX_3060: MockGpu = {
+    vendor: 'nvidia',
+    kind: 'discrete',
+    index: 0,
+    name: 'NVIDIA GeForce RTX 3060',
+    memoryMiB: 12288,
+    uuid: 'GPU-aaa',
+  };
+  const RTX_3090: MockGpu = {
+    vendor: 'nvidia',
+    kind: 'discrete',
+    index: 1,
+    name: 'NVIDIA GeForce RTX 3090',
+    memoryMiB: 24576,
+    uuid: 'GPU-bbb',
+  };
+  const RX_6700: MockGpu = {
+    vendor: 'amd',
+    kind: 'discrete',
+    index: null,
+    name: 'AMD Radeon RX 6700 XT',
+    memoryMiB: null,
+    uuid: null,
+  };
+  const INTEL_IGPU: MockGpu = {
+    vendor: 'intel',
+    kind: 'integrated',
+    index: null,
+    name: 'Intel UHD Graphics 770',
+    memoryMiB: null,
+    uuid: null,
+  };
+
+  function setupApi(gpus: MockGpu[], opts?: { storedGpuDevice?: string }) {
+    const setSpy = vi.fn().mockResolvedValue(undefined);
+    (window as any).electronAPI = {
+      config: {
+        get: vi.fn().mockImplementation(async (key: string) => {
+          if (key === 'server.runtimeProfile') return 'gpu';
+          if (key === 'server.gpuAutoDetectDone') return true;
+          if (key === 'server.gpuDevice') return opts?.storedGpuDevice ?? 'auto';
+          return undefined;
+        }),
+        set: setSpy,
+      },
+      docker: {
+        readComposeEnvValue: vi.fn().mockResolvedValue('false'),
+        checkModelCache: vi.fn().mockResolvedValue({}),
+        resetGpuCache: vi.fn().mockResolvedValue(undefined),
+        checkGpu: vi.fn().mockResolvedValue({
+          gpu: gpus.some((g) => g.vendor === 'nvidia'),
+          toolkit: true,
+          vulkan: false,
+          gpus,
+        }),
+      },
+      app: {
+        getArch: vi.fn().mockReturnValue('x64'),
+        getConfigDir: vi.fn().mockResolvedValue('/mock/config'),
+      },
+      mlx: {
+        getStatus: vi.fn().mockResolvedValue('stopped'),
+        onStatusChanged: vi.fn().mockReturnValue(vi.fn()),
+      },
+      tailscale: {
+        getHostname: vi.fn().mockResolvedValue('my-server.tail1234.ts.net'),
+      },
+      server: {
+        checkFirewallPort: vi.fn().mockResolvedValue(null),
+      },
+    };
+    return { setSpy };
+  }
+
+  /** Mount, then force a re-detect so the per-test checkGpu payload replaces
+   *  the module-level cache leaked by earlier describes. */
+  async function mountAndRedetect() {
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    const redetect = await screen.findByRole('button', { name: 'Re-detect' });
+    fireEvent.click(redetect);
+    await waitFor(() => {
+      expect((window as any).electronAPI.docker.checkGpu).toHaveBeenCalled();
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDocker.available = true;
+    mockDocker.images = [];
+    mockDocker.remoteTags = [];
+    mockDocker.variantTags = null;
+    mockDocker.container = { exists: false, running: false, status: 'unknown', health: undefined };
+    mockDocker.operationError = null;
+    mockDocker.operating = false;
+    mockDocker.composeAvailable = true;
+    mockAdminStatus.status = { models: {} };
+  });
+
+  it('shows the GPU picker with one option per NVIDIA card when two are detected', async () => {
+    setupApi([RTX_3060, RTX_3090]);
+    await mountAndRedetect();
+    const select = (await screen.findByLabelText('GPU for inference')) as HTMLSelectElement;
+    const labels = Array.from(select.options).map((o) => o.textContent);
+    expect(labels).toEqual([
+      'Automatic (Docker default)',
+      'GPU 0: NVIDIA GeForce RTX 3060 (12 GB)',
+      'GPU 1: NVIDIA GeForce RTX 3090 (24 GB)',
+    ]);
+    expect(select.value).toBe('auto');
+  });
+
+  it('persists a picked card to server.gpuDevice as its UUID', async () => {
+    const { setSpy } = setupApi([RTX_3060, RTX_3090]);
+    await mountAndRedetect();
+    const select = (await screen.findByLabelText('GPU for inference')) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'GPU-bbb' } });
+    await waitFor(() => {
+      expect(setSpy).toHaveBeenCalledWith('server.gpuDevice', 'GPU-bbb');
+    });
+    expect(select.value).toBe('GPU-bbb');
+  });
+
+  it('hydrates a persisted selection from server.gpuDevice', async () => {
+    setupApi([RTX_3060, RTX_3090], { storedGpuDevice: 'GPU-bbb' });
+    await mountAndRedetect();
+    const select = (await screen.findByLabelText('GPU for inference')) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(select.value).toBe('GPU-bbb');
+    });
+  });
+
+  it('hides the picker when only one NVIDIA GPU is present', async () => {
+    setupApi([RTX_3090]);
+    await mountAndRedetect();
+    await waitFor(() => {
+      expect((window as any).electronAPI.docker.checkGpu).toHaveBeenCalled();
+    });
+    expect(screen.queryByLabelText('GPU for inference')).toBeNull();
+  });
+
+  it('keeps the Vulkan tiles selectable on a mixed NVIDIA + AMD host', async () => {
+    setupApi([RTX_3090, RX_6700]);
+    await mountAndRedetect();
+    const runtimeGroup = within(screen.getByText('Runtime').closest('.space-y-2') as HTMLElement);
+    // Only the Metal tile still carries the NVIDIA badge; the Vulkan tiles are
+    // free so inference can be routed to the AMD card.
+    await waitFor(() => {
+      expect(runtimeGroup.getAllByText('NVIDIA detected').length).toBe(1);
+    });
+    const vulkanLinux = runtimeGroup
+      .getByText('Vulkan Linux')
+      .closest('button') as HTMLButtonElement;
+    expect(vulkanLinux.disabled).toBe(false);
+    const metal = runtimeGroup.getByText('Metal').closest('button') as HTMLButtonElement;
+    expect(metal.disabled).toBe(true);
+    // Mixed-vendor hint under the CUDA runtime.
+    expect(screen.getByText(/CUDA uses only NVIDIA cards/)).toBeTruthy();
+  });
+
+  it('does not show the picker on an NVIDIA-only single-GPU host with an AMD card present', async () => {
+    setupApi([RTX_3090, RX_6700]);
+    await mountAndRedetect();
+    // The AMD card must not count toward the NVIDIA picker threshold.
+    await waitFor(() => {
+      expect(screen.getByText(/CUDA uses only NVIDIA cards/)).toBeTruthy();
+    });
+    expect(screen.queryByLabelText('GPU for inference')).toBeNull();
+  });
+
+  it('keeps the Vulkan lockout when the only extra GPU is an integrated one', async () => {
+    setupApi([RTX_3090, INTEL_IGPU]);
+    await mountAndRedetect();
+    const runtimeGroup = within(screen.getByText('Runtime').closest('.space-y-2') as HTMLElement);
+    // iGPUs and virtual adapters must not read as a routable second card:
+    // both Vulkan tiles and Metal keep the NVIDIA badge.
+    await waitFor(() => {
+      expect(runtimeGroup.getAllByText('NVIDIA detected').length).toBe(3);
+    });
+    const vulkanLinux = runtimeGroup
+      .getByText('Vulkan Linux')
+      .closest('button') as HTMLButtonElement;
+    expect(vulkanLinux.disabled).toBe(true);
+    expect(screen.queryByText(/CUDA uses only NVIDIA cards/)).toBeNull();
+  });
+
+  it('surfaces a stale pin as an explicit option instead of silently claiming Automatic', async () => {
+    setupApi([RTX_3060, RTX_3090], { storedGpuDevice: 'GPU-gone' });
+    await mountAndRedetect();
+    const select = (await screen.findByLabelText('GPU for inference')) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(select.value).toBe('GPU-gone');
+    });
+    expect(
+      screen.getByText('Previously selected GPU not detected - starts as Automatic'),
+    ).toBeTruthy();
   });
 });

--- a/dashboard/components/__tests__/ServerView.test.tsx
+++ b/dashboard/components/__tests__/ServerView.test.tsx
@@ -179,27 +179,56 @@ vi.mock('@headlessui/react', () => {
     typeof children === 'function' ? (children as (a: any) => React.ReactNode)(args) : children;
   const passthrough = ({ children }: { children?: React.ReactNode }) =>
     React.createElement('div', null, renderChildren(children));
+  // Same render-prop mock convention as SessionImportTab.output-format.test.tsx:
+  // ListboxButton forwards aria-label so getByRole('button', { name }) works,
+  // and ListboxOption wires its click to the Listbox onChange via context so
+  // selecting an option drives the component (used by the GPU picker tests).
+  const OnChangeCtx = React.createContext<(value: unknown) => void>(() => {});
   return {
     Dialog: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
       open ? React.createElement('div', { role: 'dialog' }, renderChildren(children)) : null,
     DialogPanel: passthrough,
     DialogTitle: ({ children }: { children: React.ReactNode }) =>
       React.createElement('h2', null, renderChildren(children)),
-    Listbox: ({ children, value }: { children: React.ReactNode; value: unknown }) =>
-      React.createElement('div', { 'data-value': value }, renderChildren(children, { open: true })),
-    ListboxButton: ({ children }: { children: React.ReactNode }) =>
+    Listbox: ({
+      children,
+      value,
+      onChange,
+    }: {
+      children: React.ReactNode;
+      value: unknown;
+      onChange?: (value: unknown) => void;
+    }) =>
+      React.createElement(
+        OnChangeCtx.Provider,
+        { value: onChange ?? (() => {}) },
+        React.createElement(
+          'div',
+          { 'data-value': value },
+          renderChildren(children, { open: true }),
+        ),
+      ),
+    ListboxButton: ({
+      children,
+      ['aria-label']: ariaLabel,
+    }: {
+      children: React.ReactNode;
+      'aria-label'?: string;
+    }) =>
       React.createElement(
         'button',
-        { type: 'button' },
+        { type: 'button', 'aria-label': ariaLabel },
         renderChildren(children, { open: true, focus: false, hover: false }),
       ),
     ListboxOptions: passthrough,
-    ListboxOption: ({ children, value }: { children: React.ReactNode; value: unknown }) =>
-      React.createElement(
+    ListboxOption: ({ children, value }: { children: React.ReactNode; value: unknown }) => {
+      const onChange = React.useContext(OnChangeCtx);
+      return React.createElement(
         'div',
-        { 'data-value': value },
+        { role: 'option', 'data-value': value, onClick: () => onChange(value) },
         renderChildren(children, { selected: false, focus: false, active: false }),
-      ),
+      );
+    },
   };
 });
 
@@ -1145,36 +1174,44 @@ describe('Multi-GPU selection', () => {
     mockAdminStatus.status = { models: {} };
   });
 
+  // The picker is a CustomSelect (headlessui Listbox). The mock above renders
+  // its options inline and always open: the trigger is the button named by
+  // aria-label, and each option is a role="option" wired to onChange.
+  const pickerButton = () => screen.queryByRole('button', { name: 'GPU for inference' });
+
   it('shows the GPU picker with one option per NVIDIA card when two are detected', async () => {
     setupApi([RTX_3060, RTX_3090]);
     await mountAndRedetect();
-    const select = (await screen.findByLabelText('GPU for inference')) as HTMLSelectElement;
-    const labels = Array.from(select.options).map((o) => o.textContent);
+    await waitFor(() => {
+      expect(pickerButton()).not.toBeNull();
+    });
+    const labels = screen.getAllByRole('option').map((o) => o.textContent);
     expect(labels).toEqual([
       'Automatic (Docker default)',
       'GPU 0: NVIDIA GeForce RTX 3060 (12 GB)',
       'GPU 1: NVIDIA GeForce RTX 3090 (24 GB)',
     ]);
-    expect(select.value).toBe('auto');
+    expect(pickerButton()?.textContent).toContain('Automatic (Docker default)');
   });
 
   it('persists a picked card to server.gpuDevice as its UUID', async () => {
     const { setSpy } = setupApi([RTX_3060, RTX_3090]);
     await mountAndRedetect();
-    const select = (await screen.findByLabelText('GPU for inference')) as HTMLSelectElement;
-    fireEvent.change(select, { target: { value: 'GPU-bbb' } });
+    await waitFor(() => {
+      expect(pickerButton()).not.toBeNull();
+    });
+    fireEvent.click(screen.getByRole('option', { name: 'GPU 1: NVIDIA GeForce RTX 3090 (24 GB)' }));
     await waitFor(() => {
       expect(setSpy).toHaveBeenCalledWith('server.gpuDevice', 'GPU-bbb');
     });
-    expect(select.value).toBe('GPU-bbb');
+    expect(pickerButton()?.textContent).toContain('GPU 1: NVIDIA GeForce RTX 3090 (24 GB)');
   });
 
   it('hydrates a persisted selection from server.gpuDevice', async () => {
     setupApi([RTX_3060, RTX_3090], { storedGpuDevice: 'GPU-bbb' });
     await mountAndRedetect();
-    const select = (await screen.findByLabelText('GPU for inference')) as HTMLSelectElement;
     await waitFor(() => {
-      expect(select.value).toBe('GPU-bbb');
+      expect(pickerButton()?.textContent).toContain('GPU 1: NVIDIA GeForce RTX 3090 (24 GB)');
     });
   });
 
@@ -1184,7 +1221,7 @@ describe('Multi-GPU selection', () => {
     await waitFor(() => {
       expect((window as any).electronAPI.docker.checkGpu).toHaveBeenCalled();
     });
-    expect(screen.queryByLabelText('GPU for inference')).toBeNull();
+    expect(pickerButton()).toBeNull();
   });
 
   it('keeps the Vulkan tiles selectable on a mixed NVIDIA + AMD host', async () => {
@@ -1213,7 +1250,7 @@ describe('Multi-GPU selection', () => {
     await waitFor(() => {
       expect(screen.getByText(/CUDA uses only NVIDIA cards/)).toBeTruthy();
     });
-    expect(screen.queryByLabelText('GPU for inference')).toBeNull();
+    expect(pickerButton()).toBeNull();
   });
 
   it('keeps the Vulkan lockout when the only extra GPU is an integrated one', async () => {
@@ -1235,12 +1272,15 @@ describe('Multi-GPU selection', () => {
   it('surfaces a stale pin as an explicit option instead of silently claiming Automatic', async () => {
     setupApi([RTX_3060, RTX_3090], { storedGpuDevice: 'GPU-gone' });
     await mountAndRedetect();
-    const select = (await screen.findByLabelText('GPU for inference')) as HTMLSelectElement;
     await waitFor(() => {
-      expect(select.value).toBe('GPU-gone');
+      expect(pickerButton()?.textContent).toContain(
+        'Previously selected GPU not detected - starts as Automatic',
+      );
     });
     expect(
-      screen.getByText('Previously selected GPU not detected - starts as Automatic'),
+      screen.getByRole('option', {
+        name: 'Previously selected GPU not detected - starts as Automatic',
+      }),
     ).toBeTruthy();
   });
 });

--- a/dashboard/components/views/ServerView.tsx
+++ b/dashboard/components/views/ServerView.tsx
@@ -160,18 +160,37 @@ function getString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+/** " (12 GB)" suffix for the GPU picker options; empty when VRAM is unknown. */
+function formatVramGb(memoryMiB: number | null): string {
+  if (memoryMiB === null || !Number.isFinite(memoryMiB) || memoryMiB <= 0) return '';
+  return ` (${Math.round(memoryMiB / 1024)} GB)`;
+}
+
+// Shape of the docker:checkGpu IPC payload. Keep in sync with
+// electron/preload.ts and electron/gpuInventory.ts (canonical GpuDevice).
+// `gpus` is the full host inventory (multi-GPU support): NVIDIA entries carry
+// an nvidia-smi index + UUID, AMD/Intel entries are vendor/name-only markers
+// used to recognize mixed NVIDIA+AMD systems. Optional so stale mocks and
+// older payload shapes stay assignable.
+interface GpuInfoPayload {
+  gpu: boolean;
+  toolkit: boolean;
+  vulkan: boolean;
+  wslSupport?: { available: boolean; gpuPassthroughDetected: boolean; reason?: string };
+  gpus?: Array<{
+    vendor: 'nvidia' | 'amd' | 'intel' | 'unknown';
+    kind: 'discrete' | 'integrated' | 'virtual' | 'unknown';
+    index: number | null;
+    name: string;
+    memoryMiB: number | null;
+    uuid: string | null;
+  }>;
+}
+
 // Session-level GPU detection cache — survives view unmount/remount.
 // `wslSupport` is populated by `checkGpu()` only on Win32 (GH-101 follow-up);
 // it gates the experimental Vulkan-WSL2 runtime profile button below.
-let cachedGpuInfo:
-  | {
-      gpu: boolean;
-      toolkit: boolean;
-      vulkan: boolean;
-      wslSupport?: { available: boolean; gpuPassthroughDetected: boolean; reason?: string };
-    }
-  | null
-  | undefined = undefined; // undefined = not yet checked
+let cachedGpuInfo: GpuInfoPayload | null | undefined = undefined; // undefined = not yet checked
 
 function normalizeModelName(value: string): string {
   return value.trim().toLowerCase();
@@ -1289,12 +1308,19 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
 
   const [setupDismissed, setSetupDismissed] = useState(true); // hide until loaded
   const [setupExpanded, setSetupExpanded] = useState(true);
-  const [gpuInfo, setGpuInfo] = useState<{
-    gpu: boolean;
-    toolkit: boolean;
-    vulkan: boolean;
-    wslSupport?: { available: boolean; gpuPassthroughDetected: boolean; reason?: string };
-  } | null>(cachedGpuInfo ?? null);
+  const [gpuInfo, setGpuInfo] = useState<GpuInfoPayload | null>(cachedGpuInfo ?? null);
+
+  // Multi-GPU: which NVIDIA card runs the inference server. Persisted as
+  // electron-store key server.gpuDevice (auto | GPU UUID) and consumed by
+  // dockerManager.startContainer(), which resolves the UUID to an nvidia-smi
+  // index for the GPU_DEVICE compose variable. Hydrated in the mount effect
+  // below; only rendered as a picker when more than one NVIDIA GPU exists.
+  const [gpuDevice, setGpuDevice] = useState<string>('auto');
+  const handleGpuDeviceChange = useCallback((value: string): void => {
+    setGpuDevice(value);
+    const api = (window as any).electronAPI;
+    api?.config?.set?.('server.gpuDevice', value)?.catch?.(() => {});
+  }, []);
 
   // ─── GPU Health Card state (NVIDIA Linux only) ─────────────────────────────
   // Phase 2 of the CUDA error 999 recovery plan. Three pieces of state feed the
@@ -1410,6 +1436,13 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
           setSetupDismissed(val === true);
         })
         .catch(() => setSetupDismissed(false));
+      // Multi-GPU: hydrate the persisted GPU picker selection (auto or a GPU UUID)
+      api.config
+        .get('server.gpuDevice')
+        .then((val: unknown) => {
+          if (typeof val === 'string' && val) setGpuDevice(val);
+        })
+        .catch(() => {});
     } else {
       setSetupDismissed(false);
     }
@@ -1417,51 +1450,44 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
     if (cachedGpuInfo === undefined && api?.docker?.checkGpu) {
       api.docker
         .checkGpu()
-        .then(
-          (info: {
-            gpu: boolean;
-            toolkit: boolean;
-            vulkan: boolean;
-            wslSupport?: { available: boolean; gpuPassthroughDetected: boolean; reason?: string };
-          }) => {
-            cachedGpuInfo = info;
-            setGpuInfo(info);
-            // Auto-set runtime profile based on hardware detection.
-            // Runs exactly once: on fresh install or upgrade from a version without the flag.
-            // Priority: Metal (Apple Silicon) > NVIDIA GPU > Vulkan (AMD/Intel) > CPU
-            api.config
-              ?.get('server.gpuAutoDetectDone')
-              .then((done: unknown) => {
-                if (done === true) return; // already ran — respect user's stored choice
-                // Determine best profile for this hardware
-                let detected: RuntimeProfile = 'cpu';
-                if (metalSupported) {
-                  detected = 'metal';
-                } else if (info.gpu && info.toolkit) {
-                  detected = 'gpu';
-                } else if (info.vulkan) {
-                  detected = 'vulkan';
-                }
-                handleRuntimeProfileChange(detected);
-                // If Metal was selected, also set the default MLX model
-                if (detected === 'metal') {
-                  api.config
-                    ?.get('server.mainModelSelection')
-                    .then((modelVal: unknown) => {
-                      const cur = typeof modelVal === 'string' ? modelVal.trim() : '';
-                      if (!cur || cur === MODEL_DEFAULT_LOADING_PLACEHOLDER) {
-                        setMainModelSelection(MLX_DEFAULT_MODEL);
-                        api.config?.set('server.mainModelSelection', MLX_DEFAULT_MODEL);
-                      }
-                    })
-                    .catch(() => {});
-                }
-                // Mark auto-detection as done so it never re-runs
-                api.config?.set('server.gpuAutoDetectDone', true);
-              })
-              .catch(() => {});
-          },
-        )
+        .then((info: GpuInfoPayload) => {
+          cachedGpuInfo = info;
+          setGpuInfo(info);
+          // Auto-set runtime profile based on hardware detection.
+          // Runs exactly once: on fresh install or upgrade from a version without the flag.
+          // Priority: Metal (Apple Silicon) > NVIDIA GPU > Vulkan (AMD/Intel) > CPU
+          api.config
+            ?.get('server.gpuAutoDetectDone')
+            .then((done: unknown) => {
+              if (done === true) return; // already ran — respect user's stored choice
+              // Determine best profile for this hardware
+              let detected: RuntimeProfile = 'cpu';
+              if (metalSupported) {
+                detected = 'metal';
+              } else if (info.gpu && info.toolkit) {
+                detected = 'gpu';
+              } else if (info.vulkan) {
+                detected = 'vulkan';
+              }
+              handleRuntimeProfileChange(detected);
+              // If Metal was selected, also set the default MLX model
+              if (detected === 'metal') {
+                api.config
+                  ?.get('server.mainModelSelection')
+                  .then((modelVal: unknown) => {
+                    const cur = typeof modelVal === 'string' ? modelVal.trim() : '';
+                    if (!cur || cur === MODEL_DEFAULT_LOADING_PLACEHOLDER) {
+                      setMainModelSelection(MLX_DEFAULT_MODEL);
+                      api.config?.set('server.mainModelSelection', MLX_DEFAULT_MODEL);
+                    }
+                  })
+                  .catch(() => {});
+              }
+              // Mark auto-detection as done so it never re-runs
+              api.config?.set('server.gpuAutoDetectDone', true);
+            })
+            .catch(() => {});
+        })
         .catch(() => {
           cachedGpuInfo = null;
           setGpuInfo(null);
@@ -1490,17 +1516,10 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
         cachedGpuInfo = undefined;
         return api.docker.checkGpu();
       })
-      .then(
-        (info: {
-          gpu: boolean;
-          toolkit: boolean;
-          vulkan: boolean;
-          wslSupport?: { available: boolean; gpuPassthroughDetected: boolean; reason?: string };
-        }) => {
-          cachedGpuInfo = info;
-          setGpuInfo(info);
-        },
-      )
+      .then((info: GpuInfoPayload) => {
+        cachedGpuInfo = info;
+        setGpuInfo(info);
+      })
       .catch(() => {
         cachedGpuInfo = null;
         setGpuInfo(null);
@@ -1530,6 +1549,34 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
   // disabled so a slower backend cannot be picked by accident. Fails open
   // while detection is pending (gpuInfo === null) and in jsdom test mounts.
   const nvidiaDetected = gpuInfo?.gpu ?? false;
+  // Multi-GPU support: NVIDIA cards eligible for the CUDA GPU picker (need an
+  // nvidia-smi index for docker device_ids and a UUID for stable persistence).
+  const nvidiaGpus = useMemo(
+    () =>
+      (gpuInfo?.gpus ?? []).filter(
+        (g) => g.vendor === 'nvidia' && g.index !== null && g.uuid !== null,
+      ),
+    [gpuInfo?.gpus],
+  );
+  // Mixed-vendor host (e.g. NVIDIA + AMD): a DISCRETE non-NVIDIA GPU exists
+  // alongside the NVIDIA one. In that case the Vulkan runtimes stay
+  // selectable so the user can route inference to the AMD / Intel card
+  // instead of CUDA. The whisper.cpp sidecar image ships Mesa drivers only,
+  // so on such a host it cannot even see the NVIDIA card and lands on the
+  // AMD / Intel one. The kind gate matters: integrated GPUs (iGPU next to an
+  // NVIDIA card, Optimus laptops) and virtual display adapters (RDP, Hyper-V)
+  // are in the inventory too and must NOT defeat the NVIDIA lockout.
+  const nonNvidiaGpuPresent = (gpuInfo?.gpus ?? []).some(
+    (g) => (g.vendor === 'amd' || g.vendor === 'intel') && g.kind === 'discrete',
+  );
+  const vulkanBlockedByNvidia = nvidiaDetected && !nonNvidiaGpuPresent;
+  // Stale selection guard: the stored UUID no longer matches a present card
+  // (removed, or the driver stopped reporting it). The pin is deliberately
+  // kept in the store so a transient failure does not erase a deliberate
+  // choice; the picker surfaces the state honestly via an explicit option
+  // instead of silently claiming Automatic. startContainer falls back to the
+  // compose defaults while the card is absent.
+  const gpuDeviceStale = gpuDevice !== 'auto' && !nvidiaGpus.some((g) => g.uuid === gpuDevice);
   // Hardware check (arm64 mac) passes immediately via Electron; server report only
   // refines whether mlx_whisper is actually installed.
   const metalSatisfied = isAppleSilicon && (mlxFeature === undefined || metalSupported);
@@ -1895,14 +1942,14 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                     selected={runtimeProfile === 'vulkan-wsl2'}
                     disabled={
                       isRunning ||
-                      nvidiaDetected ||
+                      vulkanBlockedByNvidia ||
                       (hostPlatform !== 'unknown' && hostPlatform !== 'win32') ||
                       (hostPlatform === 'win32' && !gpuInfo?.wslSupport?.gpuPassthroughDetected)
                     }
                     badge={
                       hostPlatform !== 'unknown' && hostPlatform !== 'win32'
                         ? 'Windows only'
-                        : nvidiaDetected
+                        : vulkanBlockedByNvidia
                           ? 'NVIDIA detected'
                           : hostPlatform === 'win32' && !gpuInfo?.wslSupport?.gpuPassthroughDetected
                             ? 'Requires WSL2 GPU'
@@ -1924,14 +1971,14 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                     selected={runtimeProfile === 'vulkan'}
                     disabled={
                       isRunning ||
-                      nvidiaDetected ||
+                      vulkanBlockedByNvidia ||
                       hostPlatform === 'win32' ||
                       hostPlatform === 'darwin'
                     }
                     badge={
                       hostPlatform === 'win32' || hostPlatform === 'darwin'
                         ? 'Linux only'
-                        : nvidiaDetected
+                        : vulkanBlockedByNvidia
                           ? 'NVIDIA detected'
                           : undefined
                     }
@@ -1967,9 +2014,60 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                     onSelect={() => handleRuntimeProfileChange('cpu')}
                   />
                 </SelectorGroup>
+                {/* Multi-GPU picker: only rendered when the host has more than
+                    one CUDA-capable card. Selection is persisted as a GPU UUID
+                    and pinned at server start via the GPU_DEVICE compose
+                    variable; Automatic keeps the previous single-GPU behavior. */}
+                {runtimeProfile === 'gpu' && nvidiaGpus.length > 1 && (
+                  <div className="mt-3">
+                    <label
+                      htmlFor="gpu-device-select"
+                      className="mb-1 block text-xs font-medium text-slate-300"
+                    >
+                      GPU for inference
+                    </label>
+                    <select
+                      id="gpu-device-select"
+                      value={gpuDevice}
+                      disabled={isRunning}
+                      onChange={(e) => handleGpuDeviceChange(e.target.value)}
+                      className="w-full max-w-sm rounded border border-white/10 bg-black/40 px-2 py-1.5 text-xs text-slate-200 disabled:cursor-not-allowed disabled:text-slate-500"
+                    >
+                      <option value="auto">Automatic (Docker default)</option>
+                      {gpuDeviceStale && (
+                        <option value={gpuDevice}>
+                          Previously selected GPU not detected - starts as Automatic
+                        </option>
+                      )}
+                      {nvidiaGpus.map((g) => (
+                        <option key={g.uuid ?? g.name} value={g.uuid ?? 'auto'}>
+                          {`GPU ${g.index}: ${g.name}${formatVramGb(g.memoryMiB)}`}
+                        </option>
+                      ))}
+                    </select>
+                    <p className="mt-1 text-xs text-slate-500 italic">
+                      Multiple NVIDIA GPUs detected - the selected card runs the inference server
+                    </p>
+                  </div>
+                )}
+                {runtimeProfile === 'gpu' &&
+                  nvidiaDetected &&
+                  nonNvidiaGpuPresent &&
+                  !isRunning && (
+                    <p className="mt-2 text-xs text-slate-500 italic">
+                      CUDA uses only NVIDIA cards - switch Runtime to Vulkan to use the AMD / Intel
+                      GPU instead
+                    </p>
+                  )}
                 {runtimeProfile === 'vulkan' && !isRunning && (
                   <p className="mt-2 text-xs text-slate-500 italic">
                     AMD/Intel GPU via whisper.cpp — no diarization; live mode via GGML models
+                  </p>
+                )}
+                {runtimeProfile === 'vulkan' && nvidiaDetected && !isRunning && (
+                  <p className="mt-1 text-xs text-slate-500 italic">
+                    The NVIDIA card stays idle here - the whisper.cpp sidecar (Mesa drivers) uses
+                    the AMD / Intel GPU
                   </p>
                 )}
                 {runtimeProfile === 'vulkan-wsl2' && !isRunning && (

--- a/dashboard/components/views/ServerView.tsx
+++ b/dashboard/components/views/ServerView.tsx
@@ -25,6 +25,7 @@ import {
   MinusCircle,
 } from 'lucide-react';
 import { GlassCard } from '../ui/GlassCard';
+import { CustomSelect } from '../ui/CustomSelect';
 import { Button } from '../ui/Button';
 import { StatusLight } from '../ui/StatusLight';
 import { ImageTagChips } from '../ui/ImageTagChips';
@@ -1549,12 +1550,15 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
   // disabled so a slower backend cannot be picked by accident. Fails open
   // while detection is pending (gpuInfo === null) and in jsdom test mounts.
   const nvidiaDetected = gpuInfo?.gpu ?? false;
-  // Multi-GPU support: NVIDIA cards eligible for the CUDA GPU picker (need an
-  // nvidia-smi index for docker device_ids and a UUID for stable persistence).
+  // Multi-GPU support: discrete NVIDIA cards eligible for the CUDA GPU picker
+  // (need an nvidia-smi index for docker device_ids and a UUID for stable
+  // persistence; the discrete gate keeps any future non-discrete inventory
+  // entries from ever counting toward the picker threshold).
   const nvidiaGpus = useMemo(
     () =>
       (gpuInfo?.gpus ?? []).filter(
-        (g) => g.vendor === 'nvidia' && g.index !== null && g.uuid !== null,
+        (g) =>
+          g.vendor === 'nvidia' && g.kind === 'discrete' && g.index !== null && g.uuid !== null,
       ),
     [gpuInfo?.gpus],
   );
@@ -1577,6 +1581,25 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
   // instead of silently claiming Automatic. startContainer falls back to the
   // compose defaults while the card is absent.
   const gpuDeviceStale = gpuDevice !== 'auto' && !nvidiaGpus.some((g) => g.uuid === gpuDevice);
+  // Option list + labels for the GPU picker CustomSelect. The stale entry (if
+  // any) sits right after Automatic so the current store value always has a
+  // visible, honestly-labelled row.
+  const gpuDeviceOptions = useMemo(() => {
+    const options = ['auto'];
+    if (gpuDeviceStale) options.push(gpuDevice);
+    for (const g of nvidiaGpus) if (g.uuid) options.push(g.uuid);
+    return options;
+  }, [nvidiaGpus, gpuDeviceStale, gpuDevice]);
+  const gpuDeviceOptionLabels = useMemo(() => {
+    const labels: Record<string, string> = { auto: 'Automatic (Docker default)' };
+    if (gpuDeviceStale) {
+      labels[gpuDevice] = 'Previously selected GPU not detected - starts as Automatic';
+    }
+    for (const g of nvidiaGpus) {
+      if (g.uuid) labels[g.uuid] = `GPU ${g.index}: ${g.name}${formatVramGb(g.memoryMiB)}`;
+    }
+    return labels;
+  }, [nvidiaGpus, gpuDeviceStale, gpuDevice]);
   // Hardware check (arm64 mac) passes immediately via Electron; server report only
   // refines whether mlx_whisper is actually installed.
   const metalSatisfied = isAppleSilicon && (mlxFeature === undefined || metalSupported);
@@ -2015,36 +2038,23 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                   />
                 </SelectorGroup>
                 {/* Multi-GPU picker: only rendered when the host has more than
-                    one CUDA-capable card. Selection is persisted as a GPU UUID
-                    and pinned at server start via the GPU_DEVICE compose
-                    variable; Automatic keeps the previous single-GPU behavior. */}
+                    one discrete CUDA-capable card. Selection is persisted as a
+                    GPU UUID and pinned at server start via the GPU_DEVICE
+                    compose variable; Automatic keeps the previous single-GPU
+                    behavior. Uses the shared CustomSelect so the popup matches
+                    the app styling instead of the OS-native menu. */}
                 {runtimeProfile === 'gpu' && nvidiaGpus.length > 1 && (
                   <div className="mt-3">
-                    <label
-                      htmlFor="gpu-device-select"
-                      className="mb-1 block text-xs font-medium text-slate-300"
-                    >
-                      GPU for inference
-                    </label>
-                    <select
-                      id="gpu-device-select"
+                    <p className="mb-1 text-xs font-medium text-slate-300">GPU for inference</p>
+                    <CustomSelect
                       value={gpuDevice}
+                      onChange={handleGpuDeviceChange}
+                      options={gpuDeviceOptions}
+                      optionLabel={gpuDeviceOptionLabels}
                       disabled={isRunning}
-                      onChange={(e) => handleGpuDeviceChange(e.target.value)}
-                      className="w-full max-w-sm rounded border border-white/10 bg-black/40 px-2 py-1.5 text-xs text-slate-200 disabled:cursor-not-allowed disabled:text-slate-500"
-                    >
-                      <option value="auto">Automatic (Docker default)</option>
-                      {gpuDeviceStale && (
-                        <option value={gpuDevice}>
-                          Previously selected GPU not detected - starts as Automatic
-                        </option>
-                      )}
-                      {nvidiaGpus.map((g) => (
-                        <option key={g.uuid ?? g.name} value={g.uuid ?? 'auto'}>
-                          {`GPU ${g.index}: ${g.name}${formatVramGb(g.memoryMiB)}`}
-                        </option>
-                      ))}
-                    </select>
+                      aria-label="GPU for inference"
+                      className="focus:ring-accent-cyan w-full max-w-sm rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white transition-shadow outline-none hover:border-white/20 focus:ring-1"
+                    />
                     <p className="mt-1 text-xs text-slate-500 italic">
                       Multiple NVIDIA GPUs detected - the selected card runs the inference server
                     </p>

--- a/dashboard/electron/__tests__/gpuInventory.test.ts
+++ b/dashboard/electron/__tests__/gpuInventory.test.ts
@@ -1,0 +1,372 @@
+// @vitest-environment node
+
+/**
+ * gpuInventory — host GPU enumeration and device-selection resolution
+ * (multi-GPU support: pick which card runs the inference server).
+ *
+ * Pure-parser and resolver tests; the enumerate* orchestration is covered via
+ * injected exec/fs fakes.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  parseNvidiaSmiList,
+  parseLspciName,
+  parseWindowsVideoControllers,
+  parseCdiDeviceNames,
+  vendorFromPciId,
+  classifyLinuxPciGpu,
+  listLinuxDriGpus,
+  enumerateGpus,
+  resolveGpuDeviceSelection,
+  type GpuDevice,
+} from '../gpuInventory.js';
+
+// ─── parseNvidiaSmiList ─────────────────────────────────────────────────────
+
+describe('parseNvidiaSmiList', () => {
+  it('parses a two-GPU csv,noheader,nounits listing', () => {
+    const csv = [
+      '0, NVIDIA GeForce RTX 3060, 12288, GPU-1c8c5f42-aaaa-bbbb-cccc-111111111111',
+      '1, NVIDIA GeForce RTX 3090, 24576, GPU-9f6dc1e3-dddd-eeee-ffff-222222222222',
+    ].join('\n');
+    const gpus = parseNvidiaSmiList(csv);
+    expect(gpus).toHaveLength(2);
+    expect(gpus[0]).toEqual({
+      vendor: 'nvidia',
+      kind: 'discrete',
+      index: 0,
+      name: 'NVIDIA GeForce RTX 3060',
+      memoryMiB: 12288,
+      uuid: 'GPU-1c8c5f42-aaaa-bbbb-cccc-111111111111',
+    });
+    expect(gpus[1].index).toBe(1);
+    expect(gpus[1].name).toBe('NVIDIA GeForce RTX 3090');
+  });
+
+  it('keeps a comma inside the GPU name intact', () => {
+    const csv = '0, NVIDIA Weird, Name GPU, 8192, GPU-1234';
+    const gpus = parseNvidiaSmiList(csv);
+    expect(gpus).toHaveLength(1);
+    expect(gpus[0].name).toBe('NVIDIA Weird, Name GPU');
+  });
+
+  it('ignores blank lines and malformed rows', () => {
+    const csv = '\n\nnot-a-gpu-row\n0, RTX 3090, 24576, GPU-abc\n';
+    expect(parseNvidiaSmiList(csv)).toHaveLength(1);
+  });
+
+  it('returns [] for empty output', () => {
+    expect(parseNvidiaSmiList('')).toEqual([]);
+  });
+});
+
+// ─── vendor / lspci / windows parsers ───────────────────────────────────────
+
+describe('vendorFromPciId', () => {
+  it.each([
+    ['0x10de', 'nvidia'],
+    ['0x1002', 'amd'],
+    ['0x8086', 'intel'],
+    ['0x1af4', 'unknown'],
+  ])('%s → %s', (id, vendor) => {
+    expect(vendorFromPciId(id)).toBe(vendor);
+  });
+
+  it('tolerates trailing newline from sysfs', () => {
+    expect(vendorFromPciId('0x1002\n')).toBe('amd');
+  });
+});
+
+describe('parseLspciName', () => {
+  it('extracts the device name after the class prefix', () => {
+    const line =
+      '0b:00.0 VGA compatible controller: Advanced Micro Devices, Inc. [AMD/ATI] Navi 22 [Radeon RX 6700 XT] (rev c1)';
+    expect(parseLspciName(line)).toBe(
+      'Advanced Micro Devices, Inc. [AMD/ATI] Navi 22 [Radeon RX 6700 XT] (rev c1)',
+    );
+  });
+
+  it('returns null for empty input', () => {
+    expect(parseLspciName('')).toBeNull();
+  });
+});
+
+describe('parseWindowsVideoControllers', () => {
+  it('infers vendors from marketing names', () => {
+    const out = 'NVIDIA GeForce RTX 3090\nAMD Radeon RX 6700 XT\nIntel(R) UHD Graphics 770\n';
+    const gpus = parseWindowsVideoControllers(out);
+    expect(gpus.map((g) => g.vendor)).toEqual(['nvidia', 'amd', 'intel']);
+    expect(gpus.map((g) => g.kind)).toEqual(['discrete', 'discrete', 'integrated']);
+    expect(gpus.every((g) => g.index === null && g.uuid === null)).toBe(true);
+  });
+
+  it('classifies virtual display adapters and APU graphics as non-discrete', () => {
+    const out = [
+      'Microsoft Remote Display Adapter',
+      'Microsoft Basic Display Adapter',
+      'Microsoft Hyper-V Video',
+      'AMD Radeon(TM) Graphics',
+      'Intel(R) Iris(R) Xe Graphics',
+      'Intel(R) Arc(TM) A770 Graphics',
+    ].join('\r\n');
+    const gpus = parseWindowsVideoControllers(out);
+    expect(gpus.map((g) => g.kind)).toEqual([
+      'virtual',
+      'virtual',
+      'virtual',
+      'integrated',
+      'integrated',
+      'discrete',
+    ]);
+  });
+
+  it('handles CRLF line endings', () => {
+    const gpus = parseWindowsVideoControllers('NVIDIA GeForce RTX 3090\r\n');
+    expect(gpus).toHaveLength(1);
+    expect(gpus[0].name).toBe('NVIDIA GeForce RTX 3090');
+  });
+});
+
+describe('parseCdiDeviceNames', () => {
+  it('extracts the gpu device suffixes from nvidia-ctk cdi list output', () => {
+    const out = [
+      'INFO[0000] Found 5 CDI devices',
+      'nvidia.com/gpu=0',
+      'nvidia.com/gpu=1',
+      'nvidia.com/gpu=GPU-fae88089-bcfc-f963-7283-fc83dfaadb17',
+      'nvidia.com/gpu=GPU-91fc582e-7d25-f03a-ddda-5cfb6579e4ed',
+      'nvidia.com/gpu=all',
+    ].join('\n');
+    expect(parseCdiDeviceNames(out)).toEqual([
+      '0',
+      '1',
+      'GPU-fae88089-bcfc-f963-7283-fc83dfaadb17',
+      'GPU-91fc582e-7d25-f03a-ddda-5cfb6579e4ed',
+      'all',
+    ]);
+  });
+
+  it('returns [] when no gpu devices are listed', () => {
+    expect(parseCdiDeviceNames('INFO[0000] Found 0 CDI devices\n')).toEqual([]);
+  });
+});
+
+describe('classifyLinuxPciGpu', () => {
+  const GIB = 1024 * 1024 * 1024;
+
+  it.each([
+    // Intel iGPU on host bus 00
+    ['intel', '0000:00:02.0', null, 'integrated'],
+    // discrete Arc behind a root port
+    ['intel', '0000:03:00.0', null, 'discrete'],
+    // discrete Radeon with a real VRAM pool
+    ['amd', '0000:0b:00.0', 12 * GIB, 'discrete'],
+    // Ryzen APU graphics: non-zero bus but tiny carve-out
+    ['amd', '0000:10:00.0', 512 * 1024 * 1024, 'integrated'],
+    // AMD with no amdgpu VRAM attribute: cannot prove discrete
+    ['amd', '0000:0b:00.0', null, 'unknown'],
+    // virtio-gpu and friends
+    ['unknown', '0000:00:01.0', null, 'unknown'],
+    // unparsable bus id
+    ['intel', 'garbage', null, 'unknown'],
+  ] as const)('%s @ %s vram=%s → %s', (vendor, busId, vram, expected) => {
+    expect(classifyLinuxPciGpu(vendor, busId, vram)).toBe(expected);
+  });
+});
+
+// ─── listLinuxDriGpus ───────────────────────────────────────────────────────
+
+describe('listLinuxDriGpus', () => {
+  const driDeps = (files: Record<string, string>, nodes: string[]) => ({
+    readdirSync: (dir: string) => {
+      if (dir !== '/sys/class/drm') throw new Error(`unexpected dir ${dir}`);
+      return nodes;
+    },
+    readFileSync: (file: string) => {
+      const content = files[file];
+      if (content === undefined) throw new Error(`ENOENT ${file}`);
+      return content;
+    },
+    realpathSync: (p: string) =>
+      `/sys/devices/pci0000:00/0000:0b:00.0`.replace(/0b/, p.includes('129') ? '0c' : '0b'),
+  });
+
+  it('lists an AMD render node and skips the NVIDIA one', async () => {
+    const deps = driDeps(
+      {
+        '/sys/class/drm/renderD128/device/vendor': '0x10de\n',
+        '/sys/class/drm/renderD129/device/vendor': '0x1002\n',
+        '/sys/class/drm/renderD129/device/mem_info_vram_total': `${12 * 1024 * 1024 * 1024}\n`,
+      },
+      ['renderD128', 'renderD129', 'card0'],
+    );
+    const gpus = await listLinuxDriGpus(deps);
+    expect(gpus).toHaveLength(1);
+    expect(gpus[0].vendor).toBe('amd');
+    expect(gpus[0].name).toBe('AMD / Radeon GPU');
+    expect(gpus[0].kind).toBe('discrete');
+    expect(gpus[0].memoryMiB).toBe(12288);
+  });
+
+  it('classifies an APU carve-out as integrated', async () => {
+    const deps = driDeps(
+      {
+        '/sys/class/drm/renderD129/device/vendor': '0x1002',
+        '/sys/class/drm/renderD129/device/mem_info_vram_total': `${512 * 1024 * 1024}`,
+      },
+      ['renderD129'],
+    );
+    const gpus = await listLinuxDriGpus(deps);
+    expect(gpus[0].kind).toBe('integrated');
+  });
+
+  it('uses lspci for the marketing name when available', async () => {
+    const deps = {
+      ...driDeps({ '/sys/class/drm/renderD128/device/vendor': '0x1002' }, ['renderD128']),
+      exec: async (cmd: string, args: string[]) => {
+        expect(cmd).toBe('lspci');
+        expect(args).toEqual(['-s', '0000:0b:00.0']);
+        return '0b:00.0 VGA compatible controller: AMD Navi 22 [Radeon RX 6700 XT]';
+      },
+    };
+    const gpus = await listLinuxDriGpus(deps);
+    expect(gpus[0].name).toBe('AMD Navi 22 [Radeon RX 6700 XT]');
+  });
+
+  it('returns [] when /sys/class/drm is unreadable', async () => {
+    const gpus = await listLinuxDriGpus({
+      readdirSync: () => {
+        throw new Error('EACCES');
+      },
+      readFileSync: () => '',
+      realpathSync: (p: string) => p,
+    });
+    expect(gpus).toEqual([]);
+  });
+});
+
+// ─── enumerateGpus ──────────────────────────────────────────────────────────
+
+describe('enumerateGpus', () => {
+  const NVIDIA_CSV =
+    '0, NVIDIA GeForce RTX 3060, 12288, GPU-aaa\n1, NVIDIA GeForce RTX 3090, 24576, GPU-bbb';
+
+  it('returns nvidia-smi devices first, then Linux DRI devices', async () => {
+    const gpus = await enumerateGpus({
+      exec: async (cmd) => {
+        if (cmd === 'nvidia-smi') return NVIDIA_CSV;
+        throw new Error(`unexpected ${cmd}`);
+      },
+      platform: 'linux',
+      dri: {
+        readdirSync: () => ['renderD128'],
+        readFileSync: () => '0x1002',
+        realpathSync: () => '/sys/devices/pci0000:00/0000:0b:00.0',
+      },
+    });
+    expect(gpus.map((g) => g.vendor)).toEqual(['nvidia', 'nvidia', 'amd']);
+    expect(gpus[1].uuid).toBe('GPU-bbb');
+  });
+
+  it('survives nvidia-smi being absent', async () => {
+    const gpus = await enumerateGpus({
+      exec: async () => {
+        throw new Error('ENOENT nvidia-smi');
+      },
+      platform: 'linux',
+      dri: {
+        readdirSync: () => ['renderD128'],
+        readFileSync: () => '0x1002',
+        realpathSync: () => '/sys/devices/pci0000:00/0000:0b:00.0',
+      },
+    });
+    expect(gpus.map((g) => g.vendor)).toEqual(['amd']);
+  });
+
+  it('drops duplicate NVIDIA rows from the Windows CIM query when nvidia-smi worked', async () => {
+    const gpus = await enumerateGpus({
+      exec: async (cmd) => {
+        if (cmd === 'nvidia-smi') return '0, NVIDIA GeForce RTX 3090, 24576, GPU-bbb';
+        return 'NVIDIA GeForce RTX 3090\nAMD Radeon RX 6700 XT';
+      },
+      platform: 'win32',
+    });
+    expect(gpus.map((g) => g.vendor)).toEqual(['nvidia', 'amd']);
+    expect(gpus[0].uuid).toBe('GPU-bbb');
+  });
+
+  it('keeps the CIM NVIDIA row when nvidia-smi failed (broken driver visibility)', async () => {
+    const gpus = await enumerateGpus({
+      exec: async (cmd) => {
+        if (cmd === 'nvidia-smi') throw new Error('not found');
+        return 'NVIDIA GeForce RTX 3090';
+      },
+      platform: 'win32',
+    });
+    expect(gpus).toHaveLength(1);
+    expect(gpus[0].vendor).toBe('nvidia');
+    expect(gpus[0].uuid).toBeNull();
+  });
+});
+
+// ─── resolveGpuDeviceSelection ──────────────────────────────────────────────
+
+describe('resolveGpuDeviceSelection', () => {
+  const GPUS: GpuDevice[] = [
+    {
+      vendor: 'nvidia',
+      kind: 'discrete',
+      index: 0,
+      name: 'RTX 3060',
+      memoryMiB: 12288,
+      uuid: 'GPU-aaa',
+    },
+    {
+      vendor: 'nvidia',
+      kind: 'discrete',
+      index: 1,
+      name: 'RTX 3090',
+      memoryMiB: 24576,
+      uuid: 'GPU-bbb',
+    },
+    {
+      vendor: 'amd',
+      kind: 'discrete',
+      index: null,
+      name: 'RX 6700 XT',
+      memoryMiB: null,
+      uuid: null,
+    },
+  ];
+
+  it('auto / unset / null leave the compose variable unset', () => {
+    for (const stored of ['auto', undefined, null, ''] as const) {
+      const res = resolveGpuDeviceSelection(stored, GPUS);
+      expect(res.composeValue).toBeNull();
+      expect(res.reason).toBe('auto');
+    }
+  });
+
+  it('resolves a stored UUID to its current nvidia-smi index', () => {
+    const res = resolveGpuDeviceSelection('GPU-bbb', GPUS);
+    expect(res.composeValue).toBe('1');
+    expect(res.reason).toBe('resolved');
+    expect(res.device?.name).toBe('RTX 3090');
+  });
+
+  it('falls back to compose defaults for a UUID that is no longer present', () => {
+    const res = resolveGpuDeviceSelection('GPU-gone', GPUS);
+    expect(res.composeValue).toBeNull();
+    expect(res.reason).toBe('stale-selection');
+  });
+
+  it('never matches non-NVIDIA devices', () => {
+    const res = resolveGpuDeviceSelection('GPU-aaa', [
+      { vendor: 'amd', kind: 'discrete', index: 2, name: 'x', memoryMiB: null, uuid: 'GPU-aaa' },
+    ]);
+    expect(res.composeValue).toBeNull();
+    expect(res.reason).toBe('stale-selection');
+  });
+});

--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -40,6 +40,13 @@ import {
 } from './containerRuntime.js';
 import { type WslSupport, resetWslSupportCache } from './wslDetect.js';
 import { hfCacheDirName } from './hfRepoAliases.js';
+import {
+  type GpuDevice,
+  enumerateGpus,
+  enumerateNvidiaGpus,
+  parseCdiDeviceNames,
+  resolveGpuDeviceSelection,
+} from './gpuInventory.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -103,6 +110,23 @@ export function readUseLegacyGpuFromStore(): boolean {
     return data['server.useLegacyGpu'] === true;
   } catch {
     return false;
+  }
+}
+
+/**
+ * Read the persisted `server.gpuDevice` selection ('auto' or an NVIDIA GPU
+ * UUID) from the electron-store JSON file on disk. Defaults to 'auto' when the
+ * file is missing or the key is absent — matches the config store default.
+ */
+export function readGpuDeviceFromStore(): string {
+  try {
+    const storePath = path.join(app.getPath('userData'), 'dashboard-config.json');
+    const raw = fs.readFileSync(storePath, 'utf8');
+    const data = JSON.parse(raw) as Record<string, unknown>;
+    const value = data['server.gpuDevice'];
+    return typeof value === 'string' && value ? value : 'auto';
+  } catch {
+    return 'auto';
   }
 }
 
@@ -2371,6 +2395,81 @@ async function startContainer(options: StartContainerOptions): Promise<string> {
     composeEnv['PYTORCH_VARIANT'] = 'cpu';
   }
 
+  // Multi-GPU: pin the container to the user-selected NVIDIA card. The
+  // selection is persisted as a GPU UUID (stable across reboots and PCI
+  // reordering) and resolved here, at start time, against a fresh nvidia-smi
+  // listing. The result feeds the GPU_DEVICE variable interpolated by
+  // docker-compose.gpu.yml (legacy: device_ids, takes an index or a UUID),
+  // docker-compose.gpu-cdi.yml and podman-compose.gpu.yml (nvidia.com/gpu=X).
+  // 'auto' or a stale UUID (card removed) leaves GPU_DEVICE empty so each
+  // overlay keeps its historical default (legacy: device 0, CDI: all GPUs).
+  // Set on composeEnv only (not persisted to .env) like PYTORCH_VARIANT above.
+  //
+  // The empty-string default is load-bearing: buildProcessEnv() spreads
+  // process.env underneath composeEnv, so without it an ambient GPU_DEVICE
+  // exported in the user's shell would silently override the compose
+  // defaults ('' triggers the ${GPU_DEVICE:-...} fallback just like unset).
+  composeEnv['GPU_DEVICE'] = '';
+  if (runtimeProfile === 'gpu') {
+    const storedGpuDevice = readGpuDeviceFromStore();
+    if (storedGpuDevice !== 'auto') {
+      // Lean NVIDIA-only listing (no lspci/CIM sweep) — resolution only ever
+      // matches NVIDIA cards, and this path blocks Start Server.
+      let inventory: GpuDevice[] = [];
+      try {
+        inventory = await enumerateNvidiaGpus((cmd, args, opts) => exec(cmd, args, opts));
+      } catch (err: any) {
+        console.warn('[DockerManager] nvidia-smi listing for GPU pin failed:', err.message);
+      }
+      const resolution = resolveGpuDeviceSelection(storedGpuDevice, inventory);
+      const device = resolution.device;
+      if (resolution.composeValue !== null && device) {
+        // CDI (Docker cdi mode and Podman) resolves nvidia.com/gpu=X against
+        // the static CDI registry (/etc/cdi/nvidia.yaml), whose device set can
+        // lag behind live hardware. Validate against `nvidia-ctk cdi list`,
+        // preferring the UUID-named device (immune to index reordering) over
+        // the index-named one. Legacy mode needs no validation: the nvidia
+        // runtime resolves UUIDs in device_ids directly.
+        const useCdi = detectedRuntimeKind === 'podman' || detectedGpuMode === 'cdi';
+        if (useCdi) {
+          let cdiNames: string[] | null = null;
+          try {
+            cdiNames = parseCdiDeviceNames(await exec('nvidia-ctk', ['cdi', 'list']));
+          } catch (err: any) {
+            console.warn('[DockerManager] nvidia-ctk cdi list failed:', err.message);
+          }
+          if (cdiNames === null) {
+            // Listing unavailable — best effort, index name is the common case
+            composeEnv['GPU_DEVICE'] = resolution.composeValue;
+          } else if (device.uuid && cdiNames.includes(device.uuid)) {
+            composeEnv['GPU_DEVICE'] = device.uuid;
+          } else if (cdiNames.includes(resolution.composeValue)) {
+            composeEnv['GPU_DEVICE'] = resolution.composeValue;
+          } else {
+            console.warn(
+              `[DockerManager] CDI registry has no device for GPU ${resolution.composeValue} ` +
+                `(${device.name}). Falling back to the default GPU assignment — regenerate the ` +
+                'spec with: sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml',
+            );
+          }
+        } else {
+          composeEnv['GPU_DEVICE'] = device.uuid ?? resolution.composeValue;
+        }
+        if (composeEnv['GPU_DEVICE'] !== '') {
+          console.log(
+            `[DockerManager] Pinning container to GPU ${resolution.composeValue} ` +
+              `(${device.name}, ${composeEnv['GPU_DEVICE']})`,
+          );
+        }
+      } else {
+        console.warn(
+          `[DockerManager] Stored GPU selection ${storedGpuDevice} not found in current ` +
+            'inventory — falling back to the default GPU assignment',
+        );
+      }
+    }
+  }
+
   // GH-125: guarantee CPU launches never request a NeMo model. The UI-side
   // reset can be bypassed on first-run auto-detect (profile is set before the
   // model selection hydrates), so enforce the faster-whisper substitution here
@@ -3371,28 +3470,66 @@ function unsubscribeFromDownloadEvents(callback: (event: BootstrapDownloadEvent)
 // ─── GPU Detection ──────────────────────────────────────────────────────────
 
 /**
+ * Session cache of the host GPU inventory. The full enumeration spawns
+ * nvidia-smi plus lspci (Linux) or a PowerShell CIM query (Windows), so it
+ * must not re-run on every checkGpu() consumer (SettingsModal calls checkGpu
+ * on every open). Cleared by resetGpuCache() so the Re-detect link picks up
+ * hardware changes without an app restart.
+ */
+let cachedGpuInventory: GpuDevice[] | null = null;
+
+/**
+ * Enumerate the host GPU inventory (NVIDIA via nvidia-smi, AMD/Intel via
+ * Linux DRI sysfs or the Windows CIM query). Best-effort: returns [] rather
+ * than throwing. Used by checkGpu() for the UI payload and by startContainer()
+ * to resolve the persisted device selection against live hardware.
+ */
+async function hostGpuInventory(): Promise<GpuDevice[]> {
+  if (cachedGpuInventory !== null) return cachedGpuInventory;
+  const gpus = await enumerateGpus({
+    exec: (cmd, args, opts) => exec(cmd, args, opts),
+    platform: process.platform,
+    dri: {
+      readdirSync: (dir) => fs.readdirSync(dir),
+      readFileSync: (file) => fs.readFileSync(file, 'utf8'),
+      realpathSync: (p) => fs.realpathSync(p),
+    },
+  });
+  cachedGpuInventory = gpus;
+  return gpus;
+}
+
+/**
  * Check for NVIDIA GPU + container toolkit availability.
  * Also probes Docker Desktop on Windows for WSL2 GPU paravirtualization
  * (GH-101 follow-up) — surfaced via the optional `wslSupport` field, which is
  * `undefined` on non-Win32 platforms.
  *
- * Returns { gpu, toolkit, vulkan, wslSupport? }.
+ * Returns { gpu, toolkit, vulkan, wslSupport?, gpus }. `gpus` is the full
+ * host inventory (multi-GPU support): NVIDIA devices carry an nvidia-smi
+ * index + UUID; AMD/Intel devices are name/vendor-only so the renderer can
+ * recognize mixed NVIDIA+AMD systems and label the Vulkan runtime.
  */
 async function checkGpu(): Promise<{
   gpu: boolean;
   toolkit: boolean;
   vulkan: boolean;
   wslSupport?: WslSupport;
+  gpus: GpuDevice[];
 }> {
   let gpu = false;
   let toolkit = false;
   let vulkan = false;
-  try {
-    const gpuName = await exec('nvidia-smi', ['--query-gpu=name', '--format=csv,noheader']);
+  const gpus = await hostGpuInventory();
+  const nvidiaGpus = gpus.filter((g) => g.vendor === 'nvidia' && g.index !== null);
+  if (nvidiaGpus.length > 0) {
     gpu = true;
-    console.log('[DockerManager] NVIDIA GPU detected:', gpuName);
-  } catch (err: any) {
-    console.warn('[DockerManager] nvidia-smi not found or failed:', err.message);
+    console.log(
+      '[DockerManager] NVIDIA GPU(s) detected:',
+      nvidiaGpus.map((g) => `${g.index}: ${g.name}`).join(', '),
+    );
+  } else {
+    console.warn('[DockerManager] nvidia-smi not found, failed, or reported no GPUs');
   }
   if (gpu) {
     const isPodman = detectedRuntimeKind === 'podman';
@@ -3440,7 +3577,15 @@ async function checkGpu(): Promise<{
   // AND /dev/dri/renderD128 (the actual render node) to be present.
   // On WSL2 or systems with partial DRI, renderD128 may exist while /dev/dri
   // is not mountable by Docker — checking both prevents false Vulkan detection.
-  if (!gpu && process.platform === 'linux') {
+  //
+  // Multi-GPU follow-up: a mixed host (NVIDIA + discrete AMD/Intel) is also a
+  // Vulkan candidate — the NVIDIA presence alone must not zero the flag,
+  // otherwise first-run auto-detect on a mixed host without the NVIDIA
+  // container toolkit would land on 'cpu' even though the whisper.cpp/Vulkan
+  // path works on the AMD card. Auto-detect priority is unchanged: a working
+  // CUDA stack (gpu && toolkit) still wins over vulkan.
+  const discreteNonNvidiaGpu = gpus.some((g) => g.vendor !== 'nvidia' && g.kind === 'discrete');
+  if ((!gpu || discreteNonNvidiaGpu) && process.platform === 'linux') {
     try {
       const fs = await import('fs');
       vulkan = fs.existsSync('/dev/dri') && fs.existsSync('/dev/dri/renderD128');
@@ -3484,7 +3629,7 @@ async function checkGpu(): Promise<{
     );
   }
 
-  return { gpu, toolkit, vulkan, wslSupport };
+  return { gpu, toolkit, vulkan, wslSupport, gpus };
 }
 
 /**
@@ -3498,6 +3643,8 @@ function resetGpuCache(): void {
   // Force `checkGpu()` to re-detect the toolkit mode (CDI vs legacy) too —
   // a user who installs nvidia-container-toolkit mid-session benefits.
   detectedGpuMode = null;
+  // Drop the GPU inventory so Re-detect sees added/removed cards.
+  cachedGpuInventory = null;
 }
 
 /**

--- a/dashboard/electron/gpuInventory.ts
+++ b/dashboard/electron/gpuInventory.ts
@@ -1,0 +1,352 @@
+/**
+ * GPU inventory — enumerates the discrete GPUs visible on the host so the
+ * dashboard can offer a device picker when more than one card could run the
+ * inference server (multi-GPU feature).
+ *
+ * Three sources, all best-effort (a failure in any of them must never break
+ * `checkGpu()`; callers get an empty/partial list instead):
+ *   - NVIDIA (all platforms): `nvidia-smi --query-gpu=index,name,memory.total,uuid`
+ *     — the only source that yields a stable UUID and a device index. The
+ *     index is nvidia-smi/PCI-bus order, which is also the order the NVIDIA
+ *     container toolkit uses for `device_ids` and CDI names (`nvidia.com/gpu=N`),
+ *     so it can be handed to docker-compose as-is. Note this deliberately is
+ *     NOT the CUDA runtime order (CUDA defaults to FASTEST_FIRST) — selection
+ *     is persisted by UUID and resolved to an index at server-start time.
+ *   - Linux non-NVIDIA (AMD/Intel): /sys/class/drm/renderD* vendor ids, with
+ *     an optional `lspci` lookup for the marketing name. These devices carry
+ *     no index/UUID — they exist so the UI can (a) tell a mixed
+ *     NVIDIA+AMD system apart from an NVIDIA-only one and (b) label the
+ *     Vulkan runtime with the actual card name.
+ *   - Windows non-NVIDIA: `Get-CimInstance Win32_VideoController` names.
+ */
+
+export type GpuVendor = 'nvidia' | 'amd' | 'intel' | 'unknown';
+
+/**
+ * Coarse device class. Only 'discrete' devices count as a usable second GPU
+ * for runtime gating: integrated GPUs (iGPU on an NVIDIA desktop, Optimus
+ * laptops) and virtual display adapters (RDP, Hyper-V, DisplayLink, virtio)
+ * must NOT unlock the Vulkan runtimes on NVIDIA hosts, otherwise the
+ * "NVIDIA detected" lockout would be defeated on most machines.
+ */
+export type GpuKind = 'discrete' | 'integrated' | 'virtual' | 'unknown';
+
+export interface GpuDevice {
+  vendor: GpuVendor;
+  kind: GpuKind;
+  /** nvidia-smi index (PCI-bus order). null for devices nvidia-smi cannot see. */
+  index: number | null;
+  name: string;
+  /** Total VRAM in MiB. null when the source does not report memory. */
+  memoryMiB: number | null;
+  /** Stable NVIDIA UUID ("GPU-..."). null for non-NVIDIA devices. */
+  uuid: string | null;
+}
+
+/** Subprocess runner signature — matches dockerManager's internal `exec`. */
+export type ExecFn = (
+  cmd: string,
+  args: string[],
+  opts?: { timeoutMs?: number },
+) => Promise<string>;
+
+/**
+ * Parse `nvidia-smi --query-gpu=index,name,memory.total,uuid --format=csv,noheader,nounits`.
+ *
+ * Example line: `0, NVIDIA GeForce RTX 3090, 24576, GPU-9f6dc1e3-...`
+ * The name is the only field that could theoretically contain a comma, so the
+ * parser takes index from the front, uuid + memory from the back, and joins
+ * whatever remains as the name.
+ */
+export function parseNvidiaSmiList(csv: string): GpuDevice[] {
+  const devices: GpuDevice[] = [];
+  for (const rawLine of csv.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const parts = line.split(',').map((p) => p.trim());
+    if (parts.length < 4) continue;
+    const index = Number.parseInt(parts[0], 10);
+    const uuid = parts[parts.length - 1];
+    const memory = Number.parseInt(parts[parts.length - 2], 10);
+    const name = parts.slice(1, parts.length - 2).join(', ');
+    if (!Number.isInteger(index) || !uuid.startsWith('GPU-') || !name) continue;
+    devices.push({
+      vendor: 'nvidia',
+      kind: 'discrete',
+      index,
+      name,
+      memoryMiB: Number.isFinite(memory) ? memory : null,
+      uuid,
+    });
+  }
+  return devices;
+}
+
+/** PCI vendor id (contents of the render node sysfs "vendor" file) → vendor. */
+export function vendorFromPciId(pciVendorId: string): GpuVendor {
+  switch (pciVendorId.trim().toLowerCase()) {
+    case '0x10de':
+      return 'nvidia';
+    case '0x1002':
+      return 'amd';
+    case '0x8086':
+      return 'intel';
+    default:
+      return 'unknown';
+  }
+}
+
+/**
+ * Extract the device name from a single-line `lspci -s <bus>` output, e.g.
+ * `0b:00.0 VGA compatible controller: AMD/ATI Navi 22 [Radeon RX 6700 XT] (rev c1)`.
+ * The first ": " separates the class prefix from the name (the ":" inside the
+ * bus id has no trailing space, so it does not split).
+ */
+export function parseLspciName(line: string): string | null {
+  const name = line.split(': ').slice(1).join(': ').trim();
+  return name || null;
+}
+
+const FALLBACK_NAME: Record<GpuVendor, string> = {
+  nvidia: 'NVIDIA GPU',
+  amd: 'AMD / Radeon GPU',
+  intel: 'Intel GPU',
+  unknown: 'Unknown GPU',
+};
+
+interface DriDeps {
+  readdirSync: (dir: string) => string[];
+  readFileSync: (file: string) => string;
+  realpathSync: (p: string) => string;
+  exec?: ExecFn;
+}
+
+/**
+ * Enumerate Linux DRI render nodes (/sys/class/drm/renderD*) with their PCI
+ * vendor. NVIDIA nodes are skipped — nvidia-smi is the authoritative (and
+ * richer) source for those; a render node for an NVIDIA card that nvidia-smi
+ * cannot see means the proprietary driver is absent, and CUDA is unusable on
+ * it anyway. Never throws; returns [] on any error.
+ */
+export async function listLinuxDriGpus(deps: DriDeps): Promise<GpuDevice[]> {
+  let nodes: string[];
+  try {
+    nodes = deps.readdirSync('/sys/class/drm').filter((n) => /^renderD\d+$/.test(n));
+  } catch {
+    return [];
+  }
+  const devices: GpuDevice[] = [];
+  for (const node of nodes) {
+    try {
+      const deviceDir = `/sys/class/drm/${node}/device`;
+      const vendor = vendorFromPciId(deps.readFileSync(`${deviceDir}/vendor`));
+      if (vendor === 'nvidia') continue;
+      // realpath of the device dir ends in the PCI address ("0000:0b:00.0").
+      let busId = '';
+      try {
+        busId = deps.realpathSync(deviceDir).split('/').pop() ?? '';
+      } catch {
+        // sysfs symlink unreadable — classification degrades to 'unknown'
+      }
+      // amdgpu exposes dedicated VRAM in bytes; used both for display and to
+      // tell a discrete Radeon (large dedicated VRAM) from an APU carve-out.
+      let vramBytes: number | null = null;
+      try {
+        const parsed = Number.parseInt(deps.readFileSync(`${deviceDir}/mem_info_vram_total`), 10);
+        vramBytes = Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+      } catch {
+        // not an amdgpu device or attribute missing
+      }
+      let name: string | null = null;
+      if (deps.exec && busId) {
+        try {
+          const lspciOut = await deps.exec('lspci', ['-s', busId], { timeoutMs: 5_000 });
+          name = parseLspciName(lspciOut.split('\n')[0] ?? '');
+        } catch {
+          // lspci missing or failed — fall back to the vendor label below
+        }
+      }
+      devices.push({
+        vendor,
+        kind: classifyLinuxPciGpu(vendor, busId, vramBytes),
+        index: null,
+        name: name ?? FALLBACK_NAME[vendor],
+        memoryMiB: vramBytes !== null ? Math.round(vramBytes / (1024 * 1024)) : null,
+        uuid: null,
+      });
+    } catch {
+      // unreadable node — skip it
+    }
+  }
+  return devices;
+}
+
+/** Discrete AMD cards worth routing inference to have at least this much dedicated VRAM. */
+const DISCRETE_VRAM_THRESHOLD_BYTES = 3 * 1024 * 1024 * 1024;
+
+/**
+ * Classify a Linux PCI GPU as integrated vs discrete. Intel iGPUs always live
+ * on host bus 00 ("0000:00:02.0") while discrete Arc cards sit behind a PCIe
+ * root port on a non-zero bus. AMD APU graphics can appear on a non-zero bus
+ * too (internal bridge on Ryzen APUs), so AMD additionally requires a
+ * discrete-sized dedicated VRAM pool (amdgpu mem_info_vram_total) — an APU
+ * carve-out is far below the threshold. Unknown vendors (virtio-gpu and
+ * friends) and unclassifiable devices never count as a usable second GPU.
+ */
+export function classifyLinuxPciGpu(
+  vendor: GpuVendor,
+  busId: string,
+  vramBytes: number | null,
+): GpuKind {
+  if (vendor === 'unknown') return 'unknown';
+  if (!/^[0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}\.[0-9a-f]$/i.test(busId)) return 'unknown';
+  if (/^[0-9a-f]{4}:00:/i.test(busId)) return 'integrated';
+  if (vendor === 'amd') {
+    if (vramBytes === null) return 'unknown';
+    return vramBytes >= DISCRETE_VRAM_THRESHOLD_BYTES ? 'discrete' : 'integrated';
+  }
+  return 'discrete';
+}
+
+/**
+ * Parse the newline-separated names from
+ * `Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty Name`.
+ * Vendor and kind are inferred from the marketing name: Win32_VideoController
+ * also lists virtual display adapters (RDP, Hyper-V, DisplayLink, Parsec) and
+ * integrated GPUs, which must not read as a usable second card.
+ */
+export function parseWindowsVideoControllers(output: string): GpuDevice[] {
+  const devices: GpuDevice[] = [];
+  for (const rawLine of output.split('\n')) {
+    const name = rawLine.trim();
+    if (!name) continue;
+    let vendor: GpuVendor = 'unknown';
+    if (/nvidia|geforce|quadro/i.test(name)) vendor = 'nvidia';
+    else if (/\bamd\b|radeon|firepro/i.test(name)) vendor = 'amd';
+    else if (/intel|\barc\b|iris|\buhd\b/i.test(name)) vendor = 'intel';
+    let kind: GpuKind;
+    if (
+      /microsoft|hyper-v|remote|virtual|displaylink|parsec|spacedesk|vmware|virtualbox|qxl/i.test(
+        name,
+      )
+    ) {
+      kind = 'virtual';
+    } else if (
+      /\biris\b|\buhd\b|\bhd graphics\b|radeon\(tm\)|\bvega \d+\b|\bradeon graphics\b/i.test(name)
+    ) {
+      kind = 'integrated';
+    } else {
+      kind = vendor === 'unknown' ? 'unknown' : 'discrete';
+    }
+    devices.push({ vendor, kind, index: null, name, memoryMiB: null, uuid: null });
+  }
+  return devices;
+}
+
+/**
+ * Parse `nvidia-ctk cdi list` output into the suffixes of the registered
+ * `nvidia.com/gpu=<suffix>` device names (indices, UUIDs, "all"). Used to
+ * validate that a CDI grant for a specific card can actually resolve before
+ * handing it to docker compose — the CDI registry is a static file that can
+ * lag behind the live nvidia-smi view of the hardware.
+ */
+export function parseCdiDeviceNames(output: string): string[] {
+  const names: string[] = [];
+  for (const rawLine of output.split('\n')) {
+    const match = rawLine.trim().match(/^nvidia\.com\/gpu=(\S+)$/);
+    if (match) names.push(match[1]);
+  }
+  return names;
+}
+
+export interface EnumerateDeps {
+  exec: ExecFn;
+  platform: NodeJS.Platform;
+  dri?: Omit<DriDeps, 'exec'>;
+}
+
+/**
+ * Run nvidia-smi enumeration. Throws when nvidia-smi is missing/failing.
+ * No explicit timeout: the caller default (120s in dockerManager) matches the
+ * pre-existing probe budget — cold nvidia-smi on multi-GPU boxes without
+ * persistence mode can take tens of seconds, and this gates Start Server.
+ */
+export async function enumerateNvidiaGpus(exec: ExecFn): Promise<GpuDevice[]> {
+  const out = await exec('nvidia-smi', [
+    '--query-gpu=index,name,memory.total,uuid',
+    '--format=csv,noheader,nounits',
+  ]);
+  return parseNvidiaSmiList(out);
+}
+
+/**
+ * Full best-effort host GPU inventory: NVIDIA first (nvidia-smi order), then
+ * non-NVIDIA devices. Never throws.
+ */
+export async function enumerateGpus(deps: EnumerateDeps): Promise<GpuDevice[]> {
+  let nvidia: GpuDevice[] = [];
+  try {
+    nvidia = await enumerateNvidiaGpus(deps.exec);
+  } catch {
+    // nvidia-smi absent — NVIDIA presence is reported by checkGpu() separately
+  }
+
+  let others: GpuDevice[] = [];
+  if (deps.platform === 'linux' && deps.dri) {
+    others = await listLinuxDriGpus({ ...deps.dri, exec: deps.exec });
+  } else if (deps.platform === 'win32') {
+    try {
+      const out = await deps.exec(
+        'powershell.exe',
+        [
+          '-NoProfile',
+          '-Command',
+          'Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty Name',
+        ],
+        { timeoutMs: 15_000 },
+      );
+      // nvidia-smi already covers NVIDIA cards with richer data; only keep a
+      // CIM NVIDIA row when nvidia-smi itself found nothing (broken driver).
+      others = parseWindowsVideoControllers(out).filter(
+        (d) => d.vendor !== 'nvidia' || nvidia.length === 0,
+      );
+    } catch {
+      // PowerShell unavailable — leave others empty
+    }
+  }
+
+  return [...nvidia, ...others];
+}
+
+export type GpuSelectionReason = 'auto' | 'resolved' | 'stale-selection';
+
+export interface GpuDeviceResolution {
+  /**
+   * Value for the GPU_DEVICE compose variable (an nvidia-smi index as a
+   * string), or null to leave the variable unset so each compose overlay
+   * falls back to its own default (legacy: device 0, CDI/Podman: all).
+   */
+  composeValue: string | null;
+  reason: GpuSelectionReason;
+  device?: GpuDevice;
+}
+
+/**
+ * Resolve the persisted `server.gpuDevice` value (either 'auto' or an NVIDIA
+ * GPU UUID) against a fresh inventory. A UUID that no longer matches any
+ * present card (card removed, driver down) resolves to the compose defaults
+ * instead of failing the server start.
+ */
+export function resolveGpuDeviceSelection(
+  stored: string | undefined | null,
+  gpus: GpuDevice[],
+): GpuDeviceResolution {
+  if (!stored || stored === 'auto') {
+    return { composeValue: null, reason: 'auto' };
+  }
+  const device = gpus.find((g) => g.vendor === 'nvidia' && g.uuid === stored && g.index !== null);
+  if (device) {
+    return { composeValue: String(device.index), reason: 'resolved', device };
+  }
+  return { composeValue: null, reason: 'stale-selection' };
+}

--- a/dashboard/electron/main.ts
+++ b/dashboard/electron/main.ts
@@ -529,6 +529,12 @@ const store = new Store({
     // selecting the Metal runtime alone must not launch the server.
     'server.mlxDesiredRunning': false,
     'server.gpuAutoDetectDone': false,
+    // Multi-GPU: which NVIDIA card runs the inference server. 'auto' keeps the
+    // compose defaults (legacy overlay: device 0, CDI: all GPUs); otherwise an
+    // NVIDIA GPU UUID ("GPU-...") resolved to an nvidia-smi index at start
+    // time by dockerManager.startContainer(). Set from the Runtime Settings
+    // GPU picker, which only appears when >1 NVIDIA GPU is detected.
+    'server.gpuDevice': 'auto',
     // Issue #83 — opt-in legacy-GPU image variant (Pascal/Maxwell support).
     // Default false keeps behaviour unchanged for existing users. When true,
     // the dashboard uses the `-legacy` GHCR repo for list/pull/tag operations.

--- a/dashboard/electron/preload.ts
+++ b/dashboard/electron/preload.ts
@@ -153,6 +153,14 @@ export interface ElectronAPI {
       toolkit: boolean;
       vulkan: boolean;
       wslSupport?: WslSupport;
+      gpus: Array<{
+        vendor: 'nvidia' | 'amd' | 'intel' | 'unknown';
+        kind: 'discrete' | 'integrated' | 'virtual' | 'unknown';
+        index: number | null;
+        name: string;
+        memoryMiB: number | null;
+        uuid: string | null;
+      }>;
     }>;
     resetGpuCache: () => Promise<void>;
     hasVulkanWsl2SidecarImage: () => Promise<boolean>;

--- a/dashboard/src/types/electron.d.ts
+++ b/dashboard/src/types/electron.d.ts
@@ -23,6 +23,16 @@ interface WslSupport {
   gpuPassthroughDetected: boolean;
   reason?: string;
 }
+
+// Keep in sync with electron/gpuInventory.ts (canonical) and electron/preload.ts
+interface HostGpuDevice {
+  vendor: 'nvidia' | 'amd' | 'intel' | 'unknown';
+  kind: 'discrete' | 'integrated' | 'virtual' | 'unknown';
+  index: number | null;
+  name: string;
+  memoryMiB: number | null;
+  uuid: string | null;
+}
 type HfTokenDecision = 'unset' | 'provided' | 'skipped';
 type ClientLogType = 'info' | 'success' | 'error' | 'warning';
 
@@ -133,6 +143,7 @@ interface ElectronAPI {
       toolkit: boolean;
       vulkan: boolean;
       wslSupport?: WslSupport;
+      gpus: HostGpuDevice[];
     }>;
     hasVulkanWsl2SidecarImage: () => Promise<boolean>;
     listImages: () => Promise<

--- a/server/docker/docker-compose.gpu-cdi.yml
+++ b/server/docker/docker-compose.gpu-cdi.yml
@@ -5,6 +5,11 @@
 # Used automatically when the dashboard detects CDI mode.
 # Usage: docker compose -f docker-compose.yml -f docker-compose.linux-host.yml -f docker-compose.gpu-cdi.yml up -d
 
+# GPU_DEVICE selects which card on multi-GPU hosts (nvidia-smi index, set by
+# the dashboard at server start from the Runtime Settings GPU picker; CDI
+# device names are generated in the same order). Unset keeps the historical
+# default of exposing all GPUs.
+
 services:
   transcriptionsuite:
     deploy:
@@ -13,5 +18,5 @@ services:
           devices:
             - driver: cdi
               device_ids:
-                - nvidia.com/gpu=all
+                - nvidia.com/gpu=${GPU_DEVICE:-all}
               capabilities: [gpu]

--- a/server/docker/docker-compose.gpu.yml
+++ b/server/docker/docker-compose.gpu.yml
@@ -1,6 +1,11 @@
 # NVIDIA GPU overlay
 # Adds GPU device reservation for CUDA-accelerated transcription.
 # Usage: docker compose -f docker-compose.yml -f docker-compose.linux-host.yml -f docker-compose.gpu.yml up -d
+#
+# GPU_DEVICE selects which card on multi-GPU hosts (nvidia-smi index, set by
+# the dashboard at server start from the Runtime Settings GPU picker). Unset
+# defaults to device 0 — the same card the previous `count: 1` reservation
+# resolved to, so manual `docker compose up` behaves as before.
 
 services:
   transcriptionsuite:
@@ -9,5 +14,6 @@ services:
         reservations:
           devices:
             - driver: nvidia
-              count: 1
+              device_ids:
+                - ${GPU_DEVICE:-0}
               capabilities: [gpu]

--- a/server/docker/podman-compose.gpu.yml
+++ b/server/docker/podman-compose.gpu.yml
@@ -1,8 +1,12 @@
 # Podman GPU overlay — uses CDI (Container Device Interface) for NVIDIA GPU access.
 # Requires nvidia-container-toolkit configured for CDI: nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
 # Usage: podman compose -f docker-compose.yml -f docker-compose.linux-host.yml -f podman-compose.gpu.yml up -d
+#
+# GPU_DEVICE selects which card on multi-GPU hosts (nvidia-smi index, set by
+# the dashboard at server start from the Runtime Settings GPU picker). Unset
+# keeps the historical default of exposing all GPUs.
 
 services:
   transcriptionsuite:
     devices:
-      - nvidia.com/gpu=all
+      - nvidia.com/gpu=${GPU_DEVICE:-all}


### PR DESCRIPTION
## Summary

Adds a GPU selector to the Server tab so hosts with more than one NVIDIA card can choose which one runs the inference server (motivating case: RTX 3060 + RTX 3090 in the same box). Also makes mixed NVIDIA + AMD systems behave deliberately instead of accidentally.

### Why this matters today

With two NVIDIA cards the current behavior is an accident of toolkit mode: the legacy overlay (`count: 1`) grants only nvidia-smi device 0 (PCI order, i.e. whichever card sits in the first slot), while the CDI overlay grants all GPUs and CUDA's default `FASTEST_FIRST` ordering picks the fastest. On this dual-GPU box the legacy path was silently running everything on the 3060 while the 3090 sat idle.

### How it works

- **Enumeration** (`dashboard/electron/gpuInventory.ts`, new): `checkGpu()` now returns a `gpus` inventory - NVIDIA cards via `nvidia-smi --query-gpu=index,name,memory.total,uuid` (nvidia-smi order = the order Docker device grants use), AMD/Intel via Linux DRI sysfs (with `lspci` names + amdgpu VRAM) or `Win32_VideoController` on Windows. Each device is classified **discrete / integrated / virtual** so iGPUs and RDP/Hyper-V adapters never masquerade as a usable second card. The inventory is session-cached and refreshed by the existing Re-detect link.
- **Picker UI** (Runtime Settings card): a dropdown appears only when >1 NVIDIA GPU is detected and the CUDA runtime is selected. Options show `GPU <index>: <name> (<VRAM>)`. Default is Automatic (previous behavior). The choice is persisted as a **GPU UUID** (`server.gpuDevice`) - UUIDs survive PCI re-seating, and nvidia-smi order deliberately differs from CUDA's `FASTEST_FIRST` order, so an index would be ambiguous.
- **Start plumbing**: `startContainer()` resolves the UUID to the current nvidia-smi index at start time and passes it via a `GPU_DEVICE` compose variable:
  - `docker-compose.gpu.yml` (legacy): `device_ids: ['${GPU_DEVICE:-0}']` - pinned by UUID directly (the nvidia runtime resolves UUIDs natively); unset keeps the historical single-device grant.
  - `docker-compose.gpu-cdi.yml` / `podman-compose.gpu.yml`: `nvidia.com/gpu=${GPU_DEVICE:-all}`. The grant is validated against `nvidia-ctk cdi list` first, preferring the **UUID-named CDI device**; if the static CDI spec is stale (card added but spec never regenerated) it logs a warning telling the user to re-run `nvidia-ctk cdi generate` and falls back to the default grant instead of hard-failing `compose up`.
  - `GPU_DEVICE` is always set on composeEnv (empty = defaults) so an ambient shell variable can never leak into the grant; it is intentionally NOT persisted to the compose `.env`.
  - A stale pin (card removed) falls back to defaults with a warning, never blocks Start Server, and the picker shows an explicit "Previously selected GPU not detected" option instead of silently claiming Automatic.
- **Backend**: intentionally unchanged. The container sees exactly one GPU as index 0, which every backend path already targets.

### Mixed NVIDIA + AMD behavior

The runtime tile picks the vendor, the dropdown picks the card within CUDA:

- The Vulkan tiles were previously hard-disabled whenever NVIDIA was detected. They are now selectable when a **discrete** AMD/Intel card is also present, so inference can be routed to the AMD card (the whisper.cpp sidecar ships Mesa drivers only, so inside the container it cannot even see the NVIDIA card - it lands on the AMD one by construction).
- Integrated GPUs (Intel iGPU, Ryzen APU carve-outs - detected via PCI bus + amdgpu VRAM heuristics) and virtual display adapters keep the NVIDIA lockout exactly as before.
- `checkGpu().vulkan` no longer short-circuits on NVIDIA presence, so first-run auto-detect on a mixed host without nvidia-container-toolkit lands on Vulkan instead of CPU. Auto-detect priority is otherwise unchanged (working CUDA still wins).
- Hint lines under the tiles explain which card each runtime will use.

### Known limitations

- No device picker for the Vulkan runtime itself (multiple discrete AMD cards): whisper.cpp picks its Vulkan device internally; mapping our host view to its enumeration order is not reliable. Documented, out of scope.
- `vulkan-wsl2` (native whisper-server.exe) has no device selection either - same reason.
- Manual `docker compose up` outside the dashboard uses the compose defaults (device 0 / all) since `GPU_DEVICE` is not persisted to `.env` - noted in the overlay comments.

## Test plan

- [x] 35 unit tests for the parsers (nvidia-smi CSV incl. comma-in-name, lspci, Win32 CIM incl. CRLF + virtual adapters, `nvidia-ctk cdi list`), the discrete/integrated classifier and the UUID resolver
- [x] 8 RTL tests: picker renders per-card options with VRAM, persists UUID on change, hydrates persisted pin, hidden for single GPU, discrete-AMD unlocks Vulkan tiles, iGPU keeps lockout, stale pin surfaces explicitly
- [x] Full dashboard suite: 131 files / 1928 tests green; typecheck, eslint, prettier, ui-contract all pass
- [x] `docker compose config` verified for both overlays with `GPU_DEVICE` unset and set
- [x] Real enumeration verified on the dual-GPU box (3060 = index 0, 3090 = index 1; both DRI nodes correctly identified as NVIDIA)
- [ ] Hardware smoke: start server pinned to the 3090, confirm `nvidia-smi` shows the container process on the 3090 only; repeat with Automatic; Re-detect after driver reload

## Review notes

GitNexus impact on the touched hubs (`checkGpu`, `composeFileArgs` callers) reported CRITICAL fan-out, mitigated by keeping every change additive (new optional payload field, new env var with behavior-preserving defaults). A 46-agent adversarial review pass ran over the diff; all 13 confirmed findings were fixed in this commit (iGPU/virtual-adapter lockout bypass, CDI stale-spec validation, ambient env leak, vulkan flag on mixed hosts, nvidia-smi timeout regression, duplicate probes, stale-pin honesty, formatting).