### PR TITLE
feat(dashboard, ui): make remote connection its own Runtime option in the Server tab

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -22,7 +22,7 @@ import { ErrorFallback } from './components/ui/ErrorFallback';
 import { queryClient } from './src/queryClient';
 import { useServerStatus } from './src/hooks/useServerStatus';
 import { useAdminStatus } from './src/hooks/useAdminStatus';
-import { initApiClient } from './src/api/client';
+import { apiClient, initApiClient } from './src/api/client';
 import { DockerProvider, useDockerContext } from './src/hooks/DockerContext';
 import { getConfig, setConfig } from './src/config/store';
 import { useLiveMode } from './src/hooks/useLiveMode';
@@ -98,14 +98,25 @@ const AppInner: React.FC = () => {
     }
   }, []);
 
-  // Track remote mode so useAuthTokenSync re-evaluates on mode switch
+  // Track remote mode so useAuthTokenSync re-evaluates on mode switch.
+  // Besides the reachability-driven re-read, subscribe to
+  // apiClient.onConfigChanged: every connection.* writer (Server tab Remote
+  // tile, SessionView Client Link, SettingsModal) ends with syncFromConfig(),
+  // which fires that event. Without it, a mode switch that does not flip
+  // reachability leaves this stale and useAuthTokenSync keeps (or skips)
+  // Docker-log token scanning for the WRONG mode — the local container's
+  // admin token could silently overwrite a freshly entered remote token.
   const [useRemote, setUseRemote] = useState(false);
   useEffect(() => {
-    const api = (window as any).electronAPI;
-    api?.config
-      ?.get?.('connection.useRemote')
-      .then((v: unknown) => setUseRemote(v === true))
-      .catch(() => {});
+    const readUseRemote = () => {
+      const api = (window as any).electronAPI;
+      api?.config
+        ?.get?.('connection.useRemote')
+        .then((v: unknown) => setUseRemote(v === true))
+        .catch(() => {});
+    };
+    readUseRemote();
+    return apiClient.onConfigChanged(readUseRemote);
   }, [serverConnection.reachable]);
 
   // Always-on Docker log token scanner
@@ -740,6 +751,7 @@ const AppInner: React.FC = () => {
             <ServerView
               onStartServer={startServerWithOnboarding}
               startupFlowPending={startupFlowPending}
+              clientRunning={clientRunning}
             />
           </ErrorBoundary>
         );

--- a/dashboard/components/__tests__/ServerView.test.tsx
+++ b/dashboard/components/__tests__/ServerView.test.tsx
@@ -94,7 +94,8 @@ vi.mock('../../src/stores/notificationsStore', () => {
   return { useNotificationsStore };
 });
 
