### PR TITLE
fix(live): make Live Mode report the real start outcome instead of a premature success

### DIFF
--- a/dashboard/src/hooks/useLiveMode.test.ts
+++ b/dashboard/src/hooks/useLiveMode.test.ts
@@ -179,6 +179,42 @@ describe('[P1] useLiveMode', () => {
       expect(result.current.error).toBe('Engine crashed');
     });
 
+    // GH-271: a terminal engine failure arrives as an out-of-band `state`
+    // frame. The hook used to drop it, leaving the UI stuck in listening.
+    it('transitions to error on state ERROR and tears down capture', async () => {
+      const { result } = renderHook(() => useLiveMode());
+      await driveToListening(result);
+
+      act(() => {
+        lastSocketCbs.onMessage!({ type: 'state', data: { state: 'ERROR' } });
+      });
+
+      expect(result.current.status).toBe('error');
+      expect(result.current.error).toContain('engine reported an error');
+      expect(result.current.statusMessage).toBeNull();
+      expect(lastCapture.stop).toHaveBeenCalled();
+    });
+
+    it('keeps the specific error message when an error frame precedes state ERROR', () => {
+      const { result } = renderHook(() => useLiveMode());
+
+      act(() => {
+        result.current.start();
+      });
+      act(() => {
+        lastSocketCbs.onMessage!({
+          type: 'error',
+          data: { message: 'Failed to start Live Mode: CUDA out of memory' },
+        });
+      });
+      act(() => {
+        lastSocketCbs.onMessage!({ type: 'state', data: { state: 'ERROR' } });
+      });
+
+      expect(result.current.status).toBe('error');
+      expect(result.current.error).toBe('Failed to start Live Mode: CUDA out of memory');
+    });
+
     it('transitions to error on socket error callback', () => {
       const { result } = renderHook(() => useLiveMode());
 

--- a/dashboard/src/hooks/useLiveMode.ts
+++ b/dashboard/src/hooks/useLiveMode.ts
@@ -185,6 +185,18 @@ export function useLiveMode(): LiveModeState {
             }
           } else if (state === 'PROCESSING') {
             setStatusTracked('processing');
+          } else if (state === 'ERROR') {
+            // GH-271: the engine reports a terminal failure out of band. This
+            // branch used to be missing, so an engine that died mid-session
+            // left the UI sitting in listening forever with audio still
+            // streaming into a dead session. Keep any more specific message
+            // that an `error` frame already delivered (or is about to): the
+            // two frames race, and the specific one always wins.
+            captureRef.current?.stop();
+            setAnalyser(null);
+            setStatusMessage(null);
+            setError((prev) => prev ?? 'Live mode stopped because the engine reported an error.');
+            setStatusTracked('error');
           } else if (state === 'STOPPED') {
             // GH-230: a server-initiated stop must tear down capture too —
             // leaving it running kept streaming audio into a dead session and

--- a/server/backend/api/routes/live.py
+++ b/server/backend/api/routes/live.py
@@ -74,6 +74,11 @@ class LiveModeSession:
         self._engine: LiveModeEngine | None = None
         self._message_queue: asyncio.Queue[dict] = asyncio.Queue()
         self._running = False
+        # GH-271: True once an engine has actually come up in this session.
+        # ``process_messages`` needs it to tell "not started yet" (keep
+        # waiting - the model may still be loading) apart from "started and
+        # now stopped" (drain and exit).
+        self._engine_started = False
         # Backend borrowed from the main engine (non-None when sharing).
         self._shared_backend: object | None = None
         # Capture the event loop so engine callbacks (from background threads)
@@ -362,14 +367,35 @@ class LiveModeSession:
                 shared_backend=shared_backend,
             )
 
-            # Start the engine
-            if self._engine.start():
+            # Start the engine.  GH-271: ``start()`` blocks until the recorder
+            # has actually been built (or has failed), which includes the model
+            # load - so run it off the event loop, otherwise queued status
+            # messages, pings and the WebSocket receive loop would all stall
+            # for the duration of the load.  Only a real "listening" outcome
+            # clears _model_displaced; a background failure now falls through
+            # to the finally block, which restores the main model immediately
+            # instead of leaving it detached for the whole session.
+            if await asyncio.to_thread(self._engine.start):
                 self._running = True
+                self._engine_started = True
                 _model_displaced = False  # Engine owns the model now
                 logger.info(f"Live Mode started for {self.client_name}")
                 return True
             else:
-                await self.send_message("error", {"message": "Failed to start engine"})
+                start_error = self._engine.start_error
+                logger.error(
+                    "Live Mode failed to initialize for %s: %s", self.client_name, start_error
+                )
+                await self.send_message(
+                    "error",
+                    {
+                        "message": (
+                            f"Failed to start Live Mode: {start_error}"
+                            if start_error
+                            else "Failed to start engine"
+                        )
+                    },
+                )
                 return False  # finally will restore
 
         except Exception as e:
@@ -532,9 +558,14 @@ class LiveModeSession:
                 await self.send_message(msg["type"], msg["data"])
             except TimeoutError:
                 # Check if we should exit - only exit when:
-                # 1. _running is False (engine stopped)
-                # 2. Queue is empty (no pending messages)
-                if not self._running and self._message_queue.empty():
+                # 1. An engine actually came up in this session.  GH-271: the
+                #    start-up window (model load) can last minutes with
+                #    _running still False, and exiting there would strand every
+                #    message the engine queues, including the LISTENING state
+                #    the client waits for before it starts capturing audio.
+                # 2. _running is False (engine stopped)
+                # 3. Queue is empty (no pending messages)
+                if self._engine_started and not self._running and self._message_queue.empty():
                     break
                 continue
             except Exception as e:

--- a/server/backend/core/live_engine.py
+++ b/server/backend/core/live_engine.py
@@ -24,6 +24,14 @@ logger = logging.getLogger(__name__)
 # Target sample rate for Whisper
 SAMPLE_RATE = 16000
 
+# How long ``start()`` waits for the background thread to finish building the
+# recorder before it gives up and reports failure (GH-271).  Initialization can
+# legitimately take minutes: the whisper.cpp sidecar gets up to 180s to report
+# /health, and a first-run faster-whisper model still has to be downloaded.
+# This ceiling exists only so ``start()`` always reaches a definite answer
+# instead of blocking a client forever; pass ``timeout=None`` to wait outright.
+INIT_TIMEOUT_SECONDS = 300.0
+
 
 class LiveModeState(Enum):
     """State of the Live Mode engine."""
@@ -103,7 +111,18 @@ class LiveModeEngine:
         self._recorder: Any | None = None
         self._state = LiveModeState.STOPPED
         self._loop_thread: threading.Thread | None = None
+        self._feeder_thread: threading.Thread | None = None
         self._stop_event = threading.Event()
+
+        # GH-271: initialization handshake between start() and
+        # _transcription_loop.  The recorder (and therefore the model load) is
+        # built on the background thread, so start() waits on this event to
+        # report the REAL outcome instead of "thread spawned successfully".
+        # The loop writes _init_ok / _init_error BEFORE setting the event, so a
+        # released caller always reads a settled result.
+        self._init_complete = threading.Event()
+        self._init_ok = False
+        self._init_error: BaseException | None = None
 
         # Track history for the UI
         self._sentence_history: list[str] = []
@@ -126,6 +145,16 @@ class LiveModeEngine:
     def sentence_history(self) -> list[str]:
         """Get history of transcribed sentences."""
         return self._sentence_history.copy()
+
+    @property
+    def start_error(self) -> BaseException | None:
+        """Exception that aborted the last ``start()``, or None if it succeeded.
+
+        Set by the transcription thread when the recorder cannot be built, and
+        by ``start()`` itself when initialization exceeds its timeout.  Callers
+        use it to tell the client *why* Live Mode did not come up (GH-271).
+        """
+        return self._init_error
 
     def _set_state(self, state: LiveModeState) -> None:
         """Set state and trigger callback."""
@@ -168,39 +197,69 @@ class LiveModeEngine:
                 logger.error(f"Sentence callback error: {e}")
 
     def _transcription_loop(self) -> None:
-        """Main transcription loop (runs in separate thread)."""
+        """Main transcription loop (runs in separate thread).
+
+        Initialization - importing and constructing the recorder, which loads
+        the model - happens here rather than in ``start()`` because it can take
+        minutes.  ``start()`` blocks on ``_init_complete`` until this method has
+        published a definite outcome, so a model-load failure can no longer be
+        reported to the caller as a successful start (GH-271).
+        """
         try:
             self._set_state(LiveModeState.STARTING)
 
-            # Import server's AudioToTextRecorder (not RealtimeSTT's)
-            from server.core.stt.engine import AudioToTextRecorder
+            try:
+                # Import server's AudioToTextRecorder (not RealtimeSTT's)
+                from server.core.stt.engine import AudioToTextRecorder
 
-            # Create recorder with configuration
-            self._recorder = AudioToTextRecorder(
-                instance_name="live_mode",
-                model=self.config.model,
-                language=self.config.language if self.config.language else "",
-                task="translate" if self.config.translation_enabled else "transcribe",
-                translation_target_language=self.config.translation_target_language,
-                compute_type=self.config.compute_type,
-                device=self.config.device,
-                gpu_device_index=self.config.gpu_device_index,
-                silero_sensitivity=self.config.silero_sensitivity,
-                webrtc_sensitivity=self.config.webrtc_sensitivity,
-                post_speech_silence_duration=self.config.post_speech_silence_duration,
-                min_length_of_recording=self.config.min_length_of_recording,
-                min_gap_between_recordings=self.config.min_gap_between_recordings,
-                ensure_sentence_starting_uppercase=self.config.ensure_sentence_starting_uppercase,
-                ensure_sentence_ends_with_period=self.config.ensure_sentence_ends_with_period,
-                beam_size=self.config.beam_size,
-                batch_size=self.config.batch_size,
-                on_recording_start=self._on_recording_start,
-                on_recording_stop=self._on_recording_stop,
-                shared_backend=self._shared_backend,
-            )
+                # Create recorder with configuration
+                self._recorder = AudioToTextRecorder(
+                    instance_name="live_mode",
+                    model=self.config.model,
+                    language=self.config.language if self.config.language else "",
+                    task="translate" if self.config.translation_enabled else "transcribe",
+                    translation_target_language=self.config.translation_target_language,
+                    compute_type=self.config.compute_type,
+                    device=self.config.device,
+                    gpu_device_index=self.config.gpu_device_index,
+                    silero_sensitivity=self.config.silero_sensitivity,
+                    webrtc_sensitivity=self.config.webrtc_sensitivity,
+                    post_speech_silence_duration=self.config.post_speech_silence_duration,
+                    min_length_of_recording=self.config.min_length_of_recording,
+                    min_gap_between_recordings=self.config.min_gap_between_recordings,
+                    ensure_sentence_starting_uppercase=(
+                        self.config.ensure_sentence_starting_uppercase
+                    ),
+                    ensure_sentence_ends_with_period=self.config.ensure_sentence_ends_with_period,
+                    beam_size=self.config.beam_size,
+                    batch_size=self.config.batch_size,
+                    on_recording_start=self._on_recording_start,
+                    on_recording_stop=self._on_recording_stop,
+                    shared_backend=self._shared_backend,
+                )
+            except Exception as e:
+                # Record the failure and publish the terminal state BEFORE
+                # releasing start(), so the caller reads a settled outcome
+                # rather than racing this thread for it.
+                logger.error(f"Live Mode initialization error: {e}")
+                self._init_error = e
+                self._set_state(LiveModeState.ERROR)
+                self._init_complete.set()
+                return
 
+            if self._stop_event.is_set():
+                # start() already gave up (timeout), or stop() raced us. Do not
+                # advertise LISTENING for a session nobody is waiting for - the
+                # client would begin streaming audio into a dead session. The
+                # finally block below shuts the freshly built recorder down.
+                logger.warning("Live Mode initialized after the start was abandoned - discarding")
+                self._init_complete.set()
+                return
+
+            self._init_ok = True
             self._set_state(LiveModeState.LISTENING)
             logger.info("Live Mode started")
+            self._init_complete.set()
 
             # Process sentences in a loop
             while not self._stop_event.is_set():
@@ -216,9 +275,14 @@ class LiveModeEngine:
                         break
 
         except Exception as e:
-            logger.error(f"Live Mode initialization error: {e}")
+            logger.error(f"Live Mode loop error: {e}")
             self._set_state(LiveModeState.ERROR)
         finally:
+            # Backstop: an exotic exit (a BaseException such as SystemExit
+            # escaping the recorder constructor) must never leave start()
+            # blocked. _init_ok is still False there, so it reports failure.
+            self._init_complete.set()
+
             if self._recorder:
                 try:
                     self._recorder.shutdown()
@@ -273,18 +337,32 @@ class LiveModeEngine:
         except queue.Full:
             logger.warning("Live Mode audio queue full, dropping chunk")
 
-    def start(self) -> bool:
+    def start(self, timeout: float | None = INIT_TIMEOUT_SECONDS) -> bool:
         """
         Start Live Mode transcription.
 
+        Blocks until initialization reaches a definite outcome - the recorder is
+        built and listening, or it failed - and reports that outcome (GH-271).
+        The model load runs on the background thread, so callers on an event
+        loop must run this in a worker thread (``asyncio.to_thread``) to keep
+        the loop responsive while the model is loading.
+
+        Args:
+            timeout: Seconds to wait for initialization before giving up.
+                ``None`` waits indefinitely.
+
         Returns:
-            True if started successfully
+            True when Live Mode is listening.  False when initialization failed
+            or timed out - ``start_error`` then holds the reason.
         """
         if self.is_running:
             logger.warning("Live Mode already running")
             return False
 
         self._stop_event.clear()
+        self._init_complete.clear()
+        self._init_ok = False
+        self._init_error = None
 
         # Clear audio queue
         while not self._audio_queue.empty():
@@ -304,6 +382,19 @@ class LiveModeEngine:
             target=self._audio_feeder_loop, daemon=True, name="LiveModeAudioFeeder"
         )
         self._feeder_thread.start()
