### PR TITLE
feat(ui, dashboard): restore the custom HuggingFace model option (GH-253)

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -43,7 +43,6 @@ import {
   MAIN_RECOMMENDED_MODEL,
   LIVE_RECOMMENDED_MODEL,
   DISABLED_MODEL_SENTINEL,
-  LEGACY_CUSTOM_OPTION,
   ONBOARDING_MAIN_MODEL_OPTIONS,
   ONBOARDING_LIVE_MODEL_OPTIONS,
   OptionalDependencyBootstrapStatus,
@@ -520,7 +519,9 @@ const AppInner: React.FC = () => {
 
           await Promise.all([
             setConfig('server.mainModelSelection', mapBackendModelToUiSelection(selectedMainModel)),
+            setConfig('server.mainCustomModel', ''),
             setConfig('server.liveModelSelection', mapBackendModelToUiSelection(selectedLiveModel)),
+            setConfig('server.liveCustomModel', ''),
             setConfig('app.modelSelectionOnboardingCompleted', true),
           ]);
         } else if (!selectedMainModel || !selectedLiveModel) {
@@ -539,37 +540,30 @@ const AppInner: React.FC = () => {
           const envMainModel = await readComposeEnvValue('MAIN_TRANSCRIBER_MODEL');
           const envLiveModel = await readComposeEnvValue('LIVE_TRANSCRIBER_MODEL');
 
-          let storedMainSelection =
+          const storedMainSelection =
             typeof storedMainSelectionRaw === 'string' && storedMainSelectionRaw.trim()
               ? storedMainSelectionRaw.trim()
               : mapBackendModelToUiSelection(envMainModel || MAIN_RECOMMENDED_MODEL);
-          let storedLiveSelection =
+          const storedLiveSelection =
             typeof storedLiveSelectionRaw === 'string' && storedLiveSelectionRaw.trim()
               ? storedLiveSelectionRaw.trim()
               : mapBackendModelToUiSelection(envLiveModel || LIVE_RECOMMENDED_MODEL);
 
-          // Legacy: pre-removal stores may still hold the retired Custom
-          // sentinel (until ServerView hydrates once and normalizes them).
-          // Adopt the old custom text so this start path keeps resolving to a
-          // real model.
           const storedMainCustom =
-            typeof storedMainCustomRaw === 'string' ? storedMainCustomRaw.trim() : '';
+            typeof storedMainCustomRaw === 'string' ? storedMainCustomRaw : '';
           const storedLiveCustom =
-            typeof storedLiveCustomRaw === 'string' ? storedLiveCustomRaw.trim() : '';
-          if (storedMainSelection === LEGACY_CUSTOM_OPTION) {
-            storedMainSelection = storedMainCustom || envMainModel || MAIN_RECOMMENDED_MODEL;
-          }
-          if (storedLiveSelection === LEGACY_CUSTOM_OPTION) {
-            storedLiveSelection = storedLiveCustom || envLiveModel || LIVE_RECOMMENDED_MODEL;
-          }
+            typeof storedLiveCustomRaw === 'string' ? storedLiveCustomRaw : '';
 
           const resolvedMainModel = resolveMainModelSelectionValue(
             storedMainSelection,
+            storedMainCustom,
             envMainModel || MAIN_RECOMMENDED_MODEL,
           );
           const resolvedLiveModel = resolveLiveModelSelectionValue(
             storedLiveSelection,
+            storedLiveCustom,
             resolvedMainModel,
+            envLiveModel || LIVE_RECOMMENDED_MODEL,
           );
 
           selectedMainModel = toBackendModelEnvValue(resolvedMainModel);

--- a/dashboard/components/__tests__/ServerView.test.tsx
+++ b/dashboard/components/__tests__/ServerView.test.tsx
@@ -147,9 +147,10 @@ vi.mock('../../src/services/modelRegistry', () => ({
 // modelSelection
 vi.mock('../../src/services/modelSelection', () => ({
   MODEL_DEFAULT_LOADING_PLACEHOLDER: 'Loading…',
-  LEGACY_CUSTOM_OPTION: 'Custom (HuggingFace repo)',
+  MAIN_MODEL_CUSTOM_OPTION: 'Custom (HuggingFace repo)',
   MAIN_RECOMMENDED_MODEL: 'openai/whisper-large-v3-turbo',
   LIVE_MODEL_SAME_AS_MAIN_OPTION: 'Same as main model',
+  LIVE_MODEL_CUSTOM_OPTION: 'Custom live model',
   MODEL_DISABLED_OPTION: 'Disabled',
   DISABLED_MODEL_SENTINEL: '__disabled__',
   WHISPER_MEDIUM: 'openai/whisper-medium',
@@ -421,8 +422,7 @@ describe('Pyannote diarization on Mac Metal (gate removed, Issue #112)', () => {
       ).toBeDefined();
     });
     expect(screen.queryAllByText(PYANNOTE_TILE).length).toBeGreaterThanOrEqual(1);
-    // The custom-repo tile was removed entirely.
-    expect(screen.queryAllByText(CUSTOM_TILE).length).toBe(0);
+    expect(screen.queryAllByText(CUSTOM_TILE).length).toBeGreaterThanOrEqual(1);
     // The "not supported on Apple Silicon" inline reason is gone.
     expect(screen.queryByText(/pyannote\.audio MPS path/i)).toBeNull();
   });
@@ -449,32 +449,25 @@ describe('Pyannote diarization on Mac Metal (gate removed, Issue #112)', () => {
     // Sortformer stays visible on non-Metal, greyed with its reason badge.
     expect(screen.queryAllByText(SORTFORMER_TILE).length).toBeGreaterThanOrEqual(1);
     expect(screen.queryByText('Requires Metal')).not.toBeNull();
-    expect(screen.queryAllByText(CUSTOM_TILE).length).toBe(0);
+    expect(screen.queryAllByText(CUSTOM_TILE).length).toBeGreaterThanOrEqual(1);
   });
 
-  it('migrates a legacy Custom diarization selection to the PyAnnote default', async () => {
-    // The custom-repo option was removed: a store persisted before the removal
-    // (Custom sentinel + retired custom text) must fall back to the pyannote
-    // default, render no custom input, and clear the retired key.
-    const setSpy = setupElectronAPI({
-      'server.runtimeProfile': 'cpu',
+  it('on Mac Metal with Custom + pyannote-prefixed value, shows NO unsupported warning', async () => {
+    setupElectronAPI({
+      'server.runtimeProfile': 'metal',
       'server.diarizationModelSelection': CUSTOM,
       'server.diarizationCustomModel': 'pyannote/some-fork',
     });
 
     render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
 
+    // The custom-repo input renders; the old amber "not supported" warning is gone.
     await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: new RegExp(PYANNOTE_TILE, 'i'), pressed: true }),
-      ).toBeDefined();
+      expect(screen.getByDisplayValue('pyannote/some-fork')).toBeDefined();
     });
-    expect(screen.queryByDisplayValue('pyannote/some-fork')).toBeNull();
-    await waitFor(() => {
-      expect(
-        setSpy.mock.calls.some(([k, v]) => k === 'server.diarizationCustomModel' && v === ''),
-      ).toBe(true);
-    });
+    expect(
+      screen.queryByText(/Custom pyannote repos are not supported on Apple Silicon/i),
+    ).toBeNull();
   });
 });
 

--- a/dashboard/components/models/ModelCardPicker.tsx
+++ b/dashboard/components/models/ModelCardPicker.tsx
@@ -4,10 +4,20 @@ import { ModelPickerRow } from './ModelPickerRow';
 import type { ModelCacheStatus } from '../../src/hooks/useModelCache';
 import type { ModelInfo } from '../../src/services/modelRegistry';
 
+interface CustomOptionConfig {
+  /** Sentinel stored in the selection when the custom card is chosen. */
+  value: string;
+  /** Current free-text repo (e.g. "owner/model-name"). */
+  text: string;
+  onTextChange: (value: string) => void;
+}
+
 interface ModelCardPickerProps {
   models: ModelInfo[];
-  /** Currently selected model id. */
+  /** Currently selected value: a model id or the custom sentinel. */
   selection: string;
+  /** When set, a "Custom (HuggingFace repo)" card closes the list. */
+  custom?: CustomOptionConfig;
   /** Badge on the selected card, naming its role (e.g. "Main", "Live"). */
   badgeLabel: string;
   isRunning: boolean;
@@ -20,11 +30,12 @@ interface ModelCardPickerProps {
 /**
  * A collapsible list of model cards. Collapsed (the default) it shows only a
  * summary of the current selection; clicking it reveals one ModelPickerRow
- * card per model.
+ * card per model plus, optionally, a custom HuggingFace repo card.
  */
 export function ModelCardPicker({
   models,
   selection,
+  custom,
   badgeLabel,
   isRunning,
   canManage,
@@ -34,8 +45,15 @@ export function ModelCardPicker({
 }: ModelCardPickerProps) {
   const [expanded, setExpanded] = useState(false);
 
+  const isCustomSelected = custom !== undefined && selection === custom.value;
   const selectedModel = models.find((model) => model.id === selection);
-  const summaryName = selectedModel ? selectedModel.displayName : 'Select a model';
+  const summaryName = selectedModel
+    ? selectedModel.displayName
+    : isCustomSelected
+      ? custom.text
+        ? `Custom: ${custom.text}`
+        : 'Custom (HuggingFace repo)'
+      : 'Select a model';
 
   const summaryDotClass = modelCacheStatus[selection]?.exists
     ? 'bg-green-500 shadow-[0_0_6px_rgba(34,197,94,0.5)]'
@@ -53,7 +71,7 @@ export function ModelCardPicker({
         <div className="flex min-w-0 items-center gap-2.5">
           <span className={`inline-block h-2.5 w-2.5 shrink-0 rounded-full ${summaryDotClass}`} />
           <span className="truncate text-sm font-medium text-white">{summaryName}</span>
-          {selectedModel && (
+          {(selectedModel || isCustomSelected) && (
             <span className="bg-accent-cyan/15 text-accent-cyan rounded px-1.5 py-0.5 text-[10px] font-semibold">
               {badgeLabel}
             </span>
@@ -84,6 +102,58 @@ export function ModelCardPicker({
               onRemove={onRemove}
             />
           ))}
+          {custom && (
+            <div
+              role="button"
+              tabIndex={isRunning ? -1 : 0}
+              aria-label="Select custom HuggingFace repo"
+              aria-pressed={isCustomSelected}
+              aria-disabled={isRunning}
+              onClick={() => {
+                if (!isRunning) onSelectionChange(custom.value);
+              }}
+              onKeyDown={(event) => {
+                if (event.target !== event.currentTarget) return;
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  if (!isRunning) onSelectionChange(custom.value);
+                }
+              }}
+              className={`rounded-lg border px-4 py-3 transition-colors duration-200 ${
+                isRunning ? 'cursor-default' : 'cursor-pointer'
+              } ${
+                isCustomSelected
+                  ? 'border-accent-magenta/60 bg-white/10'
+                  : `border-white/10 bg-white/5 ${isRunning ? '' : 'hover:bg-white/10'}`
+              }`}
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-2.5">
+                  <span className="truncate text-sm font-medium text-white">
+                    Custom (HuggingFace repo)
+                  </span>
+                  {isCustomSelected && (
+                    <span className="bg-accent-cyan/15 text-accent-cyan rounded px-1.5 py-0.5 text-[10px] font-semibold">
+                      {badgeLabel}
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              {isCustomSelected && (
+                <input
+                  type="text"
+                  value={custom.text}
+                  onChange={(e) => custom.onTextChange(e.target.value)}
+                  onClick={(e) => e.stopPropagation()}
+                  placeholder="owner/model-name"
+                  disabled={isRunning}
+                  className={`focus:ring-accent-magenta mt-2 h-10 w-full rounded-lg border border-white/10 bg-white/5 px-3 text-sm text-white placeholder-slate-500 transition-shadow outline-none focus:ring-1 ${isRunning ? 'cursor-not-allowed opacity-50' : ''}`}
+                />
+              )}
+            </div>
+          )}
+
           <p className="text-xs text-slate-500 italic">
             Missing models are downloaded automatically when the server starts.
           </p>

--- a/dashboard/components/models/__tests__/ModelCardPicker.test.tsx
+++ b/dashboard/components/models/__tests__/ModelCardPicker.test.tsx
@@ -87,12 +87,20 @@ describe('ModelCardPicker', () => {
     expect(screen.queryByText('Main')).not.toBeInTheDocument();
   });
 
-  it('never offers a custom repo card', () => {
+  it('omits the custom card when no custom option is configured', () => {
     setup();
     expand();
 
     expect(screen.queryByText('Custom (HuggingFace repo)')).not.toBeInTheDocument();
-    expect(screen.queryByPlaceholderText('owner/model-name')).not.toBeInTheDocument();
+  });
+
+  it('renders the custom card when a custom option is configured', () => {
+    setup({
+      custom: { value: 'Custom (HuggingFace repo)', text: '', onTextChange: vi.fn() },
+    });
+    expand();
+
+    expect(screen.getByRole('button', { name: /select custom/i })).toBeInTheDocument();
   });
 
   it('falls back to a placeholder summary for an unknown selection', () => {

--- a/dashboard/components/views/ServerView.tsx
+++ b/dashboard/components/views/ServerView.tsx
@@ -62,13 +62,13 @@ import {
 import { getModelsByFamily } from '../../src/services/modelRegistry';
 import {
   MODEL_DEFAULT_LOADING_PLACEHOLDER,
-  LEGACY_CUSTOM_OPTION,
+  MAIN_MODEL_CUSTOM_OPTION,
   LIVE_MODEL_SAME_AS_MAIN_OPTION,
+  LIVE_MODEL_CUSTOM_OPTION,
   MODEL_DISABLED_OPTION,
   DISABLED_MODEL_SENTINEL,
   WHISPER_MEDIUM,
   MAIN_MODEL_PRESETS,
-  MAIN_RECOMMENDED_MODEL,
   LIVE_MODEL_PRESETS,
   VULKAN_RECOMMENDED_MODEL,
   resolveMainModelSelectionValue,
@@ -78,6 +78,7 @@ import {
 import {
   DIARIZATION_CAMPP_OPTION,
   DIARIZATION_DEFAULT_MODEL,
+  DIARIZATION_MODEL_CUSTOM_OPTION,
   DIARIZATION_SORTFORMER_OPTION,
   MLX_DEFAULT_MODEL,
   defaultMainModelFor,
@@ -128,24 +129,29 @@ const MAIN_MODEL_SELECTION_OPTIONS = new Set([
   MODEL_DEFAULT_LOADING_PLACEHOLDER,
   ...MAIN_MODEL_PRESETS,
   MODEL_DISABLED_OPTION,
+  MAIN_MODEL_CUSTOM_OPTION,
 ]);
 const LIVE_MODEL_SELECTION_OPTIONS = new Set([
   LIVE_MODEL_SAME_AS_MAIN_OPTION,
   ...LIVE_MODEL_PRESETS,
   MODEL_DISABLED_OPTION,
+  LIVE_MODEL_CUSTOM_OPTION,
 ]);
 const DIARIZATION_MODEL_SELECTION_OPTIONS = new Set([
   DIARIZATION_CAMPP_OPTION,
   DIARIZATION_SORTFORMER_OPTION,
   DIARIZATION_DEFAULT_MODEL,
+  DIARIZATION_MODEL_CUSTOM_OPTION,
 ]);
 
 const UI_SENTINEL_VALUES = new Set([
   MODEL_DEFAULT_LOADING_PLACEHOLDER,
-  LEGACY_CUSTOM_OPTION,
+  MAIN_MODEL_CUSTOM_OPTION,
   LIVE_MODEL_SAME_AS_MAIN_OPTION,
+  LIVE_MODEL_CUSTOM_OPTION,
   DIARIZATION_CAMPP_OPTION,
   DIARIZATION_SORTFORMER_OPTION,
+  DIARIZATION_MODEL_CUSTOM_OPTION,
 ]);
 
 function sanitizeModelName(value: string): string {
@@ -215,21 +221,25 @@ function normalizeLiveModelToWhisper(modelName: string): string {
   return isLiveCompatibleModel(modelName) ? modelName : FALLBACK_LIVE_WHISPER_MODEL;
 }
 
-// Map server-reported model names to UI selections. The custom-repo option is
-// gone, so a model the pickers cannot represent falls back to a preset default
-// instead of a "Custom" selection.
-function mapMainModelToSelection(modelName: string): string {
+function mapMainModelToSelection(modelName: string): { selection: string; custom: string } {
   const normalizedModel = normalizeModelName(modelName);
   if (!normalizedModel || normalizedModel === normalizeModelName(DISABLED_MODEL_SENTINEL)) {
-    return MODEL_DISABLED_OPTION;
+    return { selection: MODEL_DISABLED_OPTION, custom: '' };
   }
-  return findCaseInsensitivePreset(modelName, MAIN_MODEL_PRESETS) ?? MAIN_RECOMMENDED_MODEL;
+  const preset = findCaseInsensitivePreset(modelName, MAIN_MODEL_PRESETS);
+  if (preset) {
+    return { selection: preset, custom: '' };
+  }
+  return { selection: MAIN_MODEL_CUSTOM_OPTION, custom: modelName };
 }
 
-function mapLiveModelToSelection(modelName: string, mainModelName: string): string {
+function mapLiveModelToSelection(
+  modelName: string,
+  mainModelName: string,
+): { selection: string; custom: string } {
   const normalizedModel = normalizeModelName(modelName);
   if (!normalizedModel || normalizedModel === normalizeModelName(DISABLED_MODEL_SENTINEL)) {
-    return MODEL_DISABLED_OPTION;
+    return { selection: MODEL_DISABLED_OPTION, custom: '' };
   }
 
   const normalizedLiveModel = normalizeLiveModelToWhisper(modelName);
@@ -239,21 +249,25 @@ function mapLiveModelToSelection(modelName: string, mainModelName: string): stri
     isWhisperModel(mainModelName) &&
     normalizeModelName(normalizedLiveModel) === normalizeModelName(mainModelName)
   ) {
-    return LIVE_MODEL_SAME_AS_MAIN_OPTION;
+    return { selection: LIVE_MODEL_SAME_AS_MAIN_OPTION, custom: '' };
   }
 
-  return (
-    findCaseInsensitivePreset(normalizedLiveModel, LIVE_MODEL_PRESETS) ??
-    FALLBACK_LIVE_WHISPER_MODEL
-  );
+  const preset = findCaseInsensitivePreset(normalizedLiveModel, LIVE_MODEL_PRESETS);
+  if (preset) {
+    return { selection: preset, custom: '' };
+  }
+  return { selection: LIVE_MODEL_CUSTOM_OPTION, custom: normalizedLiveModel };
 }
 
-function mapDiarizationModelToSelection(modelName: string): string {
+function mapDiarizationModelToSelection(modelName: string): { selection: string; custom: string } {
   const normalizedModel = normalizeModelName(modelName);
   if (!normalizedModel) {
-    return DIARIZATION_SORTFORMER_OPTION;
+    return { selection: DIARIZATION_SORTFORMER_OPTION, custom: '' };
   }
-  return DIARIZATION_DEFAULT_MODEL;
+  if (normalizedModel === normalizeModelName(DIARIZATION_DEFAULT_MODEL)) {
+    return { selection: DIARIZATION_DEFAULT_MODEL, custom: '' };
+  }
+  return { selection: DIARIZATION_MODEL_CUSTOM_OPTION, custom: modelName };
 }
 
 export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFlowPending }) => {
@@ -262,12 +276,15 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
 
   // Model selection state
   const [mainModelSelection, setMainModelSelection] = useState(MODEL_DEFAULT_LOADING_PLACEHOLDER);
+  const [mainCustomModel, setMainCustomModel] = useState('');
   const [liveModelSelection, setLiveModelSelection] = useState(LIVE_MODEL_SAME_AS_MAIN_OPTION);
+  const [liveCustomModel, setLiveCustomModel] = useState('');
   const [localSelectionsHydrated, setLocalSelectionsHydrated] = useState(false);
   const [modelsHydrated, setModelsHydrated] = useState(false);
   const [diarizationModelSelection, setDiarizationModelSelection] = useState(
     DIARIZATION_SORTFORMER_OPTION,
   );
+  const [diarizationCustomModel, setDiarizationCustomModel] = useState('');
   const [diarizationHydrated, setDiarizationHydrated] = useState(false);
   const [modelsLoading, setModelsLoading] = useState(false);
 
@@ -471,18 +488,9 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
         ]: unknown[]) => {
           if (!active) return;
 
-          // ── Legacy custom-repo migration ──────────────────────────────────
-          // The "Custom (HuggingFace repo)" option was removed. If a stored
-          // selection is the old Custom sentinel, adopt the stored custom text
-          // as the candidate model name — it may match a preset (e.g. a repo
-          // that later became a registry model); anything else falls through
-          // the unknown-value fallbacks below. The retired custom keys are
-          // cleared afterwards so this can never re-fire.
           let nextMainSelection =
             getString(storedMainSelection) ?? MODEL_DEFAULT_LOADING_PLACEHOLDER;
-          if (nextMainSelection === LEGACY_CUSTOM_OPTION) {
-            nextMainSelection = getString(storedMainCustom) ?? '';
-          }
+          let nextMainCustom = getString(storedMainCustom) ?? '';
 
           if (!MAIN_MODEL_SELECTION_OPTIONS.has(nextMainSelection)) {
             if (
@@ -490,16 +498,23 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
             ) {
               nextMainSelection = MODEL_DISABLED_OPTION;
             } else {
-              nextMainSelection =
-                findCaseInsensitivePreset(nextMainSelection, MAIN_MODEL_PRESETS) ??
-                MODEL_DEFAULT_LOADING_PLACEHOLDER;
+              const preset = findCaseInsensitivePreset(nextMainSelection, MAIN_MODEL_PRESETS);
+              if (preset) {
+                nextMainSelection = preset;
+              } else if (nextMainSelection) {
+                nextMainCustom = nextMainSelection;
+                nextMainSelection = MAIN_MODEL_CUSTOM_OPTION;
+              } else {
+                nextMainSelection = MODEL_DEFAULT_LOADING_PLACEHOLDER;
+              }
             }
+          }
+          if (nextMainSelection !== MAIN_MODEL_CUSTOM_OPTION) {
+            nextMainCustom = '';
           }
 
           let nextLiveSelection = getString(storedLiveSelection) ?? LIVE_MODEL_SAME_AS_MAIN_OPTION;
-          if (nextLiveSelection === LEGACY_CUSTOM_OPTION) {
-            nextLiveSelection = getString(storedLiveCustom) ?? '';
-          }
+          let nextLiveCustom = getString(storedLiveCustom) ?? '';
 
           if (!LIVE_MODEL_SELECTION_OPTIONS.has(nextLiveSelection)) {
             if (
@@ -507,22 +522,38 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
             ) {
               nextLiveSelection = MODEL_DISABLED_OPTION;
             } else {
-              nextLiveSelection =
-                findCaseInsensitivePreset(nextLiveSelection, LIVE_MODEL_PRESETS) ??
-                LIVE_MODEL_SAME_AS_MAIN_OPTION;
+              const preset = findCaseInsensitivePreset(nextLiveSelection, LIVE_MODEL_PRESETS);
+              if (preset) {
+                nextLiveSelection = preset;
+              } else if (nextLiveSelection) {
+                nextLiveCustom = nextLiveSelection;
+                nextLiveSelection = LIVE_MODEL_CUSTOM_OPTION;
+              } else {
+                nextLiveSelection = LIVE_MODEL_SAME_AS_MAIN_OPTION;
+              }
             }
           }
+          if (nextLiveSelection !== LIVE_MODEL_CUSTOM_OPTION) {
+            nextLiveCustom = '';
+          }
 
-          const resolvedMainModel = resolveMainModelSelectionValue(nextMainSelection, '');
+          const resolvedMainModel = resolveMainModelSelectionValue(
+            nextMainSelection,
+            nextMainCustom,
+            '',
+          );
           const resolvedLiveModel = resolveLiveModelSelectionValue(
             nextLiveSelection,
+            nextLiveCustom,
             resolvedMainModel,
+            '',
           );
           if (
             resolvedLiveModel !== DISABLED_MODEL_SENTINEL &&
             !isLiveCompatibleModel(resolvedLiveModel)
           ) {
             nextLiveSelection = FALLBACK_LIVE_WHISPER_MODEL;
+            nextLiveCustom = '';
           }
 
           // ── Merged diarization control (one-shot migration) ──────────────
@@ -541,9 +572,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
           const legacyEngineRaw = getString(storedSensevoiceEngine);
           let nextDiarizationSelection =
             getString(storedDiarizationSelection) ?? DIARIZATION_SORTFORMER_OPTION;
-          if (nextDiarizationSelection === LEGACY_CUSTOM_OPTION) {
-            nextDiarizationSelection = getString(storedDiarizationCustom) ?? '';
-          }
+          let nextDiarizationCustom = getString(storedDiarizationCustom) ?? '';
 
           if (legacyEngineRaw) {
             // Preserve EFFECTIVE behavior: pre-merge, a SenseVoice main plus
@@ -552,6 +581,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
             // because engine=funasr was a no-op for non-SenseVoice mains.
             const migratedMainModel = resolveMainModelSelectionValue(
               nextMainSelection,
+              nextMainCustom,
               configuredMainModel,
             );
             if (
@@ -575,11 +605,14 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
             ) {
               nextDiarizationSelection = DIARIZATION_DEFAULT_MODEL;
             } else if (nextDiarizationSelection) {
-              // Formerly a custom repo — fall back to the pyannote default.
-              nextDiarizationSelection = DIARIZATION_DEFAULT_MODEL;
+              nextDiarizationCustom = nextDiarizationSelection;
+              nextDiarizationSelection = DIARIZATION_MODEL_CUSTOM_OPTION;
             } else {
               nextDiarizationSelection = DIARIZATION_SORTFORMER_OPTION;
             }
+          }
+          if (nextDiarizationSelection !== DIARIZATION_MODEL_CUSTOM_OPTION) {
+            nextDiarizationCustom = '';
           }
 
           // Branch B migration: the dedicated "GGML Sidecar Model" selector is
@@ -598,24 +631,15 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                   (isWhisperCppModel(storedGgml) ? storedGgml : undefined))) ??
               VULKAN_RECOMMENDED_MODEL;
             nextMainSelection = migratedId;
-          }
-
-          // Consume the retired custom-repo keys (one-shot; see migration
-          // note above). Failures are benign — the same normalization simply
-          // re-runs on the next mount.
-          if (
-            getString(storedMainCustom) ||
-            getString(storedLiveCustom) ||
-            getString(storedDiarizationCustom)
-          ) {
-            void api.config.set('server.mainCustomModel', '').catch(() => {});
-            void api.config.set('server.liveCustomModel', '').catch(() => {});
-            void api.config.set('server.diarizationCustomModel', '').catch(() => {});
+            nextMainCustom = '';
           }
 
           setMainModelSelection(nextMainSelection);
+          setMainCustomModel(nextMainCustom);
           setLiveModelSelection(nextLiveSelection);
+          setLiveCustomModel(nextLiveCustom);
           setDiarizationModelSelection(nextDiarizationSelection);
+          setDiarizationCustomModel(nextDiarizationCustom);
         },
       )
       .catch(() => {})
@@ -647,14 +671,16 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
       // recommended default. Subsumes the old special cases (MLX ids off
       // Metal, NeMo on CPU — GH-125) and also covers GGML mains left over
       // from a Vulkan profile, which used to survive the switch.
-      const resolvedMain = resolveMainModelSelectionValue(mainModelSelection, '');
+      const resolvedMain = resolveMainModelSelectionValue(mainModelSelection, mainCustomModel, '');
       const mainFamily = familyChoiceForModel(resolvedMain);
       let mainAfterReset = resolvedMain;
       if (mainFamily && !isFamilyChoiceEnabledFor(mainFamily, profile)) {
         const nextDefault = defaultMainModelFor(profile);
         mainAfterReset = nextDefault;
         setMainModelSelection(nextDefault);
+        setMainCustomModel('');
         api?.config?.set('server.mainModelSelection', nextDefault);
+        api?.config?.set('server.mainCustomModel', '');
       }
       // Live picks are whisper/whispercpp-only; GGML live models are invalid
       // off Vulkan and MLX ids are never valid. Fall back to Same-as-main —
@@ -664,7 +690,12 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
         liveModelSelection !== LIVE_MODEL_SAME_AS_MAIN_OPTION &&
         liveModelSelection !== MODEL_DISABLED_OPTION
       ) {
-        const resolvedLive = resolveLiveModelSelectionValue(liveModelSelection, mainAfterReset);
+        const resolvedLive = resolveLiveModelSelectionValue(
+          liveModelSelection,
+          liveCustomModel,
+          mainAfterReset,
+          '',
+        );
         const liveFamily = familyChoiceForModel(resolvedLive);
         const liveInvalid =
           liveFamily !== null &&
@@ -707,7 +738,9 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
     },
     [
       mainModelSelection,
+      mainCustomModel,
       liveModelSelection,
+      liveCustomModel,
       isAppleSilicon,
       metalSupported,
       mlxFeature,
@@ -880,8 +913,13 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
     // away and returning would overwrite the user's selection with whatever model
     // the server happens to be running (which may be an older choice).
     if (mainModelSelection === MODEL_DEFAULT_LOADING_PLACEHOLDER) {
-      setMainModelSelection(mapMainModelToSelection(configuredMainModel));
-      setLiveModelSelection(mapLiveModelToSelection(configuredLiveModel, configuredMainModel));
+      const mappedMain = mapMainModelToSelection(configuredMainModel);
+      const mappedLive = mapLiveModelToSelection(configuredLiveModel, configuredMainModel);
+
+      setMainModelSelection(mappedMain.selection);
+      setMainCustomModel(mappedMain.custom);
+      setLiveModelSelection(mappedLive.selection);
+      setLiveCustomModel(mappedLive.custom);
     }
 
     setModelsHydrated(true);
@@ -903,7 +941,9 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
     // otherwise navigating away and returning would overwrite the user's
     // selection with whatever the server reports.
     if (diarizationModelSelection === DIARIZATION_SORTFORMER_OPTION) {
-      setDiarizationModelSelection(mapDiarizationModelToSelection(configuredDiarizationModel));
+      const mappedDiarization = mapDiarizationModelToSelection(configuredDiarizationModel);
+      setDiarizationModelSelection(mappedDiarization.selection);
+      setDiarizationCustomModel(mappedDiarization.custom);
     }
 
     setDiarizationHydrated(true);
@@ -915,11 +955,20 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
     localSelectionsHydrated,
   ]);
 
-  const activeTranscriber = resolveMainModelSelectionValue(mainModelSelection, configuredMainModel);
+  const activeTranscriber = resolveMainModelSelectionValue(
+    mainModelSelection,
+    mainCustomModel,
+    configuredMainModel,
+  );
   // SenseVoice-only: the diarization-engine selector is greyed unless the main
   // transcriber is a SenseVoice model.
   const isSenseVoiceMain = isSenseVoiceModel(activeTranscriber);
-  const activeLiveModel = resolveLiveModelSelectionValue(liveModelSelection, activeTranscriber);
+  const activeLiveModel = resolveLiveModelSelectionValue(
+    liveModelSelection,
+    liveCustomModel,
+    activeTranscriber,
+    configuredLiveModel,
+  );
   const normalizedLiveModel = normalizeLiveModelToWhisper(activeLiveModel);
   // Vulkan sidecar boot/launch model, derived from the Main Transcriber pick
   // (Branch B). The backend swaps to the live model at runtime via /load; this
@@ -939,10 +988,12 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
   // single-pass diarizer while leaving the config.yaml pyannote default in place
   // as the fallback if cam++ fails to load.
   const activeDiarizationModel =
-    diarizationModelSelection === DIARIZATION_SORTFORMER_OPTION ||
-    diarizationModelSelection === DIARIZATION_CAMPP_OPTION
-      ? ''
-      : DIARIZATION_DEFAULT_MODEL;
+    diarizationModelSelection === DIARIZATION_MODEL_CUSTOM_OPTION
+      ? diarizationCustomModel.trim() || configuredDiarizationModel || DIARIZATION_DEFAULT_MODEL
+      : diarizationModelSelection === DIARIZATION_SORTFORMER_OPTION ||
+          diarizationModelSelection === DIARIZATION_CAMPP_OPTION
+        ? ''
+        : DIARIZATION_DEFAULT_MODEL;
 
   // SenseVoice diarization engine env value: 'funasr' only when the merged
   // dropdown is set to CAM++, else 'pyannote'. This is a harmless no-op unless
@@ -1101,7 +1152,10 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
   // Live Mode accepts faster-whisper and whisper.cpp (GGML) backends, but the
   // Same-as-main tile additionally requires a faster-whisper main: with a
   // whisper.cpp main, Same-as-main is demoted to an explicit GGML pick of the
-  // same model (or the whisper default if that GGML has no live role).
+  // same model (or the whisper default if that GGML has no live role). A custom
+  // GGML main can never be a preset, so it demotes to the recommended GGML —
+  // falling to faster-whisper there would silently move Live Mode off the
+  // Vulkan sidecar.
   useEffect(() => {
     if (!localSelectionsHydrated || activeLiveModel === DISABLED_MODEL_SENTINEL) return;
     if (
@@ -1111,22 +1165,26 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
       setLiveModelSelection(
         LIVE_MODEL_PRESETS.includes(activeLiveModel)
           ? activeLiveModel
-          : FALLBACK_LIVE_WHISPER_MODEL,
+          : mainModelSelection === MAIN_MODEL_CUSTOM_OPTION
+            ? VULKAN_RECOMMENDED_MODEL
+            : FALLBACK_LIVE_WHISPER_MODEL,
       );
       return;
     }
     if (isLiveCompatibleModel(activeLiveModel)) return;
     setLiveModelSelection(FALLBACK_LIVE_WHISPER_MODEL);
-  }, [activeLiveModel, liveModelSelection, localSelectionsHydrated]);
+    setLiveCustomModel('');
+  }, [activeLiveModel, liveModelSelection, mainModelSelection, localSelectionsHydrated]);
 
   // Metal mode: auto-switch a non-MLX main model to the MLX default.
   useEffect(() => {
     if (!localSelectionsHydrated || runtimeProfile !== 'metal') return;
-    const resolved = resolveMainModelSelectionValue(mainModelSelection, '');
+    const resolved = resolveMainModelSelectionValue(mainModelSelection, mainCustomModel, '');
     if (resolved && !isMLXModel(resolved) && resolved !== MODEL_DEFAULT_LOADING_PLACEHOLDER) {
       setMainModelSelection(MLX_DEFAULT_MODEL);
+      setMainCustomModel('');
     }
-  }, [runtimeProfile, localSelectionsHydrated, mainModelSelection]);
+  }, [runtimeProfile, localSelectionsHydrated, mainModelSelection, mainCustomModel]);
 
   useEffect(() => {
     // Sortformer is Metal/MLX-only; on any non-Metal runtime fall back to the
@@ -1183,8 +1241,22 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
     if (!localSelectionsHydrated) return;
     const api = (window as any).electronAPI;
     if (!api?.config) return;
+    void api.config.set('server.mainCustomModel', mainCustomModel).catch(() => {});
+  }, [localSelectionsHydrated, mainCustomModel]);
+
+  useEffect(() => {
+    if (!localSelectionsHydrated) return;
+    const api = (window as any).electronAPI;
+    if (!api?.config) return;
     void api.config.set('server.liveModelSelection', liveModelSelection).catch(() => {});
   }, [localSelectionsHydrated, liveModelSelection]);
+
+  useEffect(() => {
+    if (!localSelectionsHydrated) return;
+    const api = (window as any).electronAPI;
+    if (!api?.config) return;
+    void api.config.set('server.liveCustomModel', liveCustomModel).catch(() => {});
+  }, [localSelectionsHydrated, liveCustomModel]);
 
   useEffect(() => {
     if (!localSelectionsHydrated) return;
@@ -1196,6 +1268,13 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
       .set('server.diarizationModelSelection', diarizationModelSelection)
       .catch(() => {});
   }, [localSelectionsHydrated, diarizationModelSelection]);
+
+  useEffect(() => {
+    if (!localSelectionsHydrated) return;
+    const api = (window as any).electronAPI;
+    if (!api?.config) return;
+    void api.config.set('server.diarizationCustomModel', diarizationCustomModel).catch(() => {});
+  }, [localSelectionsHydrated, diarizationCustomModel]);
 
   // Check model download cache whenever the active model names or container state
   // change. GH-213: covers every option the selectors can show (not just the 3
@@ -1525,6 +1604,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                     if (!cur || cur === MODEL_DEFAULT_LOADING_PLACEHOLDER) {
                       setMainModelSelection(MLX_DEFAULT_MODEL);
                       api.config?.set('server.mainModelSelection', MLX_DEFAULT_MODEL);
+                      api.config?.set('server.mainCustomModel', '');
                     }
                   })
                   .catch(() => {});
@@ -2695,10 +2775,16 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                   isRunning={isRunning}
                   mainModelSelection={mainModelSelection}
                   onMainModelSelectionChange={setMainModelSelection}
+                  mainCustomModel={mainCustomModel}
+                  onMainCustomModelChange={setMainCustomModel}
                   liveModelSelection={liveModelSelection}
                   onLiveModelSelectionChange={setLiveModelSelection}
+                  liveCustomModel={liveCustomModel}
+                  onLiveCustomModelChange={setLiveCustomModel}
                   diarizationModelSelection={diarizationModelSelection}
                   onDiarizationModelSelectionChange={setDiarizationModelSelection}
+                  diarizationCustomModel={diarizationCustomModel}
+                  onDiarizationCustomModelChange={setDiarizationCustomModel}
                   activeTranscriber={activeTranscriber}
                   activeLiveModel={activeLiveModel}
                   diarizationStatusModelId={diarizationStatusModelId}

--- a/dashboard/components/views/SettingsModal.tsx
+++ b/dashboard/components/views/SettingsModal.tsx
@@ -67,10 +67,7 @@ const DEFAULT_SHORTCUTS = {
   stopTranscribe: 'Alt+Ctrl+X',
 } as const;
 const REMOTE_PROFILE_OPTIONS = ['Tailscale', 'LAN'] as const;
-// Legacy sentinel of the removed custom-repo option. Old stores may still hold
-// it in server.mainModelSelection until ServerView hydrates once and
-// normalizes them, so this reader keeps tolerating it.
-const LEGACY_CUSTOM_OPTION = 'Custom (HuggingFace repo)';
+const MAIN_MODEL_CUSTOM_OPTION = 'Custom (HuggingFace repo)';
 const MODEL_DEFAULT_LOADING_PLACEHOLDER = 'Loading server default...';
 // GH-120 — Folder Watch duplicate-handling policy. Display order + labels for
 // the App-tab dropdown; values map to importQueueStore's DuplicatePolicy.
@@ -95,7 +92,7 @@ function resolveConfiguredMainModel(cfg: Record<string, unknown>): string {
   const selection = normalizeConfigString(cfg['server.mainModelSelection']);
   const custom = normalizeConfigString(cfg['server.mainCustomModel']);
 
-  if (selection === LEGACY_CUSTOM_OPTION) return custom;
+  if (selection === MAIN_MODEL_CUSTOM_OPTION) return custom;
   if (!selection || selection === MODEL_DEFAULT_LOADING_PLACEHOLDER) return custom;
   return selection;
 }

--- a/dashboard/components/views/server/InstanceSettingsSelectors.tsx
+++ b/dashboard/components/views/server/InstanceSettingsSelectors.tsx
@@ -9,6 +9,7 @@ import {
   Link2,
   Mic,
   MicOff,
+  PenLine,
   Radio,
   Sparkles,
   Speech,
@@ -23,6 +24,7 @@ import type { TileAccent } from '../../ui/SelectorTile';
 import { MainModelPicker } from './MainModelPicker';
 import { ModelCardPicker } from '../../models/ModelCardPicker';
 import {
+  DIARIZATION_MODEL_CUSTOM_OPTION,
   type FamilyChoiceId,
   defaultModelForFamilyChoice,
   diarizationTilesFor,
@@ -34,8 +36,10 @@ import {
 } from '../../../src/services/instanceMatrix';
 import {
   DISABLED_MODEL_SENTINEL,
+  LIVE_MODEL_CUSTOM_OPTION,
   LIVE_MODEL_SAME_AS_MAIN_OPTION,
   LIVE_RECOMMENDED_MODEL,
+  MAIN_MODEL_CUSTOM_OPTION,
   MODEL_DEFAULT_LOADING_PLACEHOLDER,
   MODEL_DISABLED_OPTION,
   VULKAN_RECOMMENDED_MODEL,
@@ -53,10 +57,16 @@ interface InstanceSettingsSelectorsProps {
   isRunning: boolean;
   mainModelSelection: string;
   onMainModelSelectionChange: (value: string) => void;
+  mainCustomModel: string;
+  onMainCustomModelChange: (value: string) => void;
   liveModelSelection: string;
   onLiveModelSelectionChange: (value: string) => void;
+  liveCustomModel: string;
+  onLiveCustomModelChange: (value: string) => void;
   diarizationModelSelection: string;
   onDiarizationModelSelectionChange: (value: string) => void;
+  diarizationCustomModel: string;
+  onDiarizationCustomModelChange: (value: string) => void;
   activeTranscriber: string;
   activeLiveModel: string;
   diarizationStatusModelId: string;
@@ -97,6 +107,7 @@ const DIARIZATION_TILE_ICONS: Record<string, React.ReactNode> = {
   campp: <Zap size={16} />,
   sortformer: <AppleIcon size={16} />,
   builtin: <Sparkles size={16} />,
+  custom: <PenLine size={16} />,
 };
 
 const DIARIZATION_TILE_ACCENTS: Record<string, TileAccent> = {
@@ -104,6 +115,7 @@ const DIARIZATION_TILE_ACCENTS: Record<string, TileAccent> = {
   campp: 'amber',
   sortformer: 'slate',
   builtin: 'blue',
+  custom: 'cyan',
 };
 
 function CacheBadge({ status }: { status: ModelCacheStatus | undefined }) {
@@ -137,10 +149,16 @@ export function InstanceSettingsSelectors({
   isRunning,
   mainModelSelection,
   onMainModelSelectionChange,
+  mainCustomModel,
+  onMainCustomModelChange,
   liveModelSelection,
   onLiveModelSelectionChange,
+  liveCustomModel,
+  onLiveCustomModelChange,
   diarizationModelSelection,
   onDiarizationModelSelectionChange,
+  diarizationCustomModel,
+  onDiarizationCustomModelChange,
   activeTranscriber,
   activeLiveModel,
   diarizationStatusModelId,
@@ -152,11 +170,14 @@ export function InstanceSettingsSelectors({
 }: InstanceSettingsSelectorsProps) {
   const familyChoices = useMemo(() => familyChoicesFor(runtimeProfile), [runtimeProfile]);
 
-  // The family tile that should light up, derived from the selected model id.
-  const selectedFamily = useMemo(
-    () => familyChoiceForModel(mainModelSelection),
-    [mainModelSelection],
-  );
+  // The family tile that should light up: derived from the dropdown value
+  // (or the custom text when the Custom option is active).
+  const selectedFamily = useMemo(() => {
+    if (mainModelSelection === MAIN_MODEL_CUSTOM_OPTION) {
+      return familyChoiceForModel(mainCustomModel) ?? 'whisper';
+    }
+    return familyChoiceForModel(mainModelSelection);
+  }, [mainModelSelection, mainCustomModel]);
 
   const liveTiles = useMemo(
     () => liveTilesFor(runtimeProfile, activeTranscriber),
@@ -214,7 +235,10 @@ export function InstanceSettingsSelectors({
             disabled={!choice.enabled || isRunning}
             badge={choice.reason}
             hint={choice.hint}
-            onSelect={() => onMainModelSelectionChange(defaultModelForFamilyChoice(choice.id))}
+            onSelect={() => {
+              onMainModelSelectionChange(defaultModelForFamilyChoice(choice.id));
+              onMainCustomModelChange('');
+            }}
             glyphs={
               <>
                 <span
@@ -258,10 +282,12 @@ export function InstanceSettingsSelectors({
       <MainModelPicker
         selectedFamily={selectedFamily}
         mainModelSelection={mainModelSelection}
+        mainCustomModel={mainCustomModel}
         isRunning={isRunning}
         canManage={canManage}
         modelCacheStatus={modelCacheStatus}
         onMainModelSelectionChange={onMainModelSelectionChange}
+        onMainCustomModelChange={onMainCustomModelChange}
         onRemove={onRemoveModel}
       />
 
@@ -295,6 +321,17 @@ export function InstanceSettingsSelectors({
         <ModelCardPicker
           models={liveModels}
           selection={liveModelSelection}
+          custom={
+            // whisper.cpp live models are a fixed GGML list; only the
+            // faster-whisper tile accepts a custom HuggingFace repo.
+            activeLiveTile === 'whispercpp'
+              ? undefined
+              : {
+                  value: LIVE_MODEL_CUSTOM_OPTION,
+                  text: liveCustomModel,
+                  onTextChange: onLiveCustomModelChange,
+                }
+          }
           badgeLabel="Live"
           isRunning={isRunning}
           canManage={canManage}
@@ -339,6 +376,19 @@ export function InstanceSettingsSelectors({
           Diarization is not available for whisper.cpp (GGML) models.
         </p>
       )}
+      {diarizationTiles.length > 0 &&
+        diarizationModelSelection === DIARIZATION_MODEL_CUSTOM_OPTION && (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <input
+              type="text"
+              value={diarizationCustomModel}
+              onChange={(e) => onDiarizationCustomModelChange(e.target.value)}
+              placeholder="owner/model-name"
+              disabled={isRunning}
+              className={`focus:ring-accent-cyan h-10 w-full rounded-lg border border-white/10 bg-white/5 px-3 text-sm text-white placeholder-slate-500 transition-shadow outline-none focus:ring-1 ${isRunning ? 'cursor-not-allowed opacity-50' : ''}`}
+            />
+          </div>
+        )}
     </div>
   );
 }

--- a/dashboard/components/views/server/MainModelPicker.tsx
+++ b/dashboard/components/views/server/MainModelPicker.tsx
@@ -5,14 +5,17 @@ import { ModelCardPicker } from '../../models/ModelCardPicker';
 import type { ModelCacheStatus } from '../../../src/hooks/useModelCache';
 import type { FamilyChoiceId } from '../../../src/services/instanceMatrix';
 import { modelsForFamilyChoice } from '../../../src/services/instanceMatrix';
+import { MAIN_MODEL_CUSTOM_OPTION } from '../../../src/services/modelSelection';
 
 interface MainModelPickerProps {
   selectedFamily: FamilyChoiceId | null;
   mainModelSelection: string;
+  mainCustomModel: string;
   isRunning: boolean;
   canManage: boolean;
   modelCacheStatus: ModelCacheStatus;
   onMainModelSelectionChange: (value: string) => void;
+  onMainCustomModelChange: (value: string) => void;
   onRemove: (id: string) => void;
 }
 
@@ -30,10 +33,12 @@ interface MainModelPickerProps {
 export function MainModelPicker({
   selectedFamily,
   mainModelSelection,
+  mainCustomModel,
   isRunning,
   canManage,
   modelCacheStatus,
   onMainModelSelectionChange,
+  onMainCustomModelChange,
   onRemove,
 }: MainModelPickerProps) {
   const models = selectedFamily ? modelsForFamilyChoice(selectedFamily) : [];
@@ -45,6 +50,11 @@ export function MainModelPicker({
       <ModelCardPicker
         models={models}
         selection={mainModelSelection}
+        custom={{
+          value: MAIN_MODEL_CUSTOM_OPTION,
+          text: mainCustomModel,
+          onTextChange: onMainCustomModelChange,
+        }}
         badgeLabel="Main"
         isRunning={isRunning}
         canManage={canManage}

--- a/dashboard/components/views/server/__tests__/MainModelPicker.test.tsx
+++ b/dashboard/components/views/server/__tests__/MainModelPicker.test.tsx
@@ -1,15 +1,18 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { MainModelPicker } from '../MainModelPicker';
+import { MAIN_MODEL_CUSTOM_OPTION } from '../../../../src/services/modelSelection';
 
 function setup(overrides: Partial<React.ComponentProps<typeof MainModelPicker>> = {}) {
   const props = {
     selectedFamily: 'nemo' as const,
     mainModelSelection: 'nvidia/parakeet-tdt-0.6b-v3',
+    mainCustomModel: '',
     isRunning: false,
     canManage: true,
     modelCacheStatus: {},
     onMainModelSelectionChange: vi.fn(),
+    onMainCustomModelChange: vi.fn(),
     onRemove: vi.fn(),
     ...overrides,
   };
@@ -63,14 +66,6 @@ describe('MainModelPicker', () => {
     expect(screen.queryByText(/Parakeet/)).not.toBeInTheDocument();
   });
 
-  it('does not offer a custom HuggingFace repo option', () => {
-    setup();
-    expand();
-
-    expect(screen.queryByText(/Custom \(HuggingFace repo\)/)).not.toBeInTheDocument();
-    expect(screen.queryByPlaceholderText('owner/model-name')).not.toBeInTheDocument();
-  });
-
   it('reports the model id when a card is selected', () => {
     const props = setup();
     expand();
@@ -94,6 +89,46 @@ describe('MainModelPicker', () => {
       'aria-pressed',
       'false',
     );
+  });
+
+  it('switches to the custom option when the custom card is chosen', () => {
+    const props = setup();
+    expand();
+
+    fireEvent.click(screen.getByRole('button', { name: /select custom/i }));
+
+    expect(props.onMainModelSelectionChange).toHaveBeenCalledWith(MAIN_MODEL_CUSTOM_OPTION);
+  });
+
+  it('hides the free-text repo input while a registry model is selected', () => {
+    setup();
+    expand();
+
+    expect(screen.queryByPlaceholderText('owner/model-name')).not.toBeInTheDocument();
+  });
+
+  it('shows the free-text repo input while the custom option is active', () => {
+    setup({ mainModelSelection: MAIN_MODEL_CUSTOM_OPTION });
+    expand();
+
+    expect(screen.getByPlaceholderText('owner/model-name')).toBeInTheDocument();
+  });
+
+  it('summarizes a custom selection in the collapsed header', () => {
+    setup({ mainModelSelection: MAIN_MODEL_CUSTOM_OPTION, mainCustomModel: 'me/my-model' });
+
+    expect(screen.getByText('Custom: me/my-model')).toBeInTheDocument();
+  });
+
+  it('reports edits to the custom repo', () => {
+    const props = setup({ mainModelSelection: MAIN_MODEL_CUSTOM_OPTION });
+    expand();
+
+    fireEvent.change(screen.getByPlaceholderText('owner/model-name'), {
+      target: { value: 'me/my-model' },
+    });
+
+    expect(props.onMainCustomModelChange).toHaveBeenCalledWith('me/my-model');
   });
 
   it('locks every card against selection while the server is running', () => {
@@ -121,14 +156,29 @@ describe('MainModelPicker', () => {
     expect(screen.queryByRole('button', { name: /download/i })).not.toBeInTheDocument();
   });
 
-  it('renders an empty list when no family is selected', () => {
+  it('renders nothing but the custom card when no family is selected', () => {
     setup({ selectedFamily: null });
     expand();
 
+    expect(screen.getByRole('button', { name: /select custom/i })).toBeInTheDocument();
     expect(screen.queryByText(/Parakeet/)).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: /select (parakeet|canary)/i }),
-    ).not.toBeInTheDocument();
-    expect(screen.getByText('Select a model')).toBeInTheDocument();
+  });
+
+  it('shows the current custom repo in the input', () => {
+    setup({ mainModelSelection: MAIN_MODEL_CUSTOM_OPTION, mainCustomModel: 'me/my-model' });
+    expand();
+
+    expect(screen.getByDisplayValue('me/my-model')).toBeInTheDocument();
+  });
+
+  it('locks the custom repo input too while the server is running', () => {
+    setup({
+      mainModelSelection: MAIN_MODEL_CUSTOM_OPTION,
+      mainCustomModel: 'me/my-model',
+      isRunning: true,
+    });
+    expand();
+
+    expect(screen.getByPlaceholderText('owner/model-name')).toBeDisabled();
   });
 });

--- a/dashboard/electron/main.ts
+++ b/dashboard/electron/main.ts
@@ -540,8 +540,11 @@ const store = new Store({
     // the dashboard uses the `-legacy` GHCR repo for list/pull/tag operations.
     'server.useLegacyGpu': false,
     'server.mainModelSelection': 'nvidia/parakeet-tdt-0.6b-v3',
+    'server.mainCustomModel': '',
     'server.liveModelSelection': 'Systran/faster-whisper-medium',
+    'server.liveCustomModel': '',
     'server.diarizationModelSelection': 'pyannote/speaker-diarization-community-1',
+    'server.diarizationCustomModel': '',
     'shortcuts.startRecording': 'Alt+Ctrl+Z',
     'shortcuts.stopTranscribe': 'Alt+Ctrl+X',
     'app.pasteAtCursor': false,
@@ -2489,10 +2492,7 @@ app.whenReady().then(async () => {
     const mainTranscriberModel =
       (store.get('server.mainModelSelection') as string) || 'mlx-community/whisper-small-asr-fp16';
 
-    // Resolve live transcriber model from stored selection sentinels. The
-    // Custom option was removed from the UI, but old stores may still hold its
-    // sentinel (plus the retired server.liveCustomModel text) until ServerView
-    // hydrates once and normalizes them — tolerate it here.
+    // Resolve live transcriber model from stored selection sentinels.
     const LIVE_SAME_AS_MAIN = 'Same as Main Transcriber';
     const LIVE_CUSTOM = 'Custom (HuggingFace repo)';
     const liveModelSelection = (store.get('server.liveModelSelection') as string) || '';
@@ -2515,8 +2515,7 @@ app.whenReady().then(async () => {
     // Resolve diarization selection sentinels the same way ServerView does. The
     // stored value is a UI label, not always a model id: CAM++, Sortformer and the
     // legacy Auto label all mean "let the server pick", which mlxServerManager
-    // expects as an empty model. The Custom sentinel is legacy-only (removed from
-    // the UI) but tolerated until ServerView normalizes the store.
+    // expects as an empty model.
     const DIARIZATION_CAMPP = 'CAM++ (fast, built-in)';
     const DIARIZATION_SORTFORMER = 'Sortformer (Metal; ≤ 4 speakers)';
     const DIARIZATION_CUSTOM = 'Custom (HuggingFace repo)';

--- a/dashboard/src/services/instanceMatrix.test.ts
+++ b/dashboard/src/services/instanceMatrix.test.ts
@@ -4,6 +4,7 @@ import {
   DIARIZATION_BUILTIN_LABEL,
   DIARIZATION_CAMPP_OPTION,
   DIARIZATION_DEFAULT_MODEL,
+  DIARIZATION_MODEL_CUSTOM_OPTION,
   DIARIZATION_SORTFORMER_OPTION,
   FAMILY_CHOICE_IDS,
   type FamilyChoiceId,
@@ -224,8 +225,8 @@ describe('instanceMatrix: diarizationTilesFor (full cross-product)', () => {
         expect(sortformer.storedValue).toBe(DIARIZATION_SORTFORMER_OPTION);
         if (runtime !== 'metal') expect(sortformer.reason).toBe('Requires Metal');
 
-        // The custom-repo tile was removed entirely.
-        expect(tiles.some((t) => t.label === 'Custom')).toBe(false);
+        expect(byId.get('custom')!.enabled).toBe(true);
+        expect(byId.get('custom')!.storedValue).toBe(DIARIZATION_MODEL_CUSTOM_OPTION);
 
         // Exactly one default, and it matches the engine hierarchy.
         const defaults = tiles.filter((t) => t.isDefault);
@@ -241,6 +242,7 @@ describe('instanceMatrix: diarizationTilesFor (full cross-product)', () => {
     expect(DIARIZATION_CAMPP_OPTION).toBe('CAM++ (fast, built-in)');
     expect(DIARIZATION_SORTFORMER_OPTION).toBe('Sortformer (Metal; ≤ 4 speakers)');
     expect(DIARIZATION_DEFAULT_MODEL).toBe('pyannote/speaker-diarization-community-1');
+    expect(DIARIZATION_MODEL_CUSTOM_OPTION).toBe('Custom (HuggingFace repo)');
     expect(DIARIZATION_BUILTIN_LABEL).toBeTruthy();
   });
 

--- a/dashboard/src/services/instanceMatrix.ts
+++ b/dashboard/src/services/instanceMatrix.ts
@@ -36,6 +36,7 @@ import {
 // (server.diarizationModelSelection); values must never change.
 export const DIARIZATION_SORTFORMER_OPTION = 'Sortformer (Metal; ≤ 4 speakers)';
 export const DIARIZATION_DEFAULT_MODEL = 'pyannote/speaker-diarization-community-1';
+export const DIARIZATION_MODEL_CUSTOM_OPTION = 'Custom (HuggingFace repo)';
 export const DIARIZATION_CAMPP_OPTION = 'CAM++ (fast, built-in)';
 export const DIARIZATION_BUILTIN_LABEL = 'Built-in';
 
@@ -370,7 +371,7 @@ export function liveModelsFor(runtime: RuntimeProfile): ModelInfo[] {
   );
 }
 
-export type DiarizationTileId = 'pyannote' | 'campp' | 'sortformer' | 'builtin';
+export type DiarizationTileId = 'pyannote' | 'campp' | 'sortformer' | 'builtin' | 'custom';
 
 export interface DiarizationTile {
   id: DiarizationTileId;
@@ -442,6 +443,14 @@ export function diarizationTilesFor(
       enabled: true,
       isDefault: defaultId === 'pyannote',
       hint: 'HuggingFace token required',
+    },
+    {
+      id: 'custom',
+      label: 'Custom',
+      storedValue: DIARIZATION_MODEL_CUSTOM_OPTION,
+      enabled: true,
+      isDefault: false,
+      hint: 'HuggingFace repo',
     },
   ];
 }

--- a/dashboard/src/services/modelSelection.test.ts
+++ b/dashboard/src/services/modelSelection.test.ts
@@ -15,7 +15,8 @@ import {
   DISABLED_MODEL_SENTINEL,
   MODEL_DISABLED_OPTION,
   MODEL_DEFAULT_LOADING_PLACEHOLDER,
-  LEGACY_CUSTOM_OPTION,
+  MAIN_MODEL_CUSTOM_OPTION,
+  LIVE_MODEL_CUSTOM_OPTION,
   LIVE_MODEL_SAME_AS_MAIN_OPTION,
   MAIN_RECOMMENDED_MODEL,
   VULKAN_RECOMMENDED_MODEL,
@@ -155,9 +156,10 @@ describe('toBackendModelEnvValue', () => {
     expect(toBackendModelEnvValue(DISABLED_MODEL_SENTINEL)).toBe(DISABLED_MODEL_SENTINEL);
   });
 
-  it('returns empty string for the placeholder and the legacy custom sentinel', () => {
+  it('returns empty string for placeholder/custom options', () => {
     expect(toBackendModelEnvValue(MODEL_DEFAULT_LOADING_PLACEHOLDER)).toBe('');
-    expect(toBackendModelEnvValue(LEGACY_CUSTOM_OPTION)).toBe('');
+    expect(toBackendModelEnvValue(MAIN_MODEL_CUSTOM_OPTION)).toBe('');
+    expect(toBackendModelEnvValue(LIVE_MODEL_CUSTOM_OPTION)).toBe('');
   });
 
   it('returns empty string for null/undefined/empty', () => {
@@ -172,17 +174,33 @@ describe('toBackendModelEnvValue', () => {
 // ---------------------------------------------------------------------------
 describe('resolveMainModelSelectionValue', () => {
   it('returns sentinel when disabled', () => {
-    expect(resolveMainModelSelectionValue(MODEL_DISABLED_OPTION, '')).toBe(DISABLED_MODEL_SENTINEL);
-  });
-
-  it('returns configured model for loading placeholder', () => {
-    expect(resolveMainModelSelectionValue(MODEL_DEFAULT_LOADING_PLACEHOLDER, 'server-model')).toBe(
-      'server-model',
+    expect(resolveMainModelSelectionValue(MODEL_DISABLED_OPTION, '', '')).toBe(
+      DISABLED_MODEL_SENTINEL,
     );
   });
 
+  it('returns custom model when custom option selected', () => {
+    expect(resolveMainModelSelectionValue(MAIN_MODEL_CUSTOM_OPTION, ' my/model ', 'fallback')).toBe(
+      'my/model',
+    );
+  });
+
+  it('falls back to configured model when custom is empty', () => {
+    expect(resolveMainModelSelectionValue(MAIN_MODEL_CUSTOM_OPTION, '', 'server-default')).toBe(
+      'server-default',
+    );
+  });
+
+  it('returns configured model for loading placeholder', () => {
+    expect(
+      resolveMainModelSelectionValue(MODEL_DEFAULT_LOADING_PLACEHOLDER, '', 'server-model'),
+    ).toBe('server-model');
+  });
+
   it('returns selection as-is for preset models', () => {
-    expect(resolveMainModelSelectionValue(MAIN_RECOMMENDED_MODEL, '')).toBe(MAIN_RECOMMENDED_MODEL);
+    expect(resolveMainModelSelectionValue(MAIN_RECOMMENDED_MODEL, '', '')).toBe(
+      MAIN_RECOMMENDED_MODEL,
+    );
   });
 });
 
@@ -191,19 +209,28 @@ describe('resolveMainModelSelectionValue', () => {
 // ---------------------------------------------------------------------------
 describe('resolveLiveModelSelectionValue', () => {
   it('returns sentinel when disabled', () => {
-    expect(resolveLiveModelSelectionValue(MODEL_DISABLED_OPTION, '')).toBe(DISABLED_MODEL_SENTINEL);
+    expect(resolveLiveModelSelectionValue(MODEL_DISABLED_OPTION, '', '', '')).toBe(
+      DISABLED_MODEL_SENTINEL,
+    );
   });
 
   it('returns resolved main model for same-as-main option', () => {
-    expect(resolveLiveModelSelectionValue(LIVE_MODEL_SAME_AS_MAIN_OPTION, 'main-model')).toBe(
-      'main-model',
-    );
+    expect(
+      resolveLiveModelSelectionValue(LIVE_MODEL_SAME_AS_MAIN_OPTION, '', 'main-model', ''),
+    ).toBe('main-model');
   });
 
-  it('returns selection as-is for preset models', () => {
-    expect(resolveLiveModelSelectionValue('Systran/faster-whisper-medium', 'main')).toBe(
-      'Systran/faster-whisper-medium',
+  it('returns custom model when custom option selected', () => {
+    expect(
+      resolveLiveModelSelectionValue(LIVE_MODEL_CUSTOM_OPTION, ' custom/live ', 'main', 'cfg'),
+    ).toBe('custom/live');
+  });
+
+  it('falls back through configured then main when custom is empty', () => {
+    expect(resolveLiveModelSelectionValue(LIVE_MODEL_CUSTOM_OPTION, '', 'main', 'cfg-live')).toBe(
+      'cfg-live',
     );
+    expect(resolveLiveModelSelectionValue(LIVE_MODEL_CUSTOM_OPTION, '', 'main', '')).toBe('main');
   });
 });
 

--- a/dashboard/src/services/modelSelection.ts
+++ b/dashboard/src/services/modelSelection.ts
@@ -16,14 +16,10 @@ export const VULKAN_RECOMMENDED_MODEL = 'ggml-large-v3-turbo-q8_0.bin';
 export const DISABLED_MODEL_SENTINEL = '__none__';
 
 export const MODEL_DEFAULT_LOADING_PLACEHOLDER = 'Loading server default...';
+export const MAIN_MODEL_CUSTOM_OPTION = 'Custom (HuggingFace repo)';
 export const LIVE_MODEL_SAME_AS_MAIN_OPTION = 'Same as Main Transcriber';
+export const LIVE_MODEL_CUSTOM_OPTION = 'Custom (HuggingFace repo)';
 export const MODEL_DISABLED_OPTION = 'None (Disabled)';
-/**
- * Sentinel of the retired "Custom (HuggingFace repo)" option. It is no longer
- * selectable anywhere, but old electron-stores may still hold it as a persisted
- * selection, so readers keep recognizing it and fall back to a preset.
- */
-export const LEGACY_CUSTOM_OPTION = 'Custom (HuggingFace repo)';
 
 export const WHISPER_LARGE_V3 = 'Systran/faster-whisper-large-v3';
 export const WHISPER_DISTIL_LARGE_V3 = 'Systran/faster-distil-whisper-large-v3';
@@ -136,7 +132,11 @@ export function toBackendModelEnvValue(value: string | null | undefined): string
   if (normalized === MODEL_DISABLED_OPTION || normalized === DISABLED_MODEL_SENTINEL) {
     return DISABLED_MODEL_SENTINEL;
   }
-  if (normalized === MODEL_DEFAULT_LOADING_PLACEHOLDER || normalized === LEGACY_CUSTOM_OPTION) {
+  if (
+    normalized === MODEL_DEFAULT_LOADING_PLACEHOLDER ||
+    normalized === MAIN_MODEL_CUSTOM_OPTION ||
+    normalized === LIVE_MODEL_CUSTOM_OPTION
+  ) {
     return '';
   }
   return normalized;
@@ -144,10 +144,14 @@ export function toBackendModelEnvValue(value: string | null | undefined): string
 
 export function resolveMainModelSelectionValue(
   mainSelection: string,
+  mainCustomModel: string,
   configuredMainModel: string,
 ): string {
   if (mainSelection === MODEL_DISABLED_OPTION) {
     return DISABLED_MODEL_SENTINEL;
+  }
+  if (mainSelection === MAIN_MODEL_CUSTOM_OPTION) {
+    return mainCustomModel.trim() || configuredMainModel;
   }
   if (mainSelection === MODEL_DEFAULT_LOADING_PLACEHOLDER) {
     return configuredMainModel || mainSelection;
@@ -157,13 +161,18 @@ export function resolveMainModelSelectionValue(
 
 export function resolveLiveModelSelectionValue(
   liveSelection: string,
+  liveCustomModel: string,
   resolvedMainModel: string,
+  configuredLiveModel: string,
 ): string {
   if (liveSelection === MODEL_DISABLED_OPTION) {
     return DISABLED_MODEL_SENTINEL;
   }
   if (liveSelection === LIVE_MODEL_SAME_AS_MAIN_OPTION) {
     return resolvedMainModel;
+  }
+  if (liveSelection === LIVE_MODEL_CUSTOM_OPTION) {
+    return liveCustomModel.trim() || configuredLiveModel || resolvedMainModel;
   }
   return liveSelection;
 }

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.12.2",
-  "contract_sha256": "94f297c326d09348c4665653968d8e2b34fa36351cd2b61b34a1d9b369cc5742",
-  "updated_at": "2026-07-18T06:36:35.094Z"
+  "spec_version": "1.13.0",
+  "contract_sha256": "6c0b2d08b8dbf6306d119d5bf26bf65e2401ccde47c8a636b97a339d55f7cf55",
+  "updated_at": "2026-07-29T19:03:10.161Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.12.2
+  spec_version: 1.13.0
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -21,6 +21,7 @@ meta:
       - components/__tests__/SessionImportTab.canary-language.test.tsx
       - components/__tests__/SessionImportTab.diarization-gate.test.tsx
       - components/__tests__/SessionImportTab.drop-feedback.test.tsx
+      - components/__tests__/SessionImportTab.ffmpeg-warning.test.tsx
       - components/__tests__/SessionImportTab.output-format.test.tsx
       - components/__tests__/SessionView.canary-language.test.tsx
       - components/__tests__/SessionView.client-link-stop.test.tsx
@@ -123,7 +124,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-07-18T06:36:20.190Z
+    generated_at: 2026-07-29T19:02:52.154Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:


### PR DESCRIPTION
## Summary

Restores the **Custom (HuggingFace repo)** free-text model option that v1.3.8 removed from all model selectors (GH-253). The removal commit (6f297e5b) was reverted rather than reimplemented, so the entire v1.3.7 plumbing returns exactly as it was: the `server.mainCustomModel` / `server.liveCustomModel` / `server.diarizationCustomModel` store keys and defaults, the ServerView state + persistence + hydration, the custom-text parameters on `resolveMainModelSelectionValue` / `resolveLiveModelSelectionValue`, the App start path, and the Metal boot path in `electron/main.ts`. The one-shot legacy-store migration that v1.3.8 shipped (consuming the retired custom keys) is retired along with the `LEGACY_CUSTOM_OPTION` sentinel.

## Adaptations to the post-removal Server tab

The Server tab changed a lot after the removal (PR #240 section reorg, PR #262 GPU picker), so the revert conflicts were resolved in favor of the current design:

- The restored custom card is **click-to-select** with the same button semantics as `ModelPickerRow` (`role=button`, `aria-pressed`, Enter/Space) instead of its old per-card **Select** button, which no longer exists anywhere. Typing in the free-text input cannot re-trigger card selection.
- The `onDownload` / Load-Unload plumbing that PR #240 removed stays removed; the missing-models auto-download note stays.
- The restored diarization custom input picks up the malformed-class-token fix from 7a390cf6 instead of resurrecting the `focus:ring-1cursor-not-allowed` concatenation bug.
- New integration fix: with a **custom GGML main** on the Vulkan runtime, the PR #240 Same-as-main demote effect used to fall through to `faster-whisper-medium` (a custom repo can never be in `LIVE_MODEL_PRESETS`), silently moving Live Mode off the whisper.cpp sidecar with no warning. It now demotes to `VULKAN_RECOMMENDED_MODEL` so Live Mode stays on the sidecar. Registry-GGML behavior is unchanged.

## Store compatibility

- v1.3.7 users who skipped v1.3.8: stored Custom sentinel + custom text resolve exactly as before.
- v1.3.8 users: the migration already normalized their store to a preset; they simply re-enter their custom repo once. Nothing crashes on the re-defaulted empty keys.

## Verification

- `npm run typecheck` clean; full vitest suite green (132 files, 1951 tests).
- UI contract regenerated at spec_version 1.13.0, baseline updated, `ui:contract:check` green (16 checks).
- Three-lens adversarial review (completeness vs v1.3.7, integration with the post-removal Server tab, migration/store semantics): the only confirmed finding was the Same-as-main demote gap fixed above.

## Test plan

- [ ] Hardware smoke: enter a custom faster-whisper repo (e.g. `primeline/whisper-large-v3-turbo-german`) as Main Transcriber, start the server, transcribe a recording.
- [ ] Hardware smoke: custom repo on the Live Mode picker (faster-whisper tile) and on the diarization Custom tile.
- [ ] Vulkan host: set a custom GGML main with Live Mode at Same-as-main and confirm Live demotes to the recommended GGML (stays on the sidecar).
- [ ] Upgrade path: a v1.3.7 profile with a stored custom model resolves to that model after upgrade.