-// apiClient
+// apiClient — onConfigChanged/syncFromConfig/setAuthToken are exercised by
+// the Remote runtime tile (mount subscription + mode-switch handlers).
 vi.mock('../../src/api/client', () => ({
   apiClient: {
     checkConnection: vi.fn().mockResolvedValue({ reachable: true, ready: true }),
@@ -102,6 +103,9 @@ vi.mock('../../src/api/client', () => ({
     loadModels: vi.fn().mockResolvedValue(undefined),
     unloadModels: vi.fn().mockResolvedValue(undefined),
     setModel: vi.fn().mockResolvedValue(undefined),
+    onConfigChanged: vi.fn().mockReturnValue(() => {}),
+    syncFromConfig: vi.fn().mockResolvedValue(undefined),
+    setAuthToken: vi.fn(),
   },
 }));
 
@@ -1339,6 +1343,9 @@ describe('Multi-GPU selection', () => {
     expect(pickerButton()?.textContent).toContain('Automatic (Docker default)');
   });
 
+  // 10s timeout: chronically ~3.4s of real mount work — the default 5s budget
+  // tips over under full-suite parallel load now that this file carries more
+  // tests.
   it('persists a picked card to server.gpuDevice as its UUID', async () => {
     const { setSpy } = setupApi([RTX_3060, RTX_3090]);
     await mountAndRedetect();
@@ -1350,7 +1357,7 @@ describe('Multi-GPU selection', () => {
       expect(setSpy).toHaveBeenCalledWith('server.gpuDevice', 'GPU-bbb');
     });
     expect(pickerButton()?.textContent).toContain('GPU 1: NVIDIA GeForce RTX 3090 (24 GB)');
-  });
+  }, 10_000);
 
   it('hydrates a persisted selection from server.gpuDevice', async () => {
     setupApi([RTX_3060, RTX_3090], { storedGpuDevice: 'GPU-bbb' });
@@ -1427,5 +1434,240 @@ describe('Multi-GPU selection', () => {
         name: 'Previously selected GPU not detected - starts as Automatic',
       }),
     ).toBeTruthy();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Remote runtime tile: connection.useRemote drives the tile selection, greys
+// the local-instance cards and swaps card 4 to the client settings.
+// remoteModeActive is read through the mocked config/store getConfig (NOT
+// electronAPI.config.get), so each test seeds it via mockImplementation.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { apiClient } from '../../src/api/client';
+
+describe('Remote runtime tile', () => {
+  function setupElectronAPI() {
+    (window as any).electronAPI = {
+      config: {
+        get: vi.fn().mockImplementation(async (key: string) => {
+          if (key === 'server.runtimeProfile') return 'cpu';
+          if (key === 'server.gpuAutoDetectDone') return true;
+          return undefined;
+        }),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+      docker: {
+        readComposeEnvValue: vi.fn().mockResolvedValue('false'),
+        checkModelCache: vi.fn().mockResolvedValue({}),
+        checkGpu: vi.fn().mockResolvedValue({ gpu: false, toolkit: false, vulkan: false }),
+      },
+      app: {
+        getArch: vi.fn().mockReturnValue('x64'),
+        getConfigDir: vi.fn().mockResolvedValue('/mock/config'),
+      },
+      mlx: {
+        getStatus: vi.fn().mockResolvedValue('stopped'),
+        onStatusChanged: vi.fn().mockReturnValue(vi.fn()),
+      },
+      tailscale: {
+        getHostname: vi.fn().mockResolvedValue('my-server.tail1234.ts.net'),
+      },
+      server: {
+        checkFirewallPort: vi.fn().mockResolvedValue(null),
+      },
+    };
+  }
+
+  function seedRemoteMode(useRemote: boolean) {
+    vi.mocked(getConfig).mockImplementation(async (key: string) => {
+      if (key === 'connection.useRemote') return useRemote;
+      if (key === 'connection.remoteProfile') return 'tailscale';
+      if (key === 'connection.remoteHost') return 'gpu-box.tail1234.ts.net';
+      if (key === 'connection.authToken') return 'remote-token';
+      if (key === 'connection.port') return 9786;
+      return undefined;
+    });
+  }
+
+  function runtimeGroup() {
+    return within(screen.getByText('Runtime').closest('.space-y-2') as HTMLElement);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDocker.available = true;
+    mockDocker.images = [];
+    mockDocker.remoteTags = [];
+    mockDocker.variantTags = null;
+    mockDocker.container = { exists: false, running: false, status: 'unknown', health: undefined };
+    mockDocker.operationError = null;
+    mockDocker.operating = false;
+    mockDocker.composeAvailable = true;
+    mockAdminStatus.status = { models: {} };
+    vi.mocked(setConfig).mockResolvedValue(undefined);
+    setupElectronAPI();
+  });
+
+  it('renders the Remote tile unselected in local mode', async () => {
+    seedRemoteMode(false);
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    const tile = runtimeGroup().getByText('Remote').closest('button') as HTMLButtonElement;
+    await waitFor(() => {
+      expect(tile.getAttribute('aria-pressed')).toBe('false');
+    });
+    // Local mode keeps the host-side card 4 (self-loading credentials view).
+    expect(screen.queryByText('Remote Profile')).toBeNull();
+  });
+
+  it('selecting the Remote tile writes useRemote + useHttps and re-syncs the api client', async () => {
+    seedRemoteMode(false);
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    const tile = runtimeGroup().getByText('Remote').closest('button') as HTMLButtonElement;
+    fireEvent.click(tile);
+    await waitFor(() => {
+      expect(vi.mocked(setConfig).mock.calls).toEqual(
+        expect.arrayContaining([
+          ['connection.useRemote', true],
+          ['connection.useHttps', true],
+        ]),
+      );
+      expect(apiClient.syncFromConfig).toHaveBeenCalled();
+    });
+  });
+
+  it('reflects a persisted remote mode: tile selected, instance cards inert, client card shown', async () => {
+    seedRemoteMode(true);
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    await waitFor(() => {
+      const tile = runtimeGroup().getByText('Remote').closest('button') as HTMLButtonElement;
+      expect(tile.getAttribute('aria-pressed')).toBe('true');
+    });
+    // Cards 2 + 3 dim and stop receiving pointer events.
+    expect(
+      screen.getByText('3. Instance Settings').closest('[aria-disabled="true"]'),
+    ).not.toBeNull();
+    expect(screen.getByText('2. Docker Image').closest('[aria-disabled="true"]')).not.toBeNull();
+    // Card 4 swaps to the client-side settings.
+    await waitFor(() => {
+      expect(screen.getByText('Remote Profile')).toBeDefined();
+    });
+    expect(screen.getAllByText('Not needed for Remote connection').length).toBeGreaterThanOrEqual(
+      3,
+    );
+    // Local runtime tiles read unselected even though runtimeProfile === 'cpu'.
+    const cpuTile = runtimeGroup().getByText('CPU Only').closest('button') as HTMLButtonElement;
+    expect(cpuTile.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('selecting a local runtime exits remote mode and restores the local profile flow', async () => {
+    seedRemoteMode(true);
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    await waitFor(() => {
+      const tile = runtimeGroup().getByText('Remote').closest('button') as HTMLButtonElement;
+      expect(tile.getAttribute('aria-pressed')).toBe('true');
+    });
+    fireEvent.click(runtimeGroup().getByText('CPU Only').closest('button') as HTMLButtonElement);
+    await waitFor(() => {
+      expect(vi.mocked(setConfig).mock.calls).toEqual(
+        expect.arrayContaining([
+          ['connection.useRemote', false],
+          ['connection.useHttps', false],
+        ]),
+      );
+      expect((window as any).electronAPI.config.set).toHaveBeenCalledWith(
+        'server.runtimeProfile',
+        'cpu',
+      );
+    });
+  });
+
+  it('serializes a rapid Remote→local click sequence so the final state is local', async () => {
+    // Stateful config store: the queued mode switches re-read
+    // connection.useRemote from config, so the mock must persist writes for
+    // the second switch to see the first one's result.
+    const store = new Map<string, unknown>();
+    vi.mocked(getConfig).mockImplementation(async (key: string) => store.get(key));
+    vi.mocked(setConfig).mockImplementation(async (key: string, value: unknown) => {
+      store.set(key, value);
+    });
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    const remoteTile = runtimeGroup().getByText('Remote').closest('button') as HTMLButtonElement;
+    const cpuTile = runtimeGroup().getByText('CPU Only').closest('button') as HTMLButtonElement;
+    fireEvent.click(remoteTile);
+    fireEvent.click(cpuTile);
+    await waitFor(() => {
+      expect(store.get('connection.useRemote')).toBe(false);
+    });
+    // Both switches ran, in click order — neither was dropped or interleaved.
+    const useRemoteWrites = vi
+      .mocked(setConfig)
+      .mock.calls.filter((c) => c[0] === 'connection.useRemote')
+      .map((c) => c[1]);
+    expect(useRemoteWrites).toEqual([true, false]);
+  });
+
+  it('restores a deliberately enabled local HTTPS preference after a remote round-trip', async () => {
+    const store = new Map<string, unknown>([['connection.useHttps', true]]);
+    vi.mocked(getConfig).mockImplementation(async (key: string) => store.get(key));
+    vi.mocked(setConfig).mockImplementation(async (key: string, value: unknown) => {
+      store.set(key, value);
+    });
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    fireEvent.click(runtimeGroup().getByText('Remote').closest('button') as HTMLButtonElement);
+    await waitFor(() => {
+      expect(store.get('connection.useRemote')).toBe(true);
+    });
+    // Entering remote snapshotted the pref and forced HTTPS on.
+    expect(store.get('connection.localUseHttps')).toBe(true);
+    expect(store.get('connection.useHttps')).toBe(true);
+    fireEvent.click(runtimeGroup().getByText('CPU Only').closest('button') as HTMLButtonElement);
+    await waitFor(() => {
+      expect(store.get('connection.useRemote')).toBe(false);
+    });
+    // Leaving remote restored the snapshot instead of clobbering to false.
+    expect(store.get('connection.useHttps')).toBe(true);
+  });
+
+  it('re-reads connection.useRemote when apiClient fires onConfigChanged', async () => {
+    seedRemoteMode(false);
+    render(React.createElement(ServerView, baseProps), { wrapper: createWrapper() });
+    const tile = () => runtimeGroup().getByText('Remote').closest('button') as HTMLButtonElement;
+    await waitFor(() => {
+      expect(tile().getAttribute('aria-pressed')).toBe('false');
+    });
+    // Another writer (SessionView Client Link, SettingsModal) flips the key
+    // and syncFromConfig() fires the config-changed event.
+    seedRemoteMode(true);
+    const listener = vi.mocked(apiClient.onConfigChanged).mock.calls[0][0] as () => void;
+    listener();
+    await waitFor(() => {
+      expect(tile().getAttribute('aria-pressed')).toBe('true');
+    });
+  });
+
+  it('blocks entering remote mode while the client link is running', async () => {
+    seedRemoteMode(false);
+    render(React.createElement(ServerView, { ...baseProps, clientRunning: true }), {
+      wrapper: createWrapper(),
+    });
+    const remoteTile = runtimeGroup().getByText('Remote').closest('button') as HTMLButtonElement;
+    await waitFor(() => {
+      expect(remoteTile.disabled).toBe(true);
+    });
+    expect(runtimeGroup().getByText('Client running')).toBeDefined();
+  });
+
+  it('blocks leaving remote mode while the client link is running', async () => {
+    seedRemoteMode(true);
+    render(React.createElement(ServerView, { ...baseProps, clientRunning: true }), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      const remoteTile = runtimeGroup().getByText('Remote').closest('button') as HTMLButtonElement;
+      expect(remoteTile.getAttribute('aria-pressed')).toBe('true');
+    });
+    const cpuTile = runtimeGroup().getByText('CPU Only').closest('button') as HTMLButtonElement;
+    expect(cpuTile.disabled).toBe(true);
   });
 });

--- a/dashboard/components/views/ServerView.tsx
+++ b/dashboard/components/views/ServerView.tsx
@@ -38,6 +38,7 @@ import { AppleIcon } from '../ui/icons/AppleIcon';
 import { GpuHealthCard } from './GpuHealthCard';
 import { GpuDiagnosticModal, type GpuDiagnosticResultProp } from './GpuDiagnosticModal';
 import { InstanceSettingsSelectors } from './server/InstanceSettingsSelectors';
+import { RemoteClientSettingsCard } from './server/RemoteClientSettingsCard';
 import { RemoteConnectionCard } from './server/RemoteConnectionCard';
 import { StartupActivityInline } from './server/StartupActivityInline';
 
@@ -104,6 +105,13 @@ interface ServerViewProps {
     },
   ) => Promise<void>;
   startupFlowPending: boolean;
+  /**
+   * True while the Session tab's client link is running. Mirrors the guard on
+   * SessionView's own Start Local / Start Remote buttons: switching the
+   * connection mode silently retargets the live apiClient, so it is blocked
+   * while a client session is active.
+   */
+  clientRunning?: boolean;
 }
 
 // The diarization option strings (CAM++, Sortformer, pyannote, Custom) are
@@ -270,7 +278,11 @@ function mapDiarizationModelToSelection(modelName: string): { selection: string;
   return { selection: DIARIZATION_MODEL_CUSTOM_OPTION, custom: modelName };
 }
 
-export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFlowPending }) => {
+export const ServerView: React.FC<ServerViewProps> = ({
+  onStartServer,
+  startupFlowPending,
+  clientRunning = false,
+}) => {
   const { status: adminStatus, refresh: refreshAdminStatus } = useAdminStatus();
   const docker = useDockerContext();
 
@@ -295,6 +307,89 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
 
   // Runtime profile (persisted in electron-store)
   const [runtimeProfile, setRuntimeProfile] = useState<RuntimeProfile>('cpu');
+
+  // Remote connection mode — the Remote tile in the Runtime selector.
+  // Deliberately NOT part of the RuntimeProfile union: it is a connection
+  // mode (this dashboard is a client of another machine's server), not a
+  // hardware runtime, mirroring compatGuard's `deployment` derivation from
+  // the same key. server.runtimeProfile keeps its last local value while
+  // remote is active, so switching back restores the previous runtime.
+  const [remoteModeActive, setRemoteModeActive] = useState(false);
+  useEffect(() => {
+    let active = true;
+    getConfig<boolean>('connection.useRemote')
+      .then((v) => {
+        if (active) setRemoteModeActive(v === true);
+      })
+      .catch(() => {});
+    // Re-read after every apiClient.syncFromConfig() — the only signal that
+    // connection.* changed (SessionView's Client Link buttons and the
+    // Settings modal both write the same key).
+    const unsubscribe = apiClient.onConfigChanged(() => {
+      getConfig<boolean>('connection.useRemote')
+        .then((v) => {
+          if (active) setRemoteModeActive(v === true);
+        })
+        .catch(() => {});
+    });
+    return () => {
+      active = false;
+      unsubscribe();
+    };
+  }, []);
+
+  // Switch between remote-client mode and local mode. Follows the established
+  // contract (SettingsModal.handleSave / SessionView.handleStartClient*):
+  // write connection.* keys, then syncFromConfig + setAuthToken so the cached
+  // apiClient target updates immediately — polling alone never picks it up.
+  // Leaving remote resets useHttps like SessionView's Start Local does: the
+  // remote save forced it on, and a stale `true` would break plain-HTTP
+  // localhost probes.
+  //
+  // Switches are SERIALIZED through a promise queue, and the target state is
+  // re-checked from config inside the queued task rather than from React
+  // state: a switch is ~10 sequential IPC round-trips, so a fast
+  // Remote→CPU click sequence would otherwise interleave writes or branch on
+  // a stale remoteModeActive closure and drop one of the switches.
+  const modeSwitchQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const applyConnectionModeChange = useCallback(
+    (useRemote: boolean): Promise<void> => {
+      const run = async () => {
+        const current = await getConfig<boolean>('connection.useRemote');
+        if ((current === true) === useRemote) return;
+        // Same guard as SessionView's Start Local / Start Remote buttons: an
+        // actual mode change retargets the live apiClient mid-session.
+        if (clientRunning) {
+          toast.error('Stop the client link in the Session tab before switching connection mode.');
+          return;
+        }
+        if (useRemote) {
+          // Snapshot the local HTTPS preference before remote forces it on,
+          // so leaving remote restores a deliberately TLS-enabled local
+          // setup instead of clobbering it to plain HTTP.
+          const priorHttps = (await getConfig<boolean>('connection.useHttps')) === true;
+          await setConfig('connection.localUseHttps', priorHttps);
+          await setConfig('connection.useRemote', true);
+          await setConfig('connection.useHttps', true);
+        } else {
+          const restoreHttps = (await getConfig<boolean>('connection.localUseHttps')) === true;
+          await setConfig('connection.useRemote', false);
+          await setConfig('connection.useHttps', restoreHttps);
+        }
+        await apiClient.syncFromConfig();
+        const token = ((await getConfig<string>('connection.authToken')) ?? '').trim();
+        apiClient.setAuthToken(token || null);
+        setRemoteModeActive(useRemote);
+        refreshAdminStatus();
+      };
+      const queued = modeSwitchQueueRef.current.then(run).catch(() => {
+        toast.error('Could not switch the connection mode.');
+      });
+      modeSwitchQueueRef.current = queued;
+      return queued;
+    },
+    [refreshAdminStatus, clientRunning],
+  );
 
   // Legacy-GPU image variant (Issue #83 — Pascal/Maxwell support).
   // Persisted in electron-store under `server.useLegacyGpu`.
@@ -747,6 +842,25 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
       docker.cancelSidecarPull,
     ],
   );
