### PR TITLE
fix(tests): make two pre-existing test defects deterministic

### DIFF
--- a/server/backend/pyproject.toml
+++ b/server/backend/pyproject.toml
@@ -169,6 +169,7 @@ markers = [
     "live_mode: Live Mode transcription engine and session",
     "model_swap: Model swap lifecycle and recovery",
     "openai_api: OpenAI-compatible API format and edge cases",
+    "slow: Long-running benchmarks intended for the nightly run, not per-PR",
 ]
 
 # The section below is needed to specifically get CUDA 12.9 (and not the default 12.8).

--- a/server/backend/tests/test_review_filter_linearity.py
+++ b/server/backend/tests/test_review_filter_linearity.py
@@ -103,24 +103,36 @@ def test_filter_linearity_r_squared_above_0_95() -> None:
     """
     sizes = [10, 100, 500, 1000]
     samples_per_size = 30
-    means: list[float] = []
+    # This measures CPU time, not wall clock, and takes the best of N.
+    #
+    # Linearity is a claim about WORK, so process_time_ns is the honest metric:
+    # it excludes every interval where the scheduler descheduled us, which is
+    # what made this test flaky. Wall-clock timing on a loaded machine inflated
+    # whichever size happened to get preempted, bending the fit; on a saturated
+    # box every sample of a size can be hit, so best-of-N alone is not enough.
+    # Best-of-N is kept on top because remaining noise is strictly additive.
+    timings: list[float] = []
     for n in sizes:
         turns = _sample_turns(n)
+        # Warm up so first-call effects (branch prediction, allocator growth)
+        # are not charged to the first measured sample.
+        for _ in range(3):
+            _ = filter_low_confidence(turns, mode="below_80")
         per_size: list[int] = []
         for _ in range(samples_per_size):
-            t0 = time.perf_counter_ns()
+            t0 = time.process_time_ns()
             _ = filter_low_confidence(turns, mode="below_80")
-            per_size.append(time.perf_counter_ns() - t0)
-        means.append(float(np.mean(per_size)))
+            per_size.append(time.process_time_ns() - t0)
+        timings.append(float(min(per_size)))
 
     # Linear regression Y = aX + b; report r²
     x = np.array(sizes, dtype=float)
-    y = np.array(means, dtype=float)
+    y = np.array(timings, dtype=float)
     slope, intercept = np.polyfit(x, y, 1)
     pred = slope * x + intercept
     ss_res = float(np.sum((y - pred) ** 2))
     ss_tot = float(np.sum((y - np.mean(y)) ** 2))
     r2 = 1.0 - (ss_res / ss_tot) if ss_tot > 0 else 1.0
     assert r2 > 0.95 or math.isclose(r2, 0.95, rel_tol=0.01), (
-        f"linearity r²={r2:.3f} < 0.95; sizes={sizes} means_ns={means}"
+        f"linearity r²={r2:.3f} < 0.95; sizes={sizes} min_ns={timings}"
     )

--- a/server/backend/tests/test_stt_engine_helpers.py
+++ b/server/backend/tests/test_stt_engine_helpers.py
@@ -52,13 +52,13 @@ def _ensure_engine_importable() -> None:
         sys.modules["scipy"] = scipy
         sys.modules["scipy.signal"] = scipy_signal
 
-    # server.core.stt.backends.factory
-    factory_mod_name = "server.core.stt.backends.factory"
-    if factory_mod_name not in sys.modules:
-        factory_stub = types.ModuleType(factory_mod_name)
-        factory_stub.create_backend = MagicMock()  # type: ignore[attr-defined]
-        factory_stub.detect_backend_type = MagicMock(return_value="whisper")  # type: ignore[attr-defined]
-        sys.modules[factory_mod_name] = factory_stub
+    # server.core.stt.backends.factory — like capabilities below, the real
+    # module only imports ``re`` at module scope (every backend import is lazy
+    # inside its factory branch), so we let it import naturally.
+    # It must NOT be stubbed: ``server.core.stt.backends.__init__`` does a
+    # from-import of several names off it, so a partial stub makes this file
+    # fail at collection with ImportError whenever it runs before whichever
+    # other test file happens to import the real module first.
 
     # server.core.stt.capabilities — the real module has no heavy deps
     # (only imports ``re``), so we let it import naturally instead of stubbing.


### PR DESCRIPTION
Two defects found while working on #269, both pre-existing and unrelated to that PR's subject. Neither changes production code - only test code and the pytest marker registry.

## 1. `test_stt_engine_helpers.py` could not be collected on its own

```
$ ../../build/.venv/bin/pytest tests/test_stt_engine_helpers.py -q
E   ImportError: cannot import name 'is_canary_model' from 'server.core.stt.backends.factory'
!!!!!!!! Interrupted: 1 error during collection !!!!!!!!
```

The file installs lightweight stubs for the engine's heavy imports before importing it. Its factory stub defined only `create_backend` and `detect_backend_type`, but `server/core/stt/backends/__init__.py` from-imports six names off that module, so the partial stub failed the import. It passed in the full suite purely by accident of ordering: the stub is installed under `if factory_mod_name not in sys.modules`, and some earlier test file imports the real factory first, so the stub was skipped and the real module was used.

Anyone running that single file directly - the normal thing to do while iterating on it - got an `ImportError` that had nothing to do with their change.

Fix: stop stubbing the factory. `factory.py` imports only `re` at module scope (every backend import is lazy inside its dispatch branch), so there was never anything heavy to stub. This is the same reasoning, and now the same treatment, that the file already documents for `server.core.stt.capabilities` a few lines below. It also removes the divergence: the full suite was already exercising the real factory.

Verified: `pytest tests/test_stt_engine_helpers.py -q` -> `55 passed`.

## 2. `test_filter_linearity_r_squared_above_0_95` was flaky under machine load

The benchmark asserts r² > 0.95 for a linear fit of runtime against input size across [10, 100, 500, 1000] turns. It timed each size with `perf_counter_ns` and fed the **mean** of 30 wall-clock samples into the regression. One preempted sample moves a mean enough to bend the fit, so the test failed whenever the machine was busy - it went red during #269's work simply because several agents were running tests concurrently.

Fix, in two parts:

- **Measure CPU time (`process_time_ns`), not wall clock.** Linearity is a claim about *work*; intervals where the scheduler descheduled the process are not work and must not be counted.
- **Take the best of N rather than the mean.** Remaining noise is strictly additive, so the minimum is the least contaminated estimate. Also added a 3-iteration warmup per size so first-call effects are not charged to the first measured sample.

Best-of-N alone was measured to be insufficient: with the mean replaced by the minimum but still on wall clock, a saturated machine hit *every* sample of one size (N=500 measured 71.6 ns/turn against N=1000's 46.4 ns/turn), still producing r²=0.928.

Verified by stress test - the benchmark run 20 times while 6 CPU-burner processes saturated the machine:

```
failures under load: 0 / 20
```

The same harness against the wall-clock version reproduced the failure.

## 3. Registered the `slow` marker

`@pytest.mark.slow` on that benchmark was never registered in `pyproject.toml`, so every full-suite run emitted `PytestUnknownMarkWarning: Unknown pytest.mark.slow - is this a typo?`. Registered it with the meaning the file's docstring already assigns it (nightly, not per-PR). Full-suite warnings drop from 2 to 1; the remaining one is a third-party Starlette deprecation.

## Tests

Full backend suite: `2255 passed, 4 skipped, 1 warning`. `ruff check` and `ruff format --check` clean on both files.