### PR TITLE
chore(dashboard): deduplicate the DockerManager listImages polling log

### DIFF
--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -1683,6 +1683,24 @@ let pullCancelled = false;
 let pullBackoffResolve: (() => void) | null = null;
 
 /**
+ * The renderer polls `listImages()` every 10s, so its routine log lines
+ * ("found N image(s) via <strategy>", fallback notices) are only printed when
+ * the call's outcome differs from the previous call — otherwise a long-running
+ * session fills the log with hundreds of identical lines. Warnings and errors
+ * are not deduplicated.
+ */
+let lastListImagesLog: string | null = null;
+
+function flushListImagesLog(lines: string[]): void {
+  const summary = lines.join(' | ');
+  if (summary === lastListImagesLog) return;
+  lastListImagesLog = summary;
+  for (const line of lines) {
+    console.log(`[DockerManager] listImages: ${line}`);
+  }
+}
+
+/**
  * List local Docker images matching our repo.
  *
  * The repo URL is chosen by the persisted `server.useLegacyGpu` setting
@@ -1691,6 +1709,7 @@ let pullBackoffResolve: (() => void) | null = null;
  */
 async function listImages(): Promise<DockerImage[]> {
   const imageRepo = resolveImageRepo(readUseLegacyGpuFromStore(), readRuntimeProfileFromStore());
+  const callLog: string[] = [];
   const parseLegacyFormat = (output: string): DockerImage[] => {
     return output
       .split('\n')
@@ -1715,9 +1734,7 @@ async function listImages(): Promise<DockerImage[]> {
       `reference=${imageRepo}`,
     ]);
     if (!output) {
-      console.log(
-        '[DockerManager] listImages: json+filter returned empty output, trying next strategy',
-      );
+      callLog.push('json+filter returned empty output, trying next strategy');
     } else {
       type ImageRecord = {
         // Docker NDJSON fields (PascalCase)
@@ -1809,13 +1826,12 @@ async function listImages(): Promise<DockerImage[]> {
       }
 
       if (parsedAnyJson && parsed.length > 0) {
-        console.log(`[DockerManager] listImages: found ${parsed.length} image(s) via json+filter`);
+        callLog.push(`found ${parsed.length} image(s) via json+filter`);
+        flushListImagesLog(callLog);
         return parsed;
       }
       if (parsedAnyJson) {
-        console.log(
-          '[DockerManager] listImages: json+filter parsed OK but found 0 images, trying next strategy',
-        );
+        callLog.push('json+filter parsed OK but found 0 images, trying next strategy');
       }
       // Fall through to next strategy if no JSON was parsed or 0 images found.
     }
@@ -1834,12 +1850,11 @@ async function listImages(): Promise<DockerImage[]> {
     ]);
     const results = parseLegacyFormat(legacyOutput);
     if (results.length > 0) {
-      console.log(
-        `[DockerManager] listImages: found ${results.length} image(s) via template+filter`,
-      );
+      callLog.push(`found ${results.length} image(s) via template+filter`);
+      flushListImagesLog(callLog);
       return results;
     }
-    console.log('[DockerManager] listImages: template+filter found 0 images, trying next strategy');
+    callLog.push('template+filter found 0 images, trying next strategy');
   } catch (err: any) {
     console.warn('[DockerManager] listImages template+filter failed:', err.message);
   }
@@ -1852,10 +1867,12 @@ async function listImages(): Promise<DockerImage[]> {
       '{{.Repository}}:{{.Tag}}\t{{.Size}}\t{{.CreatedAt}}\t{{.ID}}',
     ]);
     const results = parseLegacyFormat(rawOutput);
-    console.log(`[DockerManager] listImages: found ${results.length} image(s) via unfiltered scan`);
+    callLog.push(`found ${results.length} image(s) via unfiltered scan`);
+    flushListImagesLog(callLog);
     return results;
   } catch (err: any) {
     console.error('[DockerManager] listImages: all strategies failed:', err.message);
+    flushListImagesLog(callLog);
     return [];
   }
 }


### PR DESCRIPTION
## Summary

The renderer's `DockerContext` polls `listImages()` every 10 seconds (`useDocker.ts`), and every successful call unconditionally logged `[DockerManager] listImages: found N image(s) via json+filter`. Over a long-running session this fills the terminal with hundreds of identical lines (see the launch log that motivated this change - roughly 200 copies in ~30 minutes).

## Changes

- `listImages()` now accumulates its routine info lines (success line + "trying next strategy" fallback notices) into a per-call buffer and flushes them through `flushListImagesLog()`, which only prints when the call's outcome differs from the previous call.
- The dedup key is the whole call's line sequence, not the last line, so a persistent multi-line fallback chain (e.g. "json+filter empty -> found 1 via template+filter") is also logged once instead of on every poll.
- `console.warn` / `console.error` paths are intentionally not deduplicated: they carry the real `err.message` and persistent failures should stay visible.

Behavior of `listImages()` itself is unchanged - same signature, same return values, same strategy order.

## Test plan

- [x] `npm run typecheck` (renderer + electron tsconfig) clean
- [x] Full dashboard vitest suite: 135 files, 1964 tests passed (the 2 reported vitest errors are pre-existing jsdom noise: canvas `getContext` and `scrollIntoView` in `SessionImportTab`, unrelated to this change)
- [x] Manual smoke: launch the AppImage, confirm the listImages line appears once at startup and again only when the image list actually changes (e.g. after a pull)