+
+  // Tile-click wrapper for the LOCAL runtime tiles: leaving remote mode is a
+  // side effect of picking any local runtime. The hardware auto-detect effect
+  // below still calls handleRuntimeProfileChange directly — it must never
+  // yank the user out of remote mode, only refresh the stored local profile.
+  // No remoteModeActive pre-check here: the queued switch no-ops against
+  // fresh config when already local, and a React-state check would read a
+  // stale closure during a rapid Remote→local click sequence.
+  const handleSelectLocalRuntime = useCallback(
+    async (profile: RuntimeProfile) => {
+      await applyConnectionModeChange(false);
+      await handleRuntimeProfileChange(profile);
+    },
+    [applyConnectionModeChange, handleRuntimeProfileChange],
+  );
+
+  const handleSelectRemoteMode = useCallback(async () => {
+    await applyConnectionModeChange(true);
+  }, [applyConnectionModeChange]);
 
   // Pulls the Vulkan sidecar image, tracking progress in the notifications
   // store. Triggered from the Start Local click handler below — only for
@@ -1728,16 +1842,22 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
   // Hardware check (arm64 mac) passes immediately via Electron; server report only
   // refines whether mlx_whisper is actually installed.
   const metalSatisfied = isAppleSilicon && (mlxFeature === undefined || metalSupported);
