### PR TITLE
fix(docker, bootstrap): survive transient network faults during dependency sync (PR #265 + review fixes)

### DIFF
--- a/docs/README_DEV.md
+++ b/docs/README_DEV.md
@@ -1329,6 +1329,8 @@ The server's `/api/status` endpoint reads this file to report backend capability
 | `BOOTSTRAP_PRUNE_UV_CACHE` | `false` | Delete `/runtime/cache` after a successful sync to reclaim disk space. |
 | `BOOTSTRAP_LOG_CHANGES` | `true` | Emit before/after package delta to logs. |
 | `BOOTSTRAP_TIMEOUT_SECONDS` | `1800` | Maximum seconds allowed for a single `uv sync` run. |
+| `BOOTSTRAP_SYNC_ATTEMPTS` | `3` | Total `uv sync` attempts when the failure is a transient network fault (dropped/stalled download). Backoff 30s, 60s, … capped at 300s. TLS-certificate failures, a full disk and unsatisfiable requirements are never retried. |
+| `UV_HTTP_TIMEOUT` | `900` | Per-HTTP-request budget handed to uv. uv's own default (30s) is too tight for the 674MB `nvidia-cudnn-cu12` wheel; an explicit value here always wins. |
 | `BOOTSTRAP_REQUIRE_HF_TOKEN` | `false` | Abort bootstrap if `HF_TOKEN` is not set. |
 | `INSTALL_WHISPER` | `false` | Force-enable the `whisper` extra regardless of configured model. |
 | `INSTALL_NEMO` | `false` | Force-enable the `nemo` extra regardless of configured model. |

--- a/docs/README_DEV.md
+++ b/docs/README_DEV.md
@@ -1330,7 +1330,7 @@ The server's `/api/status` endpoint reads this file to report backend capability
 | `BOOTSTRAP_LOG_CHANGES` | `true` | Emit before/after package delta to logs. |
 | `BOOTSTRAP_TIMEOUT_SECONDS` | `1800` | Maximum seconds allowed for a single `uv sync` run. |
 | `BOOTSTRAP_SYNC_ATTEMPTS` | `3` | Total `uv sync` attempts when the failure is a transient network fault (dropped/stalled download). Backoff 30s, 60s, … capped at 300s. TLS-certificate failures, a full disk and unsatisfiable requirements are never retried. |
-| `UV_HTTP_TIMEOUT` | `900` | Per-HTTP-request budget handed to uv. uv's own default (30s) is too tight for the 674MB `nvidia-cudnn-cu12` wheel; an explicit value here always wins. |
+| `UV_HTTP_TIMEOUT` | `900` | uv's read timeout: how long a download may stall between reads before uv gives up on it. The 30s default is too twitchy for the 674MB `nvidia-cudnn-cu12` wheel on a congested link; an explicit value here always wins. |
 | `BOOTSTRAP_REQUIRE_HF_TOKEN` | `false` | Abort bootstrap if `HF_TOKEN` is not set. |
 | `INSTALL_WHISPER` | `false` | Force-enable the `whisper` extra regardless of configured model. |
 | `INSTALL_NEMO` | `false` | Force-enable the `nemo` extra regardless of configured model. |

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -207,11 +207,13 @@ Failed to download `nvidia-cudnn-cu12==9.10.2.21`
   operation timed out
 ```
 
-The bootstrap now handles this itself: each request gets a 900s budget
-(`UV_HTTP_TIMEOUT`) instead of uv's 30s default, and the whole sync is retried up
-to 3 times with a 30s/60s backoff. TLS-certificate failures, a full disk and
-unsatisfiable requirements are *not* retried — those never succeed on a second
-attempt.
+The bootstrap now handles this itself: a stalled transfer gets 900s between
+reads (`UV_HTTP_TIMEOUT`, uv's read timeout) instead of uv's 30s default, and
+the whole sync is retried up to 3 times with a 30s/60s backoff. TLS-certificate
+failures, a full disk and unsatisfiable requirements are *not* retried — those
+never succeed on a second attempt. The flip side of the larger timeout: a
+connection that dies silently can take up to 15 minutes per request to be
+detected, so on a genuinely dead link the final error takes longer to appear.
 
 If it still fails after the retries:
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -193,6 +193,43 @@ CUDA wheels. Selecting the **CPU profile** in the dashboard (or
 A whisper/nemo-only CPU install no longer needs any git access — the VibeVoice
 git dependency is resolved from declared metadata, not cloned (GH #125).
 
+### Dependency download fails on a network error (`operation timed out`)
+
+A first start downloads ~4GB of PyTorch/CUDA wheels, one of which
+(`nvidia-cudnn-cu12`) is 674MB on its own. If the connection drops or stalls
+mid-transfer, `uv sync` fails with text like:
+
+```
+Failed to download `nvidia-cudnn-cu12==9.10.2.21`
+  Request failed after 4 retries
+  error sending request for url (https://files.pythonhosted.org/...)
+  client error (Connect)
+  operation timed out
+```
+
+The bootstrap now handles this itself: each request gets a 900s budget
+(`UV_HTTP_TIMEOUT`) instead of uv's 30s default, and the whole sync is retried up
+to 3 times with a 30s/60s backoff. TLS-certificate failures, a full disk and
+unsatisfiable requirements are *not* retried — those never succeed on a second
+attempt.
+
+If it still fails after the retries:
+
+1. **Just start the server again.** Every wheel that finished downloading stays
+   in the uv cache on the `transcriptionsuite-runtime` volume, so each attempt
+   picks up where the last one stopped. Do not set
+   `BOOTSTRAP_PRUNE_UV_CACHE=true` while you are working through this — it
+   deletes exactly that progress.
+2. Prefer a wired connection over Wi-Fi/VPN for the first start.
+3. On a slow link, give it more room: `UV_HTTP_TIMEOUT=1800` and
+   `BOOTSTRAP_SYNC_ATTEMPTS=6`.
+4. No NVIDIA GPU? Use the **CPU profile** (`PYTORCH_VARIANT=cpu`) — it skips the
+   CUDA wheels entirely.
+
+A network failure during a *delta*-sync (only `uv.lock` changed) no longer wipes
+the existing venv: the environment is intact, so the next start retries the cheap
+delta-sync instead of re-downloading everything.
+
 ## TLS / Remote Access
 
 ### Tailscale Setup

--- a/server/backend/tests/test_bootstrap_runtime.py
+++ b/server/backend/tests/test_bootstrap_runtime.py
@@ -1996,6 +1996,393 @@ def test_build_uv_sync_env_does_not_override_user_ca_vars(
     assert env["REQUESTS_CA_BUNDLE"] == str(ca)  # filled in from SSL_CERT_FILE
 
 
+# ---------------------------------------------------------------------------
+# Transient network failures during dependency download
+#
+# Regression: a single dropped connection while fetching nvidia-cudnn-cu12
+# (674MB, one of ~4GB of CUDA wheels) aborted the whole bootstrap after 40
+# minutes of downloading, and the container exited with no runtime venv.
+# ---------------------------------------------------------------------------
+
+
+# The failure exactly as it reached the user, trimmed to the parts the
+# classifier sees.
+_REPORTED_DOWNLOAD_FAILURE = (
+    "Command failed (1): uv sync --frozen --no-dev --project /app/server "
+    "--extra nemo --extra whisper\n"
+    "x Failed to download `nvidia-cudnn-cu12==9.10.2.21`\n"
+    "|-> Request failed after 4 retries\n"
+    "|-> Failed to fetch: `https://files.pythonhosted.org/packages/ba/51/"
+    "nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl`\n"
+    "|-> error sending request for url (https://files.pythonhosted.org/...)\n"
+    "|-> client error (Connect)\n"
+    "`-> operation timed out\n"
+)
+
+
+def test_is_transient_network_failure_matches_reported_download_timeout() -> None:
+    """The exact wheel-download timeout from the bug report must be retryable."""
+    module = _load_bootstrap_module()
+    assert module.is_transient_network_failure(_REPORTED_DOWNLOAD_FAILURE) is True
+
+
+def test_is_transient_network_failure_matches_other_transport_faults() -> None:
+    module = _load_bootstrap_module()
+    samples = [
+        "error sending request for url (https://pypi.org/simple/torch/)",
+        "connection reset by peer",
+        "error decoding response body: connection closed before message completed",
+        "Temporary failure in name resolution",
+        "503 Service Unavailable",
+    ]
+    for text in samples:
+        assert module.is_transient_network_failure(text) is True, text
+
+
+def test_is_transient_network_failure_excludes_tls_interception() -> None:
+    """TLS interception reads like a connect failure but no retry can fix it.
+
+    Retrying would hide the actionable CA hint behind three more multi-GB
+    download attempts, so it must classify as permanent (GH #125).
+    """
+    module = _load_bootstrap_module()
+    tls_error = (
+        "Failed to download `torch`: client error (Connect): "
+        "invalid peer certificate: UnknownIssuer"
+    )
+    assert module.detect_tls_interception(tls_error) is True
+    assert module.is_transient_network_failure(tls_error) is False
+
+
+def test_is_transient_network_failure_excludes_permanent_errors() -> None:
+    module = _load_bootstrap_module()
+    for text in (
+        "failed to write to the cache: No space left on device",
+        "your project's requirements are unsatisfiable",
+        "error sending request for url ... 404 Not Found",
+    ):
+        assert module.is_transient_network_failure(text) is False, text
+
+
+def _stub_sync_attempts(
+    module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    outcomes: list[Exception | None],
+    events: list[tuple[tuple[object, ...], dict[str, object]]] | None = None,
+) -> tuple[list[int], list[int]]:
+    """Drive run_dependency_sync through *outcomes*; capture attempts and sleeps."""
+    attempts: list[int] = []
+    sleeps: list[int] = []
+    sink = events if events is not None else []
+
+    def fake_sync(**_: object) -> None:
+        attempts.append(len(attempts) + 1)
+        outcome = outcomes[len(attempts) - 1]
+        if outcome is not None:
+            raise outcome
+
+    monkeypatch.setattr(module, "run_dependency_sync", fake_sync)
+    monkeypatch.setattr(module, "_sleep_between_sync_attempts", lambda s: sleeps.append(s))
+    monkeypatch.setattr(module, "log", lambda _msg: None)
+    monkeypatch.setattr(module, "emit_event", lambda *a, **k: sink.append((a, k)))
+    return attempts, sleeps
+
+
+def test_sync_retries_transient_failure_and_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two dropped downloads then success — the bootstrap must not fail."""
+    module = _load_bootstrap_module()
+    attempts, sleeps = _stub_sync_attempts(
+        module,
+        monkeypatch,
+        [
+            RuntimeError(_REPORTED_DOWNLOAD_FAILURE),
+            RuntimeError("error sending request for url (https://files.pythonhosted.org/...)"),
+            None,
+        ],
+    )
+
+    module.run_dependency_sync_with_retries(
+        venv_dir=Path("/tmp/venv"),
+        cache_dir=Path("/tmp/cache"),
+        timeout_seconds=300,
+        attempts=3,
+    )
+
+    assert len(attempts) == 3, "must retry until a download attempt succeeds"
+    # Exponential backoff, so a link that is down for a minute still recovers.
+    assert sleeps == [30, 60]
+
+
+def test_sync_retry_progress_event_uses_the_documented_protocol(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retry progress reaches the dashboard as a single updating warning item.
+
+    startup_events only accepts active/complete/error statuses and
+    download/server/warning/info categories, and treats a repeated id as an
+    update — so all retries must share one id instead of stacking up.
+    """
+    module = _load_bootstrap_module()
+    events: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    _stub_sync_attempts(
+        module,
+        monkeypatch,
+        [RuntimeError(_REPORTED_DOWNLOAD_FAILURE), RuntimeError(_REPORTED_DOWNLOAD_FAILURE), None],
+        events=events,
+    )
+
+    module.run_dependency_sync_with_retries(
+        venv_dir=Path("/tmp/venv"),
+        cache_dir=Path("/tmp/cache"),
+        timeout_seconds=300,
+        attempts=3,
+    )
+
+    assert len(events) == 2
+    for args, kwargs in events:
+        assert args[0] == "bootstrap-retry"
+        assert args[1] in {"download", "server", "warning", "info"}
+        assert kwargs["status"] in {"active", "complete", "error"}
+
+
+def test_sync_retries_are_exhausted_then_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_bootstrap_module()
+    attempts, sleeps = _stub_sync_attempts(
+        module,
+        monkeypatch,
+        [RuntimeError(_REPORTED_DOWNLOAD_FAILURE)] * 3,
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        module.run_dependency_sync_with_retries(
+            venv_dir=Path("/tmp/venv"),
+            cache_dir=Path("/tmp/cache"),
+            timeout_seconds=300,
+            attempts=3,
+        )
+
+    assert len(attempts) == 3
+    assert len(sleeps) == 2, "no sleep after the final attempt"
+    # The original uv output survives so the hint/classification still works.
+    assert "nvidia-cudnn-cu12" in str(excinfo.value)
+
+
+def test_sync_does_not_retry_non_transient_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A TLS/CA failure must surface immediately, not after three downloads."""
+    module = _load_bootstrap_module()
+    attempts, sleeps = _stub_sync_attempts(
+        module,
+        monkeypatch,
+        [RuntimeError("invalid peer certificate: UnknownIssuer")] * 3,
+    )
+
+    with pytest.raises(RuntimeError):
+        module.run_dependency_sync_with_retries(
+            venv_dir=Path("/tmp/venv"),
+            cache_dir=Path("/tmp/cache"),
+            timeout_seconds=300,
+            attempts=3,
+        )
+
+    assert len(attempts) == 1
+    assert sleeps == []
+
+
+def test_sync_does_not_retry_subprocess_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sync blowing its own 3h budget is not a retryable blip."""
+    module = _load_bootstrap_module()
+    attempts, _ = _stub_sync_attempts(
+        module,
+        monkeypatch,
+        [subprocess.TimeoutExpired(cmd=["uv", "sync"], timeout=10800)] * 2,
+    )
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        module.run_dependency_sync_with_retries(
+            venv_dir=Path("/tmp/venv"),
+            cache_dir=Path("/tmp/cache"),
+            timeout_seconds=300,
+            attempts=2,
+        )
+
+    assert len(attempts) == 1
+
+
+def test_sync_attempt_count_is_configurable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_bootstrap_module()
+    monkeypatch.setenv("BOOTSTRAP_SYNC_ATTEMPTS", "5")
+    attempts, _ = _stub_sync_attempts(
+        module,
+        monkeypatch,
+        [RuntimeError(_REPORTED_DOWNLOAD_FAILURE)] * 5,
+    )
+
+    with pytest.raises(RuntimeError):
+        module.run_dependency_sync_with_retries(
+            venv_dir=Path("/tmp/venv"),
+            cache_dir=Path("/tmp/cache"),
+            timeout_seconds=300,
+        )
+
+    assert len(attempts) == 5
+
+
+def test_build_uv_sync_env_raises_http_timeout_for_large_wheels(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """uv's 30s default per-request timeout is too tight for 674MB wheels."""
+    module = _load_bootstrap_module()
+    monkeypatch.delenv("UV_HTTP_TIMEOUT", raising=False)
+
+    env = module.build_uv_sync_env(venv_dir=tmp_path / "venv", cache_dir=tmp_path / "cache")
+
+    assert int(env["UV_HTTP_TIMEOUT"]) >= 600
+
+
+def test_build_uv_sync_env_keeps_user_http_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_bootstrap_module()
+    monkeypatch.setenv("UV_HTTP_TIMEOUT", "45")
+
+    env = module.build_uv_sync_env(venv_dir=tmp_path / "venv", cache_dir=tmp_path / "cache")
+
+    assert env["UV_HTTP_TIMEOUT"] == "45"
+
+
+def test_rebuild_sync_survives_transient_network_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: the reported first-run failure now completes the bootstrap."""
+    module = _load_bootstrap_module()
+    runtime_dir = tmp_path / "runtime"
+    cache_dir = tmp_path / "runtime-cache"
+    runtime_dir.mkdir()
+    cache_dir.mkdir()
+    _patch_fingerprint_context(module, monkeypatch)
+    monkeypatch.setattr(module, "_sleep_between_sync_attempts", lambda _s: None)
+
+    calls = 0
+
+    def fake_sync(**_: object) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError(_REPORTED_DOWNLOAD_FAILURE)
+        _touch_runtime_python(runtime_dir)
+
+    monkeypatch.setattr(module, "run_dependency_sync", fake_sync)
+
+    _, sync_mode, _, diagnostics = module.ensure_runtime_dependencies(
+        runtime_dir=runtime_dir,
+        cache_dir=cache_dir,
+        timeout_seconds=300,
+        log_changes=False,
+    )
+
+    assert sync_mode == "rebuild-sync"
+    assert diagnostics["selection_reason"] == "venv_missing"
+    assert calls == 2
+    persisted = json.loads(
+        (runtime_dir / ".runtime-bootstrap-marker.json").read_text(encoding="utf-8")
+    )
+    assert persisted["sync_mode"] == "rebuild-sync"
+
+
+def test_delta_sync_network_failure_keeps_existing_venv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A network fault must not escalate to a venv-wiping rebuild.
+
+    The venv is fine; deleting it would discard a working environment and force
+    a full multi-GB re-download over the same broken link. Contrast with
+    test_delta_sync_fallback_to_rebuild, where a non-network failure still
+    escalates.
+    """
+    module = _load_bootstrap_module()
+    runtime_dir = tmp_path / "runtime"
+    cache_dir = tmp_path / "runtime-cache"
+    runtime_dir.mkdir()
+    cache_dir.mkdir()
+    _touch_runtime_python(runtime_dir)
+    _write_marker(
+        runtime_dir,
+        {
+            "schema_version": module.BOOTSTRAP_SCHEMA_VERSION,
+            "fingerprint": "old-fingerprint",
+            "python_abi": "abi",
+            "arch": "arch",
+            "structural_fingerprint": "struct-fp",
+            "lock_fingerprint": "old-lock-fp",
+        },
+    )
+    _patch_fingerprint_context(module, monkeypatch)
+    monkeypatch.setattr(module, "_sleep_between_sync_attempts", lambda _s: None)
+
+    rmtree_calls: list[Path] = []
+    calls = 0
+
+    def fake_sync(**_: object) -> None:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError(_REPORTED_DOWNLOAD_FAILURE)
+
+    monkeypatch.setattr(module, "run_dependency_sync", fake_sync)
+    monkeypatch.setattr(module.shutil, "rmtree", lambda p, **_: rmtree_calls.append(Path(p)))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        module.ensure_runtime_dependencies(
+            runtime_dir=runtime_dir,
+            cache_dir=cache_dir,
+            timeout_seconds=300,
+            log_changes=False,
+        )
+
+    assert "Dependency sync failed for mode=delta-sync" in str(excinfo.value)
+    assert rmtree_calls == [], "the venv must survive a network failure"
+    assert (runtime_dir / ".venv/bin/python").exists()
+    # Retried within delta-sync, but never re-attempted as a full rebuild.
+    assert calls == module.DEFAULT_SYNC_ATTEMPTS
+
+
+def test_raise_dependency_sync_failure_emits_network_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After retries are exhausted the user gets a network-specific remedy."""
+    module = _load_bootstrap_module()
+    logs: list[str] = []
+    events: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    monkeypatch.setattr(module, "log", lambda msg: logs.append(msg))
+    monkeypatch.setattr(module, "emit_event", lambda *a, **k: events.append((a, k)))
+
+    with pytest.raises(RuntimeError):
+        module._raise_dependency_sync_failure(
+            RuntimeError(_REPORTED_DOWNLOAD_FAILURE), "rebuild-sync"
+        )
+
+    hint = "\n".join(logs)
+    # The single most useful instruction: restart, the cache keeps the progress.
+    assert "start the server again" in hint
+    assert "BOOTSTRAP_PRUNE_UV_CACHE" in hint
+    assert any(kwargs.get("status") == "error" for _, kwargs in events)
+    # A network failure must not be mislabeled as a certificate problem.
+    assert "EXTRA_CA_CERTS_DIR" not in hint
+
+
 def test_pyproject_declares_vibevoice_dependency_metadata() -> None:
     """P0 regression guard for the reopen: the [tool.uv.dependency-metadata] entry
     for vibevoice must exist so a whisper/nemo-only CPU re-resolve never git-clones

--- a/server/backend/tests/test_bootstrap_runtime.py
+++ b/server/backend/tests/test_bootstrap_runtime.py
@@ -2034,6 +2034,9 @@ def test_is_transient_network_failure_matches_other_transport_faults() -> None:
         "error decoding response body: connection closed before message completed",
         "Temporary failure in name resolution",
         "503 Service Unavailable",
+        # Rate limiting is exactly the transient index/CDN hiccup this feature
+        # exists for: ten concurrent multi-hundred-MB downloads can trip it.
+        "HTTP status client error (429 Too Many Requests) for url (https://pypi.org/...)",
     ]
     for text in samples:
         assert module.is_transient_network_failure(text) is True, text
@@ -2141,10 +2144,18 @@ def test_sync_retry_progress_event_uses_the_documented_protocol(
     )
 
     assert len(events) == 2
-    for args, kwargs in events:
+    for attempt_no, (args, kwargs) in enumerate(events, start=1):
         assert args[0] == "bootstrap-retry"
-        assert args[1] in {"download", "server", "warning", "info"}
-        assert kwargs["status"] in {"active", "complete", "error"}
+        # Exact values, not just protocol membership: the mapper derives the
+        # rendered state from `severity` (status alone leaves the item looking
+        # like a completed green entry), and an in-progress retry must be an
+        # active warning.
+        assert args[1] == "warning"
+        assert kwargs["status"] == "active"
+        assert kwargs["severity"] == "warning"
+        # Same attempt/total fraction as the container log, so an operator
+        # cross-referencing the two surfaces sees one consistent count.
+        assert f"(attempt {attempt_no}/3)" in args[2]
 
 
 def test_sync_retries_are_exhausted_then_raises(
@@ -2381,6 +2392,104 @@ def test_raise_dependency_sync_failure_emits_network_hint(
     assert any(kwargs.get("status") == "error" for _, kwargs in events)
     # A network failure must not be mislabeled as a certificate problem.
     assert "EXTRA_CA_CERTS_DIR" not in hint
+
+
+def test_is_transient_network_exception_excludes_subprocess_timeout() -> None:
+    """A whole-sync TimeoutExpired must never be treated as a network blip.
+
+    str(TimeoutExpired) renders as "Command '[...]' timed out after N seconds",
+    which satisfies the "timed out" transient marker even though the retry loop
+    deliberately refuses to retry this exception. The exception-aware wrapper is
+    what every post-retry decision point must use.
+    """
+    module = _load_bootstrap_module()
+    timeout_exc = subprocess.TimeoutExpired(cmd=["uv", "sync"], timeout=10800)
+    assert "timed out" in str(timeout_exc)
+    assert module.is_transient_network_failure(str(timeout_exc)) is True
+    assert module.is_transient_network_exception(timeout_exc) is False
+    # The wrapper stays equivalent to the text classifier for real network faults.
+    assert module.is_transient_network_exception(RuntimeError(_REPORTED_DOWNLOAD_FAILURE)) is True
+
+
+def test_delta_sync_subprocess_timeout_still_escalates_to_rebuild(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A whole-sync timeout in delta-sync keeps the pre-retry escalation path.
+
+    Only *network* failures may keep the venv (see
+    test_delta_sync_network_failure_keeps_existing_venv); a sync that blew its
+    subprocess budget proves nothing about the network, so it must still fall
+    back to the venv-wiping rebuild-sync exactly as before the retry feature.
+    """
+    module = _load_bootstrap_module()
+    runtime_dir = tmp_path / "runtime"
+    cache_dir = tmp_path / "runtime-cache"
+    runtime_dir.mkdir()
+    cache_dir.mkdir()
+    _touch_runtime_python(runtime_dir)
+    _write_marker(
+        runtime_dir,
+        {
+            "schema_version": module.BOOTSTRAP_SCHEMA_VERSION,
+            "fingerprint": "old-fingerprint",
+            "python_abi": "abi",
+            "arch": "arch",
+            "structural_fingerprint": "struct-fp",
+            "lock_fingerprint": "old-lock-fp",
+        },
+    )
+    _patch_fingerprint_context(module, monkeypatch)
+    monkeypatch.setattr(module, "_sleep_between_sync_attempts", lambda _s: None)
+
+    rmtree_calls: list[Path] = []
+    calls = 0
+
+    def fake_sync(**_: object) -> None:
+        nonlocal calls
+        calls += 1
+        raise subprocess.TimeoutExpired(cmd=["uv", "sync"], timeout=10800)
+
+    monkeypatch.setattr(module, "run_dependency_sync", fake_sync)
+    monkeypatch.setattr(module.shutil, "rmtree", lambda p, **_: rmtree_calls.append(Path(p)))
+
+    with pytest.raises(RuntimeError) as excinfo:
+        module.ensure_runtime_dependencies(
+            runtime_dir=runtime_dir,
+            cache_dir=cache_dir,
+            timeout_seconds=300,
+            log_changes=False,
+        )
+
+    assert "Dependency sync failed for mode=rebuild-sync" in str(excinfo.value)
+    assert rmtree_calls == [runtime_dir / ".venv"], "timeout must still wipe and rebuild"
+    # One delta attempt plus one rebuild attempt; TimeoutExpired is never retried.
+    assert calls == 2
+
+
+def test_raise_dependency_sync_failure_no_network_hint_for_subprocess_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The network remedy must not fire for a whole-sync timeout.
+
+    The hint claims the download "did not recover after the automatic retries";
+    for TimeoutExpired no retry was ever attempted, so showing it would send the
+    operator down the wrong path.
+    """
+    module = _load_bootstrap_module()
+    logs: list[str] = []
+    events: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    monkeypatch.setattr(module, "log", lambda msg: logs.append(msg))
+    monkeypatch.setattr(module, "emit_event", lambda *a, **k: events.append((a, k)))
+
+    with pytest.raises(RuntimeError):
+        module._raise_dependency_sync_failure(
+            subprocess.TimeoutExpired(cmd=["uv", "sync"], timeout=10800), "rebuild-sync"
+        )
+
+    hint = "\n".join(logs)
+    assert "start the server again" not in hint
+    assert events == []
 
 
 def test_pyproject_declares_vibevoice_dependency_metadata() -> None:

--- a/server/docker/bootstrap_runtime.py
+++ b/server/docker/bootstrap_runtime.py
@@ -37,8 +37,9 @@ DEFAULT_DIARIZATION_MODEL = "pyannote/speaker-diarization-community-1"
 BOOTSTRAP_SCHEMA_VERSION = 2
 _BOOTSTRAP_START = time.perf_counter()
 
-# Per-HTTP-request timeout handed to uv (seconds). uv defaults to 30s, which is
-# far too tight for the multi-hundred-MB CUDA wheels this project installs.
+# uv read-timeout (seconds): how long a download may stall between reads before
+# uv abandons it. uv's 30s default is too twitchy for a congested link fetching
+# the multi-hundred-MB CUDA wheels this project installs.
 DEFAULT_UV_HTTP_TIMEOUT_SECONDS = 900
 # Total `uv sync` attempts (1 initial + retries) when the failure looks like a
 # transient network fault. Overridable via BOOTSTRAP_SYNC_ATTEMPTS.
@@ -429,12 +430,14 @@ def build_uv_sync_env(venv_dir: Path, cache_dir: Path) -> dict[str, str]:
     env["UV_PROJECT_ENVIRONMENT"] = str(venv_dir)
     env["UV_CACHE_DIR"] = str(cache_dir)
     env["UV_PYTHON"] = "/usr/bin/python3.13"
-    # The CUDA wheel set is ~4GB and individual wheels reach 674MB
-    # (nvidia-cudnn-cu12), all fetched concurrently. uv's default 30s per-request
-    # timeout is sized for ordinary PyPI packages and trips as soon as a slow or
-    # congested link stalls one of those transfers, aborting the whole sync with
-    # "operation timed out". Give each request a much larger budget; the sync as
-    # a whole is still bounded by run_dependency_sync's subprocess timeout.
+    # UV_HTTP_TIMEOUT is uv's *read* timeout: how long a transfer may stall
+    # between reads before uv abandons the request (connection establishment is
+    # governed separately by UV_HTTP_CONNECT_TIMEOUT). The 30s default is fine
+    # for ordinary PyPI packages, but this project pulls ~4GB of CUDA wheels
+    # (674MB for nvidia-cudnn-cu12 alone) concurrently, where a brief stall on a
+    # slow or congested link is routine and aborts the whole sync with
+    # "operation timed out". Give a stalled read a much larger budget; the sync
+    # as a whole is still bounded by run_dependency_sync's subprocess timeout.
     # An explicit UV_HTTP_TIMEOUT from the user always wins.
     env.setdefault("UV_HTTP_TIMEOUT", str(DEFAULT_UV_HTTP_TIMEOUT_SECONDS))
     # GH #125: on TLS-intercepting networks (corporate proxy / antivirus HTTPS
@@ -601,6 +604,9 @@ _TRANSIENT_NETWORK_MARKERS: tuple[str, ...] = (
     "502 bad gateway",
     "503 service unavailable",
     "504 gateway timeout",
+    # Concurrent multi-hundred-MB downloads are exactly the burst pattern that
+    # trips CDN/PyPI rate limiting; a 429 clears on its own, so retry it.
+    "429 too many requests",
 )
 
 # Failures that also mention transport-sounding words but will never succeed on a
@@ -627,6 +633,20 @@ def is_transient_network_failure(error_text: str) -> bool:
     if any(marker in lowered for marker in _PERMANENT_FAILURE_MARKERS):
         return False
     return any(marker in lowered for marker in _TRANSIENT_NETWORK_MARKERS)
+
+
+def is_transient_network_exception(exc: Exception) -> bool:
+    """Exception-aware wrapper over :func:`is_transient_network_failure`.
+
+    ``str(subprocess.TimeoutExpired)`` renders as "Command '[...]' timed out
+    after N seconds", which satisfies the "timed out" transient marker even
+    though a whole-sync timeout says nothing about the network. Every decision
+    made *after* the retry loop (keep-the-venv, the network hint) must go
+    through this wrapper so a timeout is never dressed up as a network fault.
+    """
+    if isinstance(exc, subprocess.TimeoutExpired):
+        return False
+    return is_transient_network_failure(str(exc))
 
 
 def _sleep_between_sync_attempts(seconds: int) -> None:
@@ -694,13 +714,17 @@ def run_dependency_sync_with_retries(
             )
             # Same id on every retry: the events protocol treats a repeated id as
             # an update, so the dashboard shows one line that counts up rather
-            # than a stack of scary-looking failures.
+            # than a stack of scary-looking failures. severity="warning" is what
+            # the dashboard mapper keys the rendered state off for this category
+            # (status alone would render as a completed green item), and the
+            # attempt fraction matches the log line above so both surfaces agree.
             emit_event(
                 "bootstrap-retry",
                 "warning",
-                f"Network error while downloading dependencies; "
-                f"retrying ({attempt}/{total_attempts - 1}) in {delay}s",
+                f"Network error while downloading dependencies "
+                f"(attempt {attempt}/{total_attempts}); retrying in {delay}s",
                 status="active",
+                severity="warning",
                 phase="bootstrap",
             )
             _sleep_between_sync_attempts(delay)
@@ -717,7 +741,7 @@ _NETWORK_FAILURE_HINT = (
     "BOOTSTRAP_PRUNE_UV_CACHE=true while you are fighting this, it throws that progress away. "
     "(2) If you are on Wi-Fi or a VPN, switch to a wired connection or drop the VPN for the "
     "first start. "
-    "(3) On a slow link, raise the per-download budget and the retry count: "
+    "(3) On a slow link, allow longer stalls and more retries: "
     "UV_HTTP_TIMEOUT=1800 and BOOTSTRAP_SYNC_ATTEMPTS=6. "
     "(4) If your machine has no NVIDIA GPU, use the CPU build instead — it skips the CUDA "
     "wheels entirely and downloads a fraction of the data."
@@ -741,7 +765,7 @@ def _raise_dependency_sync_failure(exc: Exception, final_sync_mode: str) -> None
             status="error",
             phase="bootstrap",
         )
-    elif is_transient_network_failure(error_text):
+    elif is_transient_network_exception(exc):
         log(_NETWORK_FAILURE_HINT)
         emit_event(
             "bootstrap-network",
@@ -969,9 +993,10 @@ def ensure_runtime_dependencies(
                 # A network fault says nothing about the venv's shape, and the
                 # rebuild path would delete a working venv only to re-download
                 # everything over the same broken link. Keep the venv and fail;
-                # the next boot retries the (much cheaper) delta-sync.
-                if is_transient_network_failure(str(delta_exc)):
-                    diagnostics["network_failure"] = True
+                # the next boot retries the (much cheaper) delta-sync. The
+                # exception-aware check keeps a whole-sync TimeoutExpired on the
+                # escalation path below, same as before the retry feature.
+                if is_transient_network_exception(delta_exc):
                     log("Delta-sync failed on a network error; keeping the existing venv")
                     _raise_dependency_sync_failure(delta_exc, final_sync_mode)
                 log("Delta-sync failed, falling back to rebuild-sync")

--- a/server/docker/bootstrap_runtime.py
+++ b/server/docker/bootstrap_runtime.py
@@ -36,6 +36,16 @@ DEFAULT_DIARIZATION_MODEL = "pyannote/speaker-diarization-community-1"
 
 BOOTSTRAP_SCHEMA_VERSION = 2
 _BOOTSTRAP_START = time.perf_counter()
+
+# Per-HTTP-request timeout handed to uv (seconds). uv defaults to 30s, which is
+# far too tight for the multi-hundred-MB CUDA wheels this project installs.
+DEFAULT_UV_HTTP_TIMEOUT_SECONDS = 900
+# Total `uv sync` attempts (1 initial + retries) when the failure looks like a
+# transient network fault. Overridable via BOOTSTRAP_SYNC_ATTEMPTS.
+DEFAULT_SYNC_ATTEMPTS = 3
+# Backoff between sync attempts: 30s, 60s, 120s … capped.
+_SYNC_RETRY_BASE_DELAY_SECONDS = 30
+_SYNC_RETRY_MAX_DELAY_SECONDS = 300
 _VIBEVOICE_ASR_IMPORT_CANDIDATES: tuple[tuple[str, str, str, str, str], ...] = (
     (
         "legacy",
@@ -419,6 +429,14 @@ def build_uv_sync_env(venv_dir: Path, cache_dir: Path) -> dict[str, str]:
     env["UV_PROJECT_ENVIRONMENT"] = str(venv_dir)
     env["UV_CACHE_DIR"] = str(cache_dir)
     env["UV_PYTHON"] = "/usr/bin/python3.13"
+    # The CUDA wheel set is ~4GB and individual wheels reach 674MB
+    # (nvidia-cudnn-cu12), all fetched concurrently. uv's default 30s per-request
+    # timeout is sized for ordinary PyPI packages and trips as soon as a slow or
+    # congested link stalls one of those transfers, aborting the whole sync with
+    # "operation timed out". Give each request a much larger budget; the sync as
+    # a whole is still bounded by run_dependency_sync's subprocess timeout.
+    # An explicit UV_HTTP_TIMEOUT from the user always wins.
+    env.setdefault("UV_HTTP_TIMEOUT", str(DEFAULT_UV_HTTP_TIMEOUT_SECONDS))
     # GH #125: on TLS-intercepting networks (corporate proxy / antivirus HTTPS
     # scanning) uv's bundled webpki roots reject the re-signed certificate
     # ("UnknownIssuer"). Opt-in UV_NATIVE_TLS makes uv trust the system/container
@@ -561,6 +579,151 @@ def detect_tls_interception(error_text: str) -> bool:
     return any(marker in lowered for marker in _TLS_INTERCEPTION_MARKERS)
 
 
+# Substrings that indicate the download died for a transport reason a retry can
+# plausibly clear: a stalled connection, a dropped socket, a flaky DNS lookup, a
+# PyPI/CDN hiccup. uv's own in-request retries (4) all happen inside one short
+# window, so they do not survive a link that is down for a minute.
+_TRANSIENT_NETWORK_MARKERS: tuple[str, ...] = (
+    "operation timed out",
+    "timed out",
+    "error sending request for url",
+    "client error (connect)",
+    "request failed after",
+    "connection reset",
+    "connection closed",
+    "connection refused",
+    "connection aborted",
+    "broken pipe",
+    "error decoding response body",
+    "temporary failure in name resolution",
+    "dns error",
+    "failed to lookup address information",
+    "502 bad gateway",
+    "503 service unavailable",
+    "504 gateway timeout",
+)
+
+# Failures that also mention transport-sounding words but will never succeed on a
+# retry — retrying them only burns another multi-GB download window.
+_PERMANENT_FAILURE_MARKERS: tuple[str, ...] = (
+    "no space left on device",
+    "unsatisfiable",
+    "404 not found",
+    "was not found in the package registry",
+)
+
+
+def is_transient_network_failure(error_text: str) -> bool:
+    """Return True when *error_text* is a retryable network fault.
+
+    TLS interception is deliberately excluded: an untrusted corporate CA
+    produces "client error (Connect)" / "Failed to fetch" text too, but no
+    number of retries will make the container trust that certificate — it needs
+    the operator action described in ``_TLS_INTERCEPTION_HINT``.
+    """
+    lowered = error_text.lower()
+    if detect_tls_interception(lowered):
+        return False
+    if any(marker in lowered for marker in _PERMANENT_FAILURE_MARKERS):
+        return False
+    return any(marker in lowered for marker in _TRANSIENT_NETWORK_MARKERS)
+
+
+def _sleep_between_sync_attempts(seconds: int) -> None:
+    """Pause before the next sync attempt (indirection so tests can stub it).
+
+    Same exemption as :func:`_utc_now_iso`: this is a synchronous, stdlib-only
+    bootstrap script with no event loop, so the project's asyncio/frozen-clock
+    discipline does not apply. Tests stub this function rather than the clock.
+    """
+    time.sleep(seconds)  # noqa: TID251 - bootstrap backoff, no event loop here
+
+
+def run_dependency_sync_with_retries(
+    venv_dir: Path,
+    cache_dir: Path,
+    timeout_seconds: int,
+    extras: tuple[str, ...] = (),
+    pytorch_variant: str = "cu129",
+    attempts: int | None = None,
+) -> None:
+    """Run :func:`run_dependency_sync`, retrying transient network failures.
+
+    A single dropped connection while fetching one of the ~4GB of CUDA wheels
+    used to abort the entire bootstrap, and the container exited without a
+    runtime venv — after having already downloaded everything else. Retrying is
+    cheap because uv writes completed downloads into ``UV_CACHE_DIR`` (persisted
+    on the ``/runtime`` volume), so a retry resumes with only the wheels that
+    never landed still to fetch.
+
+    Only transport-level faults are retried; deterministic failures (TLS
+    interception, unsatisfiable requirements, a full disk) and a subprocess
+    timeout of the sync as a whole propagate on the first attempt.
+    """
+    total_attempts = max(
+        1,
+        attempts
+        if attempts is not None
+        else parse_int_env("BOOTSTRAP_SYNC_ATTEMPTS", DEFAULT_SYNC_ATTEMPTS),
+    )
+
+    for attempt in range(1, total_attempts + 1):
+        try:
+            run_dependency_sync(
+                venv_dir=venv_dir,
+                cache_dir=cache_dir,
+                timeout_seconds=timeout_seconds,
+                extras=extras,
+                pytorch_variant=pytorch_variant,
+            )
+            return
+        except subprocess.TimeoutExpired:
+            # The whole sync exceeded its (already 3h) budget — a retry would
+            # just spend another one.
+            raise
+        except Exception as exc:
+            if attempt >= total_attempts or not is_transient_network_failure(str(exc)):
+                raise
+            delay = min(
+                _SYNC_RETRY_BASE_DELAY_SECONDS * (2 ** (attempt - 1)),
+                _SYNC_RETRY_MAX_DELAY_SECONDS,
+            )
+            log(
+                f"Dependency download hit a network error (attempt {attempt}/{total_attempts}); "
+                f"retrying in {delay}s — already-downloaded wheels are kept in the uv cache"
+            )
+            # Same id on every retry: the events protocol treats a repeated id as
+            # an update, so the dashboard shows one line that counts up rather
+            # than a stack of scary-looking failures.
+            emit_event(
+                "bootstrap-retry",
+                "warning",
+                f"Network error while downloading dependencies; "
+                f"retrying ({attempt}/{total_attempts - 1}) in {delay}s",
+                status="active",
+                phase="bootstrap",
+            )
+            _sleep_between_sync_attempts(delay)
+
+
+_NETWORK_FAILURE_HINT = (
+    "Downloading the Python dependencies failed for a network reason and did not recover "
+    "after the automatic retries. This is a connectivity problem, not a broken install: "
+    "the PyTorch/CUDA wheels are about 4GB and a single one is 674MB, so an unstable or "
+    "throttled connection can drop a transfer. What to do: "
+    "(1) Simply start the server again — every wheel that finished downloading is kept in "
+    "the uv cache on the 'transcriptionsuite-runtime' volume, so the next attempt only "
+    "fetches what is missing and gets further each time. Do NOT set "
+    "BOOTSTRAP_PRUNE_UV_CACHE=true while you are fighting this, it throws that progress away. "
+    "(2) If you are on Wi-Fi or a VPN, switch to a wired connection or drop the VPN for the "
+    "first start. "
+    "(3) On a slow link, raise the per-download budget and the retry count: "
+    "UV_HTTP_TIMEOUT=1800 and BOOTSTRAP_SYNC_ATTEMPTS=6. "
+    "(4) If your machine has no NVIDIA GPU, use the CPU build instead — it skips the CUDA "
+    "wheels entirely and downloads a fraction of the data."
+)
+
+
 def _raise_dependency_sync_failure(exc: Exception, final_sync_mode: str) -> None:
     """Log an actionable hint for recognized causes, then raise a RuntimeError.
 
@@ -575,6 +738,15 @@ def _raise_dependency_sync_failure(exc: Exception, final_sync_mode: str) -> None
             "bootstrap-tls",
             "server",
             _TLS_INTERCEPTION_HINT,
+            status="error",
+            phase="bootstrap",
+        )
+    elif is_transient_network_failure(error_text):
+        log(_NETWORK_FAILURE_HINT)
+        emit_event(
+            "bootstrap-network",
+            "server",
+            _NETWORK_FAILURE_HINT,
             status="error",
             phase="bootstrap",
         )
@@ -778,7 +950,7 @@ def ensure_runtime_dependencies(
             log(f"Installing Python runtime dependencies (mode={final_sync_mode})...")
             sync_start = time.perf_counter()
             try:
-                run_dependency_sync(
+                run_dependency_sync_with_retries(
                     venv_dir=venv_dir,
                     cache_dir=cache_dir,
                     timeout_seconds=timeout_seconds,
@@ -794,6 +966,14 @@ def ensure_runtime_dependencies(
                     f"dependency sync failed (mode={final_sync_mode})",
                     sync_start,
                 )
+                # A network fault says nothing about the venv's shape, and the
+                # rebuild path would delete a working venv only to re-download
+                # everything over the same broken link. Keep the venv and fail;
+                # the next boot retries the (much cheaper) delta-sync.
+                if is_transient_network_failure(str(delta_exc)):
+                    diagnostics["network_failure"] = True
+                    log("Delta-sync failed on a network error; keeping the existing venv")
+                    _raise_dependency_sync_failure(delta_exc, final_sync_mode)
                 log("Delta-sync failed, falling back to rebuild-sync")
                 diagnostics["escalated_to_rebuild"] = True
                 diagnostics["delta_sync_error"] = str(delta_exc)[:240]
@@ -805,7 +985,7 @@ def ensure_runtime_dependencies(
                 log(f"Installing Python runtime dependencies (mode={final_sync_mode})...")
                 sync_start = time.perf_counter()
                 try:
-                    run_dependency_sync(
+                    run_dependency_sync_with_retries(
                         venv_dir=venv_dir,
                         cache_dir=cache_dir,
                         timeout_seconds=timeout_seconds,
@@ -845,7 +1025,7 @@ def ensure_runtime_dependencies(
             log(f"Installing Python runtime dependencies (mode={final_sync_mode})...")
             sync_start = time.perf_counter()
             try:
-                run_dependency_sync(
+                run_dependency_sync_with_retries(
                     venv_dir=venv_dir,
                     cache_dir=cache_dir,
                     timeout_seconds=timeout_seconds,


### PR DESCRIPTION
Builds on #265 with the contributor's commit preserved as-is, and adds the fixes from its code review on top, so the feature can land without another review round-trip. Addresses the failure mode reported in #121 (first-start CUDA wheel download dying ~40 minutes in on a dropped connection and discarding all progress).

## Base feature (from #265, unchanged)

* `uv sync` is retried up to 3 times (`BOOTSTRAP_SYNC_ATTEMPTS`) on transient network failures, with 30s/60s backoff; completed wheels survive in the uv cache on the runtime volume, so each retry only fetches what is missing
* `UV_HTTP_TIMEOUT` defaults to 900s so a stalled transfer is not abandoned after uv's 30s default
* transient-vs-permanent failure classifier; TLS interception, full disk and unsatisfiable requirements are never retried, so the GH #125 CA hint keeps firing on that path
* a delta-sync network failure keeps the existing venv instead of escalating to a venv-wiping rebuild
* dashboard progress event per retry and an actionable operator hint when retries are exhausted, plus tests and docs

## Review fixes added on top

* **TimeoutExpired misclassification (bug):** `str(subprocess.TimeoutExpired)` contains "timed out" and matched the transient marker at every post-retry decision point. New `is_transient_network_exception()` wrapper: a whole-sync timeout now escalates delta-sync to rebuild-sync exactly as before the retry feature, and no longer produces the misleading "did not recover after the automatic retries" hint.
* **Retry event rendered as completed:** the startup-event mapper derives the display state from `severity` for warning-category events, so the retry showed a green checkmark while waiting to retry. Now passes `severity="warning"` (same pattern as `model-preload-error`) and uses the same attempt N/total fraction as the container log.
* **429 rate limiting** added to the retryable markers (concurrent multi-hundred-MB downloads are the canonical way to trip it).
* **Dead write removed:** `diagnostics["network_failure"]` was set immediately before an unconditional raise.
* **Docs corrected:** `UV_HTTP_TIMEOUT` is uv's read timeout (stall allowance), not a per-request budget; the quoted connect-phase error is fixed by the retry loop, not the timeout. Docs now also mention that a silently dead link takes longer to surface its final error.
* **Tests:** 3 new tests for the timeout classification/escalation/hint, a 429 classifier sample, and the retry-event test tightened to exact category/status/severity values.

## Test plan

- [x] Full backend suite from the build venv: 2343 passed, 4 skipped, 0 failed
- [x] All 15 tests from #265 still pass unchanged in behavior (one tightened by design)
- [x] `ruff check` and `ruff format --check` clean on both touched Python files
- [ ] Hardware smoke: real first start on a throttled/flaky link (unit coverage stands in for now)

Known follow-up (pre-existing, out of scope): terminal `bootstrap-network`/`bootstrap-tls` errors are still masked by the aggregate "Starting server..." card in the dashboard, so the exhausted-retries hint reaches the container log but not the UI.