### PR TITLE
feat(server): VRAM discipline - post-job cache release, leak fixes, low VRAM mode

### DIFF
--- a/dashboard/src/api/types.ts
+++ b/dashboard/src/api/types.ts
@@ -15,17 +15,30 @@ export interface ReadyResponse {
   models?: Record<string, unknown>;
 }
 
+export interface GpuMemoryInfo {
+  available: boolean;
+  /** This process's PyTorch caching allocator only (excludes CTranslate2). */
+  allocated_gb?: number;
+  reserved_gb?: number;
+  total_gb?: number;
+  free_gb?: number;
+  /** Device-wide numbers from the driver (include all processes). */
+  device_free_gb?: number;
+  device_used_gb?: number;
+  error?: string;
+}
+
 export interface ServerStatus {
   status: string;
   version?: string;
   models?: Record<string, unknown> & {
     transcription?: { selected_model?: string; loaded?: boolean; disabled?: boolean };
+    gpu_memory?: GpuMemoryInfo | null;
   };
   features?: Record<string, unknown>;
   ready?: boolean;
   uptime?: number;
   gpu_available?: boolean;
-  gpu_memory?: string;
   gpu_error?: string;
   gpu_error_action?: string;
   /**

--- a/docs/superpowers/plans/2026-08-01-vram-discipline.md
+++ b/docs/superpowers/plans/2026-08-01-vram-discipline.md
@@ -122,7 +122,7 @@ class TestPostJobGpuCleanup:
             au.post_job_gpu_cleanup("test job")  # must not raise
 ```
 
-Note: `test_unavailable_when_no_cuda` already exists — keep it, add the new methods to the same class.
+Note: `test_unavailable_when_no_cuda` already exists - keep it, add the new methods to the same class.
 
 - [ ] **Step 2: Run tests to verify the new ones fail**
 
@@ -145,7 +145,7 @@ def get_gpu_memory_info(device_index: int = 0) -> dict:
       allocator only. The CTranslate2 transcription model allocates outside
       this allocator and is invisible here.
     - device_free_gb/device_used_gb: the whole device as the driver sees it
-      (includes CTranslate2 and other processes). Best-effort — absent when
+      (includes CTranslate2 and other processes). Best-effort - absent when
       the runtime does not support mem_get_info.
 
     Args:
@@ -188,7 +188,7 @@ def post_job_gpu_cleanup(context: str = "job") -> None:
 
     Hands the caching allocators' unused blocks back to the driver so
     co-resident GPU workloads (e.g. a local LLM sharing the card) get the
-    VRAM between jobs. The transcription model itself stays warm — only
+    VRAM between jobs. The transcription model itself stays warm - only
     freed-but-cached blocks are returned. Best-effort: never raises.
 
     Args:
@@ -224,7 +224,7 @@ git commit -m "feat(server): device-wide GPU memory reporting and a post-job cle
 
 ### Task 2: Run the cleanup at every job-completion site
 
-Today no job-completion path touches the GPU (verified). Add `post_job_gpu_cleanup()` to the `finally` of all five completion sites. Explicitly EXCLUDED: `preview_transcription()` (`websocket.py:339-346`) — the rolling preview fires every few seconds during recording and clearing the cache per preview chunk would thrash the allocator.
+Today no job-completion path touches the GPU (verified). Add `post_job_gpu_cleanup()` to the `finally` of all five completion sites. Explicitly EXCLUDED: `preview_transcription()` (`websocket.py:339-346`) - the rolling preview fires every few seconds during recording and clearing the cache per preview chunk would thrash the allocator.
 
 The helper's signature is `post_job_gpu_cleanup(context: str = "job", device_index: int = 0)`. Every completion site has a `model_manager` in scope, so pass the server's configured device index instead of assuming GPU 0. `ModelManager` keeps that as the private `_gpu_device_index`; expose it as a read-only property (4 lines) rather than reaching into a private attribute from the route layer.
 
@@ -236,7 +236,7 @@ The helper's signature is `post_job_gpu_cleanup(context: str = "job", device_ind
 - Modify: `server/backend/api/routes/openai_audio.py` (`create_transcription` finally ~465-468; `create_translation` finally ~583-586)
 - Test: `server/backend/tests/test_post_job_gpu_cleanup_sites.py` (new), `server/backend/tests/test_p0_durability.py` (extend), `server/backend/tests/test_retry_clears_gpu_cache.py` (extend)
 
-- [ ] **Step 1: Write the failing tests — new file**
+- [ ] **Step 1: Write the failing tests - new file**
 
 Create `server/backend/tests/test_post_job_gpu_cleanup_sites.py`:
 
@@ -410,7 +410,7 @@ def test_openai_translation_runs_gpu_cleanup(monkeypatch):
     assert ended == ["job-1"]
 ```
 
-Adaptation notes for the executor: (a) check `create_translation`'s actual signature in `openai_audio.py` before writing its test — mirror `create_transcription`'s calling convention with that function's own required params; (b) if either notebook/import function requires an additional keyword not listed in its signature shown here, read the signature at `transcription.py:839-857` / `notebook.py:835-852` — both were verified current at plan time.
+Adaptation notes for the executor: (a) check `create_translation`'s actual signature in `openai_audio.py` before writing its test - mirror `create_transcription`'s calling convention with that function's own required params; (b) if either notebook/import function requires an additional keyword not listed in its signature shown here, read the signature at `transcription.py:839-857` / `notebook.py:835-852` - both were verified current at plan time.
 
 - [ ] **Step 2: Extend the WS durability tests**
 
@@ -472,11 +472,11 @@ def test_gpu_cleanup_runs_after_retry_completes(monkeypatch):
     assert trace == ["clear_gpu_cache", "transcribe_file", "post_job_gpu_cleanup"]
 ```
 
-(If `_drive_retry` needs other assertions updated because the trace list now has an extra entry, adjust existing assertions to check membership/prefix rather than exact equality — do NOT delete existing order checks between `clear_gpu_cache` and `transcribe_file`.)
+(If `_drive_retry` needs other assertions updated because the trace list now has an extra entry, adjust existing assertions to check membership/prefix rather than exact equality - do NOT delete existing order checks between `clear_gpu_cache` and `transcribe_file`.)
 
 **Required in this file:** both `SimpleNamespace` model-manager fakes (the one inside `_drive_retry` and the one inside `test_retry_still_succeeds_if_cache_clear_fails`, ~line 113) lack a `gpu_device_index`. Add `gpu_device_index=0,` to each, otherwise the new `model_manager.gpu_device_index` lookup in `_run_retry`'s finally raises AttributeError and both pre-existing tests break. Apply the same check to every other fake model manager the suite feeds into the five edited paths.
 
-- [ ] **Step 4: Run all three test files — expect the new tests to FAIL**
+- [ ] **Step 4: Run all three test files - expect the new tests to FAIL**
 
 ```bash
 cd server/backend
@@ -485,15 +485,15 @@ cd server/backend
 
 - [ ] **Step 5: Implement the five site edits**
 
-Context strings must match the tests exactly. All five files already use lazy imports for audio_utils; use the absolute form (`from server.core.audio_utils import ...`) — the relative import inside `_run_retry` is a one-off, don't copy it.
+Context strings must match the tests exactly. All five files already use lazy imports for audio_utils; use the absolute form (`from server.core.audio_utils import ...`) - the relative import inside `_run_retry` is a one-off, don't copy it.
 
 **Ordering rule (learned from review, applies to every site): the cleanup goes LAST in each `finally`, after every pre-existing statement.** Two reasons, both concrete:
-1. The async sites `await asyncio.to_thread(...)`. If the surrounding task is cancelled while inside that await, `CancelledError` propagates immediately and skips whatever follows in the same `finally`. At the retry and OpenAI sites the thing that follows is `job_tracker.end_job(...)` — and `TranscriptionJobTracker` is a single slot with no timeout and no admin force-release, so skipping it makes the server answer 429 "a transcription is already running" for every future job until restart.
+1. The async sites `await asyncio.to_thread(...)`. If the surrounding task is cancelled while inside that await, `CancelledError` propagates immediately and skips whatever follows in the same `finally`. At the retry and OpenAI sites the thing that follows is `job_tracker.end_job(...)` - and `TranscriptionJobTracker` is a single slot with no timeout and no admin force-release, so skipping it makes the server answer 429 "a transcription is already running" for every future job until restart.
 2. The argument expression `model_manager.gpu_device_index` is evaluated unguarded. If it ever raised, it would abort the `finally` before the pre-existing temp-file unlink.
 
-Putting the cleanup last makes both failure modes harmless: nothing important is sequenced behind it. The cost is that the job slot is released a fraction of a second before the cache clear runs, which is fine — `empty_cache()` is safe to call while another thread allocates.
+Putting the cleanup last makes both failure modes harmless: nothing important is sequenced behind it. The cost is that the job slot is released a fraction of a second before the cache clear runs, which is fine - `empty_cache()` is safe to call while another thread allocates.
 
-**(0) `model_manager.py`** — add next to the other properties (e.g. above `transcription_engine`, line ~714):
+**(0) `model_manager.py`** - add next to the other properties (e.g. above `transcription_engine`, line ~714):
 
 ```python
     @property
@@ -510,7 +510,7 @@ Putting the cleanup last makes both failure modes harmless: nothing important is
             # workloads (e.g. a local LLM) get the VRAM between jobs. The
             # model stays warm; run in a thread because empty_cache blocks.
             # The local model_manager is bound inside the try, so resolve the
-            # device index from the singleton instead — a failure before that
+            # device index from the singleton instead - a failure before that
             # binding must not turn into a NameError in this finally.
             from server.core.audio_utils import post_job_gpu_cleanup
             from server.core.model_manager import get_model_manager
@@ -521,11 +521,11 @@ Putting the cleanup last makes both failure modes harmless: nothing important is
                 _device_index = 0
             await asyncio.to_thread(post_job_gpu_cleanup, "longform recording", _device_index)
 
-            # Only delete files in /tmp — persistent audio in recordings_dir must survive
+            # Only delete files in /tmp - persistent audio in recordings_dir must survive
 ```
-(`asyncio` is already imported in websocket.py — verify, add if not. Verified at plan time: `model_manager = get_model_manager()` sits at `websocket.py:429`, inside the same `try` whose `finally` this is, hence the guard.)
+(`asyncio` is already imported in websocket.py - verify, add if not. Verified at plan time: `model_manager = get_model_manager()` sits at `websocket.py:429`, inside the same `try` whose `finally` this is, hence the guard.)
 
-**(b) `transcription.py` `_run_file_import` finally (lines ~1182-1187)** — this is a sync function running in a thread; call directly. Insert at the top of the `finally:` block:
+**(b) `transcription.py` `_run_file_import` finally (lines ~1182-1187)** - this is a sync function running in a thread; call directly. Insert at the top of the `finally:` block:
 
 ```python
     finally:
@@ -536,7 +536,7 @@ Putting the cleanup last makes both failure modes harmless: nothing important is
         # Cleanup temp file
 ```
 
-**(c) `transcription.py` `_run_retry` finally (lines ~1642-1644)** — async function; keep the existing pre-flight `clear_gpu_cache` untouched and add post-job cleanup before `end_job`:
+**(c) `transcription.py` `_run_retry` finally (lines ~1642-1644)** - async function; keep the existing pre-flight `clear_gpu_cache` untouched and add post-job cleanup before `end_job`:
 
 ```python
     finally:
@@ -547,7 +547,7 @@ Putting the cleanup last makes both failure modes harmless: nothing important is
             model_manager.job_tracker.end_job(tracker_job_id)
 ```
 
-**(d) `notebook.py` `_run_transcription` finally (lines ~1250-1255)** — sync, direct call:
+**(d) `notebook.py` `_run_transcription` finally (lines ~1250-1255)** - sync, direct call:
 
 ```python
     finally:
@@ -558,7 +558,7 @@ Putting the cleanup last makes both failure modes harmless: nothing important is
         # Cleanup temp file
 ```
 
-**(e) `openai_audio.py` both handlers' finally blocks (~465-468 and ~583-586)** — async; cleanup goes LAST, after `end_job` and the temp-file unlink (see the ordering rule below):
+**(e) `openai_audio.py` both handlers' finally blocks (~465-468 and ~583-586)** - async; cleanup goes LAST, after `end_job` and the temp-file unlink (see the ordering rule below):
 
 ```python
     finally:
@@ -573,7 +573,7 @@ Putting the cleanup last makes both failure modes harmless: nothing important is
 ```
 (second handler: context string `"openai translation"`.)
 
-- [ ] **Step 6: Run the three test files again — all PASS — then the FULL suite**
+- [ ] **Step 6: Run the three test files again - all PASS - then the FULL suite**
 
 ```bash
 cd server/backend
@@ -591,13 +591,13 @@ git commit -m "feat(server): release cached GPU memory after every transcription
 
 ### Task 3: Fix the parallel-diarization VRAM leak
 
-`transcribe_and_diarize()` (`parallel_diarize.py:120-259`) loads the diarization model and never unloads it — it stays resident forever after the first parallel-diarize job. Its sequential sibling `transcribe_then_diarize()` unloads in a `finally` (lines 103-117). Mirror that. Known tradeoff (accepted): back-to-back diarized imports in parallel mode will reload the diarization model per job (~10-20 s); consistency and VRAM discipline win.
+`transcribe_and_diarize()` (`parallel_diarize.py:120-259`) loads the diarization model and never unloads it - it stays resident forever after the first parallel-diarize job. Its sequential sibling `transcribe_then_diarize()` unloads in a `finally` (lines 103-117). Mirror that. Known tradeoff (accepted): back-to-back diarized imports in parallel mode will reload the diarization model per job (~10-20 s); consistency and VRAM discipline win.
 
 **Files:**
 - Modify: `server/backend/core/parallel_diarize.py:120-259`
 - Test: `server/backend/tests/test_parallel_diarize.py`
 
-- [ ] **Step 1: Write the failing tests** — add to `test_parallel_diarize.py` (imports/patterns already in the file):
+- [ ] **Step 1: Write the failing tests** - add to `test_parallel_diarize.py` (imports/patterns already in the file):
 
 ```python
 @patch("server.core.audio_utils.load_audio", return_value=(MagicMock(), 16000))
@@ -637,7 +637,7 @@ def test_parallel_transcribe_failure_still_unloads_diarization_model(mock_load_a
 
 @patch("server.core.audio_utils.load_audio", side_effect=RuntimeError("bad audio"))
 def test_preload_failure_unloads_diarization_model(mock_load_audio):
-    """load_diarization_model may succeed before load_audio fails — release it."""
+    """load_diarization_model may succeed before load_audio fails - release it."""
     engine = MagicMock()
     engine.transcribe_file.return_value = MagicMock(words=[], segments=[])
     mm = MagicMock()
@@ -651,7 +651,7 @@ def test_preload_failure_unloads_diarization_model(mock_load_audio):
     mm.unload_diarization_model.assert_called_once()
 ```
 
-- [ ] **Step 2: Run — expect FAIL** (`unload_diarization_model` never called):
+- [ ] **Step 2: Run - expect FAIL** (`unload_diarization_model` never called):
 
 ```bash
 ../../build/.venv/bin/pytest tests/test_parallel_diarize.py -v --tb=short
@@ -659,7 +659,7 @@ def test_preload_failure_unloads_diarization_model(mock_load_audio):
 
 - [ ] **Step 3: Implement.** ONE edit: wrap everything after the Phase 1 pre-load block in a single `try/finally`.
 
-The `try:` opens immediately after the pre-load `except Exception:` block (i.e. just before the `# If pre-load failed, just transcribe normally` comment at `parallel_diarize.py:163`) and the `finally:` closes at the end of the function. Everything in between — the transcription-only fallback branch, the Sortformer sequential hand-off, and the whole `ThreadPoolExecutor` block — gets re-indented one level and is otherwise unchanged.
+The `try:` opens immediately after the pre-load `except Exception:` block (i.e. just before the `# If pre-load failed, just transcribe normally` comment at `parallel_diarize.py:163`) and the `finally:` closes at the end of the function. Everything in between - the transcription-only fallback branch, the Sortformer sequential hand-off, and the whole `ThreadPoolExecutor` block - gets re-indented one level and is otherwise unchanged.
 
 This single wrap covers all four exits (fallback return, Sortformer return, success return, exception) instead of duplicating the unload per branch. It also fixes the fallback path, where `load_diarization_model()` may have succeeded before `load_audio()` failed, leaving a loaded model behind while running transcription-only.
 
@@ -676,19 +676,19 @@ This single wrap covers all four exits (fallback return, Sortformer return, succ
         ...  # one level deeper
     finally:
         # Mirror transcribe_then_diarize: the diarization model is only
-        # needed during this job — release its VRAM instead of leaving it
+        # needed during this job - release its VRAM instead of leaving it
         # resident forever (this path never unloaded it before). Idempotent,
         # so the Sortformer branch unloading on its own is fine.
         model_manager.unload_diarization_model()
 ```
 
-**Superseded by review (2026-08-01):** guard it instead — `try: model_manager.unload_diarization_model() except Exception: logger.warning(...)` — and apply the same guard to the sequential sibling's call at line 110. Reason: the new `finally` also covers the cancellation exit, and an unload failure would replace an in-flight `TranscriptionCancelledError`, which the routes catch specifically to return HTTP 499 instead of a 500. The original instruction was:
+**Superseded by review (2026-08-01):** guard it instead - `try: model_manager.unload_diarization_model() except Exception: logger.warning(...)` - and apply the same guard to the sequential sibling's call at line 110. Reason: the new `finally` also covers the cancellation exit, and an unload failure would replace an in-flight `TranscriptionCancelledError`, which the routes catch specifically to return HTTP 499 instead of a 500. The original instruction was:
 
-~~Call `unload_diarization_model()` unguarded, exactly as the sequential sibling does at line 110 — it already swallows the failures it can (`AttributeError` on `unload()`, any error from `shutdown_mlx_thread`), and diverging from the sibling's shape here would be worse than the residual risk.~~
+~~Call `unload_diarization_model()` unguarded, exactly as the sequential sibling does at line 110 - it already swallows the failures it can (`AttributeError` on `unload()`, any error from `shutdown_mlx_thread`), and diverging from the sibling's shape here would be worse than the residual risk.~~
 
-Also add: a test proving a raising `unload_diarization_model` does not mask the original transcription exception, and a test pinning the real idempotency of `ModelManager.unload_diarization_model` (the outer `finally` depends on it, since the Sortformer branch already unloaded via the sibling). Do NOT assert `assert_called_once()` on a Sortformer-path mock — the mock is legitimately called twice there; the idempotency lives in the real implementation.
+Also add: a test proving a raising `unload_diarization_model` does not mask the original transcription exception, and a test pinning the real idempotency of `ModelManager.unload_diarization_model` (the outer `finally` depends on it, since the Sortformer branch already unloaded via the sibling). Do NOT assert `assert_called_once()` on a Sortformer-path mock - the mock is legitimately called twice there; the idempotency lives in the real implementation.
 
-- [ ] **Step 4: Run `test_parallel_diarize.py` — all PASS** (the pre-existing 12 tests use a MagicMock model_manager, so the new unload call cannot break them).
+- [ ] **Step 4: Run `test_parallel_diarize.py` - all PASS** (the pre-existing 12 tests use a MagicMock model_manager, so the new unload call cannot break them).
 
 - [ ] **Step 5: Commit**
 
@@ -701,13 +701,13 @@ git commit -m "fix(server): unload the diarization model after parallel diarizat
 
 ### Task 4: `shutdown()` must unload owned backends
 
-`AudioToTextRecorder.shutdown()` (`engine.py:1165-1187`) drops `self._backend` without calling `backend.unload()`, so VRAM release is left to the garbage collector and cached allocator blocks are never returned. `unload_model()` (lines 1196-1206) does it correctly — mirror it.
+`AudioToTextRecorder.shutdown()` (`engine.py:1165-1187`) drops `self._backend` without calling `backend.unload()`, so VRAM release is left to the garbage collector and cached allocator blocks are never returned. `unload_model()` (lines 1196-1206) does it correctly - mirror it.
 
 **Files:**
 - Modify: `server/backend/core/stt/engine.py:1180-1184` (the "Cleanup backend" tail of `shutdown()`)
-- Test: `server/backend/tests/test_stt_engine_helpers.py` (this file already imports the engine module successfully — follow ITS import style; do not invent a new import path, the engine module needs the conftest-provided mocks)
+- Test: `server/backend/tests/test_stt_engine_helpers.py` (this file already imports the engine module successfully - follow ITS import style; do not invent a new import path, the engine module needs the conftest-provided mocks)
 
-- [ ] **Step 1: Write the failing tests** — add to `test_stt_engine_helpers.py`. Verified in that file: `AudioToTextRecorder` is imported directly (no module alias), `MagicMock` is already imported, `object.__new__(AudioToTextRecorder)` is the established fixture pattern (see `_bare_recorder` at line 177), and `threading` is imported locally inside such helpers rather than at module top.
+- [ ] **Step 1: Write the failing tests** - add to `test_stt_engine_helpers.py`. Verified in that file: `AudioToTextRecorder` is imported directly (no module alias), `MagicMock` is already imported, `object.__new__(AudioToTextRecorder)` is the established fixture pattern (see `_bare_recorder` at line 177), and `threading` is imported locally inside such helpers rather than at module top.
 
 ```python
 def _make_recorder_for_shutdown(owns_backend: bool):
@@ -766,7 +766,7 @@ class TestShutdownUnloadsBackend:
         assert rec._backend is None
 ```
 
-- [ ] **Step 2: Run — expect FAIL** (`unload` never called):
+- [ ] **Step 2: Run - expect FAIL** (`unload` never called):
 
 ```bash
 ../../build/.venv/bin/pytest tests/test_stt_engine_helpers.py -v --tb=short -k Shutdown
@@ -783,7 +783,7 @@ class TestShutdownUnloadsBackend:
 with:
 
 ```python
-        # Cleanup backend — actually unload owned backends instead of just
+        # Cleanup backend - actually unload owned backends instead of just
         # dropping the reference: a dropped reference leaves the model's VRAM
         # to the garbage collector and never returns cached allocator blocks
         # to the driver. Shared backends belong to the caller (Live Mode).
@@ -806,9 +806,9 @@ git commit -m "fix(server): shutdown() unloads owned STT backends instead of dro
 
 ---
 
-### Task 5: `low_vram_mode` — batch cap
+### Task 5: `low_vram_mode` - batch cap
 
-One opt-in boolean (`main_transcriber.low_vram_mode`, default `false`). When ON, the transcription batch size is capped at 4, which shrinks the measured +2.8 GB transient peak roughly in half. Both the transcription model and the alignment model always stay warm — this mode changes nothing about model residency, only the per-job working set. **Dashboard UI is free:** `ServerConfigEditor.tsx` auto-renders every boolean template key as an AppleSwitch with the yaml comment as description — no dashboard code changes.
+One opt-in boolean (`main_transcriber.low_vram_mode`, default `false`). When ON, the transcription batch size is capped at 4, which shrinks the measured +2.8 GB transient peak roughly in half. Both the transcription model and the alignment model always stay warm - this mode changes nothing about model residency, only the per-job working set. **Dashboard UI is free:** `ServerConfigEditor.tsx` auto-renders every boolean template key as an AppleSwitch with the yaml comment as description - no dashboard code changes.
 
 **Do NOT** touch `whisperx_backend.py` or `engine.py` in this task. An earlier draft of this plan also released the alignment model in this mode; the user removed that from scope. There is no engine→backend plumbing to add: `_scale_batch_size` reads `self.config` directly.
 
@@ -818,7 +818,7 @@ One opt-in boolean (`main_transcriber.low_vram_mode`, default `false`). When ON,
 - Modify: `server/backend/core/model_manager.py` (`_scale_batch_size`, lines 672-712)
 - Test: `server/backend/tests/test_low_vram_mode.py` (new)
 
-- [ ] **Step 1: Write the failing tests — new file** `server/backend/tests/test_low_vram_mode.py`:
+- [ ] **Step 1: Write the failing tests - new file** `server/backend/tests/test_low_vram_mode.py`:
 
 ```python
 """Low VRAM mode: cap the transcription batch size at 4.
@@ -885,14 +885,14 @@ class TestScaleBatchSizeLowVram:
             assert mm._scale_batch_size(16) == 8
 ```
 
-- [ ] **Step 2: Run the new test file — expect FAIL** (`ImportError: cannot import name 'resolve_low_vram_mode'`):
+- [ ] **Step 2: Run the new test file - expect FAIL** (`ImportError: cannot import name 'resolve_low_vram_mode'`):
 
 ```bash
 cd server/backend
 ../../build/.venv/bin/pytest tests/test_low_vram_mode.py -v --tb=short
 ```
 
-- [ ] **Step 3: Implement — config layer.**
+- [ ] **Step 3: Implement - config layer.**
 
 `server/backend/config.py`: next to `DEFAULT_PARALLEL_DIARIZATION = False` (line 37) add:
 
@@ -931,7 +931,7 @@ def resolve_low_vram_mode(config: "ServerConfig | dict[str, Any]") -> bool:
     low_vram_mode: false
 ```
 
-- [ ] **Step 4: Implement — batch cap.** In `model_manager.py` `_scale_batch_size`, insert after the `if not self.gpu_available:` early return:
+- [ ] **Step 4: Implement - batch cap.** In `model_manager.py` `_scale_batch_size`, insert after the `if not self.gpu_available:` early return:
 
 ```python
         from server.config import resolve_low_vram_mode
@@ -945,7 +945,7 @@ def resolve_low_vram_mode(config: "ServerConfig | dict[str, Any]") -> bool:
             return configured_batch_size
 ```
 
-- [ ] **Step 5: Run the new test file — PASS — then the FULL backend suite.** Also check `test_model_manager*.py` specifically: any existing `_scale_batch_size` test builds its manager without a `low_vram_mode` key, so the resolver must tolerate a missing key (it does — that is what `test_default_is_off` pins).
+- [ ] **Step 5: Run the new test file - PASS - then the FULL backend suite.** Also check `test_model_manager*.py` specifically: any existing `_scale_batch_size` test builds its manager without a `low_vram_mode` key, so the resolver must tolerate a missing key (it does - that is what `test_default_is_off` pins).
 
 The toggle needs no dashboard work: `ServerConfigEditor` renders template keys generically (boolean → AppleSwitch, yaml comment → description). Note in the PR that the new key needs a server restart to apply, like every `main_transcriber` key.
 
@@ -960,7 +960,7 @@ git commit -m "feat(server): opt-in low VRAM mode that caps the transcription ba
 
 ### Task 6: Fix the stale dashboard type for `gpu_memory`
 
-`dashboard/src/api/types.ts:28` declares `gpu_memory?: string` at the top level of `ServerStatus`, but the backend actually nests a dict under `models.gpu_memory` (and sends no top-level `gpu_memory` at all). Verified: there are ZERO runtime consumers of this field anywhere in `dashboard/` — the fix is type-only, no UI, no ui-contract impact (no CSS classes touched).
+`dashboard/src/api/types.ts:28` declares `gpu_memory?: string` at the top level of `ServerStatus`, but the backend actually nests a dict under `models.gpu_memory` (and sends no top-level `gpu_memory` at all). Verified: there are ZERO runtime consumers of this field anywhere in `dashboard/` - the fix is type-only, no UI, no ui-contract impact (no CSS classes touched).
 
 **Files:**
 - Modify: `dashboard/src/api/types.ts:18-47`
@@ -1022,14 +1022,14 @@ cd server/backend
 
 - [ ] **Step 2: Dashboard suite** (`cd dashboard && nvm use && npx vitest run`).
 
-- [ ] **Step 3: GitNexus regression check:** `detect_changes({scope: "compare", base_ref: "main", repo: "TranscriptionSuite"})` — confirm only the intended symbols/flows changed.
+- [ ] **Step 3: GitNexus regression check:** `detect_changes({scope: "compare", base_ref: "main", repo: "TranscriptionSuite"})` - confirm only the intended symbols/flows changed.
 
 - [ ] **Step 4: Safety sweep:** `git diff main...HEAD` and check: no AI attribution anywhere, no leftover debug prints, comments state constraints (not narration).
 
 - [ ] **Step 5: Open the PR directly on GitHub** (no local draft files):
 
 ```bash
-gh pr create --title "feat(server): VRAM discipline — post-job cache release, leak fixes, low VRAM mode" --body "..."
+gh pr create --title "feat(server): VRAM discipline - post-job cache release, leak fixes, low VRAM mode" --body "..."
 ```
 
 PR body should cover: the measured baseline (5.83 GB anatomy, +2.8 GB transient peaks, motivation = LM Studio coexistence on a shared 3060), the five changes with one line each, the accepted tradeoffs (parallel diarization reloads the diarization model per job; low_vram_mode roughly halves batched throughput), and a **hardware smoke checklist** (not run in CI):
@@ -1045,9 +1045,9 @@ PR body should cover: the measured baseline (5.83 GB anatomy, +2.8 GB transient 
 
 ## Self-review notes (already applied)
 
-- The preview path (`preview_transcription`) is deliberately NOT wired to the cleanup — do not "fix" that during review.
+- The preview path (`preview_transcription`) is deliberately NOT wired to the cleanup - do not "fix" that during review.
 - The retry route keeps its pre-flight `clear_gpu_cache` AND gains the post-job cleanup; both are wanted.
-- `post_job_gpu_cleanup` contexts are load-bearing strings — tests assert them verbatim.
+- `post_job_gpu_cleanup` contexts are load-bearing strings - tests assert them verbatim.
 - `_scale_batch_size`'s existing tiered caps are unchanged when the mode is off; `test_tiered_caps_unchanged_when_off` pins that.
 - The WhisperX alignment model is never released between jobs (user decision). `whisperx_backend.py` is not touched by this plan at all.
 - All five completion-site edits use the absolute import form (`from server.core.audio_utils import post_job_gpu_cleanup`), matching house style; the relative import inside `_run_retry` predates this plan and stays as-is.

--- a/docs/superpowers/plans/2026-08-01-vram-discipline.md
+++ b/docs/superpowers/plans/2026-08-01-vram-discipline.md
@@ -487,6 +487,12 @@ cd server/backend
 
 Context strings must match the tests exactly. All five files already use lazy imports for audio_utils; use the absolute form (`from server.core.audio_utils import ...`) — the relative import inside `_run_retry` is a one-off, don't copy it.
 
+**Ordering rule (learned from review, applies to every site): the cleanup goes LAST in each `finally`, after every pre-existing statement.** Two reasons, both concrete:
+1. The async sites `await asyncio.to_thread(...)`. If the surrounding task is cancelled while inside that await, `CancelledError` propagates immediately and skips whatever follows in the same `finally`. At the retry and OpenAI sites the thing that follows is `job_tracker.end_job(...)` — and `TranscriptionJobTracker` is a single slot with no timeout and no admin force-release, so skipping it makes the server answer 429 "a transcription is already running" for every future job until restart.
+2. The argument expression `model_manager.gpu_device_index` is evaluated unguarded. If it ever raised, it would abort the `finally` before the pre-existing temp-file unlink.
+
+Putting the cleanup last makes both failure modes harmless: nothing important is sequenced behind it. The cost is that the job slot is released a fraction of a second before the cache clear runs, which is fine — `empty_cache()` is safe to call while another thread allocates.
+
 **(0) `model_manager.py`** — add next to the other properties (e.g. above `transcription_engine`, line ~714):
 
 ```python
@@ -552,7 +558,7 @@ Context strings must match the tests exactly. All five files already use lazy im
         # Cleanup temp file
 ```
 
-**(e) `openai_audio.py` both handlers' finally blocks (~465-468 and ~583-586)** — async; cleanup BEFORE `end_job` so the single job slot is still held while the cache clears (no race with the next job):
+**(e) `openai_audio.py` both handlers' finally blocks (~465-468 and ~583-586)** — async; cleanup goes LAST, after `end_job` and the temp-file unlink (see the ordering rule below):
 
 ```python
     finally:
@@ -627,6 +633,22 @@ def test_parallel_transcribe_failure_still_unloads_diarization_model(mock_load_a
         transcribe_and_diarize(engine=engine, model_manager=mm, file_path="/tmp/test.wav")
 
     mm.unload_diarization_model.assert_called_once()
+
+
+@patch("server.core.audio_utils.load_audio", side_effect=RuntimeError("bad audio"))
+def test_preload_failure_unloads_diarization_model(mock_load_audio):
+    """load_diarization_model may succeed before load_audio fails — release it."""
+    engine = MagicMock()
+    engine.transcribe_file.return_value = MagicMock(words=[], segments=[])
+    mm = MagicMock()
+    mm.diarization_engine = MagicMock()
+
+    result, diar = transcribe_and_diarize(
+        engine=engine, model_manager=mm, file_path="/tmp/test.wav"
+    )
+
+    assert diar is None
+    mm.unload_diarization_model.assert_called_once()
 ```
 
 - [ ] **Step 2: Run — expect FAIL** (`unload_diarization_model` never called):
@@ -635,33 +657,36 @@ def test_parallel_transcribe_failure_still_unloads_diarization_model(mock_load_a
 ../../build/.venv/bin/pytest tests/test_parallel_diarize.py -v --tb=short
 ```
 
-- [ ] **Step 3: Implement.** Two edits in `transcribe_and_diarize()`:
+- [ ] **Step 3: Implement.** ONE edit: wrap everything after the Phase 1 pre-load block in a single `try/finally`.
 
-(1) In the pre-load-failed fallback branch (the `if diar_engine is None or audio_data is None:` block), add a best-effort unload before transcribing — `load_diarization_model()` may have succeeded before `load_audio()` failed:
+The `try:` opens immediately after the pre-load `except Exception:` block (i.e. just before the `# If pre-load failed, just transcribe normally` comment at `parallel_diarize.py:163`) and the `finally:` closes at the end of the function. Everything in between — the transcription-only fallback branch, the Sortformer sequential hand-off, and the whole `ThreadPoolExecutor` block — gets re-indented one level and is otherwise unchanged.
 
-```python
-    if diar_engine is None or audio_data is None:
-        # Pre-load may have loaded the diarization model before load_audio
-        # failed — release it, we are about to run transcription-only.
-        model_manager.unload_diarization_model()
-        result = engine.transcribe_file(
-```
-
-(2) Wrap everything from the Sortformer check to the end of the function in `try/finally` (re-indent the existing code one level; the Sortformer branch's inner `transcribe_then_diarize` unloads on its own, so the outer finally is a harmless no-op there — `unload_diarization_model()` is idempotent):
+This single wrap covers all four exits (fallback return, Sortformer return, success return, exception) instead of duplicating the unload per branch. It also fixes the fallback path, where `load_diarization_model()` may have succeeded before `load_audio()` failed, leaving a loaded model behind while running transcription-only.
 
 ```python
+    # If pre-load failed, just transcribe normally
     try:
-        # Sortformer uses MLX/Metal — running it in parallel with MLX Whisper
-        # (also Metal) deadlocks the GPU.  Fall back to sequential mode.
-        from server.core.sortformer_engine import SortformerEngine
-        ...  # existing code through the end of the ThreadPoolExecutor block,
-        ...  # unchanged apart from one indentation level
+        if diar_engine is None or audio_data is None:
+            result = engine.transcribe_file(
+                ...  # unchanged, one level deeper
+            )
+            return result, None
+
+        ...  # Sortformer branch and ThreadPoolExecutor block, unchanged,
+        ...  # one level deeper
     finally:
         # Mirror transcribe_then_diarize: the diarization model is only
-        # needed during this job — release its VRAM instead of keeping it
-        # resident forever (it was never unloaded on this path before).
+        # needed during this job — release its VRAM instead of leaving it
+        # resident forever (this path never unloaded it before). Idempotent,
+        # so the Sortformer branch unloading on its own is fine.
         model_manager.unload_diarization_model()
 ```
+
+**Superseded by review (2026-08-01):** guard it instead — `try: model_manager.unload_diarization_model() except Exception: logger.warning(...)` — and apply the same guard to the sequential sibling's call at line 110. Reason: the new `finally` also covers the cancellation exit, and an unload failure would replace an in-flight `TranscriptionCancelledError`, which the routes catch specifically to return HTTP 499 instead of a 500. The original instruction was:
+
+~~Call `unload_diarization_model()` unguarded, exactly as the sequential sibling does at line 110 — it already swallows the failures it can (`AttributeError` on `unload()`, any error from `shutdown_mlx_thread`), and diverging from the sibling's shape here would be worse than the residual risk.~~
+
+Also add: a test proving a raising `unload_diarization_model` does not mask the original transcription exception, and a test pinning the real idempotency of `ModelManager.unload_diarization_model` (the outer `finally` depends on it, since the Sortformer branch already unloaded via the sibling). Do NOT assert `assert_called_once()` on a Sortformer-path mock — the mock is legitimately called twice there; the idempotency lives in the real implementation.
 
 - [ ] **Step 4: Run `test_parallel_diarize.py` — all PASS** (the pre-existing 12 tests use a MagicMock model_manager, so the new unload call cannot break them).
 
@@ -682,11 +707,13 @@ git commit -m "fix(server): unload the diarization model after parallel diarizat
 - Modify: `server/backend/core/stt/engine.py:1180-1184` (the "Cleanup backend" tail of `shutdown()`)
 - Test: `server/backend/tests/test_stt_engine_helpers.py` (this file already imports the engine module successfully — follow ITS import style; do not invent a new import path, the engine module needs the conftest-provided mocks)
 
-- [ ] **Step 1: Write the failing tests** — add to `test_stt_engine_helpers.py`, reusing that file's existing engine-module import (call it `engine_mod` below) plus `threading` and `MagicMock`:
+- [ ] **Step 1: Write the failing tests** — add to `test_stt_engine_helpers.py`. Verified in that file: `AudioToTextRecorder` is imported directly (no module alias), `MagicMock` is already imported, `object.__new__(AudioToTextRecorder)` is the established fixture pattern (see `_bare_recorder` at line 177), and `threading` is imported locally inside such helpers rather than at module top.
 
 ```python
 def _make_recorder_for_shutdown(owns_backend: bool):
-    rec = object.__new__(engine_mod.AudioToTextRecorder)
+    import threading
+
+    rec = object.__new__(AudioToTextRecorder)
     rec.instance_name = "test"
     rec.is_shut_down = False
     rec.is_running = True

--- a/docs/superpowers/plans/2026-08-01-vram-discipline.md
+++ b/docs/superpowers/plans/2026-08-01-vram-discipline.md
@@ -226,7 +226,10 @@ git commit -m "feat(server): device-wide GPU memory reporting and a post-job cle
 
 Today no job-completion path touches the GPU (verified). Add `post_job_gpu_cleanup()` to the `finally` of all five completion sites. Explicitly EXCLUDED: `preview_transcription()` (`websocket.py:339-346`) — the rolling preview fires every few seconds during recording and clearing the cache per preview chunk would thrash the allocator.
 
+The helper's signature is `post_job_gpu_cleanup(context: str = "job", device_index: int = 0)`. Every completion site has a `model_manager` in scope, so pass the server's configured device index instead of assuming GPU 0. `ModelManager` keeps that as the private `_gpu_device_index`; expose it as a read-only property (4 lines) rather than reaching into a private attribute from the route layer.
+
 **Files:**
+- Modify: `server/backend/core/model_manager.py` (add a `gpu_device_index` property next to the other properties)
 - Modify: `server/backend/api/routes/websocket.py` (`process_transcription` finally, lines ~645-658)
 - Modify: `server/backend/api/routes/transcription.py` (`_run_file_import` finally ~1182-1187; `_run_retry` finally ~1642-1644)
 - Modify: `server/backend/api/routes/notebook.py` (`_run_transcription` finally ~1250-1255)
@@ -265,7 +268,7 @@ def _trace_cleanup(monkeypatch) -> list[str]:
     monkeypatch.setattr(
         audio_utils,
         "post_job_gpu_cleanup",
-        lambda ctx="job": calls.append(ctx),
+        lambda ctx="job", device_index=0: calls.append(ctx),
         raising=False,
     )
     return calls
@@ -286,6 +289,7 @@ def test_file_import_runs_gpu_cleanup_even_on_failure(monkeypatch, tmp_path):
             is_cancelled=lambda: False,
         ),
         ensure_transcription_loaded=_raise_boom,
+        gpu_device_index=0,
     )
     wav = tmp_path / "a.wav"
     wav.write_bytes(b"RIFF")
@@ -322,6 +326,7 @@ def test_notebook_import_runs_gpu_cleanup_even_on_failure(monkeypatch, tmp_path)
             is_cancelled=lambda: False,
         ),
         ensure_transcription_loaded=_raise_boom,
+        gpu_device_index=0,
     )
     wav = tmp_path / "a.wav"
     wav.write_bytes(b"RIFF")
@@ -355,6 +360,7 @@ def _openai_request(mm: SimpleNamespace) -> SimpleNamespace:
 def _openai_model_manager(ended: list[Any]) -> SimpleNamespace:
     return SimpleNamespace(
         ensure_transcription_loaded=lambda: None,
+        gpu_device_index=0,
         job_tracker=SimpleNamespace(
             try_start_job=lambda _c: (True, "job-1", None),
             end_job=lambda job_id: ended.append(job_id),
@@ -422,7 +428,7 @@ class TestPostJobGpuCleanupOnWs(_BaseProcessTranscription):
         monkeypatch.setattr(
             audio_utils,
             "post_job_gpu_cleanup",
-            lambda ctx="job": calls.append(ctx),
+            lambda ctx="job", device_index=0: calls.append(ctx),
             raising=False,
         )
         return calls
@@ -453,7 +459,7 @@ In `server/backend/tests/test_retry_clears_gpu_cache.py`, inside `_drive_retry` 
     monkeypatch.setattr(
         audio_utils,
         "post_job_gpu_cleanup",
-        lambda ctx="job": trace.append("post_job_gpu_cleanup"),
+        lambda ctx="job", device_index=0: trace.append("post_job_gpu_cleanup"),
         raising=False,
     )
 ```
@@ -468,6 +474,8 @@ def test_gpu_cleanup_runs_after_retry_completes(monkeypatch):
 
 (If `_drive_retry` needs other assertions updated because the trace list now has an extra entry, adjust existing assertions to check membership/prefix rather than exact equality — do NOT delete existing order checks between `clear_gpu_cache` and `transcribe_file`.)
 
+**Required in this file:** both `SimpleNamespace` model-manager fakes (the one inside `_drive_retry` and the one inside `test_retry_still_succeeds_if_cache_clear_fails`, ~line 113) lack a `gpu_device_index`. Add `gpu_device_index=0,` to each, otherwise the new `model_manager.gpu_device_index` lookup in `_run_retry`'s finally raises AttributeError and both pre-existing tests break. Apply the same check to every other fake model manager the suite feeds into the five edited paths.
+
 - [ ] **Step 4: Run all three test files — expect the new tests to FAIL**
 
 ```bash
@@ -479,6 +487,15 @@ cd server/backend
 
 Context strings must match the tests exactly. All five files already use lazy imports for audio_utils; use the absolute form (`from server.core.audio_utils import ...`) — the relative import inside `_run_retry` is a one-off, don't copy it.
 
+**(0) `model_manager.py`** — add next to the other properties (e.g. above `transcription_engine`, line ~714):
+
+```python
+    @property
+    def gpu_device_index(self) -> int:
+        """Configured GPU device index (``transcription.gpu_device_index``)."""
+        return self._gpu_device_index
+```
+
 **(a) `websocket.py` `process_transcription` finally (lines ~645-658).** Insert at the TOP of the existing `finally:` block, before the temp-file cleanup:
 
 ```python
@@ -486,13 +503,21 @@ Context strings must match the tests exactly. All five files already use lazy im
             # Hand cached GPU blocks back to the driver so co-resident
             # workloads (e.g. a local LLM) get the VRAM between jobs. The
             # model stays warm; run in a thread because empty_cache blocks.
+            # The local model_manager is bound inside the try, so resolve the
+            # device index from the singleton instead — a failure before that
+            # binding must not turn into a NameError in this finally.
             from server.core.audio_utils import post_job_gpu_cleanup
+            from server.core.model_manager import get_model_manager
 
-            await asyncio.to_thread(post_job_gpu_cleanup, "longform recording")
+            try:
+                _device_index = get_model_manager().gpu_device_index
+            except Exception:
+                _device_index = 0
+            await asyncio.to_thread(post_job_gpu_cleanup, "longform recording", _device_index)
 
             # Only delete files in /tmp — persistent audio in recordings_dir must survive
 ```
-(`asyncio` is already imported in websocket.py — verify, add if not.)
+(`asyncio` is already imported in websocket.py — verify, add if not. Verified at plan time: `model_manager = get_model_manager()` sits at `websocket.py:429`, inside the same `try` whose `finally` this is, hence the guard.)
 
 **(b) `transcription.py` `_run_file_import` finally (lines ~1182-1187)** — this is a sync function running in a thread; call directly. Insert at the top of the `finally:` block:
 
@@ -500,7 +525,7 @@ Context strings must match the tests exactly. All five files already use lazy im
     finally:
         from server.core.audio_utils import post_job_gpu_cleanup
 
-        post_job_gpu_cleanup("file import")
+        post_job_gpu_cleanup("file import", model_manager.gpu_device_index)
 
         # Cleanup temp file
 ```
@@ -511,7 +536,7 @@ Context strings must match the tests exactly. All five files already use lazy im
     finally:
         from server.core.audio_utils import post_job_gpu_cleanup
 
-        await asyncio.to_thread(post_job_gpu_cleanup, "retry")
+        await asyncio.to_thread(post_job_gpu_cleanup, "retry", model_manager.gpu_device_index)
         if tracker_job_id:
             model_manager.job_tracker.end_job(tracker_job_id)
 ```
@@ -522,7 +547,7 @@ Context strings must match the tests exactly. All five files already use lazy im
     finally:
         from server.core.audio_utils import post_job_gpu_cleanup
 
-        post_job_gpu_cleanup("notebook import")
+        post_job_gpu_cleanup("notebook import", model_manager.gpu_device_index)
 
         # Cleanup temp file
 ```
@@ -533,7 +558,9 @@ Context strings must match the tests exactly. All five files already use lazy im
     finally:
         from server.core.audio_utils import post_job_gpu_cleanup
 
-        await asyncio.to_thread(post_job_gpu_cleanup, "openai transcription")
+        await asyncio.to_thread(
+            post_job_gpu_cleanup, "openai transcription", model_manager.gpu_device_index
+        )
         model_manager.job_tracker.end_job(job_id)
         if tmp_path:
             Path(tmp_path).unlink(missing_ok=True)
@@ -550,7 +577,7 @@ cd server/backend
 - [ ] **Step 7: Commit**
 
 ```bash
-git add server/backend/api/routes/websocket.py server/backend/api/routes/transcription.py server/backend/api/routes/notebook.py server/backend/api/routes/openai_audio.py server/backend/tests/test_post_job_gpu_cleanup_sites.py server/backend/tests/test_p0_durability.py server/backend/tests/test_retry_clears_gpu_cache.py
+git add server/backend/core/model_manager.py server/backend/api/routes/websocket.py server/backend/api/routes/transcription.py server/backend/api/routes/notebook.py server/backend/api/routes/openai_audio.py server/backend/tests/test_post_job_gpu_cleanup_sites.py server/backend/tests/test_p0_durability.py server/backend/tests/test_retry_clears_gpu_cache.py
 git commit -m "feat(server): release cached GPU memory after every transcription job"
 ```
 

--- a/docs/superpowers/plans/2026-08-01-vram-discipline.md
+++ b/docs/superpowers/plans/2026-08-01-vram-discipline.md
@@ -1,0 +1,999 @@
+# VRAM Discipline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the transcription model warm while returning every byte of VRAM the app does not actively need, so the server coexists safely with other GPU workloads (LM Studio LLMs on the same RTX 3060).
+
+**Architecture:** Five independent improvements, ordered so each commit is self-contained: (1) honest GPU memory reporting + a reusable post-job cleanup helper, (2) wiring that helper into every job-completion path, (3) fixing the parallel-diarization VRAM leak, (4) fixing `AudioToTextRecorder.shutdown()` dropping backends without unloading, (5) an opt-in `low_vram_mode` config key that caps batch size at 4. The dashboard UI for (5) comes for free: `ServerConfigEditor.tsx` is template-driven and auto-renders any new boolean key in `server/config.yaml` as a toggle.
+
+**Explicitly out of scope (user decision, 2026-08-01):** do NOT release the WhisperX wav2vec2 alignment model between jobs, in any mode. The alignment model stays warm exactly like the transcription model. Any suggestion to shed it during review must be rejected.
+
+**Tech Stack:** Python 3.13 / FastAPI backend (`server/backend/`), pytest via the build venv, PyTorch CUDA APIs (`empty_cache`, `mem_get_info`), TypeScript/React dashboard (types-only change).
+
+**Evidence base (measured 2026-08-01 on the RTX 3060):** idle baseline ~5.83 GB = CT2 large-v3 + CUDA context + WhisperX VAD (~4.5 GB) + alignment model (~1.2 GB, loads on first job, never released). Transient peaks during batched inference reach +2.8 GB. torch reserved-minus-allocated at idle ≈ 0.6 GB (what `empty_cache` reclaims). No job-completion path currently touches the GPU; the only `clear_gpu_cache()` at the route layer is the retry pre-flight (`transcription.py:1566`).
+
+---
+
+## Project conventions (read first, they bite)
+
+- **Branch:** create `feat/vram-discipline` off `main` before the first commit.
+- **Backend tests** run from `server/backend/` using the **build venv**:
+  ```bash
+  cd server/backend
+  ../../build/.venv/bin/pytest tests/ -v --tb=short
+  ```
+  Always finish with the FULL suite, not just the new files.
+- **GitNexus:** before modifying any listed function, run `impact({target: "<symbol>", direction: "upstream", repo: "TranscriptionSuite"})` and report blast radius. Before committing run `detect_changes()`. Warn on HIGH/CRITICAL.
+- **Patch `audio_utils.*`, never `model_manager.*`** when mocking GPU helpers in tests (established project pattern).
+- **Never `pip`, always `uv`** (not expected to be needed here).
+- **Commit style** (no line-splitting of long lines, NO AI attribution of any kind):
+  ```
+  feat(server): <summary>
+
+  * feat(server): change 1
+  * fix(server): change 2
+  ```
+- **Dashboard tests:** `cd dashboard && nvm use` first (vitest needs Node 22), then `npx vitest run`.
+- The user's Docker container is running their live server. Do NOT restart or touch the container; all work is code + host-venv tests.
+
+---
+
+### Task 1: Honest GPU memory numbers + `post_job_gpu_cleanup()` helper
+
+The current `get_gpu_memory_info()` reports only the torch caching-allocator view; the CT2 model (~4 GB) is invisible to it and `free_gb` is misleading. Add device-wide numbers via `torch.cuda.mem_get_info()` and a never-raising post-job cleanup helper that clears the cache and logs the after-state.
+
+**Files:**
+- Modify: `server/backend/core/audio_utils.py` (functions at lines 195-210 and 397-420)
+- Test: `server/backend/tests/test_audio_utils.py` (class `TestGetGpuMemoryInfo` at line 460)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `server/backend/tests/test_audio_utils.py`, inside/after the existing `TestGetGpuMemoryInfo` class (line 460; the file already imports `MagicMock`, `patch`, and `server.core.audio_utils as au`):
+
+```python
+class TestGetGpuMemoryInfo:
+    def test_unavailable_when_no_cuda(self):
+        with patch.object(au, "HAS_TORCH", False):
+            info = au.get_gpu_memory_info()
+
+        assert info == {"available": False}
+
+    def test_reports_torch_and_device_wide_numbers(self):
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.memory_allocated.return_value = 2 * 1024**3
+        mock_torch.cuda.memory_reserved.return_value = 3 * 1024**3
+        mock_torch.cuda.get_device_properties.return_value = MagicMock(
+            total_memory=12 * 1024**3
+        )
+        mock_torch.cuda.mem_get_info.return_value = (4 * 1024**3, 12 * 1024**3)
+
+        with patch.object(au, "torch", mock_torch), patch.object(au, "HAS_TORCH", True):
+            info = au.get_gpu_memory_info()
+
+        assert info["allocated_gb"] == 2.0
+        assert info["reserved_gb"] == 3.0
+        assert info["total_gb"] == 12.0
+        assert info["free_gb"] == 9.0
+        assert info["device_free_gb"] == 4.0
+        assert info["device_used_gb"] == 8.0
+
+    def test_device_wide_failure_keeps_torch_view(self):
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.memory_allocated.return_value = 2 * 1024**3
+        mock_torch.cuda.memory_reserved.return_value = 3 * 1024**3
+        mock_torch.cuda.get_device_properties.return_value = MagicMock(
+            total_memory=12 * 1024**3
+        )
+        mock_torch.cuda.mem_get_info.side_effect = RuntimeError("not supported")
+
+        with patch.object(au, "torch", mock_torch), patch.object(au, "HAS_TORCH", True):
+            info = au.get_gpu_memory_info()
+
+        assert info["allocated_gb"] == 2.0
+        assert "device_free_gb" not in info
+        assert "device_used_gb" not in info
+
+
+class TestPostJobGpuCleanup:
+    def test_clears_cache_and_logs(self):
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.memory_allocated.return_value = 1 * 1024**3
+        mock_torch.cuda.memory_reserved.return_value = 1 * 1024**3
+        mock_torch.cuda.get_device_properties.return_value = MagicMock(
+            total_memory=12 * 1024**3
+        )
+        mock_torch.cuda.mem_get_info.return_value = (6 * 1024**3, 12 * 1024**3)
+
+        with patch.object(au, "torch", mock_torch), patch.object(au, "HAS_TORCH", True):
+            au.post_job_gpu_cleanup("test job")
+
+        mock_torch.cuda.empty_cache.assert_called_once()
+        mock_torch.cuda.synchronize.assert_called_once()
+
+    def test_never_raises(self):
+        with patch.object(au, "clear_gpu_cache", side_effect=RuntimeError("boom")):
+            au.post_job_gpu_cleanup("test job")  # must not raise
+
+    def test_noop_without_cuda(self):
+        with patch.object(au, "HAS_TORCH", False):
+            au.post_job_gpu_cleanup("test job")  # must not raise
+```
+
+Note: `test_unavailable_when_no_cuda` already exists — keep it, add the new methods to the same class.
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+```bash
+cd server/backend
+../../build/.venv/bin/pytest tests/test_audio_utils.py -v --tb=short -k "GpuMemoryInfo or PostJobGpuCleanup"
+```
+Expected: the two new `TestGetGpuMemoryInfo` tests FAIL (KeyError `device_free_gb`), `TestPostJobGpuCleanup` FAILS with `AttributeError: ... has no attribute 'post_job_gpu_cleanup'`.
+
+- [ ] **Step 3: Implement**
+
+In `server/backend/core/audio_utils.py`, replace the body of `get_gpu_memory_info()` (currently lines 397-420):
+
+```python
+def get_gpu_memory_info(device_index: int = 0) -> dict:
+    """Get GPU memory usage information.
+
+    Reports two views that measure different things:
+    - allocated_gb/reserved_gb/free_gb: THIS process's PyTorch caching
+      allocator only. The CTranslate2 transcription model allocates outside
+      this allocator and is invisible here.
+    - device_free_gb/device_used_gb: the whole device as the driver sees it
+      (includes CTranslate2 and other processes). Best-effort — absent when
+      the runtime does not support mem_get_info.
+
+    Args:
+        device_index: GPU device index to query (default 0).
+    """
+    if not check_cuda_available():
+        return {"available": False}
+
+    try:
+        allocated = torch.cuda.memory_allocated(device_index) / (1024**3)  # GB
+        reserved = torch.cuda.memory_reserved(device_index) / (1024**3)  # GB
+        total = torch.cuda.get_device_properties(device_index).total_memory / (1024**3)  # GB
+
+        info = {
+            "available": True,
+            "allocated_gb": round(allocated, 2),
+            "reserved_gb": round(reserved, 2),
+            "total_gb": round(total, 2),
+            "free_gb": round(total - reserved, 2),
+        }
+
+        try:
+            device_free, device_total = torch.cuda.mem_get_info(device_index)
+            info["device_free_gb"] = round(device_free / (1024**3), 2)
+            info["device_used_gb"] = round((device_total - device_free) / (1024**3), 2)
+        except Exception:
+            logger.debug("torch.cuda.mem_get_info unavailable", exc_info=True)
+
+        return info
+    except Exception as e:
+        logger.error(f"Error getting GPU memory info: {e}")
+        return {"available": True, "error": str(e)}
+```
+
+Then add the helper directly below `clear_gpu_cache()` (after line 210):
+
+```python
+def post_job_gpu_cleanup(context: str = "job") -> None:
+    """Release cached GPU memory after a transcription job completes.
+
+    Hands the caching allocators' unused blocks back to the driver so
+    co-resident GPU workloads (e.g. a local LLM sharing the card) get the
+    VRAM between jobs. The transcription model itself stays warm — only
+    freed-but-cached blocks are returned. Best-effort: never raises.
+
+    Args:
+        context: Short label for the completed job type, used in the log line.
+    """
+    try:
+        clear_gpu_cache()
+        info = get_gpu_memory_info()
+        if info.get("available"):
+            logger.info(
+                "GPU memory after %s: torch allocated=%s GB reserved=%s GB, device used=%s GB",
+                context,
+                info.get("allocated_gb", "n/a"),
+                info.get("reserved_gb", "n/a"),
+                info.get("device_used_gb", "n/a"),
+            )
+    except Exception as e:
+        logger.debug("Post-job GPU cleanup failed (non-critical): %s", e)
+```
+
+- [ ] **Step 4: Run the tests again**
+
+Same command as Step 2. Expected: all PASS. Then run the full `test_audio_utils.py` to catch regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/backend/core/audio_utils.py server/backend/tests/test_audio_utils.py
+git commit -m "feat(server): device-wide GPU memory reporting and a post-job cleanup helper"
+```
+
+---
+
+### Task 2: Run the cleanup at every job-completion site
+
+Today no job-completion path touches the GPU (verified). Add `post_job_gpu_cleanup()` to the `finally` of all five completion sites. Explicitly EXCLUDED: `preview_transcription()` (`websocket.py:339-346`) — the rolling preview fires every few seconds during recording and clearing the cache per preview chunk would thrash the allocator.
+
+**Files:**
+- Modify: `server/backend/api/routes/websocket.py` (`process_transcription` finally, lines ~645-658)
+- Modify: `server/backend/api/routes/transcription.py` (`_run_file_import` finally ~1182-1187; `_run_retry` finally ~1642-1644)
+- Modify: `server/backend/api/routes/notebook.py` (`_run_transcription` finally ~1250-1255)
+- Modify: `server/backend/api/routes/openai_audio.py` (`create_transcription` finally ~465-468; `create_translation` finally ~583-586)
+- Test: `server/backend/tests/test_post_job_gpu_cleanup_sites.py` (new), `server/backend/tests/test_p0_durability.py` (extend), `server/backend/tests/test_retry_clears_gpu_cache.py` (extend)
+
+- [ ] **Step 1: Write the failing tests — new file**
+
+Create `server/backend/tests/test_post_job_gpu_cleanup_sites.py`:
+
+```python
+"""Every job completion must hand cached GPU memory back to the driver.
+
+The cleanup lives in each site's ``finally`` so it runs on success, failure
+and cancellation alike. These tests drive the cheapest deterministic path
+(usually a failure right at engine load) and assert the cleanup still fired.
+
+Run:  ../../build/.venv/bin/pytest tests/test_post_job_gpu_cleanup_sites.py -v --tb=short
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from server.api.routes import openai_audio, transcription
+from server.api.routes import notebook as notebook_routes
+
+
+def _trace_cleanup(monkeypatch) -> list[str]:
+    calls: list[str] = []
+    audio_utils = importlib.import_module("server.core.audio_utils")
+    monkeypatch.setattr(
+        audio_utils,
+        "post_job_gpu_cleanup",
+        lambda ctx="job": calls.append(ctx),
+        raising=False,
+    )
+    return calls
+
+
+def _raise_boom() -> Any:
+    raise RuntimeError("boom")
+
+
+def test_file_import_runs_gpu_cleanup_even_on_failure(monkeypatch, tmp_path):
+    calls = _trace_cleanup(monkeypatch)
+    ended: list[Any] = []
+    model_manager = SimpleNamespace(
+        job_tracker=SimpleNamespace(
+            update_progress=lambda *a: None,
+            set_phase=lambda *_: None,
+            end_job=lambda job_id, result=None: ended.append(result),
+            is_cancelled=lambda: False,
+        ),
+        ensure_transcription_loaded=_raise_boom,
+    )
+    wav = tmp_path / "a.wav"
+    wav.write_bytes(b"RIFF")
+
+    transcription._run_file_import(
+        model_manager=model_manager,
+        tmp_path=wav,
+        filename="a.wav",
+        language=None,
+        translation_enabled=False,
+        translation_target_language=None,
+        enable_diarization=False,
+        enable_word_timestamps=True,
+        expected_speakers=None,
+        parallel_diarization=None,
+        use_parallel_default=False,
+        multitrack=False,
+        job_id="job12345",
+        event_loop=None,
+    )
+
+    assert calls == ["file import"]
+    assert ended and "error" in ended[-1]
+
+
+def test_notebook_import_runs_gpu_cleanup_even_on_failure(monkeypatch, tmp_path):
+    calls = _trace_cleanup(monkeypatch)
+    ended: list[Any] = []
+    model_manager = SimpleNamespace(
+        job_tracker=SimpleNamespace(
+            update_progress=lambda *a: None,
+            set_phase=lambda *_: None,
+            end_job=lambda job_id, result=None: ended.append(result),
+            is_cancelled=lambda: False,
+        ),
+        ensure_transcription_loaded=_raise_boom,
+    )
+    wav = tmp_path / "a.wav"
+    wav.write_bytes(b"RIFF")
+
+    notebook_routes._run_transcription(
+        model_manager=model_manager,
+        tmp_path=wav,
+        filename="a.wav",
+        language=None,
+        translation_enabled=False,
+        translation_target_language=None,
+        enable_diarization=False,
+        enable_word_timestamps=True,
+        file_created_at=None,
+        expected_speakers=None,
+        parallel_diarization=None,
+        use_parallel_default=False,
+        title=None,
+        job_id="job12345",
+        event_loop=None,
+    )
+
+    assert calls == ["notebook import"]
+    assert ended and "error" in ended[-1]
+
+
+def _openai_request(mm: SimpleNamespace) -> SimpleNamespace:
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(model_manager=mm)))
+
+
+def _openai_model_manager(ended: list[Any]) -> SimpleNamespace:
+    return SimpleNamespace(
+        ensure_transcription_loaded=lambda: None,
+        job_tracker=SimpleNamespace(
+            try_start_job=lambda _c: (True, "job-1", None),
+            end_job=lambda job_id: ended.append(job_id),
+        ),
+    )
+
+
+def test_openai_transcription_runs_gpu_cleanup(monkeypatch):
+    calls = _trace_cleanup(monkeypatch)
+    monkeypatch.setattr(openai_audio, "_assert_model_loaded", lambda _r: None)
+    monkeypatch.setattr(openai_audio, "get_client_name", lambda _r: "test-client")
+
+    async def _boom(**_kw: Any) -> Any:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(openai_audio, "_run_transcription", _boom)
+    ended: list[Any] = []
+    mm = _openai_model_manager(ended)
+    file = MagicMock()
+    file.filename = "a.wav"
+    file.read = AsyncMock(return_value=b"riff")
+
+    asyncio.run(openai_audio.create_transcription(request=_openai_request(mm), file=file))
+
+    assert calls == ["openai transcription"]
+    assert ended == ["job-1"]
+
+
+def test_openai_translation_runs_gpu_cleanup(monkeypatch):
+    calls = _trace_cleanup(monkeypatch)
+    monkeypatch.setattr(openai_audio, "_assert_model_loaded", lambda _r: None)
+    monkeypatch.setattr(openai_audio, "get_client_name", lambda _r: "test-client")
+
+    async def _boom(**_kw: Any) -> Any:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(openai_audio, "_run_transcription", _boom)
+    ended: list[Any] = []
+    mm = _openai_model_manager(ended)
+    file = MagicMock()
+    file.filename = "a.wav"
+    file.read = AsyncMock(return_value=b"riff")
+
+    asyncio.run(openai_audio.create_translation(request=_openai_request(mm), file=file))
+
+    assert calls == ["openai translation"]
+    assert ended == ["job-1"]
+```
+
+Adaptation notes for the executor: (a) check `create_translation`'s actual signature in `openai_audio.py` before writing its test — mirror `create_transcription`'s calling convention with that function's own required params; (b) if either notebook/import function requires an additional keyword not listed in its signature shown here, read the signature at `transcription.py:839-857` / `notebook.py:835-852` — both were verified current at plan time.
+
+- [ ] **Step 2: Extend the WS durability tests**
+
+In `server/backend/tests/test_p0_durability.py`, add at the end (the file already has `_make_session`, `_BaseProcessTranscription`, `asyncio`, `ws_mod`; add `import importlib` to its imports if missing):
+
+```python
+@pytest.mark.p0
+@pytest.mark.durability
+class TestPostJobGpuCleanupOnWs(_BaseProcessTranscription):
+    """The longform WS path must release cached VRAM in its finally."""
+
+    def _trace(self, monkeypatch) -> list[str]:
+        calls: list[str] = []
+        audio_utils = importlib.import_module("server.core.audio_utils")
+        monkeypatch.setattr(
+            audio_utils,
+            "post_job_gpu_cleanup",
+            lambda ctx="job": calls.append(ctx),
+            raising=False,
+        )
+        return calls
+
+    def test_cleanup_runs_after_success(self, monkeypatch):
+        calls = self._trace(monkeypatch)
+        session = _make_session()
+
+        asyncio.run(session.process_transcription())
+
+        assert calls == ["longform recording"]
+
+    def test_cleanup_runs_when_transcription_fails(self, monkeypatch):
+        calls = self._trace(monkeypatch)
+        self._engine.transcribe_file.side_effect = RuntimeError("CUDA OOM")
+        session = _make_session()
+
+        asyncio.run(session.process_transcription())
+
+        assert calls == ["longform recording"]
+```
+
+- [ ] **Step 3: Extend the retry test**
+
+In `server/backend/tests/test_retry_clears_gpu_cache.py`, inside `_drive_retry` where `clear_gpu_cache` is monkeypatched (line ~101), add a second monkeypatch right after it:
+
+```python
+    monkeypatch.setattr(
+        audio_utils,
+        "post_job_gpu_cleanup",
+        lambda ctx="job": trace.append("post_job_gpu_cleanup"),
+        raising=False,
+    )
+```
+
+and add a new test asserting the full order:
+
+```python
+def test_gpu_cleanup_runs_after_retry_completes(monkeypatch):
+    trace = _drive_retry(monkeypatch)
+    assert trace == ["clear_gpu_cache", "transcribe_file", "post_job_gpu_cleanup"]
+```
+
+(If `_drive_retry` needs other assertions updated because the trace list now has an extra entry, adjust existing assertions to check membership/prefix rather than exact equality — do NOT delete existing order checks between `clear_gpu_cache` and `transcribe_file`.)
+
+- [ ] **Step 4: Run all three test files — expect the new tests to FAIL**
+
+```bash
+cd server/backend
+../../build/.venv/bin/pytest tests/test_post_job_gpu_cleanup_sites.py tests/test_p0_durability.py tests/test_retry_clears_gpu_cache.py -v --tb=short
+```
+
+- [ ] **Step 5: Implement the five site edits**
+
+Context strings must match the tests exactly. All five files already use lazy imports for audio_utils; use the absolute form (`from server.core.audio_utils import ...`) — the relative import inside `_run_retry` is a one-off, don't copy it.
+
+**(a) `websocket.py` `process_transcription` finally (lines ~645-658).** Insert at the TOP of the existing `finally:` block, before the temp-file cleanup:
+
+```python
+        finally:
+            # Hand cached GPU blocks back to the driver so co-resident
+            # workloads (e.g. a local LLM) get the VRAM between jobs. The
+            # model stays warm; run in a thread because empty_cache blocks.
+            from server.core.audio_utils import post_job_gpu_cleanup
+
+            await asyncio.to_thread(post_job_gpu_cleanup, "longform recording")
+
+            # Only delete files in /tmp — persistent audio in recordings_dir must survive
+```
+(`asyncio` is already imported in websocket.py — verify, add if not.)
+
+**(b) `transcription.py` `_run_file_import` finally (lines ~1182-1187)** — this is a sync function running in a thread; call directly. Insert at the top of the `finally:` block:
+
+```python
+    finally:
+        from server.core.audio_utils import post_job_gpu_cleanup
+
+        post_job_gpu_cleanup("file import")
+
+        # Cleanup temp file
+```
+
+**(c) `transcription.py` `_run_retry` finally (lines ~1642-1644)** — async function; keep the existing pre-flight `clear_gpu_cache` untouched and add post-job cleanup before `end_job`:
+
+```python
+    finally:
+        from server.core.audio_utils import post_job_gpu_cleanup
+
+        await asyncio.to_thread(post_job_gpu_cleanup, "retry")
+        if tracker_job_id:
+            model_manager.job_tracker.end_job(tracker_job_id)
+```
+
+**(d) `notebook.py` `_run_transcription` finally (lines ~1250-1255)** — sync, direct call:
+
+```python
+    finally:
+        from server.core.audio_utils import post_job_gpu_cleanup
+
+        post_job_gpu_cleanup("notebook import")
+
+        # Cleanup temp file
+```
+
+**(e) `openai_audio.py` both handlers' finally blocks (~465-468 and ~583-586)** — async; cleanup BEFORE `end_job` so the single job slot is still held while the cache clears (no race with the next job):
+
+```python
+    finally:
+        from server.core.audio_utils import post_job_gpu_cleanup
+
+        await asyncio.to_thread(post_job_gpu_cleanup, "openai transcription")
+        model_manager.job_tracker.end_job(job_id)
+        if tmp_path:
+            Path(tmp_path).unlink(missing_ok=True)
+```
+(second handler: context string `"openai translation"`.)
+
+- [ ] **Step 6: Run the three test files again — all PASS — then the FULL suite**
+
+```bash
+cd server/backend
+../../build/.venv/bin/pytest tests/ -v --tb=short
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/backend/api/routes/websocket.py server/backend/api/routes/transcription.py server/backend/api/routes/notebook.py server/backend/api/routes/openai_audio.py server/backend/tests/test_post_job_gpu_cleanup_sites.py server/backend/tests/test_p0_durability.py server/backend/tests/test_retry_clears_gpu_cache.py
+git commit -m "feat(server): release cached GPU memory after every transcription job"
+```
+
+---
+
+### Task 3: Fix the parallel-diarization VRAM leak
+
+`transcribe_and_diarize()` (`parallel_diarize.py:120-259`) loads the diarization model and never unloads it — it stays resident forever after the first parallel-diarize job. Its sequential sibling `transcribe_then_diarize()` unloads in a `finally` (lines 103-117). Mirror that. Known tradeoff (accepted): back-to-back diarized imports in parallel mode will reload the diarization model per job (~10-20 s); consistency and VRAM discipline win.
+
+**Files:**
+- Modify: `server/backend/core/parallel_diarize.py:120-259`
+- Test: `server/backend/tests/test_parallel_diarize.py`
+
+- [ ] **Step 1: Write the failing tests** — add to `test_parallel_diarize.py` (imports/patterns already in the file):
+
+```python
+@patch("server.core.audio_utils.load_audio", return_value=(MagicMock(), 16000))
+def test_parallel_success_unloads_diarization_model(mock_load_audio):
+    """After a successful parallel run the diarization model must be unloaded."""
+    engine = MagicMock()
+    engine.transcribe_file.return_value = MagicMock(words=[], segments=[])
+    mm = MagicMock()
+    diar_engine = MagicMock()
+    diar_result = MagicMock()
+    diar_result.segments = [MagicMock()]
+    diar_result.num_speakers = 2
+    diar_engine.diarize_audio.return_value = diar_result
+    mm.diarization_engine = diar_engine
+
+    result, diar = transcribe_and_diarize(
+        engine=engine, model_manager=mm, file_path="/tmp/test.wav"
+    )
+
+    assert diar is diar_result
+    mm.unload_diarization_model.assert_called_once()
+
+
+@patch("server.core.audio_utils.load_audio", return_value=(MagicMock(), 16000))
+def test_parallel_transcribe_failure_still_unloads_diarization_model(mock_load_audio):
+    """A transcription crash must not leave the diarization model resident."""
+    engine = MagicMock()
+    engine.transcribe_file.side_effect = RuntimeError("boom")
+    mm = MagicMock()
+    mm.diarization_engine = MagicMock()
+
+    with pytest.raises(RuntimeError):
+        transcribe_and_diarize(engine=engine, model_manager=mm, file_path="/tmp/test.wav")
+
+    mm.unload_diarization_model.assert_called_once()
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`unload_diarization_model` never called):
+
+```bash
+../../build/.venv/bin/pytest tests/test_parallel_diarize.py -v --tb=short
+```
+
+- [ ] **Step 3: Implement.** Two edits in `transcribe_and_diarize()`:
+
+(1) In the pre-load-failed fallback branch (the `if diar_engine is None or audio_data is None:` block), add a best-effort unload before transcribing — `load_diarization_model()` may have succeeded before `load_audio()` failed:
+
+```python
+    if diar_engine is None or audio_data is None:
+        # Pre-load may have loaded the diarization model before load_audio
+        # failed — release it, we are about to run transcription-only.
+        model_manager.unload_diarization_model()
+        result = engine.transcribe_file(
+```
+
+(2) Wrap everything from the Sortformer check to the end of the function in `try/finally` (re-indent the existing code one level; the Sortformer branch's inner `transcribe_then_diarize` unloads on its own, so the outer finally is a harmless no-op there — `unload_diarization_model()` is idempotent):
+
+```python
+    try:
+        # Sortformer uses MLX/Metal — running it in parallel with MLX Whisper
+        # (also Metal) deadlocks the GPU.  Fall back to sequential mode.
+        from server.core.sortformer_engine import SortformerEngine
+        ...  # existing code through the end of the ThreadPoolExecutor block,
+        ...  # unchanged apart from one indentation level
+    finally:
+        # Mirror transcribe_then_diarize: the diarization model is only
+        # needed during this job — release its VRAM instead of keeping it
+        # resident forever (it was never unloaded on this path before).
+        model_manager.unload_diarization_model()
+```
+
+- [ ] **Step 4: Run `test_parallel_diarize.py` — all PASS** (the pre-existing 12 tests use a MagicMock model_manager, so the new unload call cannot break them).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/backend/core/parallel_diarize.py server/backend/tests/test_parallel_diarize.py
+git commit -m "fix(server): unload the diarization model after parallel diarization jobs"
+```
+
+---
+
+### Task 4: `shutdown()` must unload owned backends
+
+`AudioToTextRecorder.shutdown()` (`engine.py:1165-1187`) drops `self._backend` without calling `backend.unload()`, so VRAM release is left to the garbage collector and cached allocator blocks are never returned. `unload_model()` (lines 1196-1206) does it correctly — mirror it.
+
+**Files:**
+- Modify: `server/backend/core/stt/engine.py:1180-1184` (the "Cleanup backend" tail of `shutdown()`)
+- Test: `server/backend/tests/test_stt_engine_helpers.py` (this file already imports the engine module successfully — follow ITS import style; do not invent a new import path, the engine module needs the conftest-provided mocks)
+
+- [ ] **Step 1: Write the failing tests** — add to `test_stt_engine_helpers.py`, reusing that file's existing engine-module import (call it `engine_mod` below) plus `threading` and `MagicMock`:
+
+```python
+def _make_recorder_for_shutdown(owns_backend: bool):
+    rec = object.__new__(engine_mod.AudioToTextRecorder)
+    rec.instance_name = "test"
+    rec.is_shut_down = False
+    rec.is_running = True
+    rec.start_recording_event = threading.Event()
+    rec.stop_recording_event = threading.Event()
+    rec.shutdown_event = threading.Event()
+    rec.recording_thread = None
+    rec._backend = MagicMock()
+    rec._owns_backend = owns_backend
+    rec._model_loaded = True
+    return rec
+
+
+class TestShutdownUnloadsBackend:
+    def test_shutdown_unloads_owned_backend(self):
+        rec = _make_recorder_for_shutdown(owns_backend=True)
+        backend = rec._backend
+
+        rec.shutdown()
+
+        backend.unload.assert_called_once()
+        assert rec._backend is None
+        assert rec._model_loaded is False
+
+    def test_shutdown_leaves_shared_backend_alone(self):
+        """A borrowed backend (Live Mode sharing) belongs to the caller."""
+        rec = _make_recorder_for_shutdown(owns_backend=False)
+        backend = rec._backend
+
+        rec.shutdown()
+
+        backend.unload.assert_not_called()
+        assert rec._backend is None
+
+    def test_shutdown_is_idempotent(self):
+        rec = _make_recorder_for_shutdown(owns_backend=True)
+        backend = rec._backend
+
+        rec.shutdown()
+        rec.shutdown()
+
+        backend.unload.assert_called_once()
+
+    def test_shutdown_survives_unload_failure(self):
+        rec = _make_recorder_for_shutdown(owns_backend=True)
+        rec._backend.unload.side_effect = RuntimeError("CUDA context gone")
+
+        rec.shutdown()  # must not raise
+
+        assert rec._backend is None
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`unload` never called):
+
+```bash
+../../build/.venv/bin/pytest tests/test_stt_engine_helpers.py -v --tb=short -k Shutdown
+```
+
+- [ ] **Step 3: Implement.** In `shutdown()`, replace:
+
+```python
+        # Cleanup backend
+        self._backend = None
+        self._model_loaded = False
+```
+
+with:
+
+```python
+        # Cleanup backend — actually unload owned backends instead of just
+        # dropping the reference: a dropped reference leaves the model's VRAM
+        # to the garbage collector and never returns cached allocator blocks
+        # to the driver. Shared backends belong to the caller (Live Mode).
+        if self._backend is not None and self._owns_backend:
+            try:
+                self._backend.unload()
+            except Exception:
+                logger.warning("Backend unload during shutdown failed", exc_info=True)
+        self._backend = None
+        self._model_loaded = False
+```
+
+- [ ] **Step 4: Run the file's full tests, then commit**
+
+```bash
+../../build/.venv/bin/pytest tests/test_stt_engine_helpers.py -v --tb=short
+git add server/backend/core/stt/engine.py server/backend/tests/test_stt_engine_helpers.py
+git commit -m "fix(server): shutdown() unloads owned STT backends instead of dropping the reference"
+```
+
+---
+
+### Task 5: `low_vram_mode` — batch cap
+
+One opt-in boolean (`main_transcriber.low_vram_mode`, default `false`). When ON, the transcription batch size is capped at 4, which shrinks the measured +2.8 GB transient peak roughly in half. Both the transcription model and the alignment model always stay warm — this mode changes nothing about model residency, only the per-job working set. **Dashboard UI is free:** `ServerConfigEditor.tsx` auto-renders every boolean template key as an AppleSwitch with the yaml comment as description — no dashboard code changes.
+
+**Do NOT** touch `whisperx_backend.py` or `engine.py` in this task. An earlier draft of this plan also released the alignment model in this mode; the user removed that from scope. There is no engine→backend plumbing to add: `_scale_batch_size` reads `self.config` directly.
+
+**Files:**
+- Modify: `server/backend/config.py` (constant near line 37; new resolver after `resolve_parallel_diarization_default`, line 552)
+- Modify: `server/config.yaml` (main_transcriber section, after the `beam_size` block at line 76)
+- Modify: `server/backend/core/model_manager.py` (`_scale_batch_size`, lines 672-712)
+- Test: `server/backend/tests/test_low_vram_mode.py` (new)
+
+- [ ] **Step 1: Write the failing tests — new file** `server/backend/tests/test_low_vram_mode.py`:
+
+```python
+"""Low VRAM mode: cap the transcription batch size at 4.
+
+The mode is an opt-in trade of throughput for GPU headroom so the server
+coexists with other GPU workloads (e.g. a local LLM). Loaded models are
+never affected: the transcription and alignment models stay warm in both
+modes, only the per-job working set shrinks.
+
+Run:  ../../build/.venv/bin/pytest tests/test_low_vram_mode.py -v --tb=short
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from server.config import DEFAULT_LOW_VRAM_MODE, resolve_low_vram_mode
+
+
+class TestResolveLowVramMode:
+    def test_default_is_off(self):
+        assert DEFAULT_LOW_VRAM_MODE is False
+        assert resolve_low_vram_mode({}) is False
+
+    def test_dict_config_on(self):
+        assert resolve_low_vram_mode({"main_transcriber": {"low_vram_mode": True}}) is True
+
+    def test_dict_config_explicit_off(self):
+        assert resolve_low_vram_mode({"main_transcriber": {"low_vram_mode": False}}) is False
+
+
+class TestScaleBatchSizeLowVram:
+    def _manager(self, config: dict):
+        from server.core.model_manager import ModelManager
+
+        mm = object.__new__(ModelManager)
+        mm.gpu_available = True
+        mm.config = config
+        mm._gpu_device_index = 0
+        return mm
+
+    def test_low_vram_caps_at_4_even_on_big_gpus(self):
+        mm = self._manager({"main_transcriber": {"low_vram_mode": True}})
+        with patch(
+            "server.core.audio_utils.get_gpu_memory_info",
+            return_value={"available": True, "total_gb": 24.0},
+        ):
+            assert mm._scale_batch_size(16) == 4
+
+    def test_low_vram_never_raises_a_smaller_configured_size(self):
+        mm = self._manager({"main_transcriber": {"low_vram_mode": True}})
+        with patch(
+            "server.core.audio_utils.get_gpu_memory_info",
+            return_value={"available": True, "total_gb": 24.0},
+        ):
+            assert mm._scale_batch_size(2) == 2
+
+    def test_tiered_caps_unchanged_when_off(self):
+        mm = self._manager({"main_transcriber": {"low_vram_mode": False}})
+        with patch(
+            "server.core.audio_utils.get_gpu_memory_info",
+            return_value={"available": True, "total_gb": 12.0},
+        ):
+            assert mm._scale_batch_size(16) == 8
+```
+
+- [ ] **Step 2: Run the new test file — expect FAIL** (`ImportError: cannot import name 'resolve_low_vram_mode'`):
+
+```bash
+cd server/backend
+../../build/.venv/bin/pytest tests/test_low_vram_mode.py -v --tb=short
+```
+
+- [ ] **Step 3: Implement — config layer.**
+
+`server/backend/config.py`: next to `DEFAULT_PARALLEL_DIARIZATION = False` (line 37) add:
+
+```python
+DEFAULT_LOW_VRAM_MODE = False
+```
+
+After `resolve_parallel_diarization_default` (line 552) add:
+
+```python
+def resolve_low_vram_mode(config: "ServerConfig | dict[str, Any]") -> bool:
+    """
+    Resolve ``main_transcriber.low_vram_mode`` (default OFF).
+
+    When ON, the transcription batch size is capped at 4, trading throughput
+    for smaller transient VRAM peaks during jobs. Intended for GPUs shared
+    with other workloads (e.g. a local LLM). Loaded models are unaffected:
+    the transcription and alignment models stay warm either way.
+    """
+    if isinstance(config, ServerConfig):
+        value = config.get("main_transcriber", "low_vram_mode", default=DEFAULT_LOW_VRAM_MODE)
+    else:
+        value = _dict_get(config, "main_transcriber", "low_vram_mode")
+        if value is None:
+            value = DEFAULT_LOW_VRAM_MODE
+    return bool(value)
+```
+
+`server/config.yaml`: in the `main_transcriber:` section, after the `beam_size` entry (line 76), add (4-space indent matching the section):
+
+```yaml
+    # Low VRAM mode: trade some speed for a smaller GPU footprint. Caps the
+    # transcription batch size at 4, which roughly halves the extra VRAM used
+    # while a job runs. Useful when sharing the GPU with other apps (e.g. a
+    # local LLM). Loaded models are not affected - they stay in VRAM either way.
+    low_vram_mode: false
+```
+
+- [ ] **Step 4: Implement — batch cap.** In `model_manager.py` `_scale_batch_size`, insert after the `if not self.gpu_available:` early return:
+
+```python
+        from server.config import resolve_low_vram_mode
+
+        if resolve_low_vram_mode(self.config):
+            if configured_batch_size > 4:
+                logger.info(
+                    "Low VRAM mode: capping batch_size %d -> 4", configured_batch_size
+                )
+                return 4
+            return configured_batch_size
+```
+
+- [ ] **Step 5: Run the new test file — PASS — then the FULL backend suite.** Also check `test_model_manager*.py` specifically: any existing `_scale_batch_size` test builds its manager without a `low_vram_mode` key, so the resolver must tolerate a missing key (it does — that is what `test_default_is_off` pins).
+
+The toggle needs no dashboard work: `ServerConfigEditor` renders template keys generically (boolean → AppleSwitch, yaml comment → description). Note in the PR that the new key needs a server restart to apply, like every `main_transcriber` key.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/backend/config.py server/config.yaml server/backend/core/model_manager.py server/backend/tests/test_low_vram_mode.py
+git commit -m "feat(server): opt-in low VRAM mode that caps the transcription batch size at 4"
+```
+
+---
+
+### Task 6: Fix the stale dashboard type for `gpu_memory`
+
+`dashboard/src/api/types.ts:28` declares `gpu_memory?: string` at the top level of `ServerStatus`, but the backend actually nests a dict under `models.gpu_memory` (and sends no top-level `gpu_memory` at all). Verified: there are ZERO runtime consumers of this field anywhere in `dashboard/` — the fix is type-only, no UI, no ui-contract impact (no CSS classes touched).
+
+**Files:**
+- Modify: `dashboard/src/api/types.ts:18-47`
+
+- [ ] **Step 1: Implement** (no test-first for a type-only change; the vitest suite is the regression net). In `types.ts`, add above `ServerStatus`:
+
+```typescript
+export interface GpuMemoryInfo {
+  available: boolean;
+  /** This process's PyTorch caching allocator only (excludes CTranslate2). */
+  allocated_gb?: number;
+  reserved_gb?: number;
+  total_gb?: number;
+  free_gb?: number;
+  /** Device-wide numbers from the driver (include all processes). */
+  device_free_gb?: number;
+  device_used_gb?: number;
+  error?: string;
+}
+```
+
+Then inside `ServerStatus`: extend the `models` intersection to include the real location and remove the wrong top-level field:
+
+```typescript
+  models?: Record<string, unknown> & {
+    transcription?: { selected_model?: string; loaded?: boolean; disabled?: boolean };
+    gpu_memory?: GpuMemoryInfo | null;
+  };
+```
+
+and delete the line `gpu_memory?: string;`.
+
+- [ ] **Step 2: Run the dashboard suite**
+
+```bash
+cd dashboard
+nvm use
+npx vitest run
+```
+Expected: green (nothing consumes the field). If the project exposes a typecheck script in `package.json`, run it too.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/src/api/types.ts
+git commit -m "fix(dashboard): correct the ServerStatus gpu_memory type to the real nested dict shape"
+```
+
+---
+
+### Task 7: Final verification and PR
+
+- [ ] **Step 1: Full backend suite** (must be green):
+
+```bash
+cd server/backend
+../../build/.venv/bin/pytest tests/ -v --tb=short
+```
+
+- [ ] **Step 2: Dashboard suite** (`cd dashboard && nvm use && npx vitest run`).
+
+- [ ] **Step 3: GitNexus regression check:** `detect_changes({scope: "compare", base_ref: "main", repo: "TranscriptionSuite"})` — confirm only the intended symbols/flows changed.
+
+- [ ] **Step 4: Safety sweep:** `git diff main...HEAD` and check: no AI attribution anywhere, no leftover debug prints, comments state constraints (not narration).
+
+- [ ] **Step 5: Open the PR directly on GitHub** (no local draft files):
+
+```bash
+gh pr create --title "feat(server): VRAM discipline — post-job cache release, leak fixes, low VRAM mode" --body "..."
+```
+
+PR body should cover: the measured baseline (5.83 GB anatomy, +2.8 GB transient peaks, motivation = LM Studio coexistence on a shared 3060), the five changes with one line each, the accepted tradeoffs (parallel diarization reloads the diarization model per job; low_vram_mode roughly halves batched throughput), and a **hardware smoke checklist** (not run in CI):
+
+```
+- [ ] With low_vram_mode OFF: idle VRAM after a job returns to ~baseline; log line "GPU memory after ..." appears after each job
+- [ ] With low_vram_mode ON (toggle visible in Server tab config editor; restart server): peak VRAM during a long import noticeably lower; idle baseline unchanged (models stay warm)
+- [ ] Parallel diarization import: diarization model unloaded after the job (nvidia-smi settles back)
+- [ ] Longform recording end-to-end still transcribes with word timestamps
+```
+
+---
+
+## Self-review notes (already applied)
+
+- The preview path (`preview_transcription`) is deliberately NOT wired to the cleanup — do not "fix" that during review.
+- The retry route keeps its pre-flight `clear_gpu_cache` AND gains the post-job cleanup; both are wanted.
+- `post_job_gpu_cleanup` contexts are load-bearing strings — tests assert them verbatim.
+- `_scale_batch_size`'s existing tiered caps are unchanged when the mode is off; `test_tiered_caps_unchanged_when_off` pins that.
+- The WhisperX alignment model is never released between jobs (user decision). `whisperx_backend.py` is not touched by this plan at all.
+- All five completion-site edits use the absolute import form (`from server.core.audio_utils import post_job_gpu_cleanup`), matching house style; the relative import inside `_run_retry` predates this plan and stays as-is.

