### PR TITLE
feat(ui,server,docs): GH #200 usability - CA folder picker, accurate TLS hint and deployment docs

### DIFF
--- a/dashboard/components/__tests__/ServerView.test.tsx
+++ b/dashboard/components/__tests__/ServerView.test.tsx
@@ -212,6 +212,8 @@ vi.mock('../../src/types/runtime', () => ({
 // ── Import after mocks ────────────────────────────────────────────────────
 
 import { ServerView } from '../views/ServerView';
+import { getConfig, setConfig } from '../../src/config/store';
+import { toast } from 'sonner';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -941,6 +943,156 @@ describe('Docker image variant selector', () => {
       expect(legacyTile.disabled).toBe(false);
     });
     expect(screen.queryByText('Not published')).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Extra CA certificates picker (GH-200) — the Volumes card exposes a folder
+// picker whose value dockerManager reads at container start and passes to
+// compose as EXTRA_CA_CERTS_DIR (TLS-intercepting antivirus/proxy networks).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Extra CA certificates picker (GH-200)', () => {
+  function setupCaApi(configMap: Record<string, unknown>) {
+    const selectFolder = vi.fn().mockResolvedValue(null);
+    (window as any).electronAPI = {
+      config: {
+        get: vi.fn().mockImplementation(async (key: string) => configMap[key]),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+      docker: {
+        readComposeEnvValue: vi.fn().mockResolvedValue('false'),
+        checkModelCache: vi.fn().mockResolvedValue({}),
+      },
+      app: {
+        getArch: vi.fn().mockReturnValue('x64'),
+        getConfigDir: vi.fn().mockResolvedValue('/mock/config'),
+      },
+      mlx: {
+        getStatus: vi.fn().mockResolvedValue('stopped'),
+        onStatusChanged: vi.fn().mockReturnValue(vi.fn()),
+        start: vi.fn().mockResolvedValue(undefined),
+        stop: vi.fn().mockResolvedValue(undefined),
+      },
+      tailscale: {
+        getHostname: vi.fn().mockResolvedValue('my-server.tail1234.ts.net'),
+      },
+      server: {
+        checkFirewallPort: vi.fn().mockResolvedValue(null),
+        checkGpu: vi.fn().mockResolvedValue({ gpu: false, toolkit: false, vulkan: false }),
+      },
+      fileIO: { selectFolder },
+    };
+    return { selectFolder };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDocker.available = true;
+    mockDocker.images = [];
+    mockDocker.volumes = [];
+    mockDocker.container = { exists: false, running: false, status: 'unknown', health: undefined };
+    mockDocker.operationError = null;
+    mockDocker.operating = false;
+    mockDocker.composeAvailable = true;
+    mockAdminStatus.status = { models: {} };
+    // Restore the module-factory default after tests that override it.
+    vi.mocked(getConfig).mockReset();
+    vi.mocked(getConfig).mockResolvedValue(undefined);
+  });
+
+  it('persists a chosen folder and shows it in the Volumes card', async () => {
+    const { selectFolder } = setupCaApi({ 'server.runtimeProfile': 'cpu' });
+    selectFolder.mockResolvedValue('/home/me/.config/TranscriptionSuite/ca');
+
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    expect(await screen.findByText('Extra CA certificates')).toBeDefined();
+
+    fireEvent.click(screen.getByText('Choose folder').closest('button') as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(vi.mocked(setConfig)).toHaveBeenCalledWith(
+        'server.extraCaCertsDir',
+        '/home/me/.config/TranscriptionSuite/ca',
+      );
+    });
+    expect(screen.getByText('/home/me/.config/TranscriptionSuite/ca')).toBeDefined();
+    expect(screen.getByText('Change')).toBeDefined();
+    expect(screen.queryByText('Choose folder')).toBeNull();
+  });
+
+  it('loads a saved folder on mount and clears it back to unset', async () => {
+    setupCaApi({ 'server.runtimeProfile': 'cpu' });
+    vi.mocked(getConfig).mockImplementation(async (key: string) =>
+      key === 'server.extraCaCertsDir'
+        ? 'C:\\Users\\me\\AppData\\Roaming\\TranscriptionSuite\\ca'
+        : undefined,
+    );
+
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    expect(
+      await screen.findByText('C:\\Users\\me\\AppData\\Roaming\\TranscriptionSuite\\ca'),
+    ).toBeDefined();
+
+    fireEvent.click(screen.getByText('Clear').closest('button') as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(vi.mocked(setConfig)).toHaveBeenCalledWith('server.extraCaCertsDir', '');
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByText('C:\\Users\\me\\AppData\\Roaming\\TranscriptionSuite\\ca'),
+      ).toBeNull();
+    });
+    expect(screen.getByText('Choose folder')).toBeDefined();
+  });
+
+  it('does not render on the Metal (bare-metal) runtime', async () => {
+    setupCaApi({ 'server.runtimeProfile': 'metal' });
+
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    expect(await screen.findByText('5. Persistent Volumes')).toBeDefined();
+    expect(screen.queryByText('Extra CA certificates')).toBeNull();
+  });
+
+  it('does not show the folder as configured when persisting fails', async () => {
+    const { selectFolder } = setupCaApi({ 'server.runtimeProfile': 'cpu' });
+    selectFolder.mockResolvedValue('/home/me/ca');
+    vi.mocked(setConfig).mockRejectedValueOnce(new Error('disk full'));
+
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    expect(await screen.findByText('Extra CA certificates')).toBeDefined();
+
+    fireEvent.click(screen.getByText('Choose folder').closest('button') as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(vi.mocked(toast.error)).toHaveBeenCalled();
+    });
+    // Container start reads the store, not the UI, so the UI must not claim
+    // a folder the store never received.
+    expect(screen.queryByText('/home/me/ca')).toBeNull();
+    expect(screen.getByText('Choose folder')).toBeDefined();
+  });
+
+  it('rejects a folder whose path contains a colon without persisting it', async () => {
+    const { selectFolder } = setupCaApi({ 'server.runtimeProfile': 'cpu' });
+    // Finder maps "/" typed in a folder name to ":" on disk; Docker cannot
+    // mount such a path.
+    selectFolder.mockResolvedValue('/home/me/Certs 06:2026');
+
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    expect(await screen.findByText('Extra CA certificates')).toBeDefined();
+
+    fireEvent.click(screen.getByText('Choose folder').closest('button') as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(vi.mocked(toast.error)).toHaveBeenCalled();
+    });
+    expect(vi.mocked(setConfig)).not.toHaveBeenCalledWith(
+      'server.extraCaCertsDir',
+      expect.anything(),
+    );
+    expect(screen.queryByText('/home/me/Certs 06:2026')).toBeNull();
   });
 });
 