-  const needsDocker = runtimeProfile !== 'metal';
-  const needsNvidia = runtimeProfile === 'gpu';
-  const needsMetal = runtimeProfile === 'metal';
+  // Remote mode needs nothing local: no Docker, no GPU, no Metal — the whole
+  // point of the Remote tile is a machine that cannot (or should not) run an
+  // instance itself.
+  const needsDocker = !remoteModeActive && runtimeProfile !== 'metal';
+  const needsNvidia = !remoteModeActive && runtimeProfile === 'gpu';
+  const needsMetal = !remoteModeActive && runtimeProfile === 'metal';
+  const notNeededHint = remoteModeActive
+    ? 'Not needed for Remote connection'
+    : 'Not needed for Metal runtime';
   const setupChecks = [
     {
       label: `${rtName} installed`,
       ok: docker.available,
       na: !needsDocker,
       hint: !needsDocker
-        ? 'Not needed for Metal runtime'
+        ? notNeededHint
         : (docker.detectionGuidance ?? 'Install Docker Engine, Docker Desktop, or Podman'),
     },
     {
@@ -1745,14 +1865,14 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
       ok: docker.composeAvailable,
       na: !needsDocker,
       hint: !needsDocker
-        ? 'Not needed for Metal runtime'
+        ? notNeededHint
         : 'Install docker-compose-v2 (Debian/Ubuntu) or Docker Desktop',
     },
     {
       label: `${rtName} image pulled`,
       ok: docker.images.length > 0,
       na: !needsDocker,
-      hint: !needsDocker ? 'Not needed for Metal runtime' : 'Pull an image below to get started',
+      hint: !needsDocker ? notNeededHint : 'Pull an image below to get started',
     },
     {
       label: 'NVIDIA GPU detected',
@@ -2067,10 +2187,12 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                     label="CUDA"
                     sublabel="NVIDIA"
                     accent="green"
-                    selected={runtimeProfile === 'gpu'}
-                    disabled={isRunning || hostPlatform === 'darwin'}
+                    selected={!remoteModeActive && runtimeProfile === 'gpu'}
+                    disabled={
+                      isRunning || hostPlatform === 'darwin' || (clientRunning && remoteModeActive)
+                    }
                     badge={hostPlatform === 'darwin' ? 'Requires NVIDIA' : undefined}
-                    onSelect={() => handleRuntimeProfileChange('gpu')}
+                    onSelect={() => handleSelectLocalRuntime('gpu')}
                   />
                   {/* Vulkan-WSL2 (GH-101 follow-up) — always rendered so the
                       full runtime matrix stays readable; selectable only on
@@ -2087,12 +2209,13 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                     label="Vulkan Windows"
                     sublabel="AMD / Intel · WSL2"
                     accent="red"
-                    selected={runtimeProfile === 'vulkan-wsl2'}
+                    selected={!remoteModeActive && runtimeProfile === 'vulkan-wsl2'}
                     disabled={
                       isRunning ||
                       vulkanBlockedByNvidia ||
                       (hostPlatform !== 'unknown' && hostPlatform !== 'win32') ||
-                      (hostPlatform === 'win32' && !gpuInfo?.wslSupport?.gpuPassthroughDetected)
+                      (hostPlatform === 'win32' && !gpuInfo?.wslSupport?.gpuPassthroughDetected) ||
+                      (clientRunning && remoteModeActive)
                     }
                     badge={
                       hostPlatform !== 'unknown' && hostPlatform !== 'win32'
@@ -2104,7 +2227,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                             : undefined
                     }
                     hint="Experimental"
-                    onSelect={() => handleRuntimeProfileChange('vulkan-wsl2')}
+                    onSelect={() => handleSelectLocalRuntime('vulkan-wsl2')}
                   />
                   <SelectorTile
                     icon={
@@ -2116,12 +2239,13 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                     label="Vulkan Linux"
                     sublabel="AMD / Intel"
                     accent="red"
-                    selected={runtimeProfile === 'vulkan'}
+                    selected={!remoteModeActive && runtimeProfile === 'vulkan'}
                     disabled={
                       isRunning ||
                       vulkanBlockedByNvidia ||
                       hostPlatform === 'win32' ||
-                      hostPlatform === 'darwin'
+                      hostPlatform === 'darwin' ||
+                      (clientRunning && remoteModeActive)
                     }
                     badge={
                       hostPlatform === 'win32' || hostPlatform === 'darwin'
@@ -2130,18 +2254,19 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                           ? 'NVIDIA detected'
                           : undefined
                     }
-                    onSelect={() => handleRuntimeProfileChange('vulkan')}
+                    onSelect={() => handleSelectLocalRuntime('vulkan')}
                   />
                   <SelectorTile
                     icon={<AppleIcon size={16} />}
                     label="Metal"
                     sublabel="Apple Silicon"
                     accent="purple"
-                    selected={runtimeProfile === 'metal'}
+                    selected={!remoteModeActive && runtimeProfile === 'metal'}
                     disabled={
                       isRunning ||
                       nvidiaDetected ||
-                      (hostPlatform !== 'unknown' && hostPlatform !== 'darwin')
+                      (hostPlatform !== 'unknown' && hostPlatform !== 'darwin') ||
+                      (clientRunning && remoteModeActive)
                     }
                     badge={
                       hostPlatform !== 'unknown' && hostPlatform !== 'darwin'
@@ -2150,16 +2275,26 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                           ? 'NVIDIA detected'
                           : undefined
                     }
-                    onSelect={() => handleRuntimeProfileChange('metal')}
+                    onSelect={() => handleSelectLocalRuntime('metal')}
                   />
                   <SelectorTile
                     icon={<Cpu size={16} />}
                     label="CPU Only"
                     sublabel="Universal"
                     accent="orange"
-                    selected={runtimeProfile === 'cpu'}
-                    disabled={isRunning}
-                    onSelect={() => handleRuntimeProfileChange('cpu')}
+                    selected={!remoteModeActive && runtimeProfile === 'cpu'}
+                    disabled={isRunning || (clientRunning && remoteModeActive)}
+                    onSelect={() => handleSelectLocalRuntime('cpu')}
+                  />
+                  <SelectorTile
+                    icon={<Globe size={16} />}
+                    label="Remote"
+                    sublabel="Another machine"
+                    accent="magenta"
+                    selected={remoteModeActive}
+                    disabled={isRunning || (clientRunning && !remoteModeActive)}
+                    badge={clientRunning && !remoteModeActive ? 'Client running' : undefined}
+                    onSelect={() => handleSelectRemoteMode()}
                   />
                 </SelectorGroup>
                 {/* Multi-GPU picker: only rendered when the host has more than
@@ -2168,7 +2303,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                     compose variable; Automatic keeps the previous single-GPU
                     behavior. Uses the shared CustomSelect so the popup matches
                     the app styling instead of the OS-native menu. */}
-                {runtimeProfile === 'gpu' && nvidiaGpus.length > 1 && (
+                {!remoteModeActive && runtimeProfile === 'gpu' && nvidiaGpus.length > 1 && (
                   <div className="mt-3">
                     <p className="mb-1 text-xs font-medium text-slate-300">GPU for inference</p>
                     <CustomSelect
@@ -2185,7 +2320,8 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                     </p>
                   </div>
                 )}
-                {runtimeProfile === 'gpu' &&
+                {!remoteModeActive &&
+                  runtimeProfile === 'gpu' &&
                   nvidiaDetected &&
                   nonNvidiaGpuPresent &&
                   !isRunning && (
@@ -2194,34 +2330,51 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                       GPU instead
                     </p>
                   )}
-                {runtimeProfile === 'vulkan' && !isRunning && (
+                {!remoteModeActive && runtimeProfile === 'vulkan' && !isRunning && (
                   <p className="mt-2 text-xs text-slate-500 italic">
                     AMD/Intel GPU via whisper.cpp — no diarization; live mode via GGML models
                   </p>
                 )}
-                {runtimeProfile === 'vulkan' && nvidiaDetected && !isRunning && (
-                  <p className="mt-1 text-xs text-slate-500 italic">
-                    The NVIDIA card stays idle here - the whisper.cpp sidecar (Mesa drivers) uses
-                    the AMD / Intel GPU
-                  </p>
-                )}
-                {runtimeProfile === 'vulkan-wsl2' && !isRunning && (
+                {!remoteModeActive &&
+                  runtimeProfile === 'vulkan' &&
+                  nvidiaDetected &&
+                  !isRunning && (
+                    <p className="mt-1 text-xs text-slate-500 italic">
+                      The NVIDIA card stays idle here - the whisper.cpp sidecar (Mesa drivers) uses
+                      the AMD / Intel GPU
+                    </p>
+                  )}
+                {!remoteModeActive && runtimeProfile === 'vulkan-wsl2' && !isRunning && (
                   <p className="text-accent-orange mt-2 text-xs italic">
                     Experimental: AMD/Intel GPU via WSL2 + Mesa dzn — see README §2.5.2
                   </p>
                 )}
-                {runtimeProfile === 'cpu' && !isRunning && (
+                {!remoteModeActive && runtimeProfile === 'cpu' && !isRunning && (
                   <p className="mt-2 text-xs text-slate-500 italic">
                     Slower transcription, no NVIDIA GPU required
+                  </p>
+                )}
+                {remoteModeActive && (
+                  <p className="mt-2 text-xs text-slate-500 italic">
+                    This dashboard connects to a remote TranscriptionSuite server — no local
+                    instance runs on this machine
                   </p>
                 )}
               </div>
             </GlassCard>
           </div>
 
-          {/* 2. Docker Image or Inference Server (metal) Card */}
+          {/* 2. Docker Image or Inference Server (metal) Card — inert while
+              the Remote runtime is selected (no local instance). The `inert`
+              attribute (React 19) blocks keyboard focus and assistive tech,
+              not just pointer events — the dimming alone left every control
+              tabbable. */}
           {runtimeProfile === 'metal' ? (
-            <div className="relative shrink-0 border-l-2 border-white/10 pb-8 pl-8 last:border-0 last:pb-0">
+            <div
+              className="relative shrink-0 border-l-2 border-white/10 pb-8 pl-8 last:border-0 last:pb-0"
+              aria-disabled={remoteModeActive || undefined}
+              inert={remoteModeActive || undefined}
+            >
               <div
                 className={`absolute top-0 -left-4.25 z-10 flex h-8 w-8 items-center justify-center rounded-full border-4 border-slate-900 transition-colors duration-300 ${mlxStatus === 'running' ? 'bg-accent-cyan text-slate-900 shadow-[0_0_15px_rgba(34,211,238,0.5)]' : mlxStatus === 'starting' || mlxStatus === 'stopping' ? 'bg-accent-orange text-slate-900 shadow-[0_0_15px_rgba(251,146,60,0.5)]' : 'bg-slate-800 text-slate-300'}`}
               >
@@ -2229,7 +2382,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
               </div>
               <GlassCard
                 title="2. Inference Server"
-                className={`transition-all duration-500 ease-in-out ${mlxStatus === 'running' ? ACTIVE_CARD_ACCENT_CLASS : ''}`}
+                className={`transition-all duration-500 ease-in-out ${mlxStatus === 'running' ? ACTIVE_CARD_ACCENT_CLASS : ''} ${remoteModeActive ? 'pointer-events-none opacity-50 select-none' : ''}`}
               >
                 <div className="flex flex-wrap items-center gap-5">
                   <div className="flex h-6 shrink-0 items-center space-x-3 border-r border-white/10 pr-5">
@@ -2306,7 +2459,11 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
               </GlassCard>
             </div>
           ) : (
-            <div className="relative shrink-0 border-l-2 border-white/10 pb-8 pl-8 last:border-0 last:pb-0">
+            <div
+              className="relative shrink-0 border-l-2 border-white/10 pb-8 pl-8 last:border-0 last:pb-0"
+              aria-disabled={remoteModeActive || undefined}
+              inert={remoteModeActive || undefined}
+            >
               <div
                 className={`absolute top-0 -left-4.25 z-10 flex h-8 w-8 items-center justify-center rounded-full border-4 border-slate-900 transition-colors duration-300 ${hasImages ? 'bg-accent-cyan text-slate-900 shadow-[0_0_15px_rgba(34,211,238,0.5)]' : 'bg-slate-800 text-slate-300'}`}
               >
@@ -2314,7 +2471,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
               </div>
               <GlassCard
                 title="2. Docker Image"
-                className={`transition-all duration-500 ease-in-out ${hasImages ? ACTIVE_CARD_ACCENT_CLASS : ''}`}
+                className={`transition-all duration-500 ease-in-out ${hasImages ? ACTIVE_CARD_ACCENT_CLASS : ''} ${remoteModeActive ? 'pointer-events-none opacity-50 select-none' : ''}`}
               >
                 <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
                   <div className="space-y-4">
@@ -2554,8 +2711,14 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
             </div>
           )}
 
-          {/* 3. Instance Settings Card */}
-          <div className="relative shrink-0 border-l-2 border-white/10 pb-8 pl-8 last:border-0 last:pb-0">
+          {/* 3. Instance Settings Card — inert while the Remote runtime is
+              selected: there is no local instance to configure, so the whole
+              card dims and stops receiving pointer events. */}
+          <div
+            className="relative shrink-0 border-l-2 border-white/10 pb-8 pl-8 last:border-0 last:pb-0"
+            aria-disabled={remoteModeActive || undefined}
+            inert={remoteModeActive || undefined}
+          >
             <div
               className={`absolute top-0 -left-4.25 z-10 flex h-8 w-8 items-center justify-center rounded-full border-4 border-slate-900 transition-colors duration-300 ${isRunning || mlxStatus === 'running' ? `bg-accent-cyan text-slate-900 ${isRunningAndHealthy || mlxStatus === 'running' ? 'shadow-[0_0_15px_rgba(34,211,238,0.5)]' : ''}` : containerStatus.exists ? 'bg-accent-orange text-slate-900 shadow-[0_0_15px_rgba(251,146,60,0.5)]' : 'bg-slate-800 text-slate-300'}`}
             >
@@ -2563,7 +2726,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
             </div>
             <GlassCard
               title="3. Instance Settings"
-              className={`transition-all duration-500 ease-in-out ${isRunningAndHealthy || mlxStatus === 'running' ? ACTIVE_CARD_ACCENT_CLASS : ''}`}
+              className={`transition-all duration-500 ease-in-out ${isRunningAndHealthy || mlxStatus === 'running' ? ACTIVE_CARD_ACCENT_CLASS : ''} ${remoteModeActive ? 'pointer-events-none opacity-50 select-none' : ''}`}
             >
               <div className="space-y-6">
                 {/* Unified instance control panel: container lifecycle controls
@@ -2652,6 +2815,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                               });
                             }}
                             disabled={
+                              remoteModeActive ||
                               docker.operating ||
                               isRunning ||
                               startupFlowPending ||
@@ -2678,6 +2842,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                               })
                             }
                             disabled={
+                              remoteModeActive ||
                               docker.operating ||
                               isRunning ||
                               startupFlowPending ||
@@ -2691,7 +2856,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                             variant="danger"
                             className="h-9 px-4 whitespace-nowrap"
                             onClick={() => docker.stopContainer()}
-                            disabled={docker.operating || !isRunning}
+                            disabled={remoteModeActive || docker.operating || !isRunning}
                           >
                             Stop
                           </Button>
@@ -2709,7 +2874,7 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                           variant={modelsLoaded === false ? 'secondary' : 'danger'}
                           className="h-9 px-4 whitespace-nowrap"
                           onClick={modelsLoaded === false ? handleLoadModels : handleUnloadModels}
-                          disabled={modelsLoading || !isRunning}
+                          disabled={remoteModeActive || modelsLoading || !isRunning}
                         >
                           {modelsLoading ? (
                             <>
@@ -2726,7 +2891,12 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
                             variant="danger"
                             className="h-9 px-4 whitespace-nowrap"
                             onClick={() => docker.removeContainer()}
-                            disabled={docker.operating || isRunning || !containerStatus.exists}
+                            disabled={
+                              remoteModeActive ||
+                              docker.operating ||
+                              isRunning ||
+                              !containerStatus.exists
+                            }
                           >
                             Remove Container
                           </Button>
@@ -2798,17 +2968,25 @@ export const ServerView: React.FC<ServerViewProps> = ({ onStartServer, startupFl
             </GlassCard>
           </div>
 
-          {/* 4. Remote Connection Card */}
+          {/* 4. Remote Connection Card — mode-aware. Local runtimes: the
+              host-side view (this machine's token + Tailscale hostname for
+              OTHER clients). Remote runtime: the client-side settings that
+              used to live in Settings > Client > Connection (which server
+              THIS machine connects to). */}
           <div className="relative shrink-0 border-l-2 border-white/10 pb-8 pl-8 last:border-0 last:pb-0">
             <div
-              className={`absolute top-0 -left-4.25 z-10 flex h-8 w-8 items-center justify-center rounded-full border-4 border-slate-900 transition-colors duration-300 ${isRunningAndHealthy && serverMode === 'remote' ? 'bg-accent-magenta text-slate-900 shadow-[0_0_15px_rgba(232,121,249,0.5)]' : 'bg-slate-800 text-slate-300'}`}
+              className={`absolute top-0 -left-4.25 z-10 flex h-8 w-8 items-center justify-center rounded-full border-4 border-slate-900 transition-colors duration-300 ${remoteModeActive || (isRunningAndHealthy && serverMode === 'remote') ? 'bg-accent-magenta text-slate-900 shadow-[0_0_15px_rgba(232,121,249,0.5)]' : 'bg-slate-800 text-slate-300'}`}
             >
               <Globe size={14} />
             </div>
-            <RemoteConnectionCard
-              title="4. Remote Connection"
-              isRunningAndHealthy={isRunningAndHealthy}
-            />
+            {remoteModeActive ? (
+              <RemoteClientSettingsCard title="4. Remote Connection" />
+            ) : (
+              <RemoteConnectionCard
+                title="4. Remote Connection"
+                isRunningAndHealthy={isRunningAndHealthy}
+              />
+            )}
           </div>
 
           {/* 5. Volumes Card */}

--- a/dashboard/components/views/SettingsModal.tsx
+++ b/dashboard/components/views/SettingsModal.tsx
@@ -68,7 +68,6 @@ const DEFAULT_SHORTCUTS = {
   startRecording: 'Alt+Ctrl+Z',
   stopTranscribe: 'Alt+Ctrl+X',
 } as const;
-const REMOTE_PROFILE_OPTIONS = ['Tailscale', 'LAN'] as const;
 const MAIN_MODEL_CUSTOM_OPTION = 'Custom (HuggingFace repo)';
 const MODEL_DEFAULT_LOADING_PLACEHOLDER = 'Loading server default...';
 // GH-120 — Folder Watch duplicate-handling policy. Display order + labels for
@@ -257,16 +256,20 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
     numSpeakers: 2,
     autoAddNotebook: false,
     localHost: 'localhost',
-    remoteHost: '',
-    lanHost: '',
-    remoteProfile: 'tailscale',
-    useRemote: false,
     authToken: '',
     port: DEFAULT_SERVER_PORT,
     useHttps: false,
     hfToken: '',
     hideTimestamps: false,
   });
+
+  // Display-only mirror of connection.useRemote, loaded when the modal opens.
+  // The remote-client fields themselves (profile, hosts, the mode switch)
+  // moved to the Server tab's Remote runtime tile + connection card; this
+  // modal never writes connection.useRemote anymore — a stale copy saved
+  // here would clobber a mode switch made in the Server tab while the modal
+  // sat open. Still needed to force-display HTTPS as on while remote.
+  const [remoteModeActive, setRemoteModeActive] = useState(false);
 
   // Sync auth token from the centralized useAuthTokenSync hook's cache.
   // Handles both new tokens (from Docker log detection) and token clearing
@@ -412,14 +415,10 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
             if (cfg) {
               const useRemote = (cfg['connection.useRemote'] as boolean) ?? false;
               const useHttps = (cfg['connection.useHttps'] as boolean) ?? false;
+              setRemoteModeActive(useRemote);
               setClientSettings((prev) => ({
                 ...prev,
                 localHost: (cfg['connection.localHost'] as string) ?? prev.localHost,
-                remoteHost: (cfg['connection.remoteHost'] as string) ?? prev.remoteHost,
-                lanHost: (cfg['connection.lanHost'] as string) ?? prev.lanHost,
-                remoteProfile:
-                  (cfg['connection.remoteProfile'] as string) === 'lan' ? 'lan' : 'tailscale',
-                useRemote,
                 authToken: (cfg['connection.authToken'] as string) ?? prev.authToken,
                 port: (cfg['connection.port'] as number) ?? prev.port,
                 useHttps: useRemote ? true : useHttps,
@@ -545,33 +544,17 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
 
   const handleSave = useCallback(async () => {
     const api = (window as any).electronAPI;
-    const normalizedRemoteProfile = clientSettings.remoteProfile === 'lan' ? 'lan' : 'tailscale';
     const normalizedLocalHost = clientSettings.localHost.trim();
-    const normalizedRemoteHost = clientSettings.remoteHost.trim();
-    const normalizedLanHost = clientSettings.lanHost.trim();
-    const normalizedUseHttps = clientSettings.useRemote ? true : clientSettings.useHttps;
-
-    if (
-      clientSettings.useRemote &&
-      normalizedRemoteProfile === 'tailscale' &&
-      !normalizedRemoteHost
-    ) {
-      toast.error('Tailscale remote mode requires a host or IP address.');
-      return;
-    }
-
-    if (clientSettings.useRemote && normalizedRemoteProfile === 'lan' && !normalizedLanHost) {
-      toast.error('LAN remote mode requires a host or IP address.');
-      return;
-    }
+    // Remote-client fields (useRemote, remoteProfile, remote/LAN host) are
+    // owned by the Server tab's Remote runtime card now — deliberately NOT
+    // written here, so a stale modal snapshot can never clobber a mode
+    // switch made while the modal was open. HTTPS stays forced on while
+    // remote mode is active (same invariant as before the move).
+    const normalizedUseHttps = remoteModeActive ? true : clientSettings.useHttps;
 
     if (api?.config) {
       const entries: [string, unknown][] = [
         ['connection.localHost', normalizedLocalHost || clientSettings.localHost],
-        ['connection.remoteHost', normalizedRemoteHost],
-        ['connection.lanHost', normalizedLanHost],
-        ['connection.remoteProfile', normalizedRemoteProfile],
-        ['connection.useRemote', clientSettings.useRemote],
         ['connection.authToken', clientSettings.authToken],
         ['connection.port', clientSettings.port],
         ['connection.useHttps', normalizedUseHttps],
@@ -661,7 +644,14 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
 
     setIsDirty(false);
     onClose();
-  }, [clientSettings, appSettings, shortcutSettings, serverConfigUpdates, onClose]);
+  }, [
+    clientSettings,
+    appSettings,
+    shortcutSettings,
+    serverConfigUpdates,
+    remoteModeActive,
+    onClose,
+  ]);
 
   const handleServerConfigFieldChange = useCallback((path: string, value: unknown) => {
     setServerConfigUpdates((prev) => ({ ...prev, [path]: value }));
@@ -1482,105 +1472,24 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
 
       <Section title="Connection">
         <div className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="mb-1.5 block text-xs font-medium tracking-wider text-slate-500 uppercase">
-                Local Host
-              </label>
-              <input
-                type="text"
-                value={clientSettings.localHost}
-                onChange={(e) =>
-                  setClientSettings((prev) => ({ ...prev, localHost: e.target.value }))
-                }
-                className="focus:border-accent-cyan/50 w-full rounded-lg border border-white/10 bg-black/20 px-3 py-2 text-sm text-white focus:outline-none"
-              />
-            </div>
-            <div className={!clientSettings.useRemote ? 'opacity-50' : ''}>
-              <label className="mb-1.5 block text-xs font-medium tracking-wider text-slate-500 uppercase">
-                {clientSettings.remoteProfile === 'lan' ? 'LAN Host / IP' : 'Tailscale Host'}
-              </label>
-              <input
-                type="text"
-                placeholder={
-                  clientSettings.remoteProfile === 'lan'
-                    ? 'e.g. 192.168.1.50 or k8s-gpu.local'
-                    : 'e.g. my-server.tail123.ts.net'
-                }
-                value={
-                  clientSettings.remoteProfile === 'lan'
-                    ? clientSettings.lanHost
-                    : clientSettings.remoteHost
-                }
-                onChange={(e) =>
-                  setClientSettings((prev) =>
-                    prev.remoteProfile === 'lan'
-                      ? { ...prev, lanHost: e.target.value }
-                      : { ...prev, remoteHost: e.target.value },
-                  )
-                }
-                disabled={!clientSettings.useRemote}
-                className="focus:border-accent-cyan/50 w-full rounded-lg border border-white/10 bg-black/20 px-3 py-2 text-sm text-white focus:outline-none"
-              />
-              {clientSettings.useRemote &&
-                clientSettings.remoteProfile !== 'lan' &&
-                /^[^.]+\.ts\.net$/i.test(clientSettings.remoteHost.trim()) && (
-                  <p className="mt-1.5 text-xs text-amber-300/80">
-                    This looks like a tailnet name. The hostname should include the machine name,
-                    e.g.{' '}
-                    <span className="font-mono">
-                      machine-name.{clientSettings.remoteHost.trim()}
-                    </span>
-                  </p>
-                )}
-            </div>
+          <div>
+            <label className="mb-1.5 block text-xs font-medium tracking-wider text-slate-500 uppercase">
+              Local Host
+            </label>
+            <input
+              type="text"
+              value={clientSettings.localHost}
+              onChange={(e) =>
+                setClientSettings((prev) => ({ ...prev, localHost: e.target.value }))
+              }
+              className="focus:border-accent-cyan/50 w-full rounded-lg border border-white/10 bg-black/20 px-3 py-2 text-sm text-white focus:outline-none"
+            />
           </div>
 
-          <AppleSwitch
-            checked={clientSettings.useRemote}
-            onChange={(v) =>
-              setClientSettings((prev) => ({
-                ...prev,
-                useRemote: v,
-                useHttps: v ? true : prev.useHttps,
-              }))
-            }
-            label="Use remote server instead of local"
-          />
-
-          {clientSettings.useRemote && (
-            <div className="rounded-lg border border-white/10 bg-white/5 p-3">
-              <div className="grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)] md:items-end">
-                <div>
-                  <label className="mb-1.5 block text-xs font-medium tracking-wider text-slate-500 uppercase">
-                    Remote Profile
-                  </label>
-                  <CustomSelect
-                    value={clientSettings.remoteProfile === 'lan' ? 'LAN' : 'Tailscale'}
-                    onChange={(value) =>
-                      setClientSettings((prev) => ({
-                        ...prev,
-                        remoteProfile: value === 'LAN' ? 'lan' : 'tailscale',
-                        useHttps: true,
-                      }))
-                    }
-                    options={[...REMOTE_PROFILE_OPTIONS]}
-                    className="h-10 rounded-lg border border-white/10 bg-black/20 px-3 text-sm text-white"
-                  />
-                </div>
-                <p className="text-xs text-slate-400">
-                  {clientSettings.remoteProfile === 'lan'
-                    ? 'LAN mode uses the same HTTPS + token auth as remote mode, but targets a local-network host/IP instead of a Tailnet DNS name.'
-                    : 'Tailscale mode uses your Tailnet hostname and the existing HTTPS + token auth flow.'}
-                </p>
-              </div>
-              {clientSettings.remoteProfile === 'lan' && !clientSettings.lanHost.trim() && (
-                <p className="mt-2 text-xs text-amber-300/80">
-                  Enter a LAN host or IP before saving this profile.
-                </p>
-              )}
-            </div>
-          )}
+          <p className="text-xs text-slate-500">
+            Connecting to a remote server? Select the <span className="font-medium">Remote</span>{' '}
+            runtime in the Server tab — the hostname and token settings live there now.
+          </p>
 
           <div className="my-2 h-px bg-white/5"></div>
 
@@ -1812,14 +1721,14 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
             </div>
             <div className="pb-1">
               <AppleSwitch
-                checked={clientSettings.useRemote ? true : clientSettings.useHttps}
+                checked={remoteModeActive ? true : clientSettings.useHttps}
                 onChange={(v) => setClientSettings((prev) => ({ ...prev, useHttps: v }))}
-                disabled={clientSettings.useRemote}
+                disabled={remoteModeActive}
                 label="Use HTTPS"
               />
             </div>
           </div>
-          {clientSettings.useRemote && (
+          {remoteModeActive && (
             <p className="text-xs text-slate-500">
               HTTPS is required for remote profiles (Tailscale and LAN) to keep token auth enabled.
             </p>

--- a/dashboard/components/views/server/RemoteClientSettingsCard.tsx
+++ b/dashboard/components/views/server/RemoteClientSettingsCard.tsx
@@ -1,0 +1,280 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Check, Copy, Eye, EyeOff, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { GlassCard } from '../../ui/GlassCard';
+import { Button } from '../../ui/Button';
+import { CustomSelect } from '../../ui/CustomSelect';
+import { StatusLight } from '../../ui/StatusLight';
+import { apiClient } from '../../../src/api/client';
+import { writeToClipboard } from '../../../src/hooks/useClipboard';
+import { useServerStatus } from '../../../src/hooks/useServerStatus';
+import { getConfig, setConfig, DEFAULT_SERVER_PORT } from '../../../src/config/store';
+
+interface RemoteClientSettingsCardProps {
+  title: string;
+}
+
+const REMOTE_PROFILE_OPTIONS = ['Tailscale', 'LAN'] as const;
+
+/**
+ * Client-side remote connection settings, shown in place of the host-side
+ * RemoteConnectionCard while the Remote runtime tile is selected. Holds the
+ * fields that used to live in Settings > Client > Connection: remote profile
+ * (Tailscale/LAN), host, auth token and port. HTTPS is not offered as a
+ * choice — remote profiles force it so token auth stays on the wire encrypted
+ * (same invariant SettingsModal enforced).
+ *
+ * Nothing is persisted until Apply: the handler validates, writes the
+ * connection.* keys, then runs the same re-sync contract as
+ * SettingsModal.handleSave / SessionView.handleStartClientRemote —
+ * apiClient.syncFromConfig() + setAuthToken + query-cache sync — so the
+ * running app switches target immediately, without a restart.
+ */
+export function RemoteClientSettingsCard({ title }: RemoteClientSettingsCardProps) {
+  const queryClient = useQueryClient();
+  const serverConnection = useServerStatus();
+
+  const [remoteProfile, setRemoteProfile] = useState<'tailscale' | 'lan'>('tailscale');
+  const [remoteHost, setRemoteHost] = useState('');
+  const [lanHost, setLanHost] = useState('');
+  const [authToken, setAuthToken] = useState('');
+  const [port, setPort] = useState<number>(DEFAULT_SERVER_PORT);
+  const [hydrated, setHydrated] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const [showAuthToken, setShowAuthToken] = useState(false);
+  const [authTokenCopied, setAuthTokenCopied] = useState(false);
+  // True while the token field holds unapplied user typing — the query-cache
+  // mirror below must not clobber it (e.g. the stale-token guard clearing the
+  // cache mid-edit would otherwise wipe the token being entered).
+  const tokenDirtyRef = useRef(false);
+
+  // Load persisted connection settings once per mount.
+  useEffect(() => {
+    let active = true;
+    Promise.all([
+      getConfig<'tailscale' | 'lan'>('connection.remoteProfile'),
+      getConfig<string>('connection.remoteHost'),
+      getConfig<string>('connection.lanHost'),
+      getConfig<string>('connection.authToken'),
+      getConfig<number>('connection.port'),
+    ])
+      .then(([storedProfile, storedRemoteHost, storedLanHost, storedToken, storedPort]) => {
+        if (!active) return;
+        setRemoteProfile(storedProfile === 'lan' ? 'lan' : 'tailscale');
+        if (typeof storedRemoteHost === 'string') setRemoteHost(storedRemoteHost);
+        if (typeof storedLanHost === 'string') setLanHost(storedLanHost);
+        if (typeof storedToken === 'string') setAuthToken(storedToken);
+        if (typeof storedPort === 'number' && Number.isFinite(storedPort)) setPort(storedPort);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (active) setHydrated(true);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // Mirror SettingsModal: follow the centralized ['authToken'] query cache so
+  // this field does not fight useAuthTokenSync (stale-token clears, manual
+  // edits saved elsewhere). Unapplied user typing always wins over the cache.
+  useEffect(() => {
+    const syncToken = (token: string | undefined) => {
+      if (tokenDirtyRef.current) return;
+      const value = token ?? '';
+      setAuthToken((prev) => (prev === value ? prev : value));
+    };
+    const unsubscribe = queryClient.getQueryCache().subscribe((event) => {
+      if (event?.query?.queryKey?.[0] !== 'authToken') return;
+      const token = queryClient.getQueryData<string>(['authToken']);
+      if (token !== undefined) syncToken(token);
+    });
+    const cached = queryClient.getQueryData<string>(['authToken']);
+    if (cached) syncToken(cached);
+    return unsubscribe;
+  }, [queryClient]);
+
+  const activeHost = remoteProfile === 'lan' ? lanHost : remoteHost;
+  const trimmedHost = activeHost.trim();
+  const looksLikeBareTailnet =
+    remoteProfile === 'tailscale' && /^[^.]+\.ts\.net$/i.test(remoteHost.trim());
+
+  const handleApply = useCallback(async () => {
+    // Same validation SettingsModal.handleSave enforced for remote saves.
+    if (remoteProfile === 'tailscale' && !remoteHost.trim()) {
+      toast.error('Tailscale remote mode requires a host or IP address.');
+      return;
+    }
+    if (remoteProfile === 'lan' && !lanHost.trim()) {
+      toast.error('LAN remote mode requires a host or IP address.');
+      return;
+    }
+    const normalizedPort = Number.isFinite(port) ? Math.trunc(port) : NaN;
+    if (!Number.isInteger(normalizedPort) || normalizedPort < 1 || normalizedPort > 65535) {
+      toast.error('Port must be a number between 1 and 65535.');
+      return;
+    }
+
+    setApplying(true);
+    try {
+      const normalizedToken = authToken.trim();
+      await Promise.all([
+        setConfig('connection.remoteProfile', remoteProfile),
+        setConfig('connection.remoteHost', remoteHost.trim()),
+        setConfig('connection.lanHost', lanHost.trim()),
+        setConfig('connection.authToken', normalizedToken),
+        setConfig('connection.port', normalizedPort),
+        setConfig('connection.useHttps', true),
+        setConfig('connection.useRemote', true),
+      ]);
+      await apiClient.syncFromConfig();
+      apiClient.setAuthToken(normalizedToken || null);
+      queryClient.setQueryData(['authToken'], normalizedToken);
+      tokenDirtyRef.current = false;
+      await queryClient.invalidateQueries({ queryKey: ['adminStatus'] });
+      serverConnection.refresh();
+      toast.success('Remote connection settings applied.');
+    } catch {
+      toast.error('Could not save the remote connection settings.');
+    } finally {
+      setApplying(false);
+    }
+  }, [remoteProfile, remoteHost, lanHost, authToken, port, queryClient, serverConnection]);
+
+  return (
+    <GlassCard title={title}>
+      <div className="space-y-4">
+        {/* Connection status — polls whatever target is currently applied. */}
+        <div className="flex items-center gap-3 border-b border-white/5 pb-3">
+          <StatusLight
+            status={serverConnection.serverStatus}
+            animate={serverConnection.serverStatus === 'active'}
+          />
+          <span className="font-mono text-sm text-slate-300">{serverConnection.serverLabel}</span>
+        </div>
+
+        {!trimmedHost && hydrated && (
+          <p className="text-xs text-amber-300/80">
+            Enter the remote server&apos;s hostname and auth token, then press Apply. Both are shown
+            on the host machine&apos;s Server tab.
+          </p>
+        )}
+
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)] md:items-end">
+          <div>
+            <label className="mb-1.5 block text-xs font-medium tracking-wider text-slate-500 uppercase">
+              Remote Profile
+            </label>
+            <CustomSelect
+              value={remoteProfile === 'lan' ? 'LAN' : 'Tailscale'}
+              onChange={(value) => setRemoteProfile(value === 'LAN' ? 'lan' : 'tailscale')}
+              options={[...REMOTE_PROFILE_OPTIONS]}
+              className="h-10 rounded-lg border border-white/10 bg-black/20 px-3 text-sm text-white"
+            />
+          </div>
+          <p className="text-xs text-slate-400">
+            {remoteProfile === 'lan'
+              ? 'LAN mode uses the same HTTPS + token auth as remote mode, but targets a local-network host/IP instead of a Tailnet DNS name.'
+              : 'Tailscale mode uses your Tailnet hostname and the existing HTTPS + token auth flow.'}
+          </p>
+        </div>
+
+        <div>
+          <label className="mb-1.5 block text-xs font-medium tracking-wider text-slate-500 uppercase">
+            {remoteProfile === 'lan' ? 'LAN Host / IP' : 'Tailscale Host'}
+          </label>
+          <input
+            type="text"
+            placeholder={
+              remoteProfile === 'lan'
+                ? 'e.g. 192.168.1.50 or k8s-gpu.local'
+                : 'e.g. my-server.tail123.ts.net'
+            }
+            value={activeHost}
+            onChange={(e) =>
+              remoteProfile === 'lan' ? setLanHost(e.target.value) : setRemoteHost(e.target.value)
+            }
+            className="focus:border-accent-cyan/50 w-full rounded-lg border border-white/10 bg-black/20 px-3 py-2 text-sm text-white focus:outline-none"
+          />
+          {looksLikeBareTailnet && (
+            <p className="mt-1.5 text-xs text-amber-300/80">
+              This looks like a tailnet name. The hostname should include the machine name, e.g.{' '}
+              <span className="font-mono">machine-name.{remoteHost.trim()}</span>
+            </p>
+          )}
+        </div>
+
+        <div>
+          <label className="mb-1.5 block text-xs font-medium tracking-wider text-slate-500 uppercase">
+            Auth Token
+          </label>
+          <div className="relative">
+            <input
+              type={showAuthToken ? 'text' : 'password'}
+              value={authToken}
+              onChange={(e) => {
+                tokenDirtyRef.current = true;
+                setAuthToken(e.target.value);
+              }}
+              placeholder="Paste the token from the host machine"
+              className="focus:border-accent-cyan/50 w-full rounded-lg border border-white/10 bg-black/20 px-3 py-2 pr-20 font-mono text-sm text-white focus:outline-none"
+            />
+            <div className="absolute top-2 right-2 flex items-center gap-1">
+              <button
+                onClick={() => {
+                  if (!authToken) return;
+                  writeToClipboard(authToken).catch(() => {});
+                  setAuthTokenCopied(true);
+                  setTimeout(() => setAuthTokenCopied(false), 2000);
+                }}
+                className="p-1 text-slate-500 transition-colors hover:text-white"
+                title="Copy token"
+              >
+                {authTokenCopied ? (
+                  <Check size={14} className="text-green-400" />
+                ) : (
+                  <Copy size={14} />
+                )}
+              </button>
+              <button
+                onClick={() => setShowAuthToken(!showAuthToken)}
+                className="p-1 text-slate-500 transition-colors hover:text-white"
+              >
+                {showAuthToken ? <EyeOff size={14} /> : <Eye size={14} />}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 items-end gap-4">
+          <div>
+            <label className="mb-1.5 block text-xs font-medium tracking-wider text-slate-500 uppercase">
+              Port
+            </label>
+            <input
+              type="number"
+              value={port}
+              onChange={(e) => setPort(parseInt(e.target.value))}
+              className="focus:border-accent-cyan/50 w-full [appearance:textfield] rounded-lg border border-white/10 bg-black/20 px-3 py-2 text-sm text-white focus:outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+            />
+          </div>
+          <div className="flex justify-end pb-1">
+            <Button
+              variant="secondary"
+              className="h-9 px-4 whitespace-nowrap"
+              onClick={handleApply}
+              disabled={applying || !hydrated}
+            >
+              {applying ? <Loader2 size={14} className="animate-spin" /> : 'Apply'}
+            </Button>
+          </div>
+        </div>
+        <p className="text-xs text-slate-500">
+          HTTPS is always used for remote profiles (Tailscale and LAN) to keep token auth enabled.
+        </p>
+      </div>
+    </GlassCard>
+  );
+}

--- a/dashboard/components/views/server/__tests__/RemoteClientSettingsCard.test.tsx
+++ b/dashboard/components/views/server/__tests__/RemoteClientSettingsCard.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * RemoteClientSettingsCard — the client-side remote connection settings shown
+ * in the Server tab while the Remote runtime tile is selected.
+ *
+ * Verifies: hydration from connection.* config, the SettingsModal-inherited
+ * validation rules (blank host per profile, port range), and the apply
+ * contract (config writes + apiClient re-sync).
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('../../../../src/api/client', () => ({
+  apiClient: {
+    checkConnection: vi
+      .fn()
+      .mockResolvedValue({ reachable: false, ready: false, status: null, error: null }),
+    syncFromConfig: vi.fn().mockResolvedValue(undefined),
+    setAuthToken: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../src/config/store', () => ({
+  getConfig: vi.fn().mockResolvedValue(undefined),
+  setConfig: vi.fn().mockResolvedValue(undefined),
+  DEFAULT_SERVER_PORT: 9786,
+}));
+
+vi.mock('../../../../src/hooks/useClipboard', () => ({
+  writeToClipboard: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+// Plain <select> stand-in so profile switching works without headlessui.
+vi.mock('../../../ui/CustomSelect', () => ({
+  CustomSelect: ({
+    value,
+    onChange,
+    options,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+    options: string[];
+  }) =>
+    React.createElement(
+      'select',
+      {
+        'aria-label': 'Remote Profile',
+        value,
+        onChange: (e: React.ChangeEvent<HTMLSelectElement>) => onChange(e.target.value),
+      },
+      options.map((o) => React.createElement('option', { key: o, value: o }, o)),
+    ),
+}));
+
+import { RemoteClientSettingsCard } from '../RemoteClientSettingsCard';
+import { getConfig, setConfig } from '../../../../src/config/store';
+import { apiClient } from '../../../../src/api/client';
+import { toast } from 'sonner';
+
+function renderCard() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const utils = render(
+    React.createElement(
+      QueryClientProvider,
+      { client: qc },
+      React.createElement(RemoteClientSettingsCard, { title: '4. Remote Connection' }),
+    ),
+  );
+  return { qc, ...utils };
+}
+
+function seedStoredConnection() {
+  vi.mocked(getConfig).mockImplementation(async (key: string) => {
+    if (key === 'connection.remoteProfile') return 'tailscale';
+    if (key === 'connection.remoteHost') return 'gpu-box.tail1234.ts.net';
+    if (key === 'connection.lanHost') return '';
+    if (key === 'connection.authToken') return 'remote-token';
+    if (key === 'connection.port') return 9786;
+    return undefined;
+  });
+}
+
+describe('RemoteClientSettingsCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getConfig).mockResolvedValue(undefined);
+    vi.mocked(setConfig).mockResolvedValue(undefined);
+  });
+
+  it('hydrates the stored connection settings into the fields', async () => {
+    seedStoredConnection();
+    renderCard();
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('gpu-box.tail1234.ts.net')).toBeDefined();
+    });
+    expect(screen.getByDisplayValue('remote-token')).toBeDefined();
+    expect(screen.getByDisplayValue('9786')).toBeDefined();
+  });
+
+  it('prompts for host + token while unconfigured and blocks Apply with a validation toast', async () => {
+    renderCard();
+    await waitFor(() => {
+      expect(screen.getByText(/hostname and auth token, then press Apply/)).toBeDefined();
+    });
+    fireEvent.click(screen.getByText('Apply').closest('button') as HTMLButtonElement);
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        'Tailscale remote mode requires a host or IP address.',
+      );
+    });
+    expect(setConfig).not.toHaveBeenCalled();
+  });
+
+  it('requires a LAN host when the LAN profile is selected', async () => {
+    seedStoredConnection();
+    renderCard();
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('gpu-box.tail1234.ts.net')).toBeDefined();
+    });
+    fireEvent.change(screen.getByLabelText('Remote Profile'), { target: { value: 'LAN' } });
+    expect(screen.getByText('LAN Host / IP')).toBeDefined();
+    fireEvent.click(screen.getByText('Apply').closest('button') as HTMLButtonElement);
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('LAN remote mode requires a host or IP address.');
+    });
+    expect(setConfig).not.toHaveBeenCalled();
+  });
+
+  it('rejects an out-of-range port', async () => {
+    seedStoredConnection();
+    renderCard();
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('9786')).toBeDefined();
+    });
+    fireEvent.change(screen.getByDisplayValue('9786'), { target: { value: '0' } });
+    fireEvent.click(screen.getByText('Apply').closest('button') as HTMLButtonElement);
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Port must be a number between 1 and 65535.');
+    });
+    expect(setConfig).not.toHaveBeenCalled();
+  });
+
+  it('applies a valid configuration: writes connection.* keys and re-syncs the api client', async () => {
+    seedStoredConnection();
+    renderCard();
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('gpu-box.tail1234.ts.net')).toBeDefined();
+    });
+    fireEvent.click(screen.getByText('Apply').closest('button') as HTMLButtonElement);
+    await waitFor(() => {
+      expect(vi.mocked(setConfig).mock.calls).toEqual(
+        expect.arrayContaining([
+          ['connection.remoteProfile', 'tailscale'],
+          ['connection.remoteHost', 'gpu-box.tail1234.ts.net'],
+          ['connection.authToken', 'remote-token'],
+          ['connection.port', 9786],
+          ['connection.useHttps', true],
+          ['connection.useRemote', true],
+        ]),
+      );
+    });
+    expect(apiClient.syncFromConfig).toHaveBeenCalled();
+    expect(apiClient.setAuthToken).toHaveBeenCalledWith('remote-token');
+    expect(toast.success).toHaveBeenCalledWith('Remote connection settings applied.');
+  });
+
+  it('surfaces a save failure and re-enables the Apply button', async () => {
+    seedStoredConnection();
+    vi.mocked(setConfig).mockRejectedValue(new Error('ipc down'));
+    renderCard();
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('gpu-box.tail1234.ts.net')).toBeDefined();
+    });
+    fireEvent.click(screen.getByText('Apply').closest('button') as HTMLButtonElement);
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Could not save the remote connection settings.');
+    });
+    // The applying state cleared: the button shows its label again, enabled.
+    const applyButton = screen.getByText('Apply').closest('button') as HTMLButtonElement;
+    expect(applyButton.disabled).toBe(false);
+  });
+
+  it('mirrors the auth token cache while pristine but never clobbers unapplied typing', async () => {
+    seedStoredConnection();
+    const { qc } = renderCard();
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('remote-token')).toBeDefined();
+    });
+    // Pristine field: a cache update (e.g. useAuthTokenSync detection) flows in.
+    act(() => {
+      qc.setQueryData(['authToken'], 'detected-token');
+    });
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('detected-token')).toBeDefined();
+    });
+    // Dirty field: unapplied user typing wins over later cache writes.
+    fireEvent.change(screen.getByDisplayValue('detected-token'), {
+      target: { value: 'typed-token' },
+    });
+    act(() => {
+      qc.setQueryData(['authToken'], 'clobber-attempt');
+    });
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('typed-token')).toBeDefined();
+    });
+    expect(screen.queryByDisplayValue('clobber-attempt')).toBeNull();
+  });
+
+  it('warns when a bare tailnet name is entered as the host', async () => {
+    vi.mocked(getConfig).mockImplementation(async (key: string) => {
+      if (key === 'connection.remoteHost') return 'tail1234.ts.net';
+      if (key === 'connection.remoteProfile') return 'tailscale';
+      return undefined;
+    });
+    renderCard();
+    await waitFor(() => {
+      expect(screen.getByText(/This looks like a tailnet name/)).toBeDefined();
+    });
+  });
+});