--- a/server/backend/api/routes/notebook.py
+++ b/server/backend/api/routes/notebook.py
@@ -1248,15 +1248,16 @@ def _run_transcription(
         )
 
     finally:
-        from server.core.audio_utils import post_job_gpu_cleanup
-
-        post_job_gpu_cleanup("notebook import", model_manager.gpu_device_index)
-
         # Cleanup temp file
         try:
             tmp_path.unlink()
         except Exception as e:
             logger.warning(f"Failed to cleanup temp file {tmp_path}: {e}")
+
+        # Must stay LAST in this finally — nothing may sit behind it.
+        from server.core.audio_utils import post_job_gpu_cleanup
+
+        post_job_gpu_cleanup("notebook import", model_manager.gpu_device_index)
 
 
 @router.post("/transcribe/upload", response_model=AcceptedResponse, status_code=202)

--- a/server/backend/api/routes/notebook.py
+++ b/server/backend/api/routes/notebook.py
@@ -1248,6 +1248,10 @@ def _run_transcription(
         )
 
     finally:
+        from server.core.audio_utils import post_job_gpu_cleanup
+
+        post_job_gpu_cleanup("notebook import", model_manager.gpu_device_index)
+
         # Cleanup temp file
         try:
             tmp_path.unlink()

--- a/server/backend/api/routes/notebook.py
+++ b/server/backend/api/routes/notebook.py
@@ -1254,7 +1254,7 @@ def _run_transcription(
         except Exception as e:
             logger.warning(f"Failed to cleanup temp file {tmp_path}: {e}")
 
-        # Must stay LAST in this finally — nothing may sit behind it.
+        # Must stay LAST in this finally - nothing may sit behind it.
         from server.core.audio_utils import post_job_gpu_cleanup
 
         post_job_gpu_cleanup("notebook import", model_manager.gpu_device_index)

--- a/server/backend/api/routes/openai_audio.py
+++ b/server/backend/api/routes/openai_audio.py
@@ -467,7 +467,7 @@ async def create_transcription(
         if tmp_path:
             Path(tmp_path).unlink(missing_ok=True)
 
-        # Must stay LAST in this finally — a cancellation landing inside the
+        # Must stay LAST in this finally - a cancellation landing inside the
         # await would otherwise skip end_job and the temp-file unlink above:
         # the single job slot has no timeout or admin force-release, so a
         # stranded slot 429s every later job until the server restarts.
@@ -595,7 +595,7 @@ async def create_translation(
         if tmp_path:
             Path(tmp_path).unlink(missing_ok=True)
 
-        # Must stay LAST in this finally — a cancellation landing inside the
+        # Must stay LAST in this finally - a cancellation landing inside the
         # await would otherwise skip end_job and the temp-file unlink above:
         # the single job slot has no timeout or admin force-release, so a
         # stranded slot 429s every later job until the server restarts.

--- a/server/backend/api/routes/openai_audio.py
+++ b/server/backend/api/routes/openai_audio.py
@@ -463,14 +463,19 @@ async def create_transcription(
         logger.exception("OpenAI transcription endpoint error")
         return _openai_error(500, "Internal server error", error_type="server_error")
     finally:
+        model_manager.job_tracker.end_job(job_id)
+        if tmp_path:
+            Path(tmp_path).unlink(missing_ok=True)
+
+        # Must stay LAST in this finally — a cancellation landing inside the
+        # await would otherwise skip end_job and the temp-file unlink above:
+        # the single job slot has no timeout or admin force-release, so a
+        # stranded slot 429s every later job until the server restarts.
         from server.core.audio_utils import post_job_gpu_cleanup
 
         await asyncio.to_thread(
             post_job_gpu_cleanup, "openai transcription", model_manager.gpu_device_index
         )
-        model_manager.job_tracker.end_job(job_id)
-        if tmp_path:
-            Path(tmp_path).unlink(missing_ok=True)
 
 
 # ------------------------------------------------------------------
@@ -586,11 +591,16 @@ async def create_translation(
         logger.exception("OpenAI translation endpoint error")
         return _openai_error(500, "Internal server error", error_type="server_error")
     finally:
+        model_manager.job_tracker.end_job(job_id)
+        if tmp_path:
+            Path(tmp_path).unlink(missing_ok=True)
+
+        # Must stay LAST in this finally — a cancellation landing inside the
+        # await would otherwise skip end_job and the temp-file unlink above:
+        # the single job slot has no timeout or admin force-release, so a
+        # stranded slot 429s every later job until the server restarts.
         from server.core.audio_utils import post_job_gpu_cleanup
 
         await asyncio.to_thread(
             post_job_gpu_cleanup, "openai translation", model_manager.gpu_device_index
         )
-        model_manager.job_tracker.end_job(job_id)
-        if tmp_path:
-            Path(tmp_path).unlink(missing_ok=True)

--- a/server/backend/api/routes/openai_audio.py
+++ b/server/backend/api/routes/openai_audio.py
@@ -463,6 +463,11 @@ async def create_transcription(
         logger.exception("OpenAI transcription endpoint error")
         return _openai_error(500, "Internal server error", error_type="server_error")
     finally:
+        from server.core.audio_utils import post_job_gpu_cleanup
+
+        await asyncio.to_thread(
+            post_job_gpu_cleanup, "openai transcription", model_manager.gpu_device_index
+        )
         model_manager.job_tracker.end_job(job_id)
         if tmp_path:
             Path(tmp_path).unlink(missing_ok=True)
@@ -581,6 +586,11 @@ async def create_translation(
         logger.exception("OpenAI translation endpoint error")
         return _openai_error(500, "Internal server error", error_type="server_error")
     finally:
+        from server.core.audio_utils import post_job_gpu_cleanup
+
+        await asyncio.to_thread(
+            post_job_gpu_cleanup, "openai translation", model_manager.gpu_device_index
+        )
         model_manager.job_tracker.end_job(job_id)
         if tmp_path:
             Path(tmp_path).unlink(missing_ok=True)

--- a/server/backend/api/routes/transcription.py
+++ b/server/backend/api/routes/transcription.py
@@ -1180,6 +1180,10 @@ def _run_file_import(
         )
 
     finally:
+        from server.core.audio_utils import post_job_gpu_cleanup
+
+        post_job_gpu_cleanup("file import", model_manager.gpu_device_index)
+
         # Cleanup temp file
         try:
             tmp_path.unlink()
@@ -1640,6 +1644,9 @@ async def _run_retry(job_id: str, audio_path: str, job: dict[str, Any], app_stat
                 "Failed to mark retry job %s as failed: %s", sanitize_log_value(job_id), _mf_err
             )
     finally:
+        from server.core.audio_utils import post_job_gpu_cleanup
+
+        await asyncio.to_thread(post_job_gpu_cleanup, "retry", model_manager.gpu_device_index)
         if tracker_job_id:
             model_manager.job_tracker.end_job(tracker_job_id)
 

--- a/server/backend/api/routes/transcription.py
+++ b/server/backend/api/routes/transcription.py
@@ -1186,7 +1186,7 @@ def _run_file_import(
         except Exception as e:
             logger.warning("File import: failed to cleanup temp file %s: %s", tmp_path, e)
 
-        # Must stay LAST in this finally — nothing may sit behind it.
+        # Must stay LAST in this finally - nothing may sit behind it.
         from server.core.audio_utils import post_job_gpu_cleanup
 
         post_job_gpu_cleanup("file import", model_manager.gpu_device_index)
@@ -1648,7 +1648,7 @@ async def _run_retry(job_id: str, audio_path: str, job: dict[str, Any], app_stat
         if tracker_job_id:
             model_manager.job_tracker.end_job(tracker_job_id)
 
-        # Must stay LAST in this finally — a cancellation landing inside the
+        # Must stay LAST in this finally - a cancellation landing inside the
         # await would otherwise skip end_job above and strand the single job
         # slot: TranscriptionJobTracker has no timeout, no self-healing sweep,
         # and no admin force-release, so every later job would 429 forever.

--- a/server/backend/api/routes/transcription.py
+++ b/server/backend/api/routes/transcription.py
@@ -1180,15 +1180,16 @@ def _run_file_import(
         )
 
     finally:
-        from server.core.audio_utils import post_job_gpu_cleanup
-
-        post_job_gpu_cleanup("file import", model_manager.gpu_device_index)
-
         # Cleanup temp file
         try:
             tmp_path.unlink()
         except Exception as e:
             logger.warning("File import: failed to cleanup temp file %s: %s", tmp_path, e)
+
+        # Must stay LAST in this finally — nothing may sit behind it.
+        from server.core.audio_utils import post_job_gpu_cleanup
+
+        post_job_gpu_cleanup("file import", model_manager.gpu_device_index)
 
 
 @router.post("/import", response_model=ImportAcceptedResponse, status_code=202)
@@ -1644,11 +1645,16 @@ async def _run_retry(job_id: str, audio_path: str, job: dict[str, Any], app_stat
                 "Failed to mark retry job %s as failed: %s", sanitize_log_value(job_id), _mf_err
             )
     finally:
+        if tracker_job_id:
+            model_manager.job_tracker.end_job(tracker_job_id)
+
+        # Must stay LAST in this finally — a cancellation landing inside the
+        # await would otherwise skip end_job above and strand the single job
+        # slot: TranscriptionJobTracker has no timeout, no self-healing sweep,
+        # and no admin force-release, so every later job would 429 forever.
         from server.core.audio_utils import post_job_gpu_cleanup
 
         await asyncio.to_thread(post_job_gpu_cleanup, "retry", model_manager.gpu_device_index)
-        if tracker_job_id:
-            model_manager.job_tracker.end_job(tracker_job_id)
 
 
 def _sorted_languages(langs: dict[str, str]) -> dict[str, str]:

--- a/server/backend/api/routes/websocket.py
+++ b/server/backend/api/routes/websocket.py
@@ -643,21 +643,6 @@ class TranscriptionSession:
                 await self.send_message("error", {"message": error_message})
 
         finally:
-            # Hand cached GPU blocks back to the driver so co-resident
-            # workloads (e.g. a local LLM) get the VRAM between jobs. The
-            # model stays warm; run in a thread because empty_cache blocks.
-            # The local model_manager is bound inside the try, so resolve the
-            # device index from the singleton instead — a failure before that
-            # binding must not turn into a NameError in this finally.
-            from server.core.audio_utils import post_job_gpu_cleanup
-            from server.core.model_manager import get_model_manager
-
-            try:
-                _device_index = get_model_manager().gpu_device_index
-            except Exception:
-                _device_index = 0
-            await asyncio.to_thread(post_job_gpu_cleanup, "longform recording", _device_index)
-
             # Only delete files in /tmp — persistent audio in recordings_dir must survive
             # so failed jobs can be retried (Wave 2) and orphan recovery can find them (Wave 3).
             if (
@@ -671,6 +656,24 @@ class TranscriptionSession:
                     logger.warning(f"Failed to delete temp file: {e}")
             self.temp_file = None
             self.audio_chunks = []
+
+            # Hand cached GPU blocks back to the driver so co-resident
+            # workloads (e.g. a local LLM) get the VRAM between jobs. The
+            # model stays warm; run in a thread because empty_cache blocks.
+            # The local model_manager is bound inside the try, so resolve the
+            # device index from the singleton instead — a failure before that
+            # binding must not turn into a NameError in this finally. This
+            # must stay LAST: a cancellation landing inside the await would
+            # otherwise skip whatever comes after it, and here that would be
+            # the temp-file cleanup and state reset above.
+            from server.core.audio_utils import post_job_gpu_cleanup
+            from server.core.model_manager import get_model_manager
+
+            try:
+                _device_index = get_model_manager().gpu_device_index
+            except Exception:
+                _device_index = 0
+            await asyncio.to_thread(post_job_gpu_cleanup, "longform recording", _device_index)
 
     async def start_recording(
         self,

--- a/server/backend/api/routes/websocket.py
+++ b/server/backend/api/routes/websocket.py
@@ -661,7 +661,7 @@ class TranscriptionSession:
             # workloads (e.g. a local LLM) get the VRAM between jobs. The
             # model stays warm; run in a thread because empty_cache blocks.
             # The local model_manager is bound inside the try, so resolve the
-            # device index from the singleton instead — a failure before that
+            # device index from the singleton instead - a failure before that
             # binding must not turn into a NameError in this finally. This
             # must stay LAST: a cancellation landing inside the await would
             # otherwise skip whatever comes after it, and here that would be

--- a/server/backend/api/routes/websocket.py
+++ b/server/backend/api/routes/websocket.py
@@ -643,6 +643,21 @@ class TranscriptionSession:
                 await self.send_message("error", {"message": error_message})
 
         finally:
+            # Hand cached GPU blocks back to the driver so co-resident
+            # workloads (e.g. a local LLM) get the VRAM between jobs. The
+            # model stays warm; run in a thread because empty_cache blocks.
+            # The local model_manager is bound inside the try, so resolve the
+            # device index from the singleton instead — a failure before that
+            # binding must not turn into a NameError in this finally.
+            from server.core.audio_utils import post_job_gpu_cleanup
+            from server.core.model_manager import get_model_manager
+
+            try:
+                _device_index = get_model_manager().gpu_device_index
+            except Exception:
+                _device_index = 0
+            await asyncio.to_thread(post_job_gpu_cleanup, "longform recording", _device_index)
+
             # Only delete files in /tmp — persistent audio in recordings_dir must survive
             # so failed jobs can be retried (Wave 2) and orphan recovery can find them (Wave 3).
             if (

--- a/server/backend/config.py
+++ b/server/backend/config.py
@@ -36,6 +36,11 @@ DISABLED_MODEL_SENTINEL = "__none__"
 # default never drifts across the routes that read it (see GH #173).
 DEFAULT_PARALLEL_DIARIZATION = False
 
+# Low VRAM mode caps the transcription batch size regardless of card size, an
+# opt-in trade of throughput for headroom on GPUs shared with other workloads
+# (e.g. a local LLM). Default OFF preserves today's tiered auto-scaling.
+DEFAULT_LOW_VRAM_MODE = False
+
 
 def _deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
     """Recursively merge *overlay* onto *base*, returning a NEW dict.
@@ -549,6 +554,24 @@ def resolve_parallel_diarization_default(config: ServerConfig | dict[str, Any]) 
         value = _dict_get(config, "diarization", "parallel")
         if value is None:
             value = DEFAULT_PARALLEL_DIARIZATION
+    return bool(value)
+
+
+def resolve_low_vram_mode(config: ServerConfig | dict[str, Any]) -> bool:
+    """
+    Resolve ``main_transcriber.low_vram_mode`` (default OFF).
+
+    When ON, the transcription batch size is capped at 4, trading throughput
+    for smaller transient VRAM peaks during jobs. Intended for GPUs shared
+    with other workloads (e.g. a local LLM). Loaded models are unaffected:
+    the transcription and alignment models stay warm either way.
+    """
+    if isinstance(config, ServerConfig):
+        value = config.get("main_transcriber", "low_vram_mode", default=DEFAULT_LOW_VRAM_MODE)
+    else:
+        value = _dict_get(config, "main_transcriber", "low_vram_mode")
+        if value is None:
+            value = DEFAULT_LOW_VRAM_MODE
     return bool(value)
 
 

--- a/server/backend/config.py
+++ b/server/backend/config.py
@@ -565,6 +565,10 @@ def resolve_low_vram_mode(config: ServerConfig | dict[str, Any]) -> bool:
     for smaller transient VRAM peaks during jobs. Intended for GPUs shared
     with other workloads (e.g. a local LLM). Loaded models are unaffected:
     the transcription and alignment models stay warm either way.
+
+    Scope: WhisperX is the only backend that reads ``batch_size``, so this
+    setting has no effect on NeMo (Parakeet/Canary), whisper.cpp, SenseVoice
+    (which batches by duration, not count), VibeVoice or the MLX backends.
     """
     if isinstance(config, ServerConfig):
         value = config.get("main_transcriber", "low_vram_mode", default=DEFAULT_LOW_VRAM_MODE)

--- a/server/backend/core/audio_utils.py
+++ b/server/backend/core/audio_utils.py
@@ -210,7 +210,7 @@ def clear_gpu_cache() -> None:
         logger.debug(f"Could not clear GPU cache: {e}")
 
 
-def post_job_gpu_cleanup(context: str = "job") -> None:
+def post_job_gpu_cleanup(context: str = "job", device_index: int = 0) -> None:
     """Release cached GPU memory after a transcription job completes.
 
     Hands the caching allocators' unused blocks back to the driver so
@@ -220,11 +220,12 @@ def post_job_gpu_cleanup(context: str = "job") -> None:
 
     Args:
         context: Short label for the completed job type, used in the log line.
+        device_index: GPU device index to query (default 0).
     """
     try:
         clear_gpu_cache()
-        info = get_gpu_memory_info()
-        if info.get("available"):
+        info = get_gpu_memory_info(device_index)
+        if info.get("available") and "error" not in info:
             logger.info(
                 "GPU memory after %s: torch allocated=%s GB reserved=%s GB, device used=%s GB",
                 context,

--- a/server/backend/core/audio_utils.py
+++ b/server/backend/core/audio_utils.py
@@ -215,7 +215,7 @@ def post_job_gpu_cleanup(context: str = "job", device_index: int = 0) -> None:
 
     Hands the caching allocators' unused blocks back to the driver so
     co-resident GPU workloads (e.g. a local LLM sharing the card) get the
-    VRAM between jobs. The transcription model itself stays warm — only
+    VRAM between jobs. The transcription model itself stays warm - only
     freed-but-cached blocks are returned. Best-effort: never raises.
 
     Args:
@@ -429,7 +429,7 @@ def get_gpu_memory_info(device_index: int = 0) -> dict:
       allocator only. The CTranslate2 transcription model allocates outside
       this allocator and is invisible here.
     - device_free_gb/device_used_gb: the whole device as the driver sees it
-      (includes CTranslate2 and other processes). Best-effort — absent when
+      (includes CTranslate2 and other processes). Best-effort - absent when
       the runtime does not support mem_get_info.
 
     Args:

--- a/server/backend/core/audio_utils.py
+++ b/server/backend/core/audio_utils.py
@@ -210,6 +210,32 @@ def clear_gpu_cache() -> None:
         logger.debug(f"Could not clear GPU cache: {e}")
 
 
+def post_job_gpu_cleanup(context: str = "job") -> None:
+    """Release cached GPU memory after a transcription job completes.
+
+    Hands the caching allocators' unused blocks back to the driver so
+    co-resident GPU workloads (e.g. a local LLM sharing the card) get the
+    VRAM between jobs. The transcription model itself stays warm — only
+    freed-but-cached blocks are returned. Best-effort: never raises.
+
+    Args:
+        context: Short label for the completed job type, used in the log line.
+    """
+    try:
+        clear_gpu_cache()
+        info = get_gpu_memory_info()
+        if info.get("available"):
+            logger.info(
+                "GPU memory after %s: torch allocated=%s GB reserved=%s GB, device used=%s GB",
+                context,
+                info.get("allocated_gb", "n/a"),
+                info.get("reserved_gb", "n/a"),
+                info.get("device_used_gb", "n/a"),
+            )
+    except Exception as e:
+        logger.debug("Post-job GPU cleanup failed (non-critical): %s", e)
+
+
 def check_cuda_available() -> bool:
     """Check if CUDA is available for GPU acceleration."""
     if _cuda_probe_failed:
@@ -397,6 +423,14 @@ def cuda_health_check(device_index: int = 0) -> dict[str, Any]:
 def get_gpu_memory_info(device_index: int = 0) -> dict:
     """Get GPU memory usage information.
 
+    Reports two views that measure different things:
+    - allocated_gb/reserved_gb/free_gb: THIS process's PyTorch caching
+      allocator only. The CTranslate2 transcription model allocates outside
+      this allocator and is invisible here.
+    - device_free_gb/device_used_gb: the whole device as the driver sees it
+      (includes CTranslate2 and other processes). Best-effort — absent when
+      the runtime does not support mem_get_info.
+
     Args:
         device_index: GPU device index to query (default 0).
     """
@@ -408,13 +442,22 @@ def get_gpu_memory_info(device_index: int = 0) -> dict:
         reserved = torch.cuda.memory_reserved(device_index) / (1024**3)  # GB
         total = torch.cuda.get_device_properties(device_index).total_memory / (1024**3)  # GB
 
-        return {
+        info = {
             "available": True,
             "allocated_gb": round(allocated, 2),
             "reserved_gb": round(reserved, 2),
             "total_gb": round(total, 2),
             "free_gb": round(total - reserved, 2),
         }
+
+        try:
+            device_free, device_total = torch.cuda.mem_get_info(device_index)
+            info["device_free_gb"] = round(device_free / (1024**3), 2)
+            info["device_used_gb"] = round((device_total - device_free) / (1024**3), 2)
+        except Exception:
+            logger.debug("torch.cuda.mem_get_info unavailable", exc_info=True)
+
+        return info
     except Exception as e:
         logger.error(f"Error getting GPU memory info: {e}")
         return {"available": True, "error": str(e)}

--- a/server/backend/core/model_manager.py
+++ b/server/backend/core/model_manager.py
@@ -712,6 +712,11 @@ class ModelManager:
         return configured_batch_size
 
     @property
+    def gpu_device_index(self) -> int:
+        """Configured GPU device index (``transcription.gpu_device_index``)."""
+        return self._gpu_device_index
+
+    @property
     def transcription_engine(self) -> "AudioToTextRecorder":
         """Get or create the unified transcription engine."""
         if self._transcription_engine is None:

--- a/server/backend/core/model_manager.py
+++ b/server/backend/core/model_manager.py
@@ -684,6 +684,14 @@ class ModelManager:
         if not self.gpu_available:
             return configured_batch_size
 
+        from server.config import resolve_low_vram_mode
+
+        if resolve_low_vram_mode(self.config):
+            if configured_batch_size > 4:
+                logger.info("Low VRAM mode: capping batch_size %d -> 4", configured_batch_size)
+                return 4
+            return configured_batch_size
+
         from server.core.audio_utils import get_gpu_memory_info
 
         gpu_info = get_gpu_memory_info(self._gpu_device_index)

--- a/server/backend/core/model_manager.py
+++ b/server/backend/core/model_manager.py
@@ -21,7 +21,7 @@ import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from server.config import resolve_main_transcriber_model
+from server.config import resolve_low_vram_mode, resolve_main_transcriber_model
 
 # Type-only imports for hints (no runtime cost)
 if TYPE_CHECKING:
@@ -680,11 +680,13 @@ class ModelManager:
 
         The scaling is conservative — it only reduces, never increases, and
         logs when it does so.
+
+        When ``main_transcriber.low_vram_mode`` is on, this short-circuits to a
+        flat cap of 4 before the GPU-tier detection below ever runs, so the
+        tiered caps and the low-VRAM cap are never combined or compared.
         """
         if not self.gpu_available:
             return configured_batch_size
-
-        from server.config import resolve_low_vram_mode
 
         if resolve_low_vram_mode(self.config):
             if configured_batch_size > 4:

--- a/server/backend/core/parallel_diarize.py
+++ b/server/backend/core/parallel_diarize.py
@@ -107,7 +107,16 @@ def transcribe_then_diarize(
         # Both are no-ops when models are already in the target state.
         # Running here (before any return) guarantees the STT model is available
         # for subsequent jobs regardless of how this function exits.
-        model_manager.unload_diarization_model()
+        # Guarded: an unguarded raise here would replace whatever exception is
+        # already propagating (e.g. TranscriptionCancelledError) on its way out
+        # of this finally, turning a clean cancel into an unrelated 500.
+        try:
+            model_manager.unload_diarization_model()
+        except Exception:
+            logger.warning(
+                "Failed to unload the diarization model after sequential run",
+                exc_info=True,
+            )
         try:
             model_manager.load_transcription_model()
         except Exception:
@@ -262,4 +271,14 @@ def transcribe_and_diarize(
         # needed during this job — release its VRAM instead of leaving it
         # resident forever (this path never unloaded it before). Idempotent,
         # so the Sortformer branch unloading on its own is fine.
-        model_manager.unload_diarization_model()
+        # Guarded: this finally also covers the parallel-execution cancellation
+        # exit above — an unguarded raise here would replace an in-flight
+        # TranscriptionCancelledError, turning a clean user cancel (HTTP 499)
+        # into a generic 500.
+        try:
+            model_manager.unload_diarization_model()
+        except Exception:
+            logger.warning(
+                "Failed to unload the diarization model after parallel run",
+                exc_info=True,
+            )

--- a/server/backend/core/parallel_diarize.py
+++ b/server/backend/core/parallel_diarize.py
@@ -268,11 +268,11 @@ def transcribe_and_diarize(
                 return result, None
     finally:
         # Mirror transcribe_then_diarize: the diarization model is only
-        # needed during this job — release its VRAM instead of leaving it
+        # needed during this job - release its VRAM instead of leaving it
         # resident forever (this path never unloaded it before). Idempotent,
         # so the Sortformer branch unloading on its own is fine.
         # Guarded: this finally also covers the parallel-execution cancellation
-        # exit above — an unguarded raise here would replace an in-flight
+        # exit above - an unguarded raise here would replace an in-flight
         # TranscriptionCancelledError, turning a clean user cancel (HTTP 499)
         # into a generic 500.
         try:

--- a/server/backend/core/parallel_diarize.py
+++ b/server/backend/core/parallel_diarize.py
@@ -161,98 +161,105 @@ def transcribe_and_diarize(
         )
 
     # If pre-load failed, just transcribe normally
-    if diar_engine is None or audio_data is None:
-        result = engine.transcribe_file(
-            file_path,
-            language=language,
-            task=task,
-            translation_target_language=translation_target_language,
-            word_timestamps=word_timestamps,
-            cancellation_check=cancellation_check,
-            progress_callback=progress_callback,
-        )
-        return result, None
-
-    # Sortformer uses MLX/Metal — running it in parallel with MLX Whisper
-    # (also Metal) deadlocks the GPU.  Fall back to sequential mode.
-    from server.core.sortformer_engine import SortformerEngine
-
-    if isinstance(diar_engine, SortformerEngine):
-        logger.info(
-            "Sortformer + MLX detected — switching to sequential mode to avoid Metal deadlock"
-        )
-        return transcribe_then_diarize(
-            engine=engine,
-            model_manager=model_manager,
-            file_path=file_path,
-            language=language,
-            task=task,
-            translation_target_language=translation_target_language,
-            word_timestamps=word_timestamps,
-            expected_speakers=expected_speakers,
-            cancellation_check=cancellation_check,
-            progress_callback=progress_callback,
-        )
-
-    # ------------------------------------------------------------------
-    # Phase 2 — Parallel execution
-    # ------------------------------------------------------------------
-    logger.info("Starting parallel transcription + diarization")
-
-    # Capture audio_data/sample_rate in closures for the diarization worker
-    _audio_data = audio_data
-    _audio_sr = audio_sample_rate
-    _expected = expected_speakers
-
-    def _do_transcribe() -> TranscriptionResult:
-        threading.current_thread().name = "parallel_diarize:transcribe"
-        return engine.transcribe_file(
-            file_path,
-            language=language,
-            task=task,
-            translation_target_language=translation_target_language,
-            word_timestamps=word_timestamps,
-            cancellation_check=cancellation_check,
-            progress_callback=progress_callback,
-        )
-
-    def _do_diarize() -> DiarizationResult:
-        threading.current_thread().name = "parallel_diarize:diarize"
-        return diar_engine.diarize_audio(_audio_data, _audio_sr, num_speakers=_expected)
-
-    transcribe_future: Future[TranscriptionResult]
-    diarize_future: Future[DiarizationResult]
-
-    model_manager.job_tracker.set_phase("transcribing_diarizing")
-    with ThreadPoolExecutor(max_workers=2, thread_name_prefix="parallel_diarize") as pool:
-        transcribe_future = pool.submit(_do_transcribe)
-        diarize_future = pool.submit(_do_diarize)
-
-        # ------------------------------------------------------------------
-        # Phase 3 — Collect results
-        # ------------------------------------------------------------------
-
-        # Wait for transcription first — it's the critical path.
-        try:
-            result = transcribe_future.result()
-        except TranscriptionCancelledError:
-            diarize_future.cancel()
-            raise
-        except Exception:
-            diarize_future.cancel()
-            raise
-
-        # Collect diarization (non-critical — failures degrade gracefully).
-        try:
-            diar_result = diarize_future.result()
-            logger.info(
-                "Parallel diarization complete: %s speakers found",
-                diar_result.num_speakers,
-            )
-            return result, diar_result
-        except Exception:
-            logger.warning(
-                "Diarization failed during parallel run — returning transcript without speakers",
-                exc_info=True,
+    try:
+        if diar_engine is None or audio_data is None:
+            result = engine.transcribe_file(
+                file_path,
+                language=language,
+                task=task,
+                translation_target_language=translation_target_language,
+                word_timestamps=word_timestamps,
+                cancellation_check=cancellation_check,
+                progress_callback=progress_callback,
             )
             return result, None
+
+        # Sortformer uses MLX/Metal — running it in parallel with MLX Whisper
+        # (also Metal) deadlocks the GPU.  Fall back to sequential mode.
+        from server.core.sortformer_engine import SortformerEngine
+
+        if isinstance(diar_engine, SortformerEngine):
+            logger.info(
+                "Sortformer + MLX detected — switching to sequential mode to avoid Metal deadlock"
+            )
+            return transcribe_then_diarize(
+                engine=engine,
+                model_manager=model_manager,
+                file_path=file_path,
+                language=language,
+                task=task,
+                translation_target_language=translation_target_language,
+                word_timestamps=word_timestamps,
+                expected_speakers=expected_speakers,
+                cancellation_check=cancellation_check,
+                progress_callback=progress_callback,
+            )
+
+        # ------------------------------------------------------------------
+        # Phase 2 — Parallel execution
+        # ------------------------------------------------------------------
+        logger.info("Starting parallel transcription + diarization")
+
+        # Capture audio_data/sample_rate in closures for the diarization worker
+        _audio_data = audio_data
+        _audio_sr = audio_sample_rate
+        _expected = expected_speakers
+
+        def _do_transcribe() -> TranscriptionResult:
+            threading.current_thread().name = "parallel_diarize:transcribe"
+            return engine.transcribe_file(
+                file_path,
+                language=language,
+                task=task,
+                translation_target_language=translation_target_language,
+                word_timestamps=word_timestamps,
+                cancellation_check=cancellation_check,
+                progress_callback=progress_callback,
+            )
+
+        def _do_diarize() -> DiarizationResult:
+            threading.current_thread().name = "parallel_diarize:diarize"
+            return diar_engine.diarize_audio(_audio_data, _audio_sr, num_speakers=_expected)
+
+        transcribe_future: Future[TranscriptionResult]
+        diarize_future: Future[DiarizationResult]
+
+        model_manager.job_tracker.set_phase("transcribing_diarizing")
+        with ThreadPoolExecutor(max_workers=2, thread_name_prefix="parallel_diarize") as pool:
+            transcribe_future = pool.submit(_do_transcribe)
+            diarize_future = pool.submit(_do_diarize)
+
+            # ------------------------------------------------------------------
+            # Phase 3 — Collect results
+            # ------------------------------------------------------------------
+
+            # Wait for transcription first — it's the critical path.
+            try:
+                result = transcribe_future.result()
+            except TranscriptionCancelledError:
+                diarize_future.cancel()
+                raise
+            except Exception:
+                diarize_future.cancel()
+                raise
+
+            # Collect diarization (non-critical — failures degrade gracefully).
+            try:
+                diar_result = diarize_future.result()
+                logger.info(
+                    "Parallel diarization complete: %s speakers found",
+                    diar_result.num_speakers,
+                )
+                return result, diar_result
+            except Exception:
+                logger.warning(
+                    "Diarization failed during parallel run — returning transcript without speakers",
+                    exc_info=True,
+                )
+                return result, None
+    finally:
+        # Mirror transcribe_then_diarize: the diarization model is only
+        # needed during this job — release its VRAM instead of leaving it
+        # resident forever (this path never unloaded it before). Idempotent,
+        # so the Sortformer branch unloading on its own is fine.
+        model_manager.unload_diarization_model()

--- a/server/backend/core/stt/engine.py
+++ b/server/backend/core/stt/engine.py
@@ -1184,6 +1184,10 @@ class AudioToTextRecorder:
         # dropping the reference: a dropped reference leaves the model's VRAM
         # to the garbage collector and never returns cached allocator blocks
         # to the driver. Shared backends belong to the caller (Live Mode).
+        # unload_model() runs during normal operation and should surface
+        # failures, but shutdown() runs during teardown, where the CUDA
+        # context may already be gone and a failure must not block the rest
+        # of the cleanup - hence the try/except here that unload_model() omits.
         if self._backend is not None and self._owns_backend:
             try:
                 self._backend.unload()

--- a/server/backend/core/stt/engine.py
+++ b/server/backend/core/stt/engine.py
@@ -1180,7 +1180,15 @@ class AudioToTextRecorder:
         if self.recording_thread and self.recording_thread.is_alive():
             self.recording_thread.join(timeout=5)
 
-        # Cleanup backend
+        # Cleanup backend — actually unload owned backends instead of just
+        # dropping the reference: a dropped reference leaves the model's VRAM
+        # to the garbage collector and never returns cached allocator blocks
+        # to the driver. Shared backends belong to the caller (Live Mode).
+        if self._backend is not None and self._owns_backend:
+            try:
+                self._backend.unload()
+            except Exception:
+                logger.warning("Backend unload during shutdown failed", exc_info=True)
         self._backend = None
         self._model_loaded = False
 

--- a/server/backend/core/stt/engine.py
+++ b/server/backend/core/stt/engine.py
@@ -1180,7 +1180,7 @@ class AudioToTextRecorder:
         if self.recording_thread and self.recording_thread.is_alive():
             self.recording_thread.join(timeout=5)
 
-        # Cleanup backend — actually unload owned backends instead of just
+        # Cleanup backend - actually unload owned backends instead of just
         # dropping the reference: a dropped reference leaves the model's VRAM
         # to the garbage collector and never returns cached allocator blocks
         # to the driver. Shared backends belong to the caller (Live Mode).

--- a/server/backend/tests/test_audio_route_durability.py
+++ b/server/backend/tests/test_audio_route_durability.py
@@ -769,6 +769,7 @@ class TestIntegratedDiarizationFallback:
             ensure_transcription_loaded=lambda: engine,
             job_tracker=_FakeTracker(),
             get_diarization_feature_status=lambda: {"reason": "ready"},
+            gpu_device_index=0,
         )
 
         # Patch diarization config fallback (not used on this path, but safe).

--- a/server/backend/tests/test_audio_utils.py
+++ b/server/backend/tests/test_audio_utils.py
@@ -6,7 +6,8 @@ Covers:
 - ``check_cuda_available()`` with _cuda_probe_failed flag
 - ``clear_gpu_cache()`` no-op when CUDA unavailable
 - ``check_cuda_available()`` with/without torch
-- ``get_gpu_memory_info()`` when CUDA unavailable
+- ``get_gpu_memory_info()`` torch-allocator and device-wide (mem_get_info) views
+- ``post_job_gpu_cleanup()`` cache clear, device-index forwarding, error-state guard
 - ``convert_to_wav()`` subprocess invocation and error handling
 - ``convert_to_mp3()`` subprocess invocation and error handling
 - ``normalize_audio_legacy()`` peak normalization (empty, silent, normal)
@@ -18,6 +19,7 @@ Covers:
 
 from __future__ import annotations
 
+import logging
 import subprocess
 from unittest.mock import MagicMock, patch
 
@@ -499,7 +501,30 @@ class TestGetGpuMemoryInfo:
 
 
 class TestPostJobGpuCleanup:
-    def test_clears_cache_and_logs(self):
+    def test_clears_cache_and_logs(self, caplog):
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.memory_allocated.return_value = 1 * 1024**3
+        mock_torch.cuda.memory_reserved.return_value = 2 * 1024**3
+        mock_torch.cuda.get_device_properties.return_value = MagicMock(total_memory=12 * 1024**3)
+        mock_torch.cuda.mem_get_info.return_value = (4 * 1024**3, 12 * 1024**3)
+
+        caplog.set_level(logging.INFO)
+        with patch.object(au, "torch", mock_torch), patch.object(au, "HAS_TORCH", True):
+            au.post_job_gpu_cleanup("test job")
+
+        mock_torch.cuda.empty_cache.assert_called_once()
+        mock_torch.cuda.synchronize.assert_called_once()
+
+        # Distinct allocated/reserved/device-used values (1.0/2.0/8.0) so a
+        # mixed-up log argument (e.g. device_used_gb logged in allocated_gb's
+        # spot) is caught rather than masked by a repeated value.
+        assert "test job" in caplog.text
+        assert "allocated=1.0" in caplog.text
+        assert "reserved=2.0" in caplog.text
+        assert "device used=8.0" in caplog.text
+
+    def test_forwards_device_index(self):
         mock_torch = MagicMock()
         mock_torch.cuda.is_available.return_value = True
         mock_torch.cuda.memory_allocated.return_value = 1 * 1024**3
@@ -508,10 +533,26 @@ class TestPostJobGpuCleanup:
         mock_torch.cuda.mem_get_info.return_value = (6 * 1024**3, 12 * 1024**3)
 
         with patch.object(au, "torch", mock_torch), patch.object(au, "HAS_TORCH", True):
+            au.post_job_gpu_cleanup("test job", device_index=1)
+
+        mock_torch.cuda.memory_allocated.assert_called_once_with(1)
+        mock_torch.cuda.memory_reserved.assert_called_once_with(1)
+        mock_torch.cuda.get_device_properties.assert_called_once_with(1)
+        mock_torch.cuda.mem_get_info.assert_called_once_with(1)
+
+    def test_no_log_when_error_state(self, caplog):
+        # get_gpu_memory_info() hitting its outer except already logs the
+        # failure itself; post_job_gpu_cleanup must not additionally claim
+        # success with "n/a" placeholders in that case.
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.memory_allocated.side_effect = RuntimeError("boom")
+
+        caplog.set_level(logging.INFO)
+        with patch.object(au, "torch", mock_torch), patch.object(au, "HAS_TORCH", True):
             au.post_job_gpu_cleanup("test job")
 
-        mock_torch.cuda.empty_cache.assert_called_once()
-        mock_torch.cuda.synchronize.assert_called_once()
+        assert "GPU memory after" not in caplog.text
 
     def test_never_raises(self):
         with patch.object(au, "clear_gpu_cache", side_effect=RuntimeError("boom")):

--- a/server/backend/tests/test_audio_utils.py
+++ b/server/backend/tests/test_audio_utils.py
@@ -464,6 +464,63 @@ class TestGetGpuMemoryInfo:
 
         assert info == {"available": False}
 
+    def test_reports_torch_and_device_wide_numbers(self):
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.memory_allocated.return_value = 2 * 1024**3
+        mock_torch.cuda.memory_reserved.return_value = 3 * 1024**3
+        mock_torch.cuda.get_device_properties.return_value = MagicMock(total_memory=12 * 1024**3)
+        mock_torch.cuda.mem_get_info.return_value = (4 * 1024**3, 12 * 1024**3)
+
+        with patch.object(au, "torch", mock_torch), patch.object(au, "HAS_TORCH", True):
+            info = au.get_gpu_memory_info()
+
+        assert info["allocated_gb"] == 2.0
+        assert info["reserved_gb"] == 3.0
+        assert info["total_gb"] == 12.0
+        assert info["free_gb"] == 9.0
+        assert info["device_free_gb"] == 4.0
+        assert info["device_used_gb"] == 8.0
+
+    def test_device_wide_failure_keeps_torch_view(self):
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.memory_allocated.return_value = 2 * 1024**3
+        mock_torch.cuda.memory_reserved.return_value = 3 * 1024**3
+        mock_torch.cuda.get_device_properties.return_value = MagicMock(total_memory=12 * 1024**3)
+        mock_torch.cuda.mem_get_info.side_effect = RuntimeError("not supported")
+
+        with patch.object(au, "torch", mock_torch), patch.object(au, "HAS_TORCH", True):
+            info = au.get_gpu_memory_info()
+
+        assert info["allocated_gb"] == 2.0
+        assert "device_free_gb" not in info
+        assert "device_used_gb" not in info
+
+
+class TestPostJobGpuCleanup:
+    def test_clears_cache_and_logs(self):
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.memory_allocated.return_value = 1 * 1024**3
+        mock_torch.cuda.memory_reserved.return_value = 1 * 1024**3
+        mock_torch.cuda.get_device_properties.return_value = MagicMock(total_memory=12 * 1024**3)
+        mock_torch.cuda.mem_get_info.return_value = (6 * 1024**3, 12 * 1024**3)
+
+        with patch.object(au, "torch", mock_torch), patch.object(au, "HAS_TORCH", True):
+            au.post_job_gpu_cleanup("test job")
+
+        mock_torch.cuda.empty_cache.assert_called_once()
+        mock_torch.cuda.synchronize.assert_called_once()
+
+    def test_never_raises(self):
+        with patch.object(au, "clear_gpu_cache", side_effect=RuntimeError("boom")):
+            au.post_job_gpu_cleanup("test job")  # must not raise
+
+    def test_noop_without_cuda(self):
+        with patch.object(au, "HAS_TORCH", False):
+            au.post_job_gpu_cleanup("test job")  # must not raise
+
 
 # ── convert_to_wav ────────────────────────────────────────────────────────
 

--- a/server/backend/tests/test_config.py
+++ b/server/backend/tests/test_config.py
@@ -141,3 +141,10 @@ def test_resolve_parallel_diarization_default_accepts_serverconfig(tmp_path):
     # base, so the resolver must return False for a stock config too.
     cfg = config.ServerConfig()
     assert config.resolve_parallel_diarization_default(cfg) is False
+
+
+def test_resolve_low_vram_mode_accepts_serverconfig(tmp_path):
+    # ServerConfig() loads the baked-in defaults (low_vram_mode: false) as the
+    # merge base, so the resolver must return False for a stock config too.
+    cfg = config.ServerConfig()
+    assert config.resolve_low_vram_mode(cfg) is False

--- a/server/backend/tests/test_low_vram_mode.py
+++ b/server/backend/tests/test_low_vram_mode.py
@@ -1,0 +1,62 @@
+"""Low VRAM mode: cap the transcription batch size at 4.
+
+The mode is an opt-in trade of throughput for GPU headroom so the server
+coexists with other GPU workloads (e.g. a local LLM). Loaded models are
+never affected: the transcription and alignment models stay warm in both
+modes, only the per-job working set shrinks.
+
+Run:  ../../build/.venv/bin/pytest tests/test_low_vram_mode.py -v --tb=short
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from server.config import DEFAULT_LOW_VRAM_MODE, resolve_low_vram_mode
+
+
+class TestResolveLowVramMode:
+    def test_default_is_off(self):
+        assert DEFAULT_LOW_VRAM_MODE is False
+        assert resolve_low_vram_mode({}) is False
+
+    def test_dict_config_on(self):
+        assert resolve_low_vram_mode({"main_transcriber": {"low_vram_mode": True}}) is True
+
+    def test_dict_config_explicit_off(self):
+        assert resolve_low_vram_mode({"main_transcriber": {"low_vram_mode": False}}) is False
+
+
+class TestScaleBatchSizeLowVram:
+    def _manager(self, config: dict):
+        from server.core.model_manager import ModelManager
+
+        mm = object.__new__(ModelManager)
+        mm.gpu_available = True
+        mm.config = config
+        mm._gpu_device_index = 0
+        return mm
+
+    def test_low_vram_caps_at_4_even_on_big_gpus(self):
+        mm = self._manager({"main_transcriber": {"low_vram_mode": True}})
+        with patch(
+            "server.core.audio_utils.get_gpu_memory_info",
+            return_value={"available": True, "total_gb": 24.0},
+        ):
+            assert mm._scale_batch_size(16) == 4
+
+    def test_low_vram_never_raises_a_smaller_configured_size(self):
+        mm = self._manager({"main_transcriber": {"low_vram_mode": True}})
+        with patch(
+            "server.core.audio_utils.get_gpu_memory_info",
+            return_value={"available": True, "total_gb": 24.0},
+        ):
+            assert mm._scale_batch_size(2) == 2
+
+    def test_tiered_caps_unchanged_when_off(self):
+        mm = self._manager({"main_transcriber": {"low_vram_mode": False}})
+        with patch(
+            "server.core.audio_utils.get_gpu_memory_info",
+            return_value={"available": True, "total_gb": 12.0},
+        ):
+            assert mm._scale_batch_size(16) == 8

--- a/server/backend/tests/test_low_vram_mode.py
+++ b/server/backend/tests/test_low_vram_mode.py
@@ -53,6 +53,16 @@ class TestScaleBatchSizeLowVram:
         ):
             assert mm._scale_batch_size(2) == 2
 
+    def test_low_vram_leaves_exactly_4_unchanged(self):
+        # Pins the boundary at the cap itself: the comparison is a strict `>`,
+        # so a configured size of exactly 4 must pass through, not be re-capped.
+        mm = self._manager({"main_transcriber": {"low_vram_mode": True}})
+        with patch(
+            "server.core.audio_utils.get_gpu_memory_info",
+            return_value={"available": True, "total_gb": 24.0},
+        ):
+            assert mm._scale_batch_size(4) == 4
+
     def test_tiered_caps_unchanged_when_off(self):
         mm = self._manager({"main_transcriber": {"low_vram_mode": False}})
         with patch(

--- a/server/backend/tests/test_notebook_upload_recovery.py
+++ b/server/backend/tests/test_notebook_upload_recovery.py
@@ -76,6 +76,7 @@ class _ModelManager:
         self._dep_error = dep_error
         self.ensure_calls = 0
         self.job_tracker = _JobTracker()
+        self.gpu_device_index = 0
 
     def ensure_transcription_loaded(self):
         self.ensure_calls += 1

--- a/server/backend/tests/test_openai_audio_routes.py
+++ b/server/backend/tests/test_openai_audio_routes.py
@@ -71,6 +71,7 @@ def openai_client():
     app.state.model_manager = SimpleNamespace(
         ensure_transcription_loaded=lambda: mock_engine,
         transcription_engine=mock_engine,
+        gpu_device_index=0,
         job_tracker=SimpleNamespace(
             try_start_job=lambda client_name: (True, "job-1", None),
             end_job=lambda job_id: None,
@@ -257,6 +258,7 @@ def test_no_model_loaded_returns_503():
     app.state.model_manager = SimpleNamespace(
         ensure_transcription_loaded=lambda: fake_engine,
         transcription_engine=fake_engine,
+        gpu_device_index=0,
         job_tracker=SimpleNamespace(
             try_start_job=lambda cn: (True, "j", None),
             end_job=lambda j: None,
@@ -283,6 +285,7 @@ def test_job_busy_returns_429():
     app.state.model_manager = SimpleNamespace(
         ensure_transcription_loaded=lambda: fake_engine,
         transcription_engine=fake_engine,
+        gpu_device_index=0,
         job_tracker=SimpleNamespace(
             try_start_job=lambda cn: (False, None, "other-user"),
             end_job=lambda j: None,
@@ -506,6 +509,7 @@ class TestEnsureTranscriptionLoadedIntegration:
         app.state.model_manager = SimpleNamespace(
             ensure_transcription_loaded=ensure_loaded,
             transcription_engine=transcription_engine,
+            gpu_device_index=0,
             job_tracker=SimpleNamespace(
                 try_start_job=lambda cn: try_start_job_result,
                 end_job=end_job,
@@ -752,6 +756,7 @@ def diarization_client():
     app.state.model_manager = SimpleNamespace(
         ensure_transcription_loaded=lambda: mock_engine,
         transcription_engine=mock_engine,
+        gpu_device_index=0,
         job_tracker=SimpleNamespace(
             try_start_job=lambda client_name: (True, "job-1", None),
             end_job=lambda job_id: None,
@@ -1198,6 +1203,7 @@ def _build_engine_resolver_app(*, backend, model_name: str, sensevoice_engine: s
     app.state.model_manager = SimpleNamespace(
         ensure_transcription_loaded=lambda: mock_engine,
         transcription_engine=mock_engine,
+        gpu_device_index=0,
         job_tracker=SimpleNamespace(
             try_start_job=lambda cn: (True, "job-1", None),
             end_job=lambda j: None,

--- a/server/backend/tests/test_p0_durability.py
+++ b/server/backend/tests/test_p0_durability.py
@@ -9,6 +9,7 @@ Run:  ../../build/.venv/bin/pytest tests/test_p0_durability.py -v --tb=short
 from __future__ import annotations
 
 import asyncio
+import importlib
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -587,3 +588,42 @@ class TestDura007PeriodicSweepBusy:
 
         assert len(mark_calls) == 1
         assert mark_calls[0][0] == "startup-orphan"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Post-job GPU cleanup: the longform WS path must release cached VRAM
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.p0
+@pytest.mark.durability
+class TestPostJobGpuCleanupOnWs(_BaseProcessTranscription):
+    """The longform WS path must release cached VRAM in its finally."""
+
+    def _trace(self, monkeypatch) -> list[str]:
+        calls: list[str] = []
+        audio_utils = importlib.import_module("server.core.audio_utils")
+        monkeypatch.setattr(
+            audio_utils,
+            "post_job_gpu_cleanup",
+            lambda ctx="job", device_index=0: calls.append(ctx),
+            raising=False,
+        )
+        return calls
+
+    def test_cleanup_runs_after_success(self, monkeypatch):
+        calls = self._trace(monkeypatch)
+        session = _make_session()
+
+        asyncio.run(session.process_transcription())
+
+        assert calls == ["longform recording"]
+
+    def test_cleanup_runs_when_transcription_fails(self, monkeypatch):
+        calls = self._trace(monkeypatch)
+        self._engine.transcribe_file.side_effect = RuntimeError("CUDA OOM")
+        session = _make_session()
+
+        asyncio.run(session.process_transcription())
+
+        assert calls == ["longform recording"]

--- a/server/backend/tests/test_parallel_diarize.py
+++ b/server/backend/tests/test_parallel_diarize.py
@@ -6,7 +6,7 @@ import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
-from server.core.model_manager import TranscriptionCancelledError
+from server.core.model_manager import ModelManager, TranscriptionCancelledError
 from server.core.parallel_diarize import (
     transcribe_and_diarize,
     transcribe_then_diarize,
@@ -249,6 +249,21 @@ def test_parallel_transcribe_failure_still_unloads_diarization_model(mock_load_a
     mm.unload_diarization_model.assert_called_once()
 
 
+@patch("server.core.audio_utils.load_audio", return_value=(MagicMock(), 16000))
+def test_parallel_unload_failure_does_not_mask_original_exception(mock_load_audio):
+    """A raising unload_diarization_model in the outer finally must not replace
+    the exception already propagating from transcription (e.g. a cancellation) —
+    it should be logged and swallowed, not let it clobber the real error."""
+    engine = MagicMock()
+    engine.transcribe_file.side_effect = RuntimeError("distinctive transcribe failure")
+    mm = MagicMock()
+    mm.diarization_engine = MagicMock()
+    mm.unload_diarization_model.side_effect = RuntimeError("unload exploded")
+
+    with pytest.raises(RuntimeError, match="distinctive transcribe failure"):
+        transcribe_and_diarize(engine=engine, model_manager=mm, file_path="/tmp/test.wav")
+
+
 @patch("server.core.audio_utils.load_audio", side_effect=RuntimeError("bad audio"))
 def test_preload_failure_unloads_diarization_model(mock_load_audio):
     """load_diarization_model may succeed before load_audio fails — release it."""
@@ -366,3 +381,31 @@ def test_sequential_passes_parameters(mock_load_audio):
     mm.diarization_engine.diarize_audio.assert_called_once()
     d_kwargs = mm.diarization_engine.diarize_audio.call_args[1]
     assert d_kwargs["num_speakers"] == 4
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# ModelManager.unload_diarization_model idempotency
+#
+# The Sortformer branch in transcribe_and_diarize relies on this method being
+# safe to call twice: transcribe_then_diarize()'s own finally unloads first,
+# then the outer finally in transcribe_and_diarize unloads again on the way
+# out. This test pins the real (non-mocked) implementation's idempotency
+# guard so a future change to it can't silently reintroduce a double
+# teardown. Lives here rather than in test_model_manager_init.py (scoped to
+# init/feature-flag logic) or test_ensure_transcription_loaded.py (scoped to
+# the transcription-reload lock) — neither covers diarization unload
+# lifecycle, and this file is where that lifecycle is exercised end to end.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_unload_diarization_model_is_idempotent():
+    """Calling unload_diarization_model twice must only tear down once."""
+    mgr = object.__new__(ModelManager)
+    engine = MagicMock()
+    mgr._diarization_engine = engine
+
+    mgr.unload_diarization_model()
+    mgr.unload_diarization_model()
+
+    engine.unload.assert_called_once()
+    assert mgr._diarization_engine is None

--- a/server/backend/tests/test_parallel_diarize.py
+++ b/server/backend/tests/test_parallel_diarize.py
@@ -214,6 +214,57 @@ def test_passes_language_and_task_to_transcribe(mock_load_audio):
     assert call_kwargs["translation_target_language"] == "en"
 
 
+@patch("server.core.audio_utils.load_audio", return_value=(MagicMock(), 16000))
+def test_parallel_success_unloads_diarization_model(mock_load_audio):
+    """After a successful parallel run the diarization model must be unloaded."""
+    engine = MagicMock()
+    engine.transcribe_file.return_value = MagicMock(words=[], segments=[])
+    mm = MagicMock()
+    diar_engine = MagicMock()
+    diar_result = MagicMock()
+    diar_result.segments = [MagicMock()]
+    diar_result.num_speakers = 2
+    diar_engine.diarize_audio.return_value = diar_result
+    mm.diarization_engine = diar_engine
+
+    result, diar = transcribe_and_diarize(
+        engine=engine, model_manager=mm, file_path="/tmp/test.wav"
+    )
+
+    assert diar is diar_result
+    mm.unload_diarization_model.assert_called_once()
+
+
+@patch("server.core.audio_utils.load_audio", return_value=(MagicMock(), 16000))
+def test_parallel_transcribe_failure_still_unloads_diarization_model(mock_load_audio):
+    """A transcription crash must not leave the diarization model resident."""
+    engine = MagicMock()
+    engine.transcribe_file.side_effect = RuntimeError("boom")
+    mm = MagicMock()
+    mm.diarization_engine = MagicMock()
+
+    with pytest.raises(RuntimeError):
+        transcribe_and_diarize(engine=engine, model_manager=mm, file_path="/tmp/test.wav")
+
+    mm.unload_diarization_model.assert_called_once()
+
+
+@patch("server.core.audio_utils.load_audio", side_effect=RuntimeError("bad audio"))
+def test_preload_failure_unloads_diarization_model(mock_load_audio):
+    """load_diarization_model may succeed before load_audio fails — release it."""
+    engine = MagicMock()
+    engine.transcribe_file.return_value = MagicMock(words=[], segments=[])
+    mm = MagicMock()
+    mm.diarization_engine = MagicMock()
+
+    result, diar = transcribe_and_diarize(
+        engine=engine, model_manager=mm, file_path="/tmp/test.wav"
+    )
+
+    assert diar is None
+    mm.unload_diarization_model.assert_called_once()
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Sequential: transcribe_then_diarize
 # ──────────────────────────────────────────────────────────────────────────────

--- a/server/backend/tests/test_parallel_diarize.py
+++ b/server/backend/tests/test_parallel_diarize.py
@@ -252,7 +252,7 @@ def test_parallel_transcribe_failure_still_unloads_diarization_model(mock_load_a
 @patch("server.core.audio_utils.load_audio", return_value=(MagicMock(), 16000))
 def test_parallel_unload_failure_does_not_mask_original_exception(mock_load_audio):
     """A raising unload_diarization_model in the outer finally must not replace
-    the exception already propagating from transcription (e.g. a cancellation) —
+    the exception already propagating from transcription (e.g. a cancellation) -
     it should be logged and swallowed, not let it clobber the real error."""
     engine = MagicMock()
     engine.transcribe_file.side_effect = RuntimeError("distinctive transcribe failure")
@@ -266,7 +266,7 @@ def test_parallel_unload_failure_does_not_mask_original_exception(mock_load_audi
 
 @patch("server.core.audio_utils.load_audio", side_effect=RuntimeError("bad audio"))
 def test_preload_failure_unloads_diarization_model(mock_load_audio):
-    """load_diarization_model may succeed before load_audio fails — release it."""
+    """load_diarization_model may succeed before load_audio fails - release it."""
     engine = MagicMock()
     engine.transcribe_file.return_value = MagicMock(words=[], segments=[])
     mm = MagicMock()
@@ -393,7 +393,7 @@ def test_sequential_passes_parameters(mock_load_audio):
 # guard so a future change to it can't silently reintroduce a double
 # teardown. Lives here rather than in test_model_manager_init.py (scoped to
 # init/feature-flag logic) or test_ensure_transcription_loaded.py (scoped to
-# the transcription-reload lock) — neither covers diarization unload
+# the transcription-reload lock) - neither covers diarization unload
 # lifecycle, and this file is where that lifecycle is exercised end to end.
 # ──────────────────────────────────────────────────────────────────────────────
 

--- a/server/backend/tests/test_post_job_gpu_cleanup_sites.py
+++ b/server/backend/tests/test_post_job_gpu_cleanup_sites.py
@@ -141,7 +141,7 @@ def test_openai_transcription_runs_gpu_cleanup(monkeypatch):
     file.read = AsyncMock(return_value=b"riff")
 
     # Calling the route directly bypasses FastAPI's Form(...) resolution, so
-    # every Form-declared parameter must be passed explicitly — left at their
+    # every Form-declared parameter must be passed explicitly - left at their
     # signature defaults they are unresolved fastapi.params.Form sentinels,
     # not the values those defaults describe, and `response_format not in
     # _VALID_RESPONSE_FORMATS` trips before the try/finally is ever reached.

--- a/server/backend/tests/test_post_job_gpu_cleanup_sites.py
+++ b/server/backend/tests/test_post_job_gpu_cleanup_sites.py
@@ -1,0 +1,200 @@
+"""Every job completion must hand cached GPU memory back to the driver.
+
+The cleanup lives in each site's ``finally`` so it runs on success, failure
+and cancellation alike. These tests drive the cheapest deterministic path
+(usually a failure right at engine load) and assert the cleanup still fired.
+
+Run:  ../../build/.venv/bin/pytest tests/test_post_job_gpu_cleanup_sites.py -v --tb=short
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from server.api.routes import notebook as notebook_routes
+from server.api.routes import openai_audio, transcription
+
+
+def _trace_cleanup(monkeypatch) -> list[str]:
+    calls: list[str] = []
+    audio_utils = importlib.import_module("server.core.audio_utils")
+    monkeypatch.setattr(
+        audio_utils,
+        "post_job_gpu_cleanup",
+        lambda ctx="job", device_index=0: calls.append(ctx),
+        raising=False,
+    )
+    return calls
+
+
+def _raise_boom() -> Any:
+    raise RuntimeError("boom")
+
+
+def test_file_import_runs_gpu_cleanup_even_on_failure(monkeypatch, tmp_path):
+    calls = _trace_cleanup(monkeypatch)
+    ended: list[Any] = []
+    model_manager = SimpleNamespace(
+        job_tracker=SimpleNamespace(
+            update_progress=lambda *a: None,
+            set_phase=lambda *_: None,
+            end_job=lambda job_id, result=None: ended.append(result),
+            is_cancelled=lambda: False,
+        ),
+        ensure_transcription_loaded=_raise_boom,
+        gpu_device_index=0,
+    )
+    wav = tmp_path / "a.wav"
+    wav.write_bytes(b"RIFF")
+
+    transcription._run_file_import(
+        model_manager=model_manager,
+        tmp_path=wav,
+        filename="a.wav",
+        language=None,
+        translation_enabled=False,
+        translation_target_language=None,
+        enable_diarization=False,
+        enable_word_timestamps=True,
+        expected_speakers=None,
+        parallel_diarization=None,
+        use_parallel_default=False,
+        multitrack=False,
+        job_id="job12345",
+        event_loop=None,
+    )
+
+    assert calls == ["file import"]
+    assert ended and "error" in ended[-1]
+
+
+def test_notebook_import_runs_gpu_cleanup_even_on_failure(monkeypatch, tmp_path):
+    calls = _trace_cleanup(monkeypatch)
+    ended: list[Any] = []
+    model_manager = SimpleNamespace(
+        job_tracker=SimpleNamespace(
+            update_progress=lambda *a: None,
+            set_phase=lambda *_: None,
+            end_job=lambda job_id, result=None: ended.append(result),
+            is_cancelled=lambda: False,
+        ),
+        ensure_transcription_loaded=_raise_boom,
+        gpu_device_index=0,
+    )
+    wav = tmp_path / "a.wav"
+    wav.write_bytes(b"RIFF")
+
+    notebook_routes._run_transcription(
+        model_manager=model_manager,
+        tmp_path=wav,
+        filename="a.wav",
+        language=None,
+        translation_enabled=False,
+        translation_target_language=None,
+        enable_diarization=False,
+        enable_word_timestamps=True,
+        file_created_at=None,
+        expected_speakers=None,
+        parallel_diarization=None,
+        use_parallel_default=False,
+        title=None,
+        job_id="job12345",
+        event_loop=None,
+    )
+
+    assert calls == ["notebook import"]
+    assert ended and "error" in ended[-1]
+
+
+def _openai_request(mm: SimpleNamespace) -> SimpleNamespace:
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(model_manager=mm)))
+
+
+def _openai_model_manager(ended: list[Any]) -> SimpleNamespace:
+    return SimpleNamespace(
+        ensure_transcription_loaded=lambda: None,
+        gpu_device_index=0,
+        job_tracker=SimpleNamespace(
+            try_start_job=lambda _c: (True, "job-1", None),
+            end_job=lambda job_id: ended.append(job_id),
+        ),
+    )
+
+
+def test_openai_transcription_runs_gpu_cleanup(monkeypatch):
+    calls = _trace_cleanup(monkeypatch)
+    monkeypatch.setattr(openai_audio, "_assert_model_loaded", lambda _r: None)
+    monkeypatch.setattr(openai_audio, "get_client_name", lambda _r: "test-client")
+
+    async def _boom(**_kw: Any) -> Any:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(openai_audio, "_run_transcription", _boom)
+    ended: list[Any] = []
+    mm = _openai_model_manager(ended)
+    file = MagicMock()
+    file.filename = "a.wav"
+    file.read = AsyncMock(return_value=b"riff")
+
+    # Calling the route directly bypasses FastAPI's Form(...) resolution, so
+    # every Form-declared parameter must be passed explicitly — left at their
+    # signature defaults they are unresolved fastapi.params.Form sentinels,
+    # not the values those defaults describe, and `response_format not in
+    # _VALID_RESPONSE_FORMATS` trips before the try/finally is ever reached.
+    asyncio.run(
+        openai_audio.create_transcription(
+            request=_openai_request(mm),
+            file=file,
+            model="whisper-1",
+            language=None,
+            prompt=None,
+            response_format="json",
+            temperature=None,
+            timestamp_granularities=None,
+            diarization=False,
+            expected_speakers=None,
+            parallel_diarization=None,
+        )
+    )
+
+    assert calls == ["openai transcription"]
+    assert ended == ["job-1"]
+
+
+def test_openai_translation_runs_gpu_cleanup(monkeypatch):
+    calls = _trace_cleanup(monkeypatch)
+    monkeypatch.setattr(openai_audio, "_assert_model_loaded", lambda _r: None)
+    monkeypatch.setattr(openai_audio, "get_client_name", lambda _r: "test-client")
+
+    async def _boom(**_kw: Any) -> Any:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(openai_audio, "_run_transcription", _boom)
+    ended: list[Any] = []
+    mm = _openai_model_manager(ended)
+    file = MagicMock()
+    file.filename = "a.wav"
+    file.read = AsyncMock(return_value=b"riff")
+
+    # Same Form(...) resolution caveat as the transcription test above.
+    asyncio.run(
+        openai_audio.create_translation(
+            request=_openai_request(mm),
+            file=file,
+            model="whisper-1",
+            prompt=None,
+            response_format="json",
+            temperature=None,
+            timestamp_granularities=None,
+            diarization=False,
+            expected_speakers=None,
+            parallel_diarization=None,
+        )
+    )
+
+    assert calls == ["openai translation"]
+    assert ended == ["job-1"]

--- a/server/backend/tests/test_retry_clears_gpu_cache.py
+++ b/server/backend/tests/test_retry_clears_gpu_cache.py
@@ -67,11 +67,18 @@ def _drive_retry(monkeypatch, *, transcribe_raises: Exception | None = None) -> 
             end_job=lambda _id: None,
         ),
         ensure_transcription_loaded=lambda: fake_engine,
+        gpu_device_index=0,
     )
 
     audio_utils = importlib.import_module("server.core.audio_utils")
     monkeypatch.setattr(
         audio_utils, "clear_gpu_cache", lambda: trace.append("clear_gpu_cache"), raising=False
+    )
+    monkeypatch.setattr(
+        audio_utils,
+        "post_job_gpu_cleanup",
+        lambda ctx="job", device_index=0: trace.append("post_job_gpu_cleanup"),
+        raising=False,
     )
 
     repo = importlib.import_module("server.database.job_repository")
@@ -116,6 +123,7 @@ def test_retry_still_succeeds_if_cache_clear_fails(monkeypatch):
             end_job=lambda _id: None,
         ),
         ensure_transcription_loaded=lambda: fake_engine,
+        gpu_device_index=0,
     )
 
     def _boom() -> None:
@@ -137,3 +145,10 @@ def test_retry_still_succeeds_if_cache_clear_fails(monkeypatch):
 
     assert "save_result" in trace, f"a failing cache clear aborted the retry: {trace}"
     assert "mark_failed" not in trace
+
+
+def test_gpu_cleanup_runs_after_retry_completes(monkeypatch):
+    # save_result also lands in the trace (patched in _drive_retry) — it runs
+    # inside the try, after transcribe_file and before the finally's cleanup.
+    trace = _drive_retry(monkeypatch)
+    assert trace == ["clear_gpu_cache", "transcribe_file", "save_result", "post_job_gpu_cleanup"]

--- a/server/backend/tests/test_retry_clears_gpu_cache.py
+++ b/server/backend/tests/test_retry_clears_gpu_cache.py
@@ -148,7 +148,7 @@ def test_retry_still_succeeds_if_cache_clear_fails(monkeypatch):
 
 
 def test_gpu_cleanup_runs_after_retry_completes(monkeypatch):
-    # save_result also lands in the trace (patched in _drive_retry) — it runs
+    # save_result also lands in the trace (patched in _drive_retry) - it runs
     # inside the try, after transcribe_file and before the finally's cleanup.
     trace = _drive_retry(monkeypatch)
     assert trace == ["clear_gpu_cache", "transcribe_file", "save_result", "post_job_gpu_cleanup"]

--- a/server/backend/tests/test_retry_persists_segments.py
+++ b/server/backend/tests/test_retry_persists_segments.py
@@ -77,6 +77,7 @@ def _make_app_state(fake_result: _FakeResult) -> SimpleNamespace:
     model_manager = SimpleNamespace(
         job_tracker=job_tracker,
         ensure_transcription_loaded=lambda: fake_engine,
+        gpu_device_index=0,
     )
     return SimpleNamespace(model_manager=model_manager)
 

--- a/server/backend/tests/test_stt_engine_helpers.py
+++ b/server/backend/tests/test_stt_engine_helpers.py
@@ -796,3 +796,62 @@ class TestComputeTypeAutoCorrection:
             self._apply_correction(rec)
 
         assert rec.compute_type == "auto"
+
+
+# ── shutdown() backend unload ────────────────────────────────────────────
+
+
+def _make_recorder_for_shutdown(owns_backend: bool):
+    import threading
+
+    rec = object.__new__(AudioToTextRecorder)
+    rec.instance_name = "test"
+    rec.is_shut_down = False
+    rec.is_running = True
+    rec.start_recording_event = threading.Event()
+    rec.stop_recording_event = threading.Event()
+    rec.shutdown_event = threading.Event()
+    rec.recording_thread = None
+    rec._backend = MagicMock()
+    rec._owns_backend = owns_backend
+    rec._model_loaded = True
+    return rec
+
+
+class TestShutdownUnloadsBackend:
+    def test_shutdown_unloads_owned_backend(self):
+        rec = _make_recorder_for_shutdown(owns_backend=True)
+        backend = rec._backend
+
+        rec.shutdown()
+
+        backend.unload.assert_called_once()
+        assert rec._backend is None
+        assert rec._model_loaded is False
+
+    def test_shutdown_leaves_shared_backend_alone(self):
+        """A borrowed backend (Live Mode sharing) belongs to the caller."""
+        rec = _make_recorder_for_shutdown(owns_backend=False)
+        backend = rec._backend
+
+        rec.shutdown()
+
+        backend.unload.assert_not_called()
+        assert rec._backend is None
+
+    def test_shutdown_is_idempotent(self):
+        rec = _make_recorder_for_shutdown(owns_backend=True)
+        backend = rec._backend
+
+        rec.shutdown()
+        rec.shutdown()
+
+        backend.unload.assert_called_once()
+
+    def test_shutdown_survives_unload_failure(self):
+        rec = _make_recorder_for_shutdown(owns_backend=True)
+        rec._backend.unload.side_effect = RuntimeError("CUDA context gone")
+
+        rec.shutdown()  # must not raise
+
+        assert rec._backend is None

--- a/server/backend/tests/test_stt_engine_helpers.py
+++ b/server/backend/tests/test_stt_engine_helpers.py
@@ -838,15 +838,29 @@ class TestShutdownUnloadsBackend:
 
         backend.unload.assert_not_called()
         assert rec._backend is None
+        assert rec._model_loaded is False
 
     def test_shutdown_is_idempotent(self):
         rec = _make_recorder_for_shutdown(owns_backend=True)
         backend = rec._backend
 
         rec.shutdown()
+
+        # Reassign to a fresh mock so the second call's effect on *this*
+        # object is what gets checked, isolating the ``is_shut_down`` guard:
+        # ``self._backend`` is already ``None`` after the first call, so an
+        # assertion against the original mock would pass even if the guard
+        # were deleted (the ``if self._backend is not None`` check alone
+        # would already stop a second unload). Swapping in a fresh backend
+        # means only the guard - not that side effect - can prevent the
+        # second call from touching it.
+        rec._backend = MagicMock()
+        fresh_backend = rec._backend
+
         rec.shutdown()
 
         backend.unload.assert_called_once()
+        fresh_backend.unload.assert_not_called()
 
     def test_shutdown_survives_unload_failure(self):
         rec = _make_recorder_for_shutdown(owns_backend=True)

--- a/server/config.yaml
+++ b/server/config.yaml
@@ -76,9 +76,11 @@ main_transcriber:
     beam_size: 5
 
     # Low VRAM mode: trade some speed for a smaller GPU footprint. Caps the
-    # transcription batch size at 4, which roughly halves the extra VRAM used
-    # while a job runs. Useful when sharing the GPU with other apps (e.g. a
-    # local LLM). Loaded models are not affected - they stay in VRAM either way.
+    # transcription batch size at 4 regardless of card size, which shrinks the
+    # extra VRAM a job needs at its peak. Useful when sharing the GPU with
+    # other apps (e.g. a local LLM). Cards with 8 GB or less already cap at 4,
+    # so this is a no-op there. Loaded models are not affected - they stay in
+    # VRAM either way.
     low_vram_mode: false
 
     # Optional initial prompt to guide transcription style/context.

--- a/server/config.yaml
+++ b/server/config.yaml
@@ -75,6 +75,12 @@ main_transcriber:
     # Beam size for decoding. Higher can improve accuracy but is slower.
     beam_size: 5
 
+    # Low VRAM mode: trade some speed for a smaller GPU footprint. Caps the
+    # transcription batch size at 4, which roughly halves the extra VRAM used
+    # while a job runs. Useful when sharing the GPU with other apps (e.g. a
+    # local LLM). Loaded models are not affected - they stay in VRAM either way.
+    low_vram_mode: false
+
     # Optional initial prompt to guide transcription style/context.
     # Example: "This is a technical transcript. ZFS, Kubernetes, TCP/IP."
     initial_prompt: null

--- a/server/config.yaml
+++ b/server/config.yaml
@@ -78,9 +78,11 @@ main_transcriber:
     # Low VRAM mode: trade some speed for a smaller GPU footprint. Caps the
     # transcription batch size at 4 regardless of card size, which shrinks the
     # extra VRAM a job needs at its peak. Useful when sharing the GPU with
-    # other apps (e.g. a local LLM). Cards with 8 GB or less already cap at 4,
-    # so this is a no-op there. Loaded models are not affected - they stay in
-    # VRAM either way.
+    # other apps (e.g. a local LLM). Only the WhisperX backend reads batch
+    # size, so this affects faster-whisper and Whisper models only - NeMo
+    # (Parakeet/Canary), whisper.cpp, SenseVoice, VibeVoice and MLX ignore it.
+    # Cards with 8 GB or less already cap at 4, so it is a no-op there too.
+    # Loaded models are not affected - they stay in VRAM either way.
     low_vram_mode: false
 
     # Optional initial prompt to guide transcription style/context.


### PR DESCRIPTION
## Why

Measured on an RTX 3060 (12 GB, headless, `Systran/faster-whisper-large-v3` via WhisperX) while the same card also hosts LM Studio models:

- **Idle baseline ~5.83 GB** with the model warm: ~4.5 GB CTranslate2 weights + CUDA context + pyannote VAD + cuDNN, plus ~1.2 GB wav2vec2 alignment model that loads on the first job.
- **Creep between jobs is real but small and converges**: +62 MiB over 7 jobs, then flat. A 20-minute job returned to baseline exactly.
- **Transient peaks are the actual problem**: batched inference spikes to +2.8 GB over baseline (8.6 GB total). With an LLM co-resident on the same card, that is what causes an out-of-memory crash mid-transcription.
- No job-completion path touched the GPU at all. The only `clear_gpu_cache()` at the route layer was the retry pre-flight.

The working principle throughout: **the model stays warm for as long as the server runs.** Nothing here unloads a transcription or alignment model. What changes is that memory the app is not using goes back to the driver, and the per-job working set can be made smaller on request.

## What changed

1. **Honest GPU numbers + a reusable cleanup helper** (`core/audio_utils.py`). `get_gpu_memory_info()` reported only the PyTorch caching allocator, so it showed ~1.2 GB allocated while the device actually held 5.8 GB - CTranslate2 allocates outside torch entirely. It now also reports `device_free_gb`/`device_used_gb` from `torch.cuda.mem_get_info()` (best-effort, keys absent when unsupported). New `post_job_gpu_cleanup(context, device_index)` clears the cache and logs the after-state; it never raises, because it is called from `finally` blocks.

2. **Cleanup wired into every job-completion path**: longform WebSocket recording, file import, notebook import, retry, and both OpenAI-compatible audio handlers. Deliberately NOT the rolling preview - it fires every few seconds during a recording and would thrash the allocator. `ModelManager` gained a read-only `gpu_device_index` property so the routes do not reach into a private attribute.

3. **Parallel-diarization leak fixed** (`core/parallel_diarize.py`). `transcribe_and_diarize()` loaded the diarization model and never unloaded it, so it stayed resident for the life of the server after a single parallel-diarized job. Its sequential sibling always did unload. A single `try/finally` now covers all four exits, including the transcription-only fallback where the model can load before `load_audio()` fails.

4. **`AudioToTextRecorder.shutdown()` now unloads owned backends** instead of dropping the reference and leaving VRAM to the garbage collector. Borrowed backends (Live Mode sharing the main model) are untouched - they belong to the caller.

5. **Opt-in `main_transcriber.low_vram_mode`** (default off) caps the transcription batch size at 4 regardless of card size, shrinking the transient peak. The toggle appears automatically in Settings -> Server tab: `ServerConfigEditor` renders any boolean template key as a switch and uses the yaml comment as its description. Like every `main_transcriber` setting, it takes effect after a server restart.

   **Scope worth knowing:** WhisperX is the only backend that reads `batch_size`, so the setting is inert for NeMo (Parakeet/Canary), whisper.cpp, SenseVoice (which batches by duration, not count), VibeVoice and the MLX backends - and the shipped default model is `nvidia/parakeet-tdt-0.6b-v3`. Both the yaml description and the resolver docstring say so explicitly rather than promising a cap that would silently do nothing.

6. **Dashboard type fix**: `ServerStatus.gpu_memory` was typed `string` at the top level, but the backend nests a dict under `models.gpu_memory` and sends no top-level field. Retyped to the real shape. Zero runtime consumers existed, so this is type-only.

## Ordering rule worth knowing about

The cleanup is the **last** statement in every `finally`. At the async sites it runs via `asyncio.to_thread`, and a cancellation landing inside that await propagates immediately, skipping anything sequenced behind it. At the retry and OpenAI sites the thing behind it would have been `job_tracker.end_job(...)` - and the tracker is a single slot with no timeout and no admin force-release, so a skipped release would make the server answer 429 for every later job until restart. Each site carries a comment saying it must stay last.

## Accepted tradeoffs

- Parallel diarization now reloads the diarization model per job (~10-20 s). This matches what the sequential path has always done; VRAM discipline wins over back-to-back throughput.
- `low_vram_mode` roughly halves batched throughput on a 12 GB card running WhisperX. It is off by default, is a no-op on cards of 8 GB or less (which already cap at 4), and has no effect at all on non-WhisperX backends.

## Tests

Backend: `2255 passed, 4 skipped` (build venv, full suite). Dashboard: `1969 passed` across 136 files, plus `npm run typecheck` clean.

New coverage includes the cleanup firing from each site's `finally` on the failure path, the WS path on both success and failure, retry call ordering, diarization unload on success/failure/pre-load-failure, unload failures not masking an in-flight cancellation, `unload_diarization_model` idempotency, `shutdown()` ownership semantics, and the batch cap including its exact-4 boundary.

## Verified live against a running server on this branch

`GET /api/status` now returns both views, which is exactly the gap this PR closes:

```
model: Systran/faster-whisper-large-v3 (loaded)
gpu_memory: torch allocated 0.01 GB / reserved 0.02 GB, device_used 3.91 GB, device_free 7.72 GB
```

Before, only the torch numbers existed, so a warm server looked like it was using 0.01 GB.

## Hardware smoke checklist (not covered by CI)

- [x] With `low_vram_mode` OFF: a `GPU memory after ...` log line appears after each job, and idle VRAM returns to about baseline
- [x] With `low_vram_mode` ON (Settings -> Server tab -> expand the "Main Transcriber" section; restart the server): peak VRAM during a long import is noticeably lower, idle baseline unchanged because models stay warm
- [ ] A diarized import with parallel diarization enabled: `nvidia-smi` settles back after the job, showing the diarization model was released
- [ ] Longform recording end to end still transcribes with word timestamps
- [ ] Retry of a failed job still works and still clears the cache before re-transcribing