### PR TITLE
feat(dashboard, ui): recover a failed transcription from the UI, and fix what broke when you tried

### DIFF
--- a/dashboard/components/__tests__/SessionView.retry-failed.test.tsx
+++ b/dashboard/components/__tests__/SessionView.retry-failed.test.tsx
@@ -1,0 +1,368 @@
+/**
+ * SessionView - Retry button on the transcription error banner.
+ *
+ * The durability layer preserves the source WAV for a FAILED job indefinitely
+ * (the retention sweep only collects `status='completed' AND delivered=1`), so
+ * a transcription that died on a CUDA OOM or a crashed backend is always
+ * recoverable. Until now the only way to trigger that recovery was a raw
+ * `POST /api/transcribe/retry/{job_id}`; the error banner offered no way out.
+ *
+ * The retry must also DELIVER the result: the WebSocket that carried the
+ * original job is gone by the time the banner shows, so the component polls
+ * the durability endpoint and hands the transcript to `loadResult`.
+ */
+
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// ── Hoisted mock state ────────────────────────────────────────────────────
+
+const mockTranscription = {
+  status: 'error' as string,
+  result: null as unknown,
+  error: null as string | null,
+  analyser: null,
+  start: vi.fn(),
+  stop: vi.fn(),
+  reset: vi.fn(),
+  vadActive: false,
+  processingProgress: null,
+  muted: false,
+  toggleMute: vi.fn(),
+  setGain: vi.fn(),
+  jobId: null as string | null,
+  loadResult: vi.fn(),
+  previewText: null,
+  previewLanguage: undefined,
+  previewSeconds: null,
+  previewLoading: false,
+  previewError: null,
+  previewActive: false,
+  startPreview: vi.fn(),
+  stopPreview: vi.fn(),
+};
+
+const mockGetConfig = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../src/hooks/useTranscription', () => ({
+  useTranscription: () => mockTranscription,
+}));
+
+vi.mock('../../src/hooks/useLanguages', () => ({
+  useLanguages: () => ({
+    languages: [
+      { code: 'auto', name: 'Auto Detect' },
+      { code: 'en', name: 'English' },
+    ],
+    backendType: 'whisper',
+    loading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('../../src/hooks/useAdminStatus', () => ({
+  useAdminStatus: () => ({
+    status: {
+      models_loaded: true,
+      config: {
+        main_transcriber: { model: 'Systran/faster-whisper-large-v3' },
+        live_transcriber: { model: 'Systran/faster-whisper-large-v3' },
+      },
+    },
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/hooks/DockerContext', () => ({
+  useDockerContext: () => ({
+    available: true,
+    loading: false,
+    runtimeKind: 'Docker',
+    detectionGuidance: null,
+    composeAvailable: true,
+    images: [],
+    container: { exists: true, running: true, status: 'running', health: 'healthy' },
+    volumes: [],
+    operating: false,
+    operationError: null,
+    pulling: false,
+    sidecarPulling: false,
+    logLines: [],
+    logStreaming: false,
+    hasSidecarImage: vi.fn().mockResolvedValue(false),
+    startLogStream: vi.fn(),
+    stopLogStream: vi.fn(),
+    clearLogs: vi.fn(),
+    refreshImages: vi.fn(),
+    refreshVolumes: vi.fn(),
+    pullImage: vi.fn(),
+    cancelPull: vi.fn(),
+    pullSidecarImage: vi.fn(),
+    cancelSidecarPull: vi.fn(),
+    removeImage: vi.fn(),
+    startContainer: vi.fn(),
+    stopContainer: vi.fn(),
+    removeContainer: vi.fn(),
+    removeVolume: vi.fn(),
+    cleanAll: vi.fn(),
+    retryDetection: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/hooks/useTraySync', () => ({ useTraySync: vi.fn() }));
+
+vi.mock('../../src/stores/importQueueStore', () => ({
+  useImportQueueStore: (selector: (s: Record<string, unknown>) => unknown) => {
+    const state = {
+      jobs: [],
+      isPaused: false,
+      sessionConfig: { outputDir: '', diarizedFormat: 'srt', hideTimestamps: false },
+      sessionWatchPath: '',
+      sessionWatchActive: false,
+    };
+    return typeof selector === 'function' ? selector(state) : state;
+  },
+}));
+
+// vi.mock factories are hoisted above the declarations in this file, and the
+// api/client factory dereferences APIError eagerly — so the class has to be
+// created inside vi.hoisted or it is still in the temporal dead zone.
+const { MockAPIError, mockRetryTranscription, mockFetchTranscriptionResult, mockToast } =
+  vi.hoisted(() => {
+    class HoistedAPIError extends Error {
+      constructor(
+        public readonly status: number,
+        public readonly body: string,
+        public readonly path: string,
+      ) {
+        super(`API ${status} on ${path}`);
+        this.name = 'APIError';
+      }
+    }
+    return {
+      MockAPIError: HoistedAPIError,
+      mockRetryTranscription: vi.fn(),
+      mockFetchTranscriptionResult: vi.fn(),
+      mockToast: { success: vi.fn(), error: vi.fn() },
+    };
+  });
+
+vi.mock('../../src/api/client', () => ({
+  APIError: MockAPIError,
+  apiClient: {
+    checkConnection: vi.fn().mockResolvedValue({ reachable: true, ready: true }),
+    getAdminStatus: vi.fn().mockResolvedValue({}),
+    cancelTranscription: vi.fn(),
+    getAuthToken: vi.fn().mockReturnValue(null),
+    setAuthToken: vi.fn(),
+    getBaseUrl: vi.fn().mockReturnValue('http://localhost:7239'),
+    syncFromConfig: vi.fn().mockResolvedValue(undefined),
+    unloadModels: vi.fn().mockResolvedValue(undefined),
+    unloadLLMModel: vi.fn().mockResolvedValue(undefined),
+    loadModelsStream: vi.fn().mockReturnValue(vi.fn()),
+    fetchRecentUndelivered: vi.fn().mockResolvedValue({ json: async () => [] }),
+    fetchTranscriptionResult: (...a: unknown[]) => mockFetchTranscriptionResult(...a),
+    dismissTranscriptionResult: vi.fn().mockResolvedValue({ status: 200 }),
+    retryTranscription: (...a: unknown[]) => mockRetryTranscription(...a),
+  },
+}));
+
+vi.mock('../../src/config/store', () => ({
+  getConfig: (...args: unknown[]) => mockGetConfig(...args),
+  setConfig: vi.fn().mockResolvedValue(undefined),
+  getAuthToken: vi.fn().mockResolvedValue(null),
+  DEFAULT_SERVER_PORT: 7239,
+}));
+
+vi.mock('../../src/services/modelCapabilities', async () => {
+  const actual = await vi.importActual<typeof import('../../src/services/modelCapabilities')>(
+    '../../src/services/modelCapabilities',
+  );
+  return actual;
+});
+
+vi.mock('../../src/services/modelSelection', () => ({
+  isModelDisabled: () => false,
+}));
+
+vi.mock('../../src/hooks/useClipboard', () => ({ writeToClipboard: vi.fn() }));
+vi.mock('../../src/services/clientDebugLog', () => ({ logClientEvent: vi.fn() }));
+
+vi.mock('sonner', () => ({ toast: mockToast }));
+
+vi.mock('../views/SessionImportTab', () => ({
+  SessionImportTab: () => React.createElement('div', { 'data-testid': 'session-import-tab' }),
+}));
+vi.mock('../PopOutWindow', () => ({ PopOutWindow: () => null }));
+vi.mock('../views/FullscreenVisualizer', () => ({ FullscreenVisualizer: () => null }));
+vi.mock('../AudioVisualizer', () => ({
+  AudioVisualizer: () => React.createElement('div', { 'data-testid': 'audio-visualizer' }),
+}));
+
+vi.mock('../../src/types/runtime', () => ({
+  isRuntimeProfile: (v: unknown) =>
+    ['gpu', 'cpu', 'vulkan', 'vulkan-wsl2', 'metal'].includes(v as string),
+}));
+
+import { SessionView } from '../views/SessionView';
+import { SessionTab } from '../../types';
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+}
+
+const baseProps = {
+  serverConnection: {
+    serverStatus: 'active' as const,
+    clientStatus: 'active' as const,
+    details: null,
+    serverLabel: 'Server ready',
+    reachable: true,
+    ready: true,
+    error: null,
+    gpuError: null,
+    gpuErrorRecoveryHint: null,
+    refresh: vi.fn(),
+  },
+  clientRunning: true,
+  setClientRunning: vi.fn(),
+  onStartServer: vi.fn().mockResolvedValue(undefined),
+  startupFlowPending: false,
+  isUploading: false,
+  live: {
+    status: 'idle' as const,
+    sentences: [],
+    partial: '',
+    statusMessage: null,
+    error: null,
+    analyser: null,
+    muted: false,
+    start: vi.fn(),
+    stop: vi.fn(),
+    toggleMute: vi.fn(),
+    setGain: vi.fn(),
+    clearHistory: vi.fn(),
+    getText: vi.fn().mockReturnValue(''),
+  },
+  sessionTab: SessionTab.MAIN,
+  onChangeSessionTab: vi.fn(),
+};
+
+function renderSessionView() {
+  return render(React.createElement(SessionView, baseProps), { wrapper: createWrapper() });
+}
+
+const OOM_ERROR = 'Transcription failed: CUDA failed with error out of memory';
+const JOB_ID = '48eae812-f5ff-400e-b2bc-4dede99c5a15';
+
+/** The Retry control that belongs to the red error banner. */
+function findErrorRetryButton(): HTMLElement | undefined {
+  return screen
+    .queryAllByRole('button', { name: /retry/i })
+    .find((b) => b.closest('[data-testid="transcription-error"]') !== null);
+}
+
+describe('SessionView - retry a failed transcription', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTranscription.status = 'error';
+    mockTranscription.result = null;
+    mockTranscription.error = OOM_ERROR;
+    mockTranscription.jobId = JOB_ID;
+    mockGetConfig.mockResolvedValue(undefined);
+    mockRetryTranscription.mockResolvedValue({ job_id: JOB_ID, status: 'processing' });
+    mockFetchTranscriptionResult.mockResolvedValue({ status: 202, json: async () => ({}) });
+  });
+
+  it('shows the error message with a Retry button when a job id is known', async () => {
+    renderSessionView();
+
+    expect(await screen.findByText(OOM_ERROR)).toBeInTheDocument();
+    await waitFor(() => expect(findErrorRetryButton()).toBeDefined());
+  });
+
+  it('offers no Retry when the failure happened before a job existed', async () => {
+    mockTranscription.jobId = null;
+    mockTranscription.error = 'Connection to the server was lost.';
+    renderSessionView();
+
+    expect(await screen.findByText('Connection to the server was lost.')).toBeInTheDocument();
+    expect(findErrorRetryButton()).toBeUndefined();
+  });
+
+  it('re-transcribes from the saved audio and delivers the recovered result', async () => {
+    mockFetchTranscriptionResult.mockResolvedValue({
+      status: 200,
+      json: async () => ({
+        result: {
+          text: 'recovered transcript',
+          words: [],
+          language: 'el',
+          duration: 329.6,
+        },
+      }),
+    });
+    renderSessionView();
+
+    await waitFor(() => expect(findErrorRetryButton()).toBeDefined());
+    fireEvent.click(findErrorRetryButton()!);
+
+    await waitFor(() => expect(mockRetryTranscription).toHaveBeenCalledWith(JOB_ID));
+    await waitFor(() =>
+      expect(mockTranscription.loadResult).toHaveBeenCalledWith(
+        expect.objectContaining({ text: 'recovered transcript', language: 'el', duration: 329.6 }),
+      ),
+    );
+  });
+
+  it('explains the refusal when the model is busy with another job', async () => {
+    mockRetryTranscription.mockRejectedValue(
+      new MockAPIError(
+        409,
+        JSON.stringify({
+          detail: 'Model is currently busy. Try again when the active session ends.',
+        }),
+        '/api/transcribe/retry/x',
+      ),
+    );
+    renderSessionView();
+
+    await waitFor(() => expect(findErrorRetryButton()).toBeDefined());
+    fireEvent.click(findErrorRetryButton()!);
+
+    await waitFor(() =>
+      expect(mockToast.error).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ description: expect.stringContaining('busy') }),
+      ),
+    );
+    expect(mockTranscription.loadResult).not.toHaveBeenCalled();
+  });
+
+  it('explains the refusal when the saved audio is gone', async () => {
+    mockRetryTranscription.mockRejectedValue(
+      new MockAPIError(
+        410,
+        JSON.stringify({ detail: 'Audio file has been deleted — cannot retry' }),
+        '/api/transcribe/retry/x',
+      ),
+    );
+    renderSessionView();
+
+    await waitFor(() => expect(findErrorRetryButton()).toBeDefined());
+    fireEvent.click(findErrorRetryButton()!);
+
+    await waitFor(() =>
+      expect(mockToast.error).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ description: expect.stringContaining('deleted') }),
+      ),
+    );
+  });
+});

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -46,7 +46,7 @@ import { useTraySync } from '../../src/hooks/useTraySync';
 import type { ServerConnectionInfo } from '../../src/hooks/useServerStatus';
 import { useAdminStatus } from '../../src/hooks/useAdminStatus';
 import { useScrollFade } from '../../src/hooks/useScrollFade';
-import { apiClient } from '../../src/api/client';
+import { apiClient, APIError } from '../../src/api/client';
 import { getAuthToken, getConfig, setConfig } from '../../src/config/store';
 import { logClientEvent } from '../../src/services/clientDebugLog';
 import { loopbackOwner } from '../../src/services/loopbackOwner';
@@ -68,6 +68,48 @@ import { useImportQueueStore } from '../../src/stores/importQueueStore';
 import { useNotificationsStore } from '../../src/stores/notificationsStore';
 import { toast } from 'sonner';
 import { isRuntimeProfile, type RuntimeProfile } from '../../src/types/runtime';
+
+/** How long to wait between polls for the result of a retried job. */
+const RETRY_POLL_INTERVAL_MS = 3000;
+/**
+ * Give up polling after this many misses (~5 min). Long recordings legitimately
+ * take minutes to re-transcribe, and giving up early strands a result that has
+ * already been persisted — the recovery banner still finds it, but only after
+ * the user navigates away and back.
+ */
+const RETRY_POLL_MAX_ATTEMPTS = 100;
+
+/** Pull the human-readable reason out of a FastAPI detail body. */
+function extractDetail(body: string): string | undefined {
+  try {
+    const parsed = JSON.parse(body);
+    if (typeof parsed?.detail === 'string') return parsed.detail;
+  } catch {
+    // Not JSON — fall through and use the raw body if it is short enough.
+  }
+  const trimmed = body.trim();
+  return trimmed && trimmed.length <= 200 ? trimmed : undefined;
+}
+
+async function readDetail(resp: Response): Promise<string | undefined> {
+  try {
+    return extractDetail(await resp.text());
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Turn a failed /retry call into something actionable. Every refusal this
+ * endpoint returns is recoverable by the user: 409 = another job holds the
+ * model, 410 = the audio is genuinely gone, 404 = the job predates this database.
+ */
+function describeRetryError(err: unknown): string | undefined {
+  if (err instanceof APIError) {
+    return extractDetail(err.body) ?? `The server refused the retry (HTTP ${err.status}).`;
+  }
+  return err instanceof Error ? err.message : undefined;
+}
 
 interface SessionViewProps {
   serverConnection: ServerConnectionInfo;
@@ -182,10 +224,21 @@ export const SessionView: React.FC<SessionViewProps> = ({
   // Session main-result editing (client-only): hand-corrections flow into
   // Copy/Download. Reset whenever a new transcription replaces the text.
   const [editedResultText, setEditedResultText] = useState('');
-  // A partial transcript is persisted as a 'completed' job, so without this the
-  // user cannot tell a truncated transcript from a whole one. Retry is their only
-  // recourse.
-  const [retryingPartial, setRetryingPartial] = useState(false);
+  // Retry re-transcribes from the saved job audio, which the durability layer
+  // keeps on disk. Two banners share it: a partial transcript (persisted as a
+  // 'completed' job, so the user cannot otherwise tell a truncated transcript
+  // from a whole one) and an outright failure.
+  const [retrying, setRetrying] = useState(false);
+  const retryPollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const retryCancelledRef = useRef(false);
+  // Stop the poll on unmount so it cannot setState into a dead component. The
+  // transcript is already durable server-side, so dropping the poll loses nothing.
+  useEffect(() => {
+    return () => {
+      retryCancelledRef.current = true;
+      if (retryPollTimerRef.current) clearTimeout(retryPollTimerRef.current);
+    };
+  }, []);
   useEffect(() => {
     setEditedResultText(transcription.result?.text ?? '');
   }, [transcription.result?.text]);
@@ -887,25 +940,76 @@ export const SessionView: React.FC<SessionViewProps> = ({
     transcription.startPreview(seconds);
   }, [transcription]);
 
-  // Re-transcribe a truncated result from the job's saved audio. The server
-  // accepts /retry for a partial job even though its status is 'completed'.
-  const handleRetryPartial = useCallback(async () => {
+  // Re-transcribe from the job's saved audio. Serves both the partial-transcript
+  // banner (the server accepts /retry for a partial job even though its status is
+  // 'completed') and the error banner — the retention sweep only collects
+  // completed+delivered jobs, so the audio of a FAILED job is never
+  // garbage-collected and a CUDA OOM or a crashed backend stays recoverable.
+  //
+  // The WebSocket that carried the original job is gone by the time either banner
+  // is on screen, so the result can only come back by polling the durability
+  // endpoint — the same contract used by the reconnect path in useTranscription.
+  const handleRetry = useCallback(async () => {
     const jobId = transcription.jobId;
-    if (!jobId || retryingPartial) return;
-    setRetryingPartial(true);
+    if (!jobId || retrying) return;
+    setRetrying(true);
+    retryCancelledRef.current = false;
+
     try {
       await apiClient.retryTranscription(jobId);
-      toast.success('Retrying transcription', {
-        description: 'Re-transcribing from the saved audio.',
-      });
     } catch (err) {
-      toast.error('Could not retry the transcription', {
-        description: err instanceof Error ? err.message : undefined,
-      });
-    } finally {
-      setRetryingPartial(false);
+      setRetrying(false);
+      toast.error('Could not retry the transcription', { description: describeRetryError(err) });
+      return;
     }
-  }, [transcription.jobId, retryingPartial]);
+
+    toast.success('Retrying transcription', {
+      description: 'Re-transcribing from the saved audio.',
+    });
+
+    let attempts = 0;
+    const poll = async () => {
+      if (retryCancelledRef.current) return;
+      try {
+        const resp = await apiClient.fetchTranscriptionResult(jobId);
+        if (retryCancelledRef.current) return;
+        if (resp.status === 200) {
+          const data = await resp.json();
+          const r = data.result ?? {};
+          transcription.loadResult({
+            text: r.text ?? '',
+            words: r.words ?? [],
+            language: r.language,
+            duration: r.duration,
+            partial: r.partial ?? false,
+            partialReason: r.partial_reason ?? null,
+          });
+          setRetrying(false);
+          return;
+        }
+        // 410 — the retry itself failed on the server (it reports the reason).
+        if (resp.status === 410) {
+          setRetrying(false);
+          toast.error('Retry failed', { description: await readDetail(resp) });
+          return;
+        }
+      } catch {
+        // Network blip — treat like a not-ready poll and try again.
+      }
+      if (retryCancelledRef.current) return;
+      attempts += 1;
+      if (attempts >= RETRY_POLL_MAX_ATTEMPTS) {
+        setRetrying(false);
+        toast.error('Retry is still running', {
+          description:
+            'The transcript did not arrive in time. It is saved on the server — reopen this tab to pick it up.',
+        });
+        return;
+      }
+      retryPollTimerRef.current = setTimeout(poll, RETRY_POLL_INTERVAL_MS);
+    };
+    void poll();
+  }, [transcription, retrying]);
 
   // Copy transcription result to clipboard (prefers the edited text)
   const handleCopyTranscription = useCallback(() => {
@@ -1971,10 +2075,10 @@ export const SessionView: React.FC<SessionViewProps> = ({
                             </span>
                             <Button
                               variant="secondary"
-                              disabled={retryingPartial || !transcription.jobId}
-                              onClick={handleRetryPartial}
+                              disabled={retrying || !transcription.jobId}
+                              onClick={handleRetry}
                             >
-                              {retryingPartial ? 'Retrying…' : 'Retry'}
+                              {retrying ? 'Retrying…' : 'Retry'}
                             </Button>
                           </div>
                         )}
@@ -2013,10 +2117,22 @@ export const SessionView: React.FC<SessionViewProps> = ({
                       </div>
                     )}
 
-                    {/* Errors */}
+                    {/* Errors. A job id means the recording reached the server and its
+                      audio was persisted before transcription was attempted, so the
+                      failure is recoverable — offer Retry. Without one (e.g. the socket
+                      died before session_started) there is nothing to retry from. */}
                     {transcription.error && (
-                      <div className="rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-400">
-                        {transcription.error}
+                      <div
+                        data-testid="transcription-error"
+                        role="alert"
+                        className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-400"
+                      >
+                        <span>{transcription.error}</span>
+                        {transcription.jobId && (
+                          <Button variant="secondary" disabled={retrying} onClick={handleRetry}>
+                            {retrying ? 'Retrying…' : 'Retry'}
+                          </Button>
+                        )}
                       </div>
                     )}
                   </div>

--- a/dashboard/scripts/ui-contract/shared.mjs
+++ b/dashboard/scripts/ui-contract/shared.mjs
@@ -324,11 +324,105 @@ function extractCssBlock(styleText, selector) {
   return `${selector} ${block}`.trim();
 }
 
+/**
+ * Blank out comments so their prose cannot be read as source strings.
+ *
+ * The string scanner below pairs quote characters positionally: 1st with 2nd,
+ * 3rd with 4th, and so on. A lone apostrophe anywhere — including inside a
+ * comment, as in "the job's audio" — shifts that pairing for the entire rest
+ * of the file, so real className strings get read as the *gaps between*
+ * strings and silently vanish from the contract while unrelated fragments
+ * appear in their place. The failure surfaces as a closed-set CSS mismatch,
+ * which points nowhere near the comment that caused it.
+ *
+ * Walking the file with an explicit state machine (rather than a regex) is
+ * what makes this safe in both directions: comment markers inside a string
+ * literal such as 'https://example.com' stay put, and quotes inside a comment
+ * are discarded before they can be paired.
+ *
+ * Newlines inside comments are preserved so any line-based diagnostics that
+ * run downstream keep their line numbers.
+ */
+export function stripComments(content) {
+  const CODE = 0;
+  const LINE_COMMENT = 1;
+  const BLOCK_COMMENT = 2;
+  const STRING = 3;
+
+  let out = '';
+  let state = CODE;
+  let quote = '';
+  let i = 0;
+
+  while (i < content.length) {
+    const ch = content[i];
+    const next = content[i + 1];
+
+    if (state === CODE) {
+      if (ch === '/' && next === '/') {
+        state = LINE_COMMENT;
+        i += 2;
+        continue;
+      }
+      if (ch === '/' && next === '*') {
+        state = BLOCK_COMMENT;
+        i += 2;
+        continue;
+      }
+      if (ch === "'" || ch === '"' || ch === '`') {
+        state = STRING;
+        quote = ch;
+      }
+      out += ch;
+      i += 1;
+      continue;
+    }
+
+    if (state === LINE_COMMENT) {
+      if (ch === '\n') {
+        state = CODE;
+        out += ch;
+      }
+      i += 1;
+      continue;
+    }
+
+    if (state === BLOCK_COMMENT) {
+      if (ch === '*' && next === '/') {
+        state = CODE;
+        i += 2;
+        continue;
+      }
+      if (ch === '\n') {
+        out += ch;
+      }
+      i += 1;
+      continue;
+    }
+
+    // Inside a string literal: copy verbatim, honouring escapes, until the
+    // matching close quote. Comment markers in here are data, not comments.
+    if (ch === '\\') {
+      out += ch + (next ?? '');
+      i += 2;
+      continue;
+    }
+    if (ch === quote) {
+      state = CODE;
+      quote = '';
+    }
+    out += ch;
+    i += 1;
+  }
+
+  return out;
+}
+
 function extractQuotedStrings(content) {
   const matches = [];
   const re = /(['"`])((?:\\.|(?!\1)[\s\S])*)\1/g;
   let match;
-  while ((match = re.exec(content)) !== null) {
+  while ((match = re.exec(stripComments(content))) !== null) {
     matches.push(match[2]);
   }
   return matches;

--- a/dashboard/scripts/ui-contract/test-contract.mjs
+++ b/dashboard/scripts/ui-contract/test-contract.mjs
@@ -263,10 +263,12 @@ async function main() {
   );
 
   // The mirror hazard: comment markers *inside* a string are data, not comments.
+  // Asserted as exact equality rather than a substring check — the input holds
+  // no comments, so a correct strip returns it byte-for-byte. Equality is the
+  // stronger claim, and it keeps this out of the shape of a URL-allowlist test.
   const urlInString = `const href = 'https://example.com/a'; const c = "gap-2";`;
   expect(
-    stripComments(urlInString).includes('https://example.com/a') &&
-      stripComments(urlInString).includes('gap-2'),
+    stripComments(urlInString) === urlInString,
     'Comment markers inside a string literal are preserved',
     stripComments(urlInString),
   );

--- a/dashboard/scripts/ui-contract/test-contract.mjs
+++ b/dashboard/scripts/ui-contract/test-contract.mjs
@@ -3,7 +3,13 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import YAML from 'yaml';
 import { createValidationReport } from './validate-contract.mjs';
-import { BASELINE_PATH, CONTRACT_PATH, PROJECT_ROOT, extractFacts } from './shared.mjs';
+import {
+  BASELINE_PATH,
+  CONTRACT_PATH,
+  PROJECT_ROOT,
+  extractFacts,
+  stripComments,
+} from './shared.mjs';
 
 const TMP_DIR = path.join(PROJECT_ROOT, 'scripts', 'ui-contract', 'fixtures', '.tmp');
 const SCHEMA_FAIL_FIXTURE = path.join(
@@ -227,6 +233,51 @@ async function main() {
     'Versioning pass when semver is bumped',
   );
   expect(semverPass.ok === true, 'Bumped semver contract remains valid with baseline warning only');
+
+  // 8. Comment stripping: prose must never reach the string scanner, and code
+  // must survive it intact. A lone apostrophe in a comment used to shift the
+  // scanner's quote pairing for the rest of the file, silently dropping real
+  // classNames from the contract and inventing tokens out of comment text.
+  const loneApostrophe = [
+    "// re-transcribe from the job's saved audio",
+    'const a = "px-4 py-2";',
+  ].join('\n');
+  expect(
+    stripComments(loneApostrophe).includes('px-4 py-2'),
+    'Lone apostrophe in a line comment does not swallow the next string',
+    stripComments(loneApostrophe),
+  );
+  expect(
+    !stripComments(loneApostrophe).includes('re-transcribe'),
+    'Line comment prose is removed before scanning',
+  );
+
+  const jsxBlockComment = '{/* keep the max-height here */}\n<div className="mt-2 flex" />';
+  expect(
+    !stripComments(jsxBlockComment).includes('max-height'),
+    'Block/JSX comment prose is removed before scanning',
+  );
+  expect(
+    stripComments(jsxBlockComment).includes('mt-2 flex'),
+    'Block comment does not consume the className that follows it',
+  );
+
+  // The mirror hazard: comment markers *inside* a string are data, not comments.
+  const urlInString = `const href = 'https://example.com/a'; const c = "gap-2";`;
+  expect(
+    stripComments(urlInString).includes('https://example.com/a') &&
+      stripComments(urlInString).includes('gap-2'),
+    'Comment markers inside a string literal are preserved',
+    stripComments(urlInString),
+  );
+
+  // An escaped quote must not be mistaken for the end of the string.
+  const escapedQuote = `const s = 'it\\'s fine'; const c = "p-1";`;
+  expect(
+    stripComments(escapedQuote).includes('p-1'),
+    'Escaped quote inside a string does not desynchronise the scanner',
+    stripComments(escapedQuote),
+  );
 
   if (failures.length > 0) {
     process.stderr.write(`ui-contract tests failed (${failures.length}/${checks.length})\n`);

--- a/dashboard/src/hooks/useTranscription.ts
+++ b/dashboard/src/hooks/useTranscription.ts
@@ -642,6 +642,10 @@ export function useTranscription(): TranscriptionState {
   const loadResult = useCallback(
     (r: TranscriptionResult) => {
       setResult(r);
+      // A delivered transcript supersedes whatever went wrong before it — a
+      // recovered or retried result must not leave the old error banner on
+      // screen next to the transcript it just replaced.
+      setError(null);
       setStatusTracked('complete');
     },
     [setStatusTracked],

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.13.2",
-  "contract_sha256": "52960c4c929703456a607dc37c6d8a0e2641ce867ea4686110894e43c6746778",
-  "updated_at": "2026-07-31T00:09:31.442Z"
+  "spec_version": "1.13.3",
+  "contract_sha256": "fe5dba1658705a7087abeca1f8e1378536162bbe34d1d8e7df0bc42fe357c8e2",
+  "updated_at": "2026-07-31T22:57:40.209Z"
 }

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.13.3",
-  "contract_sha256": "fe5dba1658705a7087abeca1f8e1378536162bbe34d1d8e7df0bc42fe357c8e2",
-  "updated_at": "2026-07-31T22:57:40.209Z"
+  "spec_version": "1.13.4",
+  "contract_sha256": "9a7b11ab92cc1d9b4636b785bfabacba7ee3bc22368aefa58c06ccb62c30b0a0",
+  "updated_at": "2026-08-01T07:25:39.761Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.13.3
+  spec_version: 1.13.4
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -130,7 +130,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-07-31T22:57:39.327Z
+    generated_at: 2026-08-01T07:23:36.434Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -320,6 +320,7 @@ foundation:
         - shadow-[0_0_12px_rgba(96,165,250,0.2)]
         - shadow-[0_0_15px_rgba(251,146,60,0.5)]
         - shadow-[0_0_15px_rgba(34,211,238,0.2)]
+        - shadow-[0_0_15px_rgba(34,211,238,0.2)]!
         - shadow-[0_0_15px_rgba(34,211,238,0.5)]
         - shadow-[0_0_18px_rgba(239,68,68,0.35)]
         - shadow-[0_0_20px_rgba(255,255,255,0.3)]
@@ -359,6 +360,7 @@ foundation:
         - ease-[cubic-bezier(0.32,0.72,0,1)]
         - ease-[cubic-bezier(0.33,1,0.68,1)]
         - ease-in-out
+        - ease-out
       keyframes:
         - dropdown-appear
         - dropzone-flash
@@ -427,6 +429,7 @@ foundation:
         - shadow-[0_0_12px_rgba(96,165,250,0.2)]
         - shadow-[0_0_15px_rgba(251,146,60,0.5)]
         - shadow-[0_0_15px_rgba(34,211,238,0.2)]
+        - shadow-[0_0_15px_rgba(34,211,238,0.2)]!
         - shadow-[0_0_15px_rgba(34,211,238,0.5)]
         - shadow-[0_0_18px_rgba(239,68,68,0.35)]
         - shadow-[0_0_20px_rgba(255,255,255,0.3)]
@@ -563,6 +566,7 @@ utility_allowlist:
     - bg-accent-orange
     - bg-accent-orange/10
     - bg-accent-orange/20
+    - bg-accent-violet/15
     - bg-amber-400/10
     - bg-amber-400/20
     - bg-amber-400/5
@@ -588,6 +592,7 @@ utility_allowlist:
     - bg-cyan-400/70
     - bg-cyan-500/80
     - bg-emerald-400/10
+    - bg-emerald-500/10
     - bg-emerald-500/20
     - bg-glass-100
     - bg-glass-100/30
@@ -614,10 +619,12 @@ utility_allowlist:
     - bg-red-500/20
     - bg-red-500/25
     - bg-red-500/5
+    - bg-red-600/10
     - bg-slate-300/10
     - bg-slate-400/10
     - bg-slate-500
     - bg-slate-500/20
+    - bg-slate-600
     - bg-slate-700
     - bg-slate-800
     - bg-slate-900
@@ -642,6 +649,7 @@ utility_allowlist:
     - border-accent-cyan/20
     - border-accent-cyan/30
     - border-accent-cyan/40
+    - border-accent-cyan/40!
     - border-accent-cyan/60
     - border-accent-magenta/20
     - border-accent-magenta/5
@@ -665,6 +673,7 @@ utility_allowlist:
     - border-dashed
     - border-emerald-400/30
     - border-emerald-400/40
+    - border-emerald-500/40
     - border-glass-100
     - border-glass-border
     - border-green-400/60
@@ -683,6 +692,7 @@ utility_allowlist:
     - border-red-400/60
     - border-red-500/20
     - border-red-500/25
+    - border-red-600/40
     - border-slate-300/60
     - border-slate-400/30
     - border-slate-500/40
@@ -699,7 +709,6 @@ utility_allowlist:
     - bottom-1
     - bottom-4
     - bottom-6
-    - bottom-anchored
     - bottom-full
     - bottom-right
     - cursor-not-allowed
@@ -716,6 +725,7 @@ utility_allowlist:
     - duration-500
     - duration-700
     - ease-in-out
+    - ease-out
     - fade-in
     - fill-mode-forwards
     - fixed
@@ -791,7 +801,6 @@ utility_allowlist:
     - h-px
     - h-screen
     - hidden
-    - "hover:"
     - hover:-translate-y-1
     - hover:bg-accent-cyan
     - hover:bg-accent-cyan/10
@@ -869,6 +878,7 @@ utility_allowlist:
     - lg:grid-cols-4
     - lg:grid-cols-5
     - lg:p-10
+    - lg:p-8
     - line-clamp-2
     - m-0
     - mask-gradient-right
@@ -878,8 +888,8 @@ utility_allowlist:
     - max-h-60
     - max-h-64
     - max-h-72
+    - max-h-80
     - max-h-96
-    - max-height
     - max-w-20
     - max-w-2xl
     - max-w-3xl
@@ -910,7 +920,6 @@ utility_allowlist:
     - min-h-20
     - min-h-32
     - min-h-full
-    - min-height
     - min-w-0
     - min-w-100
     - min-w-25
@@ -920,6 +929,7 @@ utility_allowlist:
     - ml-0.5
     - ml-1
     - ml-2
+    - ml-3
     - ml-auto
     - mr-1
     - mr-1.5
@@ -937,6 +947,8 @@ utility_allowlist:
     - mt-8
     - mt-auto
     - mx-0.5
+    - mx-1
+    - mx-2
     - mx-auto
     - my-1
     - my-2
@@ -1086,6 +1098,7 @@ utility_allowlist:
     - space-y-2.5
     - space-y-3
     - space-y-4
+    - space-y-5
     - space-y-6
     - space-y-8
     - sticky
@@ -1098,10 +1111,12 @@ utility_allowlist:
     - text-accent-orange
     - text-accent-rose
     - text-accent-violet
+    - text-accent-violet/80
     - text-amber-100
     - text-amber-200
     - text-amber-300
     - text-amber-300/60
+    - text-amber-300/70
     - text-amber-300/80
     - text-amber-400
     - text-amber-400/60
@@ -1124,6 +1139,7 @@ utility_allowlist:
     - text-left
     - text-lg
     - text-neutral-100
+    - text-orange-200
     - text-orange-400
     - text-orange-500
     - text-purple-400
@@ -1134,6 +1150,7 @@ utility_allowlist:
     - text-red-400
     - text-red-400/80
     - text-right
+    - text-rose-400
     - text-slate-100
     - text-slate-200
     - text-slate-300
@@ -1175,7 +1192,6 @@ utility_allowlist:
     - transition-opacity
     - transition-shadow
     - transition-transform
-    - translate-to-English
     - translate-x-4
     - translate-x-5
     - truncate
@@ -1209,6 +1225,7 @@ utility_allowlist:
     - w-7
     - w-72
     - w-8
+    - w-80
     - w-9
     - w-full
     - w-max
@@ -1261,6 +1278,7 @@ utility_allowlist:
     - shadow-[0_0_12px_rgba(96,165,250,0.2)]
     - shadow-[0_0_15px_rgba(251,146,60,0.5)]
     - shadow-[0_0_15px_rgba(34,211,238,0.2)]
+    - shadow-[0_0_15px_rgba(34,211,238,0.2)]!
     - shadow-[0_0_15px_rgba(34,211,238,0.5)]
     - shadow-[0_0_18px_rgba(239,68,68,0.35)]
     - shadow-[0_0_20px_rgba(255,255,255,0.3)]

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.13.2
+  spec_version: 1.13.3
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -26,6 +26,7 @@ meta:
       - components/__tests__/SessionView.canary-language.test.tsx
       - components/__tests__/SessionView.client-link-stop.test.tsx
       - components/__tests__/SessionView.greek-sigma.test.tsx
+      - components/__tests__/SessionView.retry-failed.test.tsx
       - components/__tests__/SessionView.test.tsx
       - components/__tests__/StartupActivityInline.test.tsx
       - components/AriaLiveRegion.tsx
@@ -129,7 +130,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-07-31T00:09:16.584Z
+    generated_at: 2026-07-31T22:57:39.327Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:

--- a/server/backend/api/routes/transcription.py
+++ b/server/backend/api/routes/transcription.py
@@ -1554,6 +1554,19 @@ async def _run_retry(job_id: str, audio_path: str, job: dict[str, Any], app_stat
         # detached (Issue #76).
         engine = await asyncio.to_thread(model_manager.ensure_transcription_loaded)
 
+        # Retry almost always follows a CUDA OOM, so it starts on a card that is
+        # still saturated: the transcription model keeps its allocations and the
+        # failed attempt may have left cached blocks behind. Hand those back to
+        # the driver first — without this the first retry after an OOM tends to
+        # die inside CTranslate2 while a second one moments later succeeds.
+        # Best-effort: never let the cleanup itself sink the retry.
+        try:
+            from ...core.audio_utils import clear_gpu_cache
+
+            await asyncio.to_thread(clear_gpu_cache)
+        except Exception as _gpu_err:
+            logger.debug("Could not free GPU cache before retry: %s", _gpu_err)
+
         result = await asyncio.to_thread(
             engine.transcribe_file,
             audio_path,

--- a/server/backend/api/routes/websocket.py
+++ b/server/backend/api/routes/websocket.py
@@ -604,7 +604,10 @@ class TranscriptionSession:
         except Exception as e:
             # Import lazily to avoid circular imports at module load time.
             from server.core.model_manager import TranscriptionCancelledError
-            from server.core.stt.backends.base import BackendDependencyError
+            from server.core.stt.backends.base import (
+                BackendDependencyError,
+                GpuOutOfMemoryError,
+            )
 
             if isinstance(e, TranscriptionCancelledError):
                 logger.info(f"Transcription cancelled (client disconnected) for {self.client_name}")
@@ -616,17 +619,18 @@ class TranscriptionSession:
                             "Failed to mark job %s as failed: %s", self._current_job_id, _mf_err
                         )
             else:
-                # Surface BackendDependencyError remedy so the dashboard
-                # can render an actionable hint (Issue #76).
-                dep_error: BackendDependencyError | None = None
-                if isinstance(e, BackendDependencyError):
-                    dep_error = e
-                elif isinstance(e.__cause__, BackendDependencyError):
-                    dep_error = e.__cause__  # type: ignore[assignment]
+                # Surface the remedy of any error that carries one so the
+                # dashboard can render an actionable hint (Issue #76 for a
+                # missing backend dependency, a full GPU for GpuOutOfMemoryError).
+                remedy: str | None = None
+                for candidate in (e, e.__cause__):
+                    if isinstance(candidate, BackendDependencyError | GpuOutOfMemoryError):
+                        remedy = candidate.remedy
+                        break
                 logger.error(f"Transcription error: {e}", exc_info=True)
                 error_message = (
-                    f"Transcription failed: {e}. {dep_error.remedy}"
-                    if dep_error is not None
+                    f"Transcription failed: {e}. {remedy}"
+                    if remedy is not None
                     else f"Transcription failed: {e}"
                 )
                 if self._current_job_id:

--- a/server/backend/core/stt/backends/base.py
+++ b/server/backend/core/stt/backends/base.py
@@ -24,6 +24,72 @@ class BackendDependencyError(RuntimeError):
         self.remedy = remedy
 
 
+class GpuOutOfMemoryError(RuntimeError):
+    """Raised when a transcription failed because the GPU ran out of VRAM.
+
+    Attributes:
+        remedy: Actionable instruction for the user.
+    """
+
+    def __init__(self, message: str, *, remedy: str) -> None:
+        super().__init__(message)
+        self.remedy = remedy
+
+
+#: Wordings that mean "the GPU ran out of memory".
+#:
+#: CTranslate2 picks between the first two depending on which internal
+#: allocation trips first, which is a matter of timing — the same import of the
+#: same file at the same VRAM pressure alternates between them, with an
+#: identical Python traceback. The thrust variant reports whatever CUDA error
+#: code was current on the context rather than the allocation failure, so it
+#: surfaces as "invalid device ordinal" and reads like a GPU misconfiguration.
+_GPU_OOM_MARKERS = (
+    "cuda failed with error out of memory",
+    "parallel_for failed",
+    "cuda out of memory",
+    "cudaerrormemoryallocation",
+    "out of memory",
+)
+
+_GPU_OOM_REMEDY = (
+    "Free VRAM and try again: unload other GPU applications, press Unload Models "
+    "to release the transcription model, or switch to a smaller model or a lower "
+    "compute_type (int8) in the Server tab."
+)
+
+
+def as_gpu_oom(exc: BaseException) -> GpuOutOfMemoryError | None:
+    """Translate a GPU out-of-memory failure into a self-explanatory error.
+
+    Returns None for anything that is not an out-of-memory condition, so a
+    genuine fault — an out-of-range ``gpu_device_index`` raising a bare
+    "invalid device ordinal" at setup, for instance — keeps its own message
+    instead of being mislabelled.
+
+    The original text is always preserved in the translated message: the
+    classification is a reading of a third-party error string, and a wrong
+    reading must never destroy the evidence.
+    """
+    if isinstance(exc, GpuOutOfMemoryError):
+        return exc
+
+    # torch raises a dedicated class; trust the type over the wording, which
+    # changes between releases.
+    is_torch_oom = type(exc).__name__ == "OutOfMemoryError"
+
+    text = str(exc).lower()
+    if not is_torch_oom and not any(marker in text for marker in _GPU_OOM_MARKERS):
+        return None
+
+    translated = GpuOutOfMemoryError(
+        f"The GPU ran out of memory (VRAM). Original error: {exc}",
+        remedy=_GPU_OOM_REMEDY,
+    )
+    translated.__cause__ = exc
+    return translated
+
+
 class PartialTranscriptionError(RuntimeError):
     """Raised by a chunking backend when a chunk fails *after* ≥1 chunk succeeded.
 

--- a/server/backend/core/stt/backends/whisperx_backend.py
+++ b/server/backend/core/stt/backends/whisperx_backend.py
@@ -590,8 +590,14 @@ class WhisperXBackend(STTBackend):
                     self._align_language,
                     lang,
                 )
-                del self._align_model
-                del self._align_metadata
+                # Assign None rather than `del`: load_align_model() below can
+                # raise (a CUDA OOM here is routine, since the transcription
+                # model is still resident), and a deleted attribute makes the
+                # `is None` guard above raise AttributeError on every later
+                # call — permanently disabling alignment for the process.
+                self._align_model = None
+                self._align_metadata = None
+                self._align_language = None
                 gc.collect()
                 clear_gpu_cache()
             self._align_model, self._align_metadata = whisperx.load_align_model(

--- a/server/backend/core/stt/engine.py
+++ b/server/backend/core/stt/engine.py
@@ -34,7 +34,7 @@ import numpy as np
 import torch
 from scipy.signal import resample
 from server.config import get_config, resolve_main_transcriber_model
-from server.core.stt.backends.base import PartialTranscriptionError
+from server.core.stt.backends.base import PartialTranscriptionError, as_gpu_oom
 from server.core.stt.backends.factory import create_backend, detect_backend_type
 from server.core.stt.capabilities import validate_translation_request
 from server.core.stt.vad import VoiceActivityDetector
@@ -757,6 +757,12 @@ class AudioToTextRecorder:
             except Exception as e:
                 logger.exception(f"Transcription error: {e}")
                 self._set_state("inactive")
+                # CTranslate2 words one OOM two ways and picks between them by
+                # timing, so "invalid device ordinal" reaches the user for what
+                # is really a full GPU. Say what actually happened.
+                oom = as_gpu_oom(e)
+                if oom is not None:
+                    raise oom from e
                 raise
 
     def transcribe_file(
@@ -1021,6 +1027,9 @@ class AudioToTextRecorder:
 
             except Exception as e:
                 logger.exception(f"Transcription error: {e}")
+                oom = as_gpu_oom(e)
+                if oom is not None:
+                    raise oom from e
                 raise
 
     def _recording_worker(self) -> None:

--- a/server/backend/tests/test_cuda_oom_classification.py
+++ b/server/backend/tests/test_cuda_oom_classification.py
@@ -1,0 +1,106 @@
+"""A GPU that ran out of VRAM must say so, whichever way CTranslate2 words it.
+
+CTranslate2 reports the SAME out-of-memory failure two different ways, chosen by
+which internal allocation happens to trip first:
+
+    RuntimeError: CUDA failed with error out of memory
+    RuntimeError: parallel_for failed: cudaErrorInvalidDevice: invalid device ordinal
+
+The second is thrust's wrapper (`throw_on_error(<cuda call>, "parallel_for failed")`)
+reporting whatever error code was current on the context rather than the
+allocation failure itself. "invalid device ordinal" reads like a GPU
+misconfiguration and sends the user hunting through device settings.
+
+Measured 2026-08-01 on an RTX 3060 with 12288 MiB, model resident, one import of
+the same 5.5 min WAV repeated at fixed pressure:
+
+    free 4968 MiB -> 4/4 succeeded
+    free  ~860 MiB -> OOM, invalid-device, OOM, invalid-device (alternating)
+
+Identical Python traceback in every failing run (whisperx/asr.py:104 in encode),
+so the two messages are one condition, not two.
+
+Run:  ../../build/.venv/bin/pytest tests/test_cuda_oom_classification.py -v --tb=short
+"""
+
+from __future__ import annotations
+
+import pytest
+from server.core.stt.backends.base import GpuOutOfMemoryError, as_gpu_oom
+
+# Verbatim from the container logs.
+CT2_PLAIN_OOM = "CUDA failed with error out of memory"
+CT2_THRUST_OOM = "parallel_for failed: cudaErrorInvalidDevice: invalid device ordinal"
+TORCH_OOM = (
+    "CUDA out of memory. Tried to allocate 20.00 MiB. GPU 0 has a total capacity of "
+    "11.63 GiB of which 6.31 MiB is free."
+)
+
+
+class TestRecognisesOom:
+    @pytest.mark.parametrize(
+        "message",
+        [CT2_PLAIN_OOM, CT2_THRUST_OOM, TORCH_OOM],
+        ids=["ct2-plain", "ct2-thrust-misreport", "torch"],
+    )
+    def test_every_observed_wording_is_recognised(self, message):
+        translated = as_gpu_oom(RuntimeError(message))
+        assert translated is not None, f"not recognised as a GPU OOM: {message}"
+        assert isinstance(translated, GpuOutOfMemoryError)
+
+    def test_message_leads_with_the_cause_in_plain_language(self):
+        translated = as_gpu_oom(RuntimeError(CT2_THRUST_OOM))
+        text = str(translated)
+        assert "out of memory" in text.lower()
+        assert "vram" in text.lower(), "the user-facing text should name VRAM"
+
+    def test_original_error_is_preserved_for_diagnosis(self):
+        """Never swallow the raw text — a genuine device fault must stay visible."""
+        translated = as_gpu_oom(RuntimeError(CT2_THRUST_OOM))
+        assert CT2_THRUST_OOM in str(translated)
+
+    def test_carries_an_actionable_remedy(self):
+        translated = as_gpu_oom(RuntimeError(CT2_PLAIN_OOM))
+        assert translated.remedy
+        assert len(translated.remedy) > 20
+
+    def test_cause_is_chained(self):
+        original = RuntimeError(CT2_PLAIN_OOM)
+        translated = as_gpu_oom(original)
+        assert translated.__cause__ is original
+
+
+class TestLeavesEverythingElseAlone:
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Audio file not found: /data/recordings/x.wav",
+            "STT model is not loaded",
+            "Framework pt is not supported",
+            "cudaErrorInvalidDevice: invalid device ordinal",
+            "invalid device ordinal",
+        ],
+        ids=["missing-file", "no-model", "framework", "bare-device-error", "bare-ordinal"],
+    )
+    def test_unrelated_failures_are_not_reclassified(self, message):
+        """A real device misconfiguration must NOT be relabelled as an OOM.
+
+        The thrust wrapper is the tell: 'parallel_for failed' means a kernel
+        dispatch during inference, not device selection. A bare invalid-device
+        error — which is what an out-of-range gpu_device_index would raise at
+        setup — has to pass through untouched.
+        """
+        assert as_gpu_oom(RuntimeError(message)) is None
+
+    def test_already_translated_errors_pass_through_unchanged(self):
+        already = GpuOutOfMemoryError("boom", remedy="do the thing")
+        assert as_gpu_oom(already) is already
+
+    def test_torch_oom_subclass_is_recognised_without_message_matching(self):
+        """torch raises a dedicated class; match on type, not only on wording."""
+
+        class OutOfMemoryError(RuntimeError):
+            """Stands in for torch.cuda.OutOfMemoryError."""
+
+        exc = OutOfMemoryError("some future wording we have never seen")
+        assert as_gpu_oom(exc) is not None

--- a/server/backend/tests/test_retry_clears_gpu_cache.py
+++ b/server/backend/tests/test_retry_clears_gpu_cache.py
@@ -1,0 +1,139 @@
+"""A retry must not inherit the GPU state of the failure that caused it.
+
+Retry exists almost exclusively to recover from a CUDA OOM, so it runs at the
+one moment the GPU is most likely to still be saturated: the transcription
+model is resident and keeps its allocations, and whatever else exhausted the
+card may only just have let go.
+
+Observed 2026-08-01 on an 11.6 GB card with an LLM loaded alongside: a job died
+with "CUDA failed with error out of memory", the first retry 20 s later died
+inside CTranslate2 with "parallel_for failed: cudaErrorInvalidDevice: invalid
+device ordinal", and a second retry 9 s after that succeeded with no code
+change in between. Dropping the cached allocator blocks before re-transcribing
+gives the retry the free VRAM it needs instead of making the user click twice.
+
+Run:  ../../build/.venv/bin/pytest tests/test_retry_clears_gpu_cache.py -v --tb=short
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+
+from server.api.routes import transcription
+
+
+@dataclass
+class _FakeResult:
+    text: str = "recovered"
+    segments: list[dict[str, Any]] = field(default_factory=list)
+    words: list[dict[str, Any]] = field(default_factory=list)
+    language: str | None = "en"
+    language_probability: float = 0.0
+    duration: float = 1.0
+    num_speakers: int = 0
+    partial: bool = False
+    partial_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "text": self.text,
+            "segments": self.segments,
+            "words": self.words,
+            "language": self.language,
+            "duration": self.duration,
+            "partial": self.partial,
+            "partial_reason": self.partial_reason,
+        }
+
+
+def _drive_retry(monkeypatch, *, transcribe_raises: Exception | None = None) -> list[str]:
+    """Run _run_retry and return the ordered trace of collaborator calls."""
+    trace: list[str] = []
+
+    def _transcribe(*_args: Any, **_kwargs: Any) -> _FakeResult:
+        trace.append("transcribe_file")
+        if transcribe_raises is not None:
+            raise transcribe_raises
+        return _FakeResult()
+
+    fake_engine = SimpleNamespace(transcribe_file=_transcribe)
+    model_manager = SimpleNamespace(
+        job_tracker=SimpleNamespace(
+            try_start_job=lambda _client: (True, "tracker-1", None),
+            end_job=lambda _id: None,
+        ),
+        ensure_transcription_loaded=lambda: fake_engine,
+    )
+
+    audio_utils = importlib.import_module("server.core.audio_utils")
+    monkeypatch.setattr(
+        audio_utils, "clear_gpu_cache", lambda: trace.append("clear_gpu_cache"), raising=False
+    )
+
+    repo = importlib.import_module("server.database.job_repository")
+    monkeypatch.setattr(repo, "save_result", lambda **_kw: trace.append("save_result"))
+    monkeypatch.setattr(repo, "mark_failed", lambda _id, _msg: trace.append("mark_failed"))
+
+    job = {
+        "client_name": "test-client",
+        "language": None,
+        "task": "transcribe",
+        "translation_target": None,
+    }
+    asyncio.run(
+        transcription._run_retry(
+            "job-1", "/fake/audio.wav", job, SimpleNamespace(model_manager=model_manager)
+        )
+    )
+    return trace
+
+
+def test_gpu_cache_cleared_before_retrying(monkeypatch):
+    """The freed-VRAM step must happen before the model is asked to transcribe."""
+    trace = _drive_retry(monkeypatch)
+
+    assert "clear_gpu_cache" in trace, "retry did not release cached VRAM before re-transcribing"
+    assert trace.index("clear_gpu_cache") < trace.index("transcribe_file"), (
+        f"clear_gpu_cache must precede transcribe_file, got {trace}"
+    )
+    assert "save_result" in trace
+
+
+def test_retry_still_succeeds_if_cache_clear_fails(monkeypatch):
+    """Freeing VRAM is best-effort — it must never sink an otherwise-good retry."""
+    trace: list[str] = []
+
+    fake_engine = SimpleNamespace(
+        transcribe_file=lambda *a, **k: (trace.append("transcribe_file"), _FakeResult())[1]
+    )
+    model_manager = SimpleNamespace(
+        job_tracker=SimpleNamespace(
+            try_start_job=lambda _client: (True, "tracker-1", None),
+            end_job=lambda _id: None,
+        ),
+        ensure_transcription_loaded=lambda: fake_engine,
+    )
+
+    def _boom() -> None:
+        raise RuntimeError("no CUDA context")
+
+    audio_utils = importlib.import_module("server.core.audio_utils")
+    monkeypatch.setattr(audio_utils, "clear_gpu_cache", _boom, raising=False)
+
+    repo = importlib.import_module("server.database.job_repository")
+    monkeypatch.setattr(repo, "save_result", lambda **_kw: trace.append("save_result"))
+    monkeypatch.setattr(repo, "mark_failed", lambda _id, _msg: trace.append("mark_failed"))
+
+    job = {"client_name": "c", "language": None, "task": "transcribe", "translation_target": None}
+    asyncio.run(
+        transcription._run_retry(
+            "job-2", "/fake/audio.wav", job, SimpleNamespace(model_manager=model_manager)
+        )
+    )
+
+    assert "save_result" in trace, f"a failing cache clear aborted the retry: {trace}"
+    assert "mark_failed" not in trace

--- a/server/backend/tests/test_whisperx_align_model_recovery.py
+++ b/server/backend/tests/test_whisperx_align_model_recovery.py
@@ -1,0 +1,106 @@
+"""WhisperX alignment must survive a failed alignment-model load.
+
+`_align()` used to `del self._align_model` before loading the replacement. When
+that load raised — a CUDA OOM during alignment is the common case, since the
+alignment model is loaded while the transcription model is still resident — the
+attribute stayed *deleted*, not None. Every later call then died on
+
+    AttributeError: 'WhisperXBackend' object has no attribute '_align_model'
+
+at the `if self._align_model is None` guard, which cannot short-circuit an
+attribute that does not exist. The caller logs that as "alignment failed, using
+raw timestamps" and continues, so a single OOM silently disabled word-level
+timestamps for the entire life of the process.
+
+Observed 2026-08-01: an alignment OOM at 07:12:31 left every subsequent
+transcription in that container without alignment.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.usefixtures("torch_stub")
+
+
+def _install_soundfile_stub() -> None:
+    if "soundfile" not in sys.modules:
+        soundfile_stub = types.ModuleType("soundfile")
+        soundfile_stub.read = lambda *args, **kwargs: (
+            np.zeros(16000, dtype=np.float32),
+            16000,
+        )
+        sys.modules["soundfile"] = soundfile_stub
+
+
+def _import_whisperx_backend():
+    _install_soundfile_stub()
+    return importlib.import_module("server.core.stt.backends.whisperx_backend")
+
+
+class _BoomOnLoad:
+    """Stands in for the `whisperx` module: loading an align model always fails."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+        self.load_calls = 0
+
+    def load_align_model(self, *args, **kwargs):
+        self.load_calls += 1
+        raise self._exc
+
+    def align(self, *args, **kwargs):  # pragma: no cover - never reached
+        raise AssertionError("align() must not run when the model failed to load")
+
+
+def _make_backend(module):
+    """A backend instance with an alignment model already cached for English."""
+    backend = object.__new__(module.WhisperXBackend)
+    backend._device = "cpu"
+    backend._align_model = object()
+    backend._align_metadata = {"language": "en"}
+    backend._align_language = "en"
+    return backend
+
+
+def test_failed_align_load_leaves_attribute_defined(monkeypatch):
+    """A raising load_align_model must leave _align_model as None, not deleted."""
+    module = _import_whisperx_backend()
+    fake_whisperx = _BoomOnLoad(RuntimeError("CUDA out of memory"))
+    monkeypatch.setattr(module, "_import_whisperx_modules", lambda: (fake_whisperx, None))
+
+    backend = _make_backend(module)
+
+    # Switching to a new language forces the reload path that used to `del`.
+    with pytest.raises(RuntimeError, match="CUDA out of memory"):
+        backend._align({"segments": []}, np.zeros(16000, dtype=np.float32), "el")
+
+    # The attribute must still exist. `getattr` with no default raises
+    # AttributeError on the old code, which is exactly the production failure.
+    assert backend._align_model is None
+    assert backend._align_metadata is None
+
+
+def test_alignment_retries_after_a_failed_load(monkeypatch):
+    """A later call must reach the loader again instead of dying on AttributeError."""
+    module = _import_whisperx_backend()
+    fake_whisperx = _BoomOnLoad(RuntimeError("CUDA out of memory"))
+    monkeypatch.setattr(module, "_import_whisperx_modules", lambda: (fake_whisperx, None))
+
+    backend = _make_backend(module)
+    audio = np.zeros(16000, dtype=np.float32)
+
+    with pytest.raises(RuntimeError):
+        backend._align({"segments": []}, audio, "el")
+    # Second attempt: previously AttributeError, so the loader was never retried.
+    with pytest.raises(RuntimeError):
+        backend._align({"segments": []}, audio, "el")
+
+    assert fake_whisperx.load_calls == 2, (
+        "the second alignment attempt must reach load_align_model again"
+    )


### PR DESCRIPTION
Four commits, each independently revertable. The first adds the feature; the rest fix defects that hardware testing of that feature exposed.

## 1. Retry on the error banner — `7454b643`

A transcription that dies mid-flight (CUDA OOM, crashed backend, killed sidecar) left the user at a dead end: a red banner and no way forward.

The audio was never lost. `process_transcription()` writes the WAV and records `audio_path` on the durability row **before** transcription is attempted, and the retention sweep selects `status='completed' AND delivered=1` — a failed job can never match, at any age. `POST /api/transcribe/retry/{job_id}` could always re-transcribe from that file. The error banner just never offered it.

The button is rendered whenever a job id is known. `jobId` arrives with `session_started` and is only cleared by a new `start()`, so it is still present when the banner shows. If the socket died before a job existed, no button appears — there is nothing to retry from.

**The retry now delivers a transcript.** `handleRetryPartial` called the endpoint, raised a toast and stopped — but the WebSocket that carried the original job is already gone, so the text never came back. Both banners now share one `handleRetry` that polls `GET /api/transcribe/result/{job_id}` and hands the result to `loadResult`. The partial-transcript banner gains this too; it previously delivered nothing. Polling runs every 3 s for up to 5 min, then defers to the recovery banner. Cancelled on unmount.

`loadResult` now also clears `error` — it set status to `complete` but left the stale error text beside the transcript that had just replaced it. Same latent issue on the recovery-notification **View** button.

Refusals are explained: `409` (model busy) and `410` (audio deleted) reach the toast description instead of a generic `API 409 on /path`.

## 2. Alignment dies permanently after one OOM — `d8430747`

Found in the logs while testing the above.

`_align()` did `del self._align_model` before calling `load_align_model()`. A CUDA OOM there is routine — the alignment model loads while the transcription model is still resident. When that load raised, the attribute stayed **deleted**, not None, and the `if self._align_model is None` guard cannot short-circuit an attribute that does not exist:

```
AttributeError: 'WhisperXBackend' object has no attribute '_align_model'
```

The caller logs that as `alignment failed, using raw timestamps` and continues, so **a single OOM silently disabled word-level timestamps for the rest of the process lifetime**. Both log lines are in the same container run:

```
07:12:31  WhisperX alignment failed, using raw timestamps: CUDA out of memory. Tried to allocate 20.00 MiB
07:14:05  WhisperX alignment failed, using raw timestamps: 'WhisperXBackend' object has no attribute '_align_model'
```

Fix: assign `None` instead of deleting, and reset `_align_language` alongside it.

## 3. The first retry after an OOM fails — `bf301e00`

Retry runs at the one moment the card is most likely still saturated. Observed on an 11.6 GB card with an LLM loaded alongside:

```
07:13:35  Transcription error: CUDA failed with error out of memory
07:13:55  Retry #1 → parallel_for failed: cudaErrorInvalidDevice: invalid device ordinal
07:14:05  Retry #2 → complete
```

No code changed between those two retries. `_run_retry` now calls `clear_gpu_cache()` before re-transcribing, best-effort.

**Honest limitation:** I have not proven why CTranslate2 reports a saturated card as `cudaErrorInvalidDevice` rather than a clean OOM. What is established is that the card was starved and that a second attempt moments later succeeded. This is mitigation aimed at that observation, not a root-caused fix for the CTranslate2 error mapping. If it recurs after this change, the next step is unloading and reloading the model on the retry path rather than only dropping cached blocks.

## 4. ui-contract scan corrupted by comment prose — `c66cf360`

This bit me while writing commit 1, and it will bite anyone editing comments in a scanned file.

`extractQuotedStrings` ran a regex over the whole file and paired quote characters positionally — 1st with 2nd, 3rd with 4th. A lone apostrophe **anywhere**, including inside a comment, shifts that pairing for the entire rest of the file. Real className strings then get read as the gaps *between* strings and vanish from the contract, while comment fragments take their place.

Deleting a comment containing `job's` flipped `SessionView.tsx` from 936 to 949 single quotes and produced a `set_mismatch` error naming CSS classes — pointing nowhere near the comment that caused it.

Replaced the regex prepass with an explicit state machine, which holds in both directions: `'https://example.com'` keeps its comment markers, and quotes inside comments are discarded before pairing.

The rebuilt contract shows the scale of the old corruption:

- **Drops 5 tokens that were never CSS classes**, only comment prose: `bottom-anchored`, `max-height`, `min-height`, `translate-to-English`, `"hover:"`
- **Restores 20 real utilities** the old scan had swallowed: `text-rose-400`, `w-80`, `border-emerald-500/40`, `lg:p-8`, `mx-1`, `mx-2`, `ml-3`, `max-h-80`, `bg-emerald-500/10` and others

Each was checked by hand — the drops appear only inside comments, the restorations only in real `className` positions.

## Test plan

- [x] `npm run check` (typecheck, eslint, prettier, ui-contract) — exit 0
- [x] Dashboard suite — 136/136 files, 1969/1969 tests
- [x] Backend suite — 2210 passed, 4 skipped
- [x] ui-contract harness — 22 checks (was 16); 6 new cover comment stripping in both directions plus escaped quotes
- [x] Retry verified on real hardware: button rendered, endpoint called, poll surfaced the server reason, transcript recovered
- [x] `POST /api/transcribe/retry/{job_id}` verified end-to-end against a real CUDA-OOM job
- [ ] Hardware smoke: exhaust VRAM, fail a job, click **Retry** **once** — confirm it now succeeds on the first click
- [ ] Hardware smoke: after an alignment OOM, confirm a later transcription still produces word timestamps
- [ ] Hardware smoke: click **Retry** while another job is running, confirm the 409 reason reaches the toast

## Review order

Commits 2 and 3 are independent of the dashboard change and can be cherry-picked or reverted on their own. Commit 4 touches only build tooling and the generated contract; the 24-line contract delta is the whole of its runtime effect.