--- a/dashboard/src/config/store.ts
+++ b/dashboard/src/config/store.ts
@@ -13,7 +13,7 @@ export interface ClientConfig {
     port: number;
     https: boolean;
   };
-  /** Connection settings (SettingsModal Client tab) */
+  /** Connection settings (Server tab Remote card + SettingsModal Client tab) */
   connection: {
     localHost: string;
     remoteHost: string;
@@ -23,6 +23,12 @@ export interface ClientConfig {
     authToken: string;
     port: number;
     useHttps: boolean;
+    /**
+     * Snapshot of useHttps taken when entering remote mode (which forces
+     * useHttps=true); restored when leaving, so a deliberately TLS-enabled
+     * local setup survives a round-trip through the Remote runtime tile.
+     */
+    localUseHttps: boolean;
   };
   /** Audio capture settings */
   audio: {
@@ -117,6 +123,7 @@ const DEFAULT_CONFIG: ClientConfig = {
     authToken: '',
     port: DEFAULT_SERVER_PORT,
     useHttps: false,
+    localUseHttps: false,
   },
   audio: {
     gracePeriod: 1.0,

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.15.0",
-  "contract_sha256": "7ccb5e79d66ba2048963739858f0198b8c56ccf7ac3abe4b12d8b94a7e7d82ef",
-  "updated_at": "2026-08-01T21:23:00.764Z"
+  "spec_version": "1.16.0",
+  "contract_sha256": "87229e8d0df2be2f5abcb1a08d0ddf0966145161ab5586cc2db87edd82cd9808",
+  "updated_at": "2026-08-02T10:21:20.184Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.15.0
+  spec_version: 1.16.0
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -113,8 +113,10 @@ meta:
       - components/views/NotebookView.tsx
       - components/views/NotificationsView.tsx
       - components/views/server/__tests__/MainModelPicker.test.tsx
+      - components/views/server/__tests__/RemoteClientSettingsCard.test.tsx
       - components/views/server/InstanceSettingsSelectors.tsx
       - components/views/server/MainModelPicker.tsx
+      - components/views/server/RemoteClientSettingsCard.tsx
       - components/views/server/RemoteConnectionCard.tsx
       - components/views/server/StartupActivityInline.tsx
       - components/views/ServerConfigEditor.tsx
@@ -131,7 +133,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-08-01T21:22:30.557Z
+    generated_at: 2026-08-02T10:20:32.229Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -986,6 +988,7 @@ utility_allowlist:
     - pb-1
     - pb-10
     - pb-2
+    - pb-3
     - pb-4
     - pb-8
     - pl-0
@@ -2636,6 +2639,23 @@ component_contracts:
         rule: Do not introduce unregistered utility, arbitrary, or inline style values.
   QueuePausedBanner:
     file: components/ui/QueuePausedBanner.tsx
+    required_tokens:
+      - colors
+      - motion
+      - radii
+      - shadows
+    allowed_variants: {}
+    structural_invariants:
+      - id: structure-stable
+        rule: Preserve current structural layout and region hierarchy for this component.
+    behavior_rules:
+      - id: motion-locked
+        rule: Use only approved motion tokens and classes from foundation token registry.
+    state_rules:
+      - id: closed-set-styles
+        rule: Do not introduce unregistered utility, arbitrary, or inline style values.
+  RemoteClientSettingsCard:
+    file: components/views/server/RemoteClientSettingsCard.tsx
     required_tokens:
       - colors
       - motion


### PR DESCRIPTION
## Summary

Makes the client-side remote connection a first-class **Runtime option** in the Server tab, instead of a buried Settings toggle. A computer that cannot (or should not) run a local instance now picks **Remote** right where every other runtime is picked.

- New **Remote** tile in `1. Runtime Settings` (Globe icon, magenta accent). Its selected state derives from the persisted `connection.useRemote` key - users who already enabled remote mode in Settings see the tile selected automatically after upgrading, no migration needed.
- While Remote is active, `2. Docker Image` / `2. Inference Server` and `3. Instance Settings` grey out (dimmed, `pointer-events-none`, `aria-disabled`) - there is no local instance to configure. The setup checklist reports Docker/GPU/Metal checks as "Not needed for Remote connection", so a Docker-less machine shows a clean checklist.
- Card `4. Remote Connection` becomes mode-aware:
  - **Local runtimes** (unchanged): host-side view - this machine's auth token + Tailscale hostname for other clients.
  - **Remote runtime**: the client-side settings that used to live in Settings > Client > Connection - Remote Profile (Tailscale/LAN), host (with the bare-tailnet-name hint), auth token, port, plus a live connection status light and an Apply button with the same validation SettingsModal enforced (blank-host per profile, port range).
- Settings > Client > Connection slims down to Local Host / Auth Token / Manage Tokens / Port / HTTPS, with a pointer to the Server tab. The modal **no longer writes** `connection.useRemote/remoteProfile/remoteHost/lanHost`, so a stale modal snapshot can never clobber a mode switch made in the Server tab while the modal sat open.

## Design decision

`'remote'` is **deliberately NOT added to the `RuntimeProfile` union** (`gpu/cpu/vulkan/vulkan-wsl2/metal`). That union is consumed by instanceMatrix (model-family gating), dockerManager (image variant selection), the Metal boot auto-start in `electron/main.ts`, and `StartContainerOptions` across four independently-declared type copies - an unknown value would silently fall through every branch (e.g. `startServerWithOnboarding` would demand local Docker for a mode whose whole point is having none). Remote is a *connection mode*, modeled exactly like the existing `compatGuard.ts` `deployment: useRemote ? 'remote' : 'local'` derivation. `server.runtimeProfile` keeps its last local value while remote is active, so switching back restores the previous runtime.

Mode switches follow the established contract (`SettingsModal.handleSave` / `SessionView.handleStartClient*`): write `connection.*` keys, then `apiClient.syncFromConfig()` + `setAuthToken()` - the cached base URL updates immediately, no restart. Selecting Remote forces `useHttps=true` (existing invariant); selecting a local runtime resets `useHttps=false`, mirroring `handleStartClientLocal`.

Also fixes a pre-existing gap this feature would have widened: `App.tsx`'s `useRemote` state (which gates `useAuthTokenSync`'s Docker-log token scanner) only re-read the key when server reachability flipped. It now also re-reads on `apiClient.onConfigChanged`, so a mode switch from the Server tab (or SessionView's Client Link) can no longer leave the scanner in the wrong mode where the local container's admin token could overwrite a freshly entered remote token.

The hardware auto-detect path still calls `handleRuntimeProfileChange` directly and can never yank the user out of remote mode - tile clicks go through a separate wrapper that exits remote mode first.

## Hardening from the adversarial review pass

An adversarial review (3 dimensions, every medium+ finding independently verified against the code) confirmed 7 findings; all are addressed in this diff:

- **Rapid-click race**: a mode switch is ~10 sequential IPC round-trips; a fast Remote→CPU click sequence could interleave writes or branch on a stale `remoteModeActive` closure and silently drop the second click. Switches now go through a serialized promise queue and re-check `connection.useRemote` from *fresh config* inside the queued task. Regression test asserts the exact write order `[true, false]` on a rapid double-click.
- **Cosmetic-only dimming**: `pointer-events-none` blocked the mouse but left every Start/Stop/Remove control tabbable and screen-reader-operable. The card wrappers now also carry `inert` (React 19) which blocks keyboard focus and assistive tech, and the instance lifecycle buttons are functionally disabled while remote.
- **Local HTTPS clobber**: leaving remote mode used to force `useHttps=false`, breaking a deliberately TLS-enabled local setup. Entering remote now snapshots the preference into `connection.localUseHttps` and leaving restores it (regression-tested round-trip).
- **No active-session guard**: switching modes silently retargets the live apiClient. Mode switches are now blocked while the Session tab's client link is running - same guard as SessionView's own Start Local/Start Remote buttons (tiles disable with a "Client running" badge + toast explanation on the config-level guard).
- **Token field vs auto-sync**: the card's auth-token field mirrors the central `['authToken']` query cache, but unapplied user typing now always wins (dirty flag) - a stale-token clear can no longer wipe a token mid-entry.
- **Coverage gaps**: the `onConfigChanged` reactive re-read, the apply failure branch, and the pristine-vs-dirty token mirroring are all now under test.

Refuted by verification (no change): the mode switch re-applying the currently stored token matches the existing SessionView/SettingsModal behavior exactly; the Remote-tile vs "Start Remote" naming adjacency is real but carries no functional defect (the buttons are inert+disabled in remote mode, and the card copy disambiguates).

## Tests

- New `Remote runtime tile` describe in `ServerView.test.tsx` (9 tests): tile selection semantics in both modes, config writes + api re-sync on tile clicks, inert cards + client card + "Not needed" checks in persisted remote mode, rapid-click serialization order, local-HTTPS snapshot/restore round-trip, `onConfigChanged` reactive re-read, and both directions of the client-link guard.
- New `RemoteClientSettingsCard.test.tsx` (8 tests): hydration, blank-host validation per profile, port-range validation, full apply contract (config writes + `syncFromConfig` + `setAuthToken` + toast), apply-failure recovery, pristine-vs-dirty token cache mirroring, bare-tailnet hint.
- Full dashboard suite: 138 files / 1996 tests green. `typecheck`, `lint`, `format:check` clean. (The chronically-borderline Multi-GPU picker test got its timeout raised 5s → 10s; it runs ~3.4s of real mount work and tips over under full-suite load.)
- ui-contract: `RemoteClientSettingsCard.tsx` added to `meta.source_files`, spec_version 1.15.0 → 1.16.0, baseline refreshed, `ui:contract:check` green (22 checks).

## Smoke checklist (hardware)

- [ ] Fresh machine without Docker: select Remote → setup checks all "Not needed", cards 2+3 dimmed, card 4 shows client settings
- [ ] Enter host + token from a real host machine → Apply → status light goes green, transcription works
- [ ] Switch Remote → CPU Only → local flow works again (http://localhost, Docker checks re-appear)
- [ ] Pre-existing remote user (configured via old Settings UI) upgrades → Remote tile pre-selected, settings carried over
- [ ] Settings > Client shows the pointer note; HTTPS switch locked on while remote