+
+        if not self._init_complete.wait(timeout):
+            self._init_error = TimeoutError(
+                f"Live Mode initialization did not finish within {timeout}s"
+            )
+            logger.error(str(self._init_error))
+
+        if not self._init_ok:
+            # Release the feeder thread and let the (possibly still-loading)
+            # transcription thread unwind on its own: it discards whatever it
+            # builds as soon as it sees the stop event.
+            self._stop_event.set()
+            return False
 
         return True
 
@@ -328,10 +419,11 @@ class LiveModeEngine:
             if self._loop_thread.is_alive():
                 logger.warning("Live Mode thread did not stop gracefully")
 
-        if hasattr(self, "_feeder_thread") and self._feeder_thread.is_alive():
+        if self._feeder_thread and self._feeder_thread.is_alive():
             self._feeder_thread.join(timeout=2.0)
 
         self._loop_thread = None
+        self._feeder_thread = None
         self._recorder = None
 
     def clear_history(self) -> None:

--- a/server/backend/tests/test_gh271_live_start_synchronous.py
+++ b/server/backend/tests/test_gh271_live_start_synchronous.py
@@ -356,7 +356,7 @@ class TestStartEngineSurfacesRealInitFailure:
         Widening it must not turn the pump into a task that never finishes on
         its own after the engine has stopped.
         """
-        _install_recorder_stub(monkeypatch, lambda **kwargs: _FakeRecorder(**kwargs))
+        _install_recorder_stub(monkeypatch, _FakeRecorder)
         mm = _mock_model_manager(is_same=True, backend=MagicMock())
         monkeypatch.setattr(live_mod, "get_model_manager", lambda: mm)
 
@@ -370,7 +370,7 @@ class TestStartEngineSurfacesRealInitFailure:
 
     async def test_successful_initialization_still_marks_the_session_running(self, monkeypatch):
         """Regression guard: the happy path is unchanged with a real engine."""
-        _install_recorder_stub(monkeypatch, lambda **kwargs: _FakeRecorder(**kwargs))
+        _install_recorder_stub(monkeypatch, _FakeRecorder)
         shared_backend = MagicMock(name="shared-backend")
         mm = _mock_model_manager(is_same=True, backend=shared_backend)
         monkeypatch.setattr(live_mod, "get_model_manager", lambda: mm)

--- a/server/backend/tests/test_gh271_live_start_synchronous.py
+++ b/server/backend/tests/test_gh271_live_start_synchronous.py
@@ -1,0 +1,386 @@
+"""GH-271: Live Mode must not report a successful start before the recorder exists.
+
+``LiveModeEngine.start()`` used to return ``True`` as soon as it had spawned the
+transcription thread.  The recorder - and with it the model load - is built on
+that thread, so a bad model name, a missing backend dependency or a CUDA OOM
+reached the caller as a *successful* start and only surfaced later as an
+out-of-band ``state: ERROR`` message.  ``start_engine`` also cleared its
+``_model_displaced`` flag on that false success, leaving the main engine
+detached for the whole session.
+
+These tests drive the REAL asynchronous initialization.  The pre-existing tests
+in ``test_p0_model_swap.py`` mock ``LiveModeEngine.start()`` itself to return
+``False`` or raise synchronously - a shape the real implementation never
+produced - so they never exercised this path.
+
+Run:  ../../build/.venv/bin/pytest tests/test_gh271_live_start_synchronous.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+import types
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from server.api.routes import live as live_mod
+from server.core.live_engine import LiveModeConfig, LiveModeEngine, LiveModeState
+from starlette.websockets import WebSocketState
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Generous enough that a loaded CI machine never trips it, short enough that a
+# genuine hang fails the test instead of stalling the whole suite.
+_WAIT = 5.0
+
+
+class _FakeRecorder:
+    """Stand-in for ``AudioToTextRecorder`` whose ``text()`` blocks until shutdown.
+
+    Mirrors the real contract the transcription loop depends on: ``text()``
+    blocks until a sentence is available (here: until ``shutdown()`` releases
+    it), and ``shutdown()`` is what unblocks it.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.shutdown_calls = 0
+        self._released = threading.Event()
+
+    def text(self) -> str:
+        self._released.wait(timeout=_WAIT)
+        return ""
+
+    def feed_audio(self, chunk: bytes, sample_rate: int = 16000) -> None:
+        return None
+
+    def shutdown(self) -> None:
+        self.shutdown_calls += 1
+        self._released.set()
+
+
+def _install_recorder_stub(monkeypatch: pytest.MonkeyPatch, factory: Any) -> None:
+    """Make the loop's lazy ``AudioToTextRecorder`` import resolve to *factory*.
+
+    ``_transcription_loop`` imports ``server.core.stt.engine`` lazily, so a stub
+    module in ``sys.modules`` intercepts it without importing the real module
+    (which pulls in torch and the whole STT backend stack).
+    """
+    module = types.ModuleType("server.core.stt.engine")
+    module.AudioToTextRecorder = factory  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "server.core.stt.engine", module)
+
+
+def _make_live_session(
+    *,
+    loop: asyncio.AbstractEventLoop,
+    client_name: str = "test-client",
+) -> live_mod.LiveModeSession:
+    """Build a LiveModeSession with minimal stubs (bypass __init__)."""
+    session = object.__new__(live_mod.LiveModeSession)
+    session.websocket = MagicMock()
+    session.websocket.client_state = WebSocketState.CONNECTED
+    session.websocket.application_state = WebSocketState.CONNECTED
+    session.websocket.send_json = AsyncMock()
+    session.client_name = client_name
+    session._engine = None
+    session._message_queue = asyncio.Queue()
+    session._running = False
+    session._engine_started = False
+    session._shared_backend = None
+    session._loop = loop
+    return session
+
+
+def _mock_model_manager(
+    *,
+    main_model: str = "Systran/faster-whisper-base",
+    is_same: bool = True,
+    backend: object | None = None,
+) -> MagicMock:
+    """Create a mock ModelManager whose load params match LiveModeConfig defaults."""
+    mm = MagicMock()
+    mm.main_model_name = main_model
+    mm.is_same_model = MagicMock(return_value=is_same)
+    mm.get_transcription_load_params = MagicMock(
+        return_value={
+            "device": "cuda",
+            "compute_type": "default",
+            "gpu_device_index": 0,
+            "batch_size": 16,
+        }
+    )
+    mm.detach_transcription_backend = MagicMock(return_value=backend or MagicMock())
+    mm.attach_transcription_backend = MagicMock()
+    mm.unload_transcription_model = MagicMock()
+    mm.load_transcription_model = MagicMock()
+    return mm
+
+
+def _messages(session: live_mod.LiveModeSession, msg_type: str) -> list[dict]:
+    """Return the ``data`` payloads of every message of *msg_type* sent so far."""
+    return [
+        call.args[0]["data"]
+        for call in session.websocket.send_json.call_args_list
+        if call.args and call.args[0].get("type") == msg_type
+    ]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Engine level: start() reports the real initialization outcome
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.p0
+@pytest.mark.live_mode
+class TestEngineStartReportsRealOutcome:
+    def test_start_returns_false_when_recorder_construction_fails(self, monkeypatch):
+        """A model that cannot load must make start() report failure, not success."""
+        boom = RuntimeError("Unable to load model 'nope/nope'")
+
+        def _factory(**kwargs):
+            raise boom
+
+        _install_recorder_stub(monkeypatch, _factory)
+        engine = LiveModeEngine(config=LiveModeConfig(model="nope/nope"))
+
+        assert engine.start() is False
+        assert engine.start_error is boom
+        assert engine.state is LiveModeState.ERROR
+        assert engine.is_running is False
+
+    def test_start_returns_true_once_the_recorder_is_listening(self, monkeypatch):
+        """The success path still works and only returns after LISTENING."""
+        recorders: list[_FakeRecorder] = []
+
+        def _factory(**kwargs):
+            recorder = _FakeRecorder(**kwargs)
+            recorders.append(recorder)
+            return recorder
+
+        _install_recorder_stub(monkeypatch, _factory)
+        engine = LiveModeEngine(config=LiveModeConfig(model="Systran/faster-whisper-base"))
+
+        try:
+            assert engine.start() is True
+            assert engine.start_error is None
+            assert engine.state is LiveModeState.LISTENING
+            assert engine.is_running is True
+            assert len(recorders) == 1
+        finally:
+            engine.stop()
+
+    def test_error_state_is_published_before_start_returns(self, monkeypatch):
+        """The ERROR state is settled before the caller is released (no race)."""
+        states: list[LiveModeState] = []
+
+        def _factory(**kwargs):
+            raise RuntimeError("backend dependency missing")
+
+        _install_recorder_stub(monkeypatch, _factory)
+        engine = LiveModeEngine(on_state_change=states.append)
+
+        assert engine.start() is False
+        assert states[0] is LiveModeState.STARTING
+        assert states[-1] is LiveModeState.ERROR
+
+    def test_start_times_out_when_initialization_hangs(self, monkeypatch):
+        """A hung load resolves to a definite failure instead of a false success."""
+        release = threading.Event()
+
+        def _factory(**kwargs):
+            release.wait(timeout=_WAIT)
+            return _FakeRecorder(**kwargs)
+
+        _install_recorder_stub(monkeypatch, _factory)
+        engine = LiveModeEngine()
+
+        try:
+            assert engine.start(timeout=0.2) is False
+            assert isinstance(engine.start_error, TimeoutError)
+        finally:
+            release.set()
+            engine.stop()
+
+    def test_late_initialization_does_not_advertise_listening(self, monkeypatch):
+        """A recorder that arrives after the timeout must not flip to LISTENING.
+
+        Otherwise the client would start streaming audio into a session the
+        caller has already given up on.
+        """
+        release = threading.Event()
+        states: list[LiveModeState] = []
+
+        def _factory(**kwargs):
+            release.wait(timeout=_WAIT)
+            return _FakeRecorder(**kwargs)
+
+        _install_recorder_stub(monkeypatch, _factory)
+        engine = LiveModeEngine(on_state_change=states.append)
+
+        assert engine.start(timeout=0.2) is False
+        release.set()
+        if engine._loop_thread is not None:
+            engine._loop_thread.join(timeout=_WAIT)
+
+        assert LiveModeState.LISTENING not in states
+        assert engine.is_running is False
+
+    def test_failed_start_releases_the_audio_feeder_thread(self, monkeypatch):
+        """A failed start must not leak the feeder daemon thread."""
+
+        def _factory(**kwargs):
+            raise RuntimeError("boom")
+
+        _install_recorder_stub(monkeypatch, _factory)
+        engine = LiveModeEngine()
+
+        assert engine.start() is False
+
+        feeder = engine._feeder_thread
+        assert feeder is not None
+        feeder.join(timeout=_WAIT)
+        assert not feeder.is_alive(), "audio feeder thread outlived a failed start"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Route level: start_engine() sees the real failure and restores the model
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.p0
+@pytest.mark.model_swap
+class TestStartEngineSurfacesRealInitFailure:
+    @pytest.fixture(autouse=True)
+    def _patch_deps(self, monkeypatch):
+        cfg = MagicMock()
+        monkeypatch.setattr(live_mod, "get_config", lambda: cfg)
+        monkeypatch.setattr(
+            live_mod, "resolve_live_transcriber_model", lambda c: "Systran/faster-whisper-base"
+        )
+        monkeypatch.setattr(live_mod, "is_live_mode_model_supported", lambda m: True)
+
+    async def test_shared_backend_is_returned_when_the_model_fails_to_load(self, monkeypatch):
+        """Shared-backend path: a background load failure reattaches the backend."""
+
+        def _factory(**kwargs):
+            raise RuntimeError("CUDA failed with error out of memory")
+
+        _install_recorder_stub(monkeypatch, _factory)
+        shared_backend = MagicMock(name="shared-backend")
+        mm = _mock_model_manager(is_same=True, backend=shared_backend)
+        monkeypatch.setattr(live_mod, "get_model_manager", lambda: mm)
+
+        session = _make_live_session(loop=asyncio.get_running_loop())
+
+        assert await session.start_engine() is False
+        assert session._running is False
+        mm.attach_transcription_backend.assert_called_once_with(shared_backend)
+
+    async def test_error_message_carries_the_underlying_failure(self, monkeypatch):
+        """The client is told WHY the start failed, on the start response path."""
+
+        def _factory(**kwargs):
+            raise RuntimeError("CUDA failed with error out of memory")
+
+        _install_recorder_stub(monkeypatch, _factory)
+        mm = _mock_model_manager(is_same=True, backend=MagicMock())
+        monkeypatch.setattr(live_mod, "get_model_manager", lambda: mm)
+
+        session = _make_live_session(loop=asyncio.get_running_loop())
+
+        assert await session.start_engine() is False
+
+        errors = [str(data.get("message", "")) for data in _messages(session, "error")]
+        assert any("out of memory" in message for message in errors), errors
+
+    async def test_main_model_is_reloaded_when_the_live_model_fails_to_load(self, monkeypatch):
+        """Full-unload path: a background load failure reloads the main model."""
+
+        def _factory(**kwargs):
+            raise RuntimeError("Unable to load model")
+
+        _install_recorder_stub(monkeypatch, _factory)
+        mm = _mock_model_manager(is_same=False)
+        monkeypatch.setattr(live_mod, "get_model_manager", lambda: mm)
+
+        session = _make_live_session(loop=asyncio.get_running_loop())
+
+        assert await session.start_engine() is False
+        mm.load_transcription_model.assert_called_once()
+
+    async def test_state_messages_survive_a_slow_model_load(self, monkeypatch):
+        """The message pump must outlive the start-up window.
+
+        ``process_messages`` exits when it goes idle while ``_running`` is
+        False - which is exactly the state the session is in for the whole
+        duration of a model load.  If it exits there, every state message the
+        engine queues (STARTING, LISTENING, and later sentences) is stranded
+        and the client never learns Live Mode came up.
+        """
+        gate = threading.Event()
+
+        def _factory(**kwargs):
+            gate.wait(timeout=_WAIT)
+            return _FakeRecorder(**kwargs)
+
+        _install_recorder_stub(monkeypatch, _factory)
+        mm = _mock_model_manager(is_same=True, backend=MagicMock())
+        monkeypatch.setattr(live_mod, "get_model_manager", lambda: mm)
+
+        session = _make_live_session(loop=asyncio.get_running_loop())
+        pump = asyncio.create_task(session.process_messages())
+        # Idle for longer than the pump's 0.1s poll timeout while the session
+        # has not started yet - the window a slow model load lives in.
+        await asyncio.sleep(0.3)
+
+        gate.set()
+        try:
+            assert await session.start_engine() is True
+            await asyncio.sleep(0.3)  # let the pump drain the queue
+
+            states = [data.get("state") for data in _messages(session, "state")]
+            assert "LISTENING" in states, f"state messages were stranded: {states}"
+        finally:
+            pump.cancel()
+            await session.stop_engine()
+
+    async def test_message_pump_still_exits_once_the_session_is_over(self, monkeypatch):
+        """Guard the other half of the pump's exit condition.
+
+        Widening it must not turn the pump into a task that never finishes on
+        its own after the engine has stopped.
+        """
+        _install_recorder_stub(monkeypatch, lambda **kwargs: _FakeRecorder(**kwargs))
+        mm = _mock_model_manager(is_same=True, backend=MagicMock())
+        monkeypatch.setattr(live_mod, "get_model_manager", lambda: mm)
+
+        session = _make_live_session(loop=asyncio.get_running_loop())
+        pump = asyncio.create_task(session.process_messages())
+
+        assert await session.start_engine() is True
+        await session.stop_engine()
+
+        await asyncio.wait_for(pump, timeout=_WAIT)
+
+    async def test_successful_initialization_still_marks_the_session_running(self, monkeypatch):
+        """Regression guard: the happy path is unchanged with a real engine."""
+        _install_recorder_stub(monkeypatch, lambda **kwargs: _FakeRecorder(**kwargs))
+        shared_backend = MagicMock(name="shared-backend")
+        mm = _mock_model_manager(is_same=True, backend=shared_backend)
+        monkeypatch.setattr(live_mod, "get_model_manager", lambda: mm)
+
+        session = _make_live_session(loop=asyncio.get_running_loop())
+
+        assert await session.start_engine() is True
+        assert session._running is True
+        # The engine owns the backend for the duration of the session.
+        mm.attach_transcription_backend.assert_not_called()
+
+        await session.stop_engine()
+        mm.attach_transcription_backend.assert_called_once_with(shared_backend)


### PR DESCRIPTION
Closes #271.

## The bug

`LiveModeEngine.start()` returned `True` as soon as it had spawned the transcription thread. The recorder - and with it the model load - is built *on* that thread, so a bad model name, a missing backend dependency or a CUDA OOM reached the caller as a **successful start**, and only surfaced later as an out-of-band `state: ERROR` message.

Two consequences, both fixed here:

1. The start response lied. `start_engine` had no reliable point at which to learn the session never came up.
2. `_model_displaced = False` on that false success disarmed the restore path, so the main engine kept a `None` backend for the whole session (covered by `ensure_transcription_loaded`'s lazy reload, but paying for a reload it did not need).

## What changed

**`core/live_engine.py`**
- `_transcription_loop` records the failure and publishes the terminal state **before** releasing `start()`, so a released caller always reads a settled result rather than racing the thread for it. The lazy `AudioToTextRecorder` import moved inside the guarded block - a missing dependency is an initialization failure too.
- `start(timeout=INIT_TIMEOUT_SECONDS)` waits on that handshake and returns the real outcome. Default 300s: enough for the whisper.cpp sidecar's 180s `/health` wait plus a first-run download, and it exists only so `start()` always reaches a definite answer. `timeout=None` waits outright.
- New `start_error` property carries the reason (the exception, or a `TimeoutError`).
- A recorder that finishes building *after* `start()` gave up is discarded instead of flipping to `LISTENING` - otherwise the client would begin streaming audio into a session nobody is waiting for.
- A failed start sets the stop event, so the audio feeder thread is released instead of leaked. `_feeder_thread` is now a declared attribute rather than a `hasattr` probe.

**`api/routes/live.py`**
- `start()` runs via `asyncio.to_thread`. It now blocks for the duration of the model load, and the event loop has to stay free for queued status messages and protocol-level pings.
- `_model_displaced` stays set when initialization fails, so the existing `finally` returns the shared backend (or reloads the main model) immediately.
- The failure is sent to the client with the underlying reason attached.
- **`process_messages` lifetime.** It exited when it went idle while `_running` was `False` - the exact state the session is in for the whole model load. Latent before (the old `start()` returned in milliseconds, so `_running = True` usually beat the 0.1s poll timeout); a guaranteed failure once `start()` spans the load. It now also requires that an engine actually came up in this session before it drains and exits. Without this, the `LISTENING` state never reaches the client and Live Mode never starts capturing.

**`dashboard/src/hooks/useLiveMode.ts`**
- The `state` handler covered `LISTENING`, `PROCESSING` and `STOPPED` only; `ERROR` fell through. An engine that died mid-session left the UI in `listening` forever with audio still streaming into a dead session. The new branch tears capture down and surfaces the error; a more specific message from an `error` frame wins in either arrival order (the two frames race - one goes through the queue, one is sent directly).

## Tests

The pre-existing tests (`test_p0_model_swap.py::test_engine_start_returns_false_restores_shared_backend`, `::test_engine_constructor_exception_restores_main`) mock `LiveModeEngine.start()` itself to return `False` or raise synchronously - a shape the real implementation never produced. They still pass, and are now actually reachable shapes.

`tests/test_gh271_live_start_synchronous.py` drives the **real** asynchronous initialization by stubbing the lazily-imported `server.core.stt.engine` module (12 tests):

- engine level: failure reporting, `start_error`, ERROR published before `start()` returns, timeout, late-initialization discard, feeder-thread release, unchanged happy path
- route level: shared-backend reattach and main-model reload on a background load failure, the error message carrying the underlying failure, message-pump survival across a slow load, and that the pump still exits once the session is genuinely over

Two of these fail on `main` in the way the issue describes (`start_engine` returns `True` while the recorder blew up); the message-pump one returns an empty list of delivered state messages.

## Verification

- Backend: `2267 passed, 4 skipped` (full suite, build venv)
- Dashboard: `136 files, 1971 tests passed` (full vitest suite). One pre-existing unrelated jsdom error in `SessionImportTab.diarization-gate.test.tsx` (`scrollIntoView is not a function`), untouched by this branch.
- `ruff check` / `ruff format` clean on the changed files; `tsc --noEmit` and `eslint` clean; `npm run ui:contract:check` passes.

## Trade-off worth knowing

Making the start response truthful means making it slow: the WebSocket receive loop does not process further client messages until initialization settles (up to the timeout). Application-level `ping` frames therefore go unanswered during a load - harmless, since nothing tracks pongs client-side, and uvicorn's protocol-level pings keep flowing because the event loop stays free. A user-initiated Stop during a load is deferred until the load finishes; the client closes the socket anyway, so the session is still cleaned up.

## Smoke checklist (hardware, not run here)

- [ ] Point Live Mode at an invalid repo id and start: the dashboard shows the concrete failure instead of hanging on "Loading Live Mode model..."
- [ ] Same, with the main model loaded: confirm the main model is usable immediately afterwards (no lazy-reload penalty on the next file transcription)
- [ ] Normal Live Mode start with a cold whisper.cpp sidecar: confirm the status messages still stream and LISTENING arrives after the sidecar's `/health` wait
- [ ] Kill the backend mid-session: the UI leaves `listening` and reports the error