--- a/dashboard/components/views/ServerView.tsx
+++ b/dashboard/components/views/ServerView.tsx
@@ -43,6 +43,8 @@ import { StartupActivityInline } from './server/StartupActivityInline';
 import { useNotificationsStore } from '../../src/stores/notificationsStore';
 import { SERVER_START_ID } from '../../src/utils/startupEventMapping';
 import { useAdminStatus } from '../../src/hooks/useAdminStatus';
+import { useFolderPicker } from '../../src/hooks/useFolderPicker';
+import { getConfig, setConfig } from '../../src/config/store';
 import { useServerStatus } from '../../src/hooks/useServerStatus';
 import { useDockerContext } from '../../src/hooks/DockerContext';
 import { useModelCache } from '../../src/hooks/useModelCache';
@@ -318,6 +320,49 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
     writeToClipboard(dir).catch(() => {});
     setCopiedPath(label);
     setTimeout(() => setCopiedPath((c) => (c === label ? null : c)), 2000);
+  }, []);
+
+  // Extra CA certificates folder for TLS-intercepting antivirus/proxy setups
+  // (GH-200). Persisted as server.extraCaCertsDir; dockerManager reads it at
+  // container start and feeds the EXTRA_CA_CERTS_DIR bind mount. Blank = unset.
+  const [extraCaCertsDir, setExtraCaCertsDir] = useState<string | null>(null);
+  const pickFolder = useFolderPicker();
+  useEffect(() => {
+    getConfig<string>('server.extraCaCertsDir')
+      .then((v) => {
+        if (typeof v === 'string' && v.trim()) setExtraCaCertsDir(v);
+      })
+      .catch(() => {});
+  }, []);
+  const handlePickCaCertsDir = useCallback(async () => {
+    const selected = await pickFolder();
+    if (!selected) return;
+    // Docker rejects a bind-mount whose host path contains ":" (the volume-spec
+    // separator; Windows drive letters like C:\ are the one exception), so
+    // refuse it here with a clear message instead of failing at server start.
+    if (selected.replace(/^[A-Za-z]:(?=[\\/])/, '').includes(':')) {
+      toast.error(
+        'Docker cannot mount a folder whose path contains ":". Rename the folder and pick it again.',
+      );
+      return;
+    }
+    // Persist first, then commit UI state: container start reads the store, not
+    // the UI, so an optimistic update on a failed write would show a folder that
+    // never mounts.
+    try {
+      await setConfig('server.extraCaCertsDir', selected);
+      setExtraCaCertsDir(selected);
+    } catch {
+      toast.error('Could not save the CA certificates folder setting.');
+    }
+  }, [pickFolder]);
+  const handleClearCaCertsDir = useCallback(async () => {
+    try {
+      await setConfig('server.extraCaCertsDir', '');
+      setExtraCaCertsDir(null);
+    } catch {
+      toast.error('Could not clear the CA certificates folder setting.');
+    }
   }, []);
 
   // Runtime profile shorthands. Valid model families, live options and
@@ -2692,6 +2737,49 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                         Clear {vol.label.replace(' Volume', '')}
                       </Button>
                     ))}
+                  </div>
+                )}
+
+                {/* Extra CA certificates mount for TLS-intercepting networks (GH-200) */}
+                {!isMetal && (
+                  <div className="border-t border-white/5 pt-4">
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="flex items-center gap-3">
+                        <div className="h-2 w-2 rounded-full bg-slate-500" />
+                        <span className="text-sm text-slate-300">Extra CA certificates</span>
+                      </div>
+                      <div className="flex shrink-0 items-center gap-2">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          icon={<FolderOpen size={14} />}
+                          onClick={handlePickCaCertsDir}
+                        >
+                          {extraCaCertsDir ? 'Change' : 'Choose folder'}
+                        </Button>
+                        {extraCaCertsDir && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            icon={<XCircle size={14} />}
+                            onClick={handleClearCaCertsDir}
+                          >
+                            Clear
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                    {extraCaCertsDir && (
+                      <div className="mt-1 pl-5 font-mono text-xs break-all text-slate-400">
+                        {extraCaCertsDir}
+                      </div>
+                    )}
+                    <p className="mt-1 pl-5 text-xs text-slate-500">
+                      Only needed when an antivirus or corporate proxy inspects HTTPS and server
+                      startup fails with certificate errors. Export the intercepting root
+                      certificate (Base-64 / PEM format) into a folder and choose it here. The
+                      container trusts it from the next server start.
+                    </p>
                   </div>
                 )}
               </div>

--- a/dashboard/electron/__tests__/dockerManagerComposeEnvPreservation.test.ts
+++ b/dashboard/electron/__tests__/dockerManagerComposeEnvPreservation.test.ts
@@ -3,11 +3,13 @@
 /**
  * GH-200 — a hand-added compose env key must survive every server start.
  *
- * On a TLS-intercepting network (corporate proxy / antivirus HTTPS scanning) the
- * only way a packaged-app user can get their root CA into the container is to add
- * `EXTRA_CA_CERTS_DIR=...` to `<userData>/docker/.env` by hand: there is no UI for
- * it yet, and the compose files themselves are overwritten from the bundle on every
- * launch.
+ * On a TLS-intercepting network (corporate proxy / antivirus HTTPS scanning) a
+ * packaged-app user can get their root CA into the container by adding
+ * `EXTRA_CA_CERTS_DIR=...` to `<userData>/docker/.env` by hand. The Server-tab
+ * folder picker (see dockerManagerExtraCaCerts.test.ts) now offers the same via
+ * process env, but the hand-edited route stays supported: the compose files
+ * themselves are overwritten from the bundle on every launch, and users who set
+ * this up pre-UI must not be broken.
  *
  * `upsertComposeEnvValues` rewrites that same file on every start. It only strips
  * the keys it is about to write, so unknown keys survive — and this test pins that,

--- a/dashboard/electron/__tests__/dockerManagerExtraCaCerts.test.ts
+++ b/dashboard/electron/__tests__/dockerManagerExtraCaCerts.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment node
+
+/**
+ * GH-200 — the Server-tab CA folder picker must reach compose interpolation.
+ *
+ * Two units under test, both consumed by startContainer (which itself is not
+ * unit-testable without a Docker runtime):
+ * - `readExtraCaCertsDirFromStore()` reads `server.extraCaCertsDir` from the
+ *   electron-store JSON. Blank/absent MUST yield null, not '': an empty
+ *   process-env value would override a hand-edited .env entry in compose
+ *   interpolation and silently re-break the pre-UI escape hatch that
+ *   dockerManagerComposeEnvPreservation.test.ts pins.
+ * - `applyExtraCaCertsEnv(composeEnv, envUpdates)` applies the value to
+ *   composeEnv ONLY. It must never let the key reach envUpdates (the record
+ *   upsertComposeEnvValues persists to the compose .env), and must skip a
+ *   folder that no longer exists on disk (compose would auto-create an empty
+ *   dir and mount it, silently reproducing the no-cert failure).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+const userDataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ts-ca-store-test-'));
+
+// Mirror the packaged-install fixture of dockerManagerComposeEnvPreservation.test.ts
+// so importing dockerManager.js behaves identically here.
+const resourcesRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ts-ca-res-test-'));
+fs.mkdirSync(path.join(resourcesRoot, 'docker'), { recursive: true });
+fs.writeFileSync(path.join(resourcesRoot, 'docker', 'docker-compose.yml'), 'services: {}\n');
+(process as NodeJS.Process & { resourcesPath: string }).resourcesPath = resourcesRoot;
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: true,
+    getPath: (_name: string) => userDataRoot,
+    setPath: vi.fn(),
+  },
+}));
+
+vi.mock('electron-store', () => ({
+  default: class MockStore {
+    get() {
+      return undefined;
+    }
+    set() {}
+  },
+}));
+
+const storePath = path.join(userDataRoot, 'dashboard-config.json');
+
+function writeStore(data: Record<string, unknown>): void {
+  fs.writeFileSync(storePath, JSON.stringify(data), 'utf8');
+}
+
+describe('readExtraCaCertsDirFromStore — GH-200 CA folder picker', () => {
+  beforeEach(() => {
+    fs.rmSync(storePath, { force: true });
+  });
+
+  it('returns the configured folder (Windows path intact)', async () => {
+    const { readExtraCaCertsDirFromStore } = await import('../dockerManager.js');
+    writeStore({
+      'server.extraCaCertsDir': 'C:\\Users\\me\\AppData\\Roaming\\TranscriptionSuite\\ca',
+    });
+    expect(readExtraCaCertsDirFromStore()).toBe(
+      'C:\\Users\\me\\AppData\\Roaming\\TranscriptionSuite\\ca',
+    );
+  });
+
+  it('trims surrounding whitespace', async () => {
+    const { readExtraCaCertsDirFromStore } = await import('../dockerManager.js');
+    writeStore({ 'server.extraCaCertsDir': '  /home/me/.config/TranscriptionSuite/ca  ' });
+    expect(readExtraCaCertsDirFromStore()).toBe('/home/me/.config/TranscriptionSuite/ca');
+  });
+
+  it('returns null when the key is absent, blank, or not a string', async () => {
+    const { readExtraCaCertsDirFromStore } = await import('../dockerManager.js');
+
+    writeStore({ 'server.port': 9786 });
+    expect(readExtraCaCertsDirFromStore()).toBeNull();
+
+    // Blank is what the UI Clear button writes — it must read back as unset.
+    writeStore({ 'server.extraCaCertsDir': '' });
+    expect(readExtraCaCertsDirFromStore()).toBeNull();
+
+    writeStore({ 'server.extraCaCertsDir': '   ' });
+    expect(readExtraCaCertsDirFromStore()).toBeNull();
+
+    writeStore({ 'server.extraCaCertsDir': 42 });
+    expect(readExtraCaCertsDirFromStore()).toBeNull();
+  });
+
+  it('returns null when the store file is missing or corrupt', async () => {
+    const { readExtraCaCertsDirFromStore } = await import('../dockerManager.js');
+
+    expect(readExtraCaCertsDirFromStore()).toBeNull();
+
+    fs.writeFileSync(storePath, 'not json at all', 'utf8');
+    expect(readExtraCaCertsDirFromStore()).toBeNull();
+  });
+});
+
+describe('applyExtraCaCertsEnv — composeEnv-only contract', () => {
+  beforeEach(() => {
+    fs.rmSync(storePath, { force: true });
+  });
+
+  it('sets composeEnv but never envUpdates when the folder exists', async () => {
+    const { applyExtraCaCertsEnv } = await import('../dockerManager.js');
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ts-ca-real-dir-'));
+    writeStore({ 'server.extraCaCertsDir': dir });
+
+    const composeEnv: Record<string, string> = {};
+    const envUpdates: Record<string, string> = { TAG: 'v1.3.8' };
+    applyExtraCaCertsEnv(composeEnv, envUpdates);
+
+    expect(composeEnv['EXTRA_CA_CERTS_DIR']).toBe(dir);
+    // The .env-persisted record must stay untouched: a persisted copy would
+    // keep applying after the picker is cleared and clobber hand-edited values.
+    expect(envUpdates).toEqual({ TAG: 'v1.3.8' });
+  });
+
+  it('leaves composeEnv without the key entirely when unset', async () => {
+    const { applyExtraCaCertsEnv } = await import('../dockerManager.js');
+    writeStore({ 'server.port': 9786 });
+
+    const composeEnv: Record<string, string> = {};
+    applyExtraCaCertsEnv(composeEnv, {});
+
+    // Absence, not '', is required: an empty process-env value overrides a
+    // hand-edited .env entry in compose interpolation.
+    expect('EXTRA_CA_CERTS_DIR' in composeEnv).toBe(false);
+  });
+
+  it('skips a configured folder that no longer exists on disk', async () => {
+    const { applyExtraCaCertsEnv } = await import('../dockerManager.js');
+    writeStore({
+      'server.extraCaCertsDir': path.join(os.tmpdir(), 'ts-ca-vanished-does-not-exist'),
+    });
+
+    const composeEnv: Record<string, string> = {};
+    applyExtraCaCertsEnv(composeEnv, {});
+
+    expect('EXTRA_CA_CERTS_DIR' in composeEnv).toBe(false);
+  });
+
+  it('drops a stray EXTRA_CA_CERTS_DIR from envUpdates (invariant enforcement)', async () => {
+    const { applyExtraCaCertsEnv } = await import('../dockerManager.js');
+
+    const composeEnv: Record<string, string> = {};
+    const envUpdates: Record<string, string> = { EXTRA_CA_CERTS_DIR: '/somewhere', TAG: 'v1' };
+    applyExtraCaCertsEnv(composeEnv, envUpdates);
+
+    expect('EXTRA_CA_CERTS_DIR' in envUpdates).toBe(false);
+    expect(envUpdates['TAG']).toBe('v1');
+  });
+});

--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -851,10 +851,11 @@ function sanitizeEnvValue(value: string): string {
   return value.replace(/[\r\n]+/g, '').trim();
 }
 
-// Exported for tests: preserving keys we do not own is load-bearing. It is the only
-// way a packaged-app user can set EXTRA_CA_CERTS_DIR to escape a TLS-intercepting
-// network (GH #200), and a refactor that stripped unknown keys would silently
-// re-break them on the next server start.
+// Exported for tests: preserving keys we do not own is load-bearing. A hand-added
+// EXTRA_CA_CERTS_DIR here is how packaged-app users escaped a TLS-intercepting
+// network before the Server-tab folder picker existed (GH #200), and a refactor
+// that stripped unknown keys would silently re-break them on the next server start.
+// The picker deliberately bypasses this file (process env only) so both routes coexist.
 export function upsertComposeEnvValues(values: Record<string, string>): void {
   const composeEnvPath = path.join(getComposeDir(), '.env');
   const entries = Object.entries(values);
@@ -927,6 +928,66 @@ function readPortFromStore(): number {
     // fall through
   }
   return DEFAULT_SERVER_PORT;
+}
+
+/**
+ * Read the extra-CA-certificates folder picked in the dashboard (Server tab →
+ * Persistent Volumes) from the electron-store JSON on disk. Exported for tests.
+ *
+ * When set, startContainer passes it as EXTRA_CA_CERTS_DIR so compose
+ * interpolates it into the `${EXTRA_CA_CERTS_DIR:-./.empty}:/ca-trust:ro` bind
+ * mount and the container trusts the TLS-intercepting antivirus/proxy root CA
+ * (GH-200). Returns null when unset/blank so the caller leaves the variable
+ * alone entirely — a hand-edited EXTRA_CA_CERTS_DIR in the compose .env (the
+ * pre-UI escape hatch preserved by upsertComposeEnvValues) then still applies.
+ */
+export function readExtraCaCertsDirFromStore(): string | null {
+  try {
+    const storePath = path.join(app.getPath('userData'), 'dashboard-config.json');
+    const raw = fs.readFileSync(storePath, 'utf8');
+    const data = JSON.parse(raw) as Record<string, unknown>;
+    const value = data['server.extraCaCertsDir'];
+    if (typeof value === 'string' && value.trim().length > 0) return value.trim();
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
+/**
+ * GH-200: inject the picked extra-CA folder into compose interpolation.
+ *
+ * The value must reach composeEnv (the compose child process env) and must
+ * NEVER be persisted to the compose .env: a stale or empty EXTRA_CA_CERTS_DIR
+ * line there would keep applying after the picker is cleared and would clobber
+ * the hand-edited escape hatch that upsertComposeEnvValues preserves. The
+ * envUpdates record is taken so that contract is enforced and testable: an
+ * entry that slips in (say, a future refactor pattern-matching the paired
+ * composeEnv/envUpdates assignments in startContainer) is dropped here before
+ * upsertComposeEnvValues writes the file. A configured folder that no longer
+ * exists is skipped with a warning: compose would silently auto-create an empty
+ * dir and mount it, reproducing the very no-cert failure this feature fixes.
+ * Exported for tests.
+ */
+export function applyExtraCaCertsEnv(
+  composeEnv: Record<string, string>,
+  envUpdates: Record<string, string>,
+): void {
+  if ('EXTRA_CA_CERTS_DIR' in envUpdates) {
+    console.warn(
+      '[DockerManager] EXTRA_CA_CERTS_DIR must never be written to the compose .env; dropping it (GH-200)',
+    );
+    delete envUpdates['EXTRA_CA_CERTS_DIR'];
+  }
+  const extraCaCertsDir = readExtraCaCertsDirFromStore();
+  if (!extraCaCertsDir) return;
+  if (!fs.existsSync(extraCaCertsDir)) {
+    console.warn(
+      `[DockerManager] Extra CA certificates folder not found, skipping /ca-trust mount: ${extraCaCertsDir}`,
+    );
+    return;
+  }
+  composeEnv['EXTRA_CA_CERTS_DIR'] = extraCaCertsDir;
 }
 
 /**
@@ -2509,6 +2570,7 @@ async function startContainer(options: StartContainerOptions): Promise<string> {
     detectedGpuMode,
   );
 
+  applyExtraCaCertsEnv(composeEnv, envUpdates);
   upsertComposeEnvValues(envUpdates);
 
   // Create host directory for startup events file (bind-mounted into container).

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -133,19 +133,42 @@ Get-ChildItem Cert:\LocalMachine\Root, Cert:\CurrentUser\Root | ForEach-Object {
 } | Set-Content -Encoding ascii "$dir\host-roots.crt"
 ```
 
-Then set `EXTRA_CA_CERTS_DIR=%APPDATA%\TranscriptionSuite\ca` and restart the
-server. (This exports every root your OS already trusts, which necessarily
-includes the interceptor's. If you prefer to trust only that one CA, export it
-alone from `certmgr.msc` → Trusted Root Certification Authorities → right-click
-→ All Tasks → Export → **Base-64 encoded X.509** and drop the file in that
-folder instead.)
+(This exports every root your OS already trusts, which necessarily includes the
+interceptor's. If you prefer to trust only that one CA, export it alone from
+`certmgr.msc` → Trusted Root Certification Authorities → right-click → All Tasks
+→ Export, and drop the file in that folder instead. **Careful:** the export
+wizard pre-selects "DER encoded binary X.509", which the container cannot read.
+Pick **Base-64 encoded X.509** instead.)
 
 On Linux/macOS the equivalent is any directory containing your CA:
 `EXTRA_CA_CERTS_DIR=~/.config/TranscriptionSuite/ca`.
 
+Then point the server at that folder. Pick the route that matches how you run it:
+
+- **Dashboard:** Server tab → *5. Persistent Volumes* → **Extra CA certificates**
+  → *Choose folder*, then start the server. Nothing else to set.
+- **`docker compose` in a terminal:** set `EXTRA_CA_CERTS_DIR` as a shell
+  environment variable, or add it to the `.env` file next to the compose file.
+  In a `.env` file always write the full expanded path
+  (`EXTRA_CA_CERTS_DIR=C:\Users\<you>\AppData\Roaming\TranscriptionSuite\ca`).
+  Compose does **not** expand `%APPDATA%`-style variables there; with a literal
+  `%APPDATA%` compose refuses to start with an error like
+  `service ... refers to undefined volume %APPDATA%\...: invalid compose project`.
+  If you see that error, replace the `%VAR%` with the real path.
+- **Dashboard without the picker (older app versions):** hand-add the same
+  `EXTRA_CA_CERTS_DIR=<full expanded path>` line to the dashboard's compose env
+  file, which survives every server start. It lives at
+  `%APPDATA%\TranscriptionSuite\docker\.env` on Windows,
+  `~/.config/TranscriptionSuite/docker/.env` on Linux, and
+  `~/Library/Application Support/TranscriptionSuite/docker/.env` on macOS.
+  (A system-wide environment variable also works, but the dashboard only
+  inherits it at app launch: fully quit and reopen the app afterwards.
+  Clicking Start/Restart alone will not pick it up.)
+
 Accepted file extensions are `.crt`, `.pem` and `.cer`; PEM bundles holding many
 certificates are split automatically. Files that are not PEM (a DER export) are
-skipped with a warning rather than corrupting the trust store.
+skipped with a `WARNING: ... holds no PEM certificate` line in the container log
+rather than corrupting the trust store.
 
 Behind a corporate proxy you likely also need `HTTP_PROXY`, `HTTPS_PROXY` and
 `NO_PROXY`, which are passed through to the container.

--- a/server/docker/bootstrap_runtime.py
+++ b/server/docker/bootstrap_runtime.py
@@ -544,9 +544,13 @@ _TLS_INTERCEPTION_HINT = (
     "connection scanning' setting and start the server again. That is the whole fix "
     "for most home users. "
     "(2) Otherwise (corporate proxy, or you want to keep the scanner on), export the "
-    "intercepting root CA and put it in a folder of its own, then set "
-    "EXTRA_CA_CERTS_DIR to that folder — the container installs it at startup and "
-    "trusts it. Certificate verification stays ON either way. "
+    "intercepting root CA as 'Base-64 encoded X.509' (PEM) - NOT the DER format the "
+    "Windows export wizard pre-selects - and put it in a folder of its own. Then "
+    "point the server at that folder: in the dashboard use Server tab -> Persistent "
+    "Volumes -> Extra CA certificates -> Choose folder; with docker compose set "
+    "EXTRA_CA_CERTS_DIR to the folder's full expanded path (%VARS% are not expanded "
+    "in a .env file). The container installs it at startup and trusts it. "
+    "Certificate verification stays ON either way. "
     "Full instructions: https://github.com/homelab-00/TranscriptionSuite/blob/main/docs/deployment-guide.md#tls-interception--corporate-network-unknownissuer"
 )
 

--- a/server/docker/docker-compose.yml
+++ b/server/docker/docker-compose.yml
@@ -149,7 +149,9 @@ services:
       # scanner re-signs traffic; the entrypoint installs every *.crt/*.pem/*.cer found
       # here into the container trust store. Docker does not propagate the host's trust
       # store into containers, so without this the re-signed cert is always rejected.
-      #   Windows: EXTRA_CA_CERTS_DIR=%APPDATA%\TranscriptionSuite\ca
+      #   Windows: EXTRA_CA_CERTS_DIR=C:\Users\<you>\AppData\Roaming\TranscriptionSuite\ca
+      #     (write the full path: %VARS% like %APPDATA% are NOT expanded in a .env file;
+      #     a literal %APPDATA% aborts startup with "refers to undefined volume %APPDATA%\...")
       #   Linux/macOS: EXTRA_CA_CERTS_DIR=~/.config/TranscriptionSuite/ca
       # Unset mounts an empty placeholder, which is a no-op.
       - ${EXTRA_CA_CERTS_DIR:-./.empty}:/ca-trust:ro

--- a/server/docker/install_ca_certs.py
+++ b/server/docker/install_ca_certs.py
@@ -25,9 +25,11 @@ keep working.
 
 Two Debian behaviours drive the design
 --------------------------------------
-* ``update-ca-certificates`` only reads files ending in ``.crt``. A ``.pem`` -- the
-  extension Windows' certmgr and OpenSSL both produce by default -- is *silently
-  ignored*. So extensions are normalized rather than copied verbatim.
+* ``update-ca-certificates`` only reads files ending in ``.crt``. A ``.pem`` (what
+  OpenSSL emits) or a ``.cer`` (certmgr's export extension; note certmgr's wizard
+  pre-selects DER encoding, which holds no PEM and is skipped with a warning, so
+  only a "Base-64 encoded X.509" export is usable) is *silently ignored* by it.
+  So extensions are normalized rather than copied verbatim.
 * Its per-file handling is not reliably multi-certificate, while a host root-store
   export is a single file holding hundreds of concatenated certificates. So bundles
   are split into one certificate per file.


### PR DESCRIPTION
## Summary

Closes the usability gaps around the GH #200 TLS-interception escape hatch (`EXTRA_CA_CERTS_DIR`). The mechanism shipped in PR #169 works end-to-end, but a dashboard user on Windows had no documented way to set the variable, the documented example value was broken, and the DER-vs-PEM certificate export trap was undocumented. Relates to #200 (left open for the reporter to confirm).

## Changes

* **feat(ui):** "Extra CA certificates" folder picker in the Server tab Persistent Volumes card (hidden on the Metal runtime)
  * persists `server.extraCaCertsDir`; `startContainer` passes it to compose as `EXTRA_CA_CERTS_DIR` via process env only, never the compose `.env`, so the pre-UI hand-edited escape hatch keeps working and clearing the picker actually clears the mount
  * `applyExtraCaCertsEnv` skips the mount with a warning when the configured folder no longer exists (compose silently auto-creates missing bind sources) and drops any stray `EXTRA_CA_CERTS_DIR` from the `.env`-persisted record (invariant enforcement)
  * the picker rejects paths containing ":" at pick time (the Docker daemon refuses such bind specs in both short and long volume syntax; verified empirically) and persists before committing UI state, with error toasts on failure
* **fix(server):** the bootstrap TLS hint now warns that the Windows certificate export wizard pre-selects DER (only Base-64/PEM is usable) and names both places to set the folder (dashboard picker, or `EXTRA_CA_CERTS_DIR` with a full expanded path for compose)
* **docs(deployment):** TLS-interception step 2 rewritten with three routes (dashboard picker / compose CLI / hand-edited dashboard `.env` with per-OS paths and the full-app-relaunch caveat for OS env vars); the literal `%APPDATA%` failure now documents the real compose error (`refers to undefined volume %APPDATA%\...`), verified empirically with Compose 5.3.1
* **chore(server):** corrected the `install_ca_certs.py` docstring (certmgr wizard pre-selects DER, not PEM) and the compose `EXTRA_CA_CERTS_DIR` example comment
* **test(dashboard):** unit tests for `readExtraCaCertsDirFromStore` and the `applyExtraCaCertsEnv` composeEnv-only contract; RTL tests for the picker (happy path, saved-value load and clear, hidden on Metal, persist failure keeps UI unset, colon path rejected)

## Design notes

* Long volume syntax was evaluated and rejected as an alternative: the daemon refuses colon-containing binds either way, and long syntax resolves a literal `%APPDATA%` as a relative path and auto-creates missing dirs silently, trading one loud failure for two silent ones. Short syntax stays.
* The value is read main-process-side from `dashboard-config.json` (same pattern as `readPortFromStore`), avoiding the triple-declared `StartContainerOptions` surface.

## Test plan

- [x] Full backend suite: 2191 passed, 4 skipped
- [x] Dashboard affected test files: 47 passed (13 new)
- [x] `npm run typecheck`, `eslint --max-warnings=0`, `npm run ui:contract:check` clean
- [ ] Manual smoke on Windows behind an HTTPS-scanning antivirus: pick the exported CA folder in the Server tab, start the server, confirm bootstrap succeeds
- [ ] Visual check of the new Volumes-card row on Linux/macOS