### PR TITLE
fix(server, dashboard): salvage the buffered head audio when a recording session drops (GH-239)

### DIFF
--- a/dashboard/components/__tests__/SessionView.recovery-refresh.test.tsx
+++ b/dashboard/components/__tests__/SessionView.recovery-refresh.test.tsx
@@ -1,0 +1,364 @@
+/**
+ * SessionView - keeping the recovery banner current (GH-239).
+ *
+ * The banner lists completed-but-undelivered jobs from GET /transcribe/recent,
+ * which is how a transcript reaches the user when the socket that ordered it is
+ * gone. It used to be fetched exactly once, on mount, so a result that landed
+ * afterwards stayed invisible until the view was remounted.
+ *
+ * GH-239 made that reachable in normal use: after a mid-recording drop the
+ * server salvages the buffered audio into the same job, and the salvage can
+ * easily outlast the hook poll that waits for it. The result is then sitting in
+ * the database, undelivered, with nothing on screen pointing at it.
+ */
+
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// ── Hoisted mock state ────────────────────────────────────────────────────
+
+const mockTranscription = {
+  status: 'error' as string,
+  result: null as unknown,
+  error: null as string | null,
+  analyser: null,
+  start: vi.fn(),
+  stop: vi.fn(),
+  reset: vi.fn(),
+  vadActive: false,
+  processingProgress: null,
+  muted: false,
+  toggleMute: vi.fn(),
+  setGain: vi.fn(),
+  jobId: null as string | null,
+  loadResult: vi.fn(),
+  previewText: null,
+  previewLanguage: undefined,
+  previewSeconds: null,
+  previewLoading: false,
+  previewError: null,
+  previewActive: false,
+  startPreview: vi.fn(),
+  stopPreview: vi.fn(),
+};
+
+const mockGetConfig = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../../src/hooks/useTranscription', () => ({
+  useTranscription: () => mockTranscription,
+}));
+
+vi.mock('../../src/hooks/useLanguages', () => ({
+  useLanguages: () => ({
+    languages: [
+      { code: 'auto', name: 'Auto Detect' },
+      { code: 'en', name: 'English' },
+    ],
+    backendType: 'whisper',
+    loading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('../../src/hooks/useAdminStatus', () => ({
+  useAdminStatus: () => ({
+    status: {
+      models_loaded: true,
+      config: {
+        main_transcriber: { model: 'Systran/faster-whisper-large-v3' },
+        live_transcriber: { model: 'Systran/faster-whisper-large-v3' },
+      },
+    },
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/hooks/DockerContext', () => ({
+  useDockerContext: () => ({
+    available: true,
+    loading: false,
+    runtimeKind: 'Docker',
+    detectionGuidance: null,
+    composeAvailable: true,
+    images: [],
+    container: { exists: true, running: true, status: 'running', health: 'healthy' },
+    volumes: [],
+    operating: false,
+    operationError: null,
+    pulling: false,
+    sidecarPulling: false,
+    logLines: [],
+    logStreaming: false,
+    hasSidecarImage: vi.fn().mockResolvedValue(false),
+    startLogStream: vi.fn(),
+    stopLogStream: vi.fn(),
+    clearLogs: vi.fn(),
+    refreshImages: vi.fn(),
+    refreshVolumes: vi.fn(),
+    pullImage: vi.fn(),
+    cancelPull: vi.fn(),
+    pullSidecarImage: vi.fn(),
+    cancelSidecarPull: vi.fn(),
+    removeImage: vi.fn(),
+    startContainer: vi.fn(),
+    stopContainer: vi.fn(),
+    removeContainer: vi.fn(),
+    removeVolume: vi.fn(),
+    cleanAll: vi.fn(),
+    retryDetection: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/hooks/useTraySync', () => ({ useTraySync: vi.fn() }));
+
+vi.mock('../../src/stores/importQueueStore', () => ({
+  useImportQueueStore: (selector: (s: Record<string, unknown>) => unknown) => {
+    const state = {
+      jobs: [],
+      isPaused: false,
+      sessionConfig: { outputDir: '', diarizedFormat: 'srt', hideTimestamps: false },
+      sessionWatchPath: '',
+      sessionWatchActive: false,
+    };
+    return typeof selector === 'function' ? selector(state) : state;
+  },
+}));
+
+// vi.mock factories are hoisted above the declarations in this file, and the
+// api/client factory dereferences APIError eagerly — so the class has to be
+// created inside vi.hoisted or it is still in the temporal dead zone.
+const {
+  MockAPIError,
+  mockRetryTranscription,
+  mockFetchTranscriptionResult,
+  mockFetchRecentUndelivered,
+  mockToast,
+} = vi.hoisted(() => {
+  class HoistedAPIError extends Error {
+    constructor(
+      public readonly status: number,
+      public readonly body: string,
+      public readonly path: string,
+    ) {
+      super(`API ${status} on ${path}`);
+      this.name = 'APIError';
+    }
+  }
+  return {
+    MockAPIError: HoistedAPIError,
+    mockRetryTranscription: vi.fn(),
+    mockFetchTranscriptionResult: vi.fn(),
+    mockFetchRecentUndelivered: vi.fn(),
+    mockToast: { success: vi.fn(), error: vi.fn() },
+  };
+});
+
+vi.mock('../../src/api/client', () => ({
+  APIError: MockAPIError,
+  apiClient: {
+    checkConnection: vi.fn().mockResolvedValue({ reachable: true, ready: true }),
+    getAdminStatus: vi.fn().mockResolvedValue({}),
+    cancelTranscription: vi.fn(),
+    getAuthToken: vi.fn().mockReturnValue(null),
+    setAuthToken: vi.fn(),
+    getBaseUrl: vi.fn().mockReturnValue('http://localhost:7239'),
+    syncFromConfig: vi.fn().mockResolvedValue(undefined),
+    unloadModels: vi.fn().mockResolvedValue(undefined),
+    unloadLLMModel: vi.fn().mockResolvedValue(undefined),
+    loadModelsStream: vi.fn().mockReturnValue(vi.fn()),
+    fetchRecentUndelivered: (...a: unknown[]) => mockFetchRecentUndelivered(...a),
+    fetchTranscriptionResult: (...a: unknown[]) => mockFetchTranscriptionResult(...a),
+    dismissTranscriptionResult: vi.fn().mockResolvedValue({ status: 200 }),
+    retryTranscription: (...a: unknown[]) => mockRetryTranscription(...a),
+  },
+}));
+
+vi.mock('../../src/config/store', () => ({
+  getConfig: (...args: unknown[]) => mockGetConfig(...args),
+  setConfig: vi.fn().mockResolvedValue(undefined),
+  getAuthToken: vi.fn().mockResolvedValue(null),
+  DEFAULT_SERVER_PORT: 7239,
+}));
+
+vi.mock('../../src/services/modelCapabilities', async () => {
+  const actual = await vi.importActual<typeof import('../../src/services/modelCapabilities')>(
+    '../../src/services/modelCapabilities',
+  );
+  return actual;
+});
+
+vi.mock('../../src/services/modelSelection', () => ({
+  isModelDisabled: () => false,
+}));
+
+vi.mock('../../src/hooks/useClipboard', () => ({ writeToClipboard: vi.fn() }));
+vi.mock('../../src/services/clientDebugLog', () => ({ logClientEvent: vi.fn() }));
+
+vi.mock('sonner', () => ({ toast: mockToast }));
+
+vi.mock('../views/SessionImportTab', () => ({
+  SessionImportTab: () => React.createElement('div', { 'data-testid': 'session-import-tab' }),
+}));
+vi.mock('../PopOutWindow', () => ({ PopOutWindow: () => null }));
+vi.mock('../views/FullscreenVisualizer', () => ({ FullscreenVisualizer: () => null }));
+vi.mock('../AudioVisualizer', () => ({
+  AudioVisualizer: () => React.createElement('div', { 'data-testid': 'audio-visualizer' }),
+}));
+
+vi.mock('../../src/types/runtime', () => ({
+  isRuntimeProfile: (v: unknown) =>
+    ['gpu', 'cpu', 'vulkan', 'vulkan-wsl2', 'metal'].includes(v as string),
+}));
+
+import { SessionView } from '../views/SessionView';
+import { SessionTab } from '../../types';
+
+function createWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+}
+
+const baseProps = {
+  serverConnection: {
+    serverStatus: 'active' as const,
+    clientStatus: 'active' as const,
+    details: null,
+    serverLabel: 'Server ready',
+    reachable: true,
+    ready: true,
+    error: null,
+    gpuError: null,
+    gpuErrorRecoveryHint: null,
+    refresh: vi.fn(),
+  },
+  clientRunning: true,
+  setClientRunning: vi.fn(),
+  onStartServer: vi.fn().mockResolvedValue(undefined),
+  startupFlowPending: false,
+  isUploading: false,
+  live: {
+    status: 'idle' as const,
+    sentences: [],
+    partial: '',
+    statusMessage: null,
+    error: null,
+    analyser: null,
+    muted: false,
+    start: vi.fn(),
+    stop: vi.fn(),
+    toggleMute: vi.fn(),
+    setGain: vi.fn(),
+    clearHistory: vi.fn(),
+    getText: vi.fn().mockReturnValue(''),
+  },
+  sessionTab: SessionTab.MAIN,
+  onChangeSessionTab: vi.fn(),
+};
+
+function renderSessionView() {
+  return render(React.createElement(SessionView, baseProps), { wrapper: createWrapper() });
+}
+
+const JOB_ID = '48eae812-f5ff-400e-b2bc-4dede99c5a15';
+
+/** Fixed so the banner's relative-time label cannot drift between runs. */
+const COMPLETED_AT = '2026-08-03T00:00:00.000Z';
+
+const SALVAGED = [
+  {
+    job_id: 'salvaged-job',
+    completed_at: COMPLETED_AT,
+    text_preview: 'the half that made it',
+  },
+];
+
+describe('SessionView - recovery banner refresh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTranscription.status = 'idle';
+    mockTranscription.result = null;
+    mockTranscription.error = null;
+    mockTranscription.jobId = null;
+    mockGetConfig.mockResolvedValue(undefined);
+    mockFetchRecentUndelivered.mockResolvedValue({ json: async () => [] });
+  });
+
+  it('lists an undelivered result found at mount', async () => {
+    mockFetchRecentUndelivered.mockResolvedValue({ json: async () => SALVAGED });
+    renderSessionView();
+
+    expect(await screen.findByText(/the half that made it/)).toBeInTheDocument();
+  });
+
+  it('re-checks when the recording ends in an error', async () => {
+    const { rerender } = renderSessionView();
+    await waitFor(() => expect(mockFetchRecentUndelivered).toHaveBeenCalledTimes(1));
+
+    // The GH-239 poll gave up. The salvage may well have finished since.
+    mockFetchRecentUndelivered.mockResolvedValue({ json: async () => SALVAGED });
+    mockTranscription.status = 'error';
+    mockTranscription.error = 'Connection to the server was lost.';
+    rerender(React.createElement(SessionView, baseProps));
+
+    expect(await screen.findByText(/the half that made it/)).toBeInTheDocument();
+  });
+
+  it('does not re-check on every unrelated re-render', async () => {
+    const { rerender } = renderSessionView();
+    await waitFor(() => expect(mockFetchRecentUndelivered).toHaveBeenCalledTimes(1));
+
+    rerender(React.createElement(SessionView, baseProps));
+    rerender(React.createElement(SessionView, baseProps));
+
+    expect(mockFetchRecentUndelivered).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-checks when the window regains focus', async () => {
+    renderSessionView();
+    await waitFor(() => expect(mockFetchRecentUndelivered).toHaveBeenCalledTimes(1));
+
+    // The user walked away while the salvage ran and has just come back.
+    mockFetchRecentUndelivered.mockResolvedValue({ json: async () => SALVAGED });
+    fireEvent(window, new Event('focus'));
+
+    expect(await screen.findByText(/the half that made it/)).toBeInTheDocument();
+  });
+
+  it('stops listening for focus once unmounted', async () => {
+    const { unmount } = renderSessionView();
+    await waitFor(() => expect(mockFetchRecentUndelivered).toHaveBeenCalledTimes(1));
+
+    unmount();
+    fireEvent(window, new Event('focus'));
+
+    expect(mockFetchRecentUndelivered).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not offer to recover the transcript already on screen', async () => {
+    // mark_delivered is best-effort, so a just-recovered job can still come
+    // back from /recent. Announcing it beside its own transcript reads as a
+    // second, missing result.
+    mockFetchRecentUndelivered.mockResolvedValue({
+      json: async () => [
+        { job_id: JOB_ID, completed_at: COMPLETED_AT, text_preview: 'on screen now' },
+        ...SALVAGED,
+      ],
+    });
+    mockTranscription.status = 'complete';
+    mockTranscription.jobId = JOB_ID;
+    mockTranscription.result = { text: 'on screen now', words: [] };
+    renderSessionView();
+
+    expect(await screen.findByText(/the half that made it/)).toBeInTheDocument();
+    // Exactly one banner: the salvaged job. Scoped to the banner wording,
+    // because the on-screen job's text also appears in the transcript box.
+    const banners = screen.getAllByText(/is available\./);
+    expect(banners).toHaveLength(1);
+    expect(banners[0].closest('div')?.textContent).toContain('the half that made it');
+  });
+});

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -1333,7 +1333,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
   const [recoveryJobs, setRecoveryJobs] = useState<
     Array<{ job_id: string; completed_at: string; text_preview: string }>
   >([]);
-  useEffect(() => {
+  const refreshRecoveryJobs = useCallback(() => {
     // Absolute base URL via apiClient — a relative fetch resolves to the
     // packaged renderer file:// origin and never reaches the backend (GH-202).
     apiClient
@@ -1344,6 +1344,31 @@ export const SessionView: React.FC<SessionViewProps> = ({
       })
       .catch(() => {});
   }, []);
+
+  useEffect(() => {
+    refreshRecoveryJobs();
+  }, [refreshRecoveryJobs]);
+
+  // GH-239: a mid-recording drop leaves the server transcribing the audio it
+  // already received, and that salvage can outlast the poll the hook runs while
+  // waiting for it. Once the poll gives up, re-check: the result may have landed
+  // in the database in the meantime, with nothing else on screen pointing at it.
+  useEffect(() => {
+    if (transcription.status === 'error') refreshRecoveryJobs();
+  }, [transcription.status, refreshRecoveryJobs]);
+
+  // Same reasoning for the longer absence: a mount-only fetch cannot see a
+  // result that arrives while the user is elsewhere, and this view can stay
+  // mounted for days.
+  useEffect(() => {
+    window.addEventListener('focus', refreshRecoveryJobs);
+    return () => window.removeEventListener('focus', refreshRecoveryJobs);
+  }, [refreshRecoveryJobs]);
+
+  // mark_delivered is best-effort, so the job whose transcript is already on
+  // screen can still come back from /recent. Offering to recover it there reads
+  // as a second, missing result.
+  const visibleRecoveryJobs = recoveryJobs.filter((job) => job.job_id !== transcription.jobId);
 
   // Scroll State
   const leftScrollRef = useRef<HTMLDivElement>(null);
@@ -1500,9 +1525,9 @@ export const SessionView: React.FC<SessionViewProps> = ({
       </div>
 
       {/* Recovery Notifications */}
-      {recoveryJobs.length > 0 && (
+      {visibleRecoveryJobs.length > 0 && (
         <div className="mb-4 flex flex-none flex-col gap-2">
-          {recoveryJobs.map((job) => {
+          {visibleRecoveryJobs.map((job) => {
             const relativeTime = (() => {
               try {
                 const completed = new Date(job.completed_at);

--- a/dashboard/src/hooks/useTranscription.test.ts
+++ b/dashboard/src/hooks/useTranscription.test.ts
@@ -988,20 +988,26 @@ describe('[P1] useTranscription', () => {
     });
 
     it('fails loudly when the socket closes unexpectedly while recording', async () => {
+      (apiClient.fetchTranscriptionResult as Mock).mockResolvedValue({ status: 202 });
       const { result } = renderHook(() => useTranscription());
       await driveToRecording(result);
       lastSocket.disconnect.mockClear();
       lastCapture.stop.mockClear();
 
-      act(() => {
+      await act(async () => {
         lastSocketCbs.onClose!(1001, 'server going away');
+        await Promise.resolve();
       });
 
-      expect(result.current.status).toBe('error');
       expect(result.current.error).toMatch(/connection.*lost/i);
       expect(lastCapture.stop).toHaveBeenCalled();
       // Auto-reconnect is halted so no zombie session is created.
       expect(lastSocket.disconnect).toHaveBeenCalledTimes(1);
+      // The status is no longer terminal: GH-239 made the server salvage the
+      // audio it already received, so the hook waits on that instead of
+      // stopping at the error. The interruption is still announced above -
+      // what changed is that it is now recoverable, not that it is quiet.
+      expect(result.current.status).toBe('processing');
     });
 
     it('does not re-send start on a reconnect during processing (poll owns recovery)', async () => {
@@ -1042,6 +1048,194 @@ describe('[P1] useTranscription', () => {
       // lastSocket is now the second socket — it sent exactly one start.
       expect(startSends()).toBe(1);
       expect(result.current.status).toBe('recording');
+    });
+  });
+
+  // ── GH-239: recover the head audio the server salvaged ──────────────
+
+  describe('GH-239: mid-recording drop recovers the salvaged partial', () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    /** Advance one poll interval and let the fetch promise settle. */
+    async function tickPoll(times = 1): Promise<void> {
+      for (let i = 0; i < times; i++) {
+        await act(async () => {
+          vi.advanceTimersByTime(3000);
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+      }
+    }
+
+    it('polls for the salvaged result when the socket drops while recording', async () => {
+      (apiClient.fetchTranscriptionResult as Mock).mockResolvedValue({
+        status: 200,
+        json: async () => ({
+          result: {
+            text: 'the half that made it',
+            words: [],
+            partial: true,
+            partial_reason: 'Client disconnected mid-recording',
+          },
+        }),
+      });
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+
+      await act(async () => {
+        lastSocketCbs.onClose!(1001, 'server going away');
+        await Promise.resolve();
+      });
+
+      expect(apiClient.fetchTranscriptionResult).toHaveBeenCalledWith('job-1');
+      expect(result.current.status).toBe('complete');
+      expect(result.current.result?.text).toBe('the half that made it');
+    });
+
+    it('surfaces the truncation so the transcript is never mistaken for whole', async () => {
+      (apiClient.fetchTranscriptionResult as Mock).mockResolvedValue({
+        status: 200,
+        json: async () => ({
+          result: {
+            text: 'the half that made it',
+            words: [],
+            partial: true,
+            partial_reason: 'Client disconnected mid-recording',
+          },
+        }),
+      });
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+
+      await act(async () => {
+        lastSocketCbs.onClose!(1001, 'server going away');
+        await Promise.resolve();
+      });
+
+      expect(result.current.result?.partial).toBe(true);
+      expect(result.current.result?.partialReason).toMatch(/disconnected/i);
+      // The red "connection lost" banner has served its purpose - the amber
+      // partial banner now carries the signal. Leaving both reads as a failure.
+      expect(result.current.error).toBeNull();
+    });
+
+    it('still halts the auto-reconnect so no zombie session is spawned', async () => {
+      (apiClient.fetchTranscriptionResult as Mock).mockResolvedValue({ status: 202 });
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+      lastSocket.disconnect.mockClear();
+      lastCapture.stop.mockClear();
+
+      await act(async () => {
+        lastSocketCbs.onClose!(1001, 'server going away');
+        await Promise.resolve();
+      });
+
+      expect(lastSocket.disconnect).toHaveBeenCalledTimes(1);
+      expect(lastCapture.stop).toHaveBeenCalled();
+    });
+
+    it('tells the user recovery is under way rather than going quiet', async () => {
+      (apiClient.fetchTranscriptionResult as Mock).mockResolvedValue({ status: 202 });
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+
+      await act(async () => {
+        lastSocketCbs.onClose!(1001, 'server going away');
+        await Promise.resolve();
+      });
+
+      expect(result.current.error).toMatch(/lost/i);
+      expect(result.current.status).toBe('processing');
+    });
+
+    it('keeps polling well past the old ten-attempt cap', async () => {
+      // Salvaging a long recording means transcribing all of it. Ten tries at
+      // 3s gave up after 30 seconds - far short of any real recording.
+      (apiClient.fetchTranscriptionResult as Mock).mockResolvedValue({ status: 202 });
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+
+      await act(async () => {
+        lastSocketCbs.onClose!(1001, 'server going away');
+        await Promise.resolve();
+      });
+      await tickPoll(30);
+
+      expect((apiClient.fetchTranscriptionResult as Mock).mock.calls.length).toBeGreaterThan(11);
+      expect(result.current.status).toBe('processing');
+    });
+
+    it('gives up loudly when the server reports the job failed', async () => {
+      (apiClient.fetchTranscriptionResult as Mock).mockResolvedValue({ status: 410 });
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+
+      await act(async () => {
+        lastSocketCbs.onClose!(1001, 'server going away');
+        await Promise.resolve();
+      });
+
+      expect(result.current.status).toBe('error');
+      expect(result.current.error).toMatch(/failed/i);
+    });
+
+    it('fails loudly without polling when the recording never got a job id', async () => {
+      // create_job failed server-side, so session_started carries no job_id.
+      // There is no row to salvage into - the GH-237 fail-loudly behaviour is
+      // still the only honest answer.
+      const { result } = renderHook(() => useTranscription());
+      act(() => {
+        result.current.start();
+      });
+      await act(async () => {
+        lastSocketCbs.onMessage!({ type: 'auth_ok' });
+      });
+      await act(async () => {
+        lastSocketCbs.onMessage!({
+          type: 'session_started',
+          data: { capture_sample_rate_hz: 16000 },
+        });
+      });
+      expect(result.current.status).toBe('recording');
+      expect(result.current.jobId).toBeNull();
+      (apiClient.fetchTranscriptionResult as Mock).mockClear();
+
+      await act(async () => {
+        lastSocketCbs.onClose!(1001, 'server going away');
+        await Promise.resolve();
+      });
+
+      expect(apiClient.fetchTranscriptionResult).not.toHaveBeenCalled();
+      expect(result.current.status).toBe('error');
+      expect(result.current.error).toMatch(/lost/i);
+    });
+
+    it('does not poll for a drop during the connecting handshake', async () => {
+      // Pre-existing GH-237 contract: no session was established yet, so the
+      // auto-reconnect re-establishes the FIRST session. Nothing to recover,
+      // and flipping to an error state here would break that.
+      const { result } = renderHook(() => useTranscription());
+      act(() => {
+        result.current.start();
+      });
+      await act(async () => {
+        lastSocketCbs.onMessage!({ type: 'auth_ok' });
+      });
+      (apiClient.fetchTranscriptionResult as Mock).mockClear();
+
+      await act(async () => {
+        lastSocketCbs.onClose!(1001, 'drop before session');
+        await Promise.resolve();
+      });
+
+      expect(apiClient.fetchTranscriptionResult).not.toHaveBeenCalled();
+      expect(result.current.status).toBe('connecting');
     });
   });
 });

--- a/dashboard/src/hooks/useTranscription.ts
+++ b/dashboard/src/hooks/useTranscription.ts
@@ -19,6 +19,20 @@ export type TranscriptionStatus =
   | 'complete'
   | 'error';
 
+/** Gap between attempts when polling for a result the socket cannot deliver. */
+const POLL_INTERVAL_MS = 3000;
+
+/**
+ * How long to keep polling for such a result before giving up.
+ *
+ * Sized for the slow case rather than the common one: after a mid-recording
+ * drop the server still has to transcribe everything it received (GH-239), so
+ * the wait scales with the length of the recording, not with the round-trip.
+ * Giving up early would strand a result that is already saved in the database -
+ * it stays reachable from the recovery list, but the user has to find it.
+ */
+const POLL_BUDGET_MS = 15 * 60 * 1000;
+
 export interface TranscriptionResult {
   text: string;
   words: Array<{ word: string; start: number; end: number; probability?: number }>;
@@ -542,25 +556,41 @@ export function useTranscription(): TranscriptionState {
           stopPreview();
           previewLoadingRef.current = false;
 
-          // GH-237: a drop WHILE recording is an unrecoverable interruption.
-          // The server cannot resume a dropped session, and the start-gate now
-          // stops the auto-reconnect from spawning a fresh job — which would
-          // leave the UI frozen in a false 'recording' state. Fail loudly
-          // instead of silently truncating: surface the interruption and halt
-          // the reconnect so no zombie session is created. (Data-loss invariant.)
-          if (statusRef.current === 'recording') {
+          // GH-237: a drop WHILE recording is an interruption the server cannot
+          // resume - every connection gets a fresh session_id and job_id. The
+          // start-gate stops the auto-reconnect from spawning a second job,
+          // which would leave the UI frozen in a false 'recording' state, so
+          // halt the reconnect here and say plainly what happened rather than
+          // silently truncating. (Data-loss invariant.)
+          const currentJobId = jobIdRef.current;
+          const wasRecording = statusRef.current === 'recording';
+          if (wasRecording) {
             setError('Connection to the server was lost. The recording was interrupted.');
-            setStatusTracked('error');
             socketRef.current?.disconnect();
-            return;
+            if (!currentJobId) {
+              // The drop landed before session_started, so no job was ever
+              // issued and there is nothing on the server to recover.
+              setStatusTracked('error');
+              return;
+            }
+            // GH-239: the server salvages whatever audio it already received
+            // into that job. Fall through to the poll so the user gets the
+            // head of their recording back instead of just an error.
+            setStatusTracked('processing');
           }
 
-          // If we were processing when the socket closed, poll for the result
-          const currentJobId = jobIdRef.current;
-          if (statusRef.current === 'processing' && currentJobId) {
-            let pollRetries = 0;
+          // Poll for a result the socket can no longer deliver: either the
+          // server was already transcribing, or it is now salvaging the
+          // interrupted recording.
+          if ((wasRecording || statusRef.current === 'processing') && currentJobId) {
             let networkErrors = 0;
             const maxRetries = 10;
+            // A wall-clock budget, not an attempt count: the server has to
+            // transcribe the whole recording before the result exists, and the
+            // old ten-attempt cap gave up after 30 seconds - short of any real
+            // recording. Date.now() is read once so a suspended machine that
+            // wakes up late gives up rather than polling forever.
+            const pollDeadline = Date.now() + POLL_BUDGET_MS;
             pollCancelledRef.current = false;
 
             // Cancel polling if the hook re-initialises a new session
@@ -582,14 +612,20 @@ export function useTranscription(): TranscriptionState {
                     duration: r.duration,
                     partial: r.partial ?? false,
                     partialReason: r.partial_reason ?? null,
+                    numSpeakers: r.num_speakers ?? 0,
+                    diarization: r.diarization,
                   });
                   setProcessingProgress(null);
+                  // The recovery succeeded, so the "connection lost" banner has
+                  // done its job. A salvaged transcript still carries `partial`,
+                  // which SessionView renders as its own amber banner - showing
+                  // a red error next to a recovered transcript reads as failure.
+                  setError(null);
                   setStatusTracked('complete');
                   return;
                 }
-                if (resp.status === 202 && pollRetries < maxRetries) {
-                  pollRetries++;
-                  pollTimerRef.current = setTimeout(poll, 3000);
+                if (resp.status === 202 && Date.now() < pollDeadline) {
+                  pollTimerRef.current = setTimeout(poll, POLL_INTERVAL_MS);
                   return;
                 }
                 // 410 = server says job failed
@@ -602,9 +638,12 @@ export function useTranscription(): TranscriptionState {
                 setStatusTracked('error');
                 setError('Transcription result unavailable');
               } catch {
+                // Network errors keep their own small budget: an unreachable
+                // server will not produce a result no matter how long we wait,
+                // so this must not inherit the long transcription budget.
                 if (!pollCancelledRef.current && networkErrors < maxRetries) {
                   networkErrors++;
-                  pollTimerRef.current = setTimeout(poll, 3000);
+                  pollTimerRef.current = setTimeout(poll, POLL_INTERVAL_MS);
                 } else if (!pollCancelledRef.current) {
                   setStatusTracked('error');
                   setError('Could not retrieve transcription result');

--- a/server/backend/api/routes/websocket.py
+++ b/server/backend/api/routes/websocket.py
@@ -226,17 +226,31 @@ class TranscriptionSession:
         # Job tracking for transcription
         self._current_job_id: str | None = None
 
-        # Set to True when the client disconnects mid-transcription so the
-        # worker thread can abort via cancellation_check.
+        # Set to True when the client disconnects so the worker thread can
+        # abort via cancellation_check. Only ever set from the receive loop,
+        # which is why it never fires mid-transcription on this path - and why
+        # ``_salvage_reason`` has to neutralise it during a salvage (GH-239).
         self._client_disconnected = False
+
+        # Non-None while finalizing a recording the client dropped out of
+        # (GH-239). Doubles as the ``partial_reason`` stamped on the result.
+        self._salvage_reason: str | None = None
 
         # Get client capabilities
         self.capabilities = get_client_capabilities({"x-client-type": client_type.value}, {})
 
-    async def send_message(self, msg_type: str, data: dict[str, Any] | None = None) -> None:
-        """Send a JSON message to the client."""
+    async def send_message(self, msg_type: str, data: dict[str, Any] | None = None) -> bool:
+        """Send a JSON message to the client. Returns whether it actually went out.
+
+        Callers that persist delivery state MUST branch on the return value:
+        ``client_state`` only flips to DISCONNECTED inside starlette's
+        ``receive()``, so a socket whose peer has vanished still reads
+        CONNECTED here and the failure surfaces as a raised send. Treating that
+        as delivered marks the job ``delivered=1`` and hides a result nobody
+        received from the ``/recent`` recovery list (GH-239).
+        """
         if self.websocket.client_state != WebSocketState.CONNECTED:
-            return
+            return False
 
         message = {
             "type": msg_type,
@@ -245,8 +259,10 @@ class TranscriptionSession:
         }
         try:
             await self.websocket.send_json(message)
+            return True
         except Exception as e:
             logger.error(f"Failed to send message: {e}")
+            return False
 
     def add_audio_chunk(self, pcm_data: bytes) -> None:
         """Add a chunk of PCM audio data."""
@@ -479,8 +495,14 @@ class TranscriptionSession:
                     # backend: the client vanished, or the user pressed Cancel
                     # (POST /cancel -> job_tracker). Binding only the former left
                     # Cancel a no-op on this, the main longform path.
+                    # A salvage run is the one case where the client is gone BY
+                    # DEFINITION (GH-239), so the disconnect signal is muted for
+                    # it - otherwise the salvage aborts on its first poll and
+                    # re-loses exactly the audio it exists to rescue. An
+                    # explicit Cancel still stops it.
                     cancellation_check=lambda: (
-                        self._client_disconnected or model_manager.job_tracker.is_cancelled()
+                        (self._client_disconnected and self._salvage_reason is None)
+                        or model_manager.job_tracker.is_cancelled()
                     ),
                 ),
             )
@@ -510,6 +532,19 @@ class TranscriptionSession:
             dispatched = transcribe_future.result()
             result = dispatched.result
             diarization_outcome = dispatched.outcome
+
+            # A salvaged recording covers only the audio that arrived before the
+            # drop, so it must carry the same truncation signal a chunking
+            # backend raises - the dashboard already renders partial/
+            # partial_reason. Stamped before the payload is built, since the
+            # payload is what gets persisted and later re-fetched.
+            if self._salvage_reason:
+                result.partial_reason = (
+                    f"{result.partial_reason}; {self._salvage_reason}"
+                    if result.partial and result.partial_reason
+                    else self._salvage_reason
+                )
+                result.partial = True
 
             # Speaker labels must be baked into result.text BEFORE the payload
             # is built: the payload is what gets persisted, and a recovery via
@@ -553,6 +588,7 @@ class TranscriptionSession:
             # fetch the result via HTTP. Wave 1 already persisted it to DB.
             _result_size = len(json.dumps(result_payload))
             _sent_as_reference = False
+            _final_delivered = False
             if _result_size > 1_000_000 and self._current_job_id:
                 # Send a lightweight reference so the client fetches via HTTP.
                 # Do NOT call mark_delivered here — the client hasn't fetched yet.
@@ -561,13 +597,21 @@ class TranscriptionSession:
                 _sent_as_reference = True
             else:
                 # Send final result (best-effort — result is in DB regardless, or logged as lost above)
-                await self.send_message("final", result_payload)
+                _final_delivered = await self.send_message("final", result_payload)
 
             # Only mark delivered when result was actually sent inline (not as reference).
             # For result_ready, the GET /result/{job_id} endpoint marks delivered on fetch.
             # Skip mark_delivered entirely if save_result failed — the row is stuck in
             # 'processing' state and will be cleaned up by orphan recovery on restart.
-            if self._current_job_id and _result_persisted and not _sent_as_reference:
+            # ``_final_delivered`` is the honest signal: a salvage sends into a
+            # dead socket, and so does any client that vanished mid-processing.
+            # Marking those delivered would bury the result (GH-239).
+            if (
+                self._current_job_id
+                and _result_persisted
+                and not _sent_as_reference
+                and _final_delivered
+            ):
                 try:
                     _mark_delivered(self._current_job_id)
                 except Exception as _e:
@@ -858,6 +902,94 @@ class TranscriptionSession:
         finally:
             # Release the job slot when transcription is done
             self._release_job()
+
+    async def finalize_interrupted_recording(self) -> None:
+        """Salvage the buffered audio when the client vanishes mid-recording (GH-239).
+
+        A recording is only ever finalized by the ``stop`` message. When the
+        socket dies first, everything the user already streamed used to be
+        dropped on the floor and the job row sat in 'processing' until the
+        orphan sweep guessed at it - a once-in-a-lifetime lecture lost to a
+        Wi-Fi blip.
+
+        Runs the ordinary ``process_transcription()`` path rather than a
+        parallel one, which is what makes the head recoverable at all: that
+        path writes the PCM to ``recordings_dir`` and records ``audio_path``
+        before its first ``await``, so even a server that dies mid-salvage
+        leaves a job the user can drive through ``POST /retry/{job_id}``.
+
+        Called from the endpoint's ``finally`` while the job slot is still
+        held, so it cannot race a second job onto the single-slot tracker, and
+        the orphan sweep's ``is_busy()`` guard skips the row while it runs.
+        Never raises: teardown must continue no matter what happens here.
+        """
+        if not self.is_recording:
+            # A clean `stop` already finalized this session - or there was
+            # never a recording to finalize.
+            return
+
+        self.is_recording = False
+        if self._realtime_engine:
+            try:
+                self._realtime_engine.stop_recording()
+            except Exception as _engine_err:
+                logger.warning("Realtime engine stop failed during salvage: %s", _engine_err)
+
+        buffered_seconds = sum(len(chunk) for chunk in self.audio_chunks) / (2 * self.sample_rate)
+        if buffered_seconds < self._min_salvage_seconds():
+            # Junk-job guard: a connect-then-drop must not manufacture an empty
+            # result. Fail the row here rather than leaving the orphan sweep to
+            # infer a reason minutes later - this one is known exactly.
+            self.audio_chunks = []
+            logger.info(
+                "Discarding %.2fs of buffered audio for %s - below the salvage minimum",
+                buffered_seconds,
+                self.client_name,
+            )
+            if self._current_job_id:
+                try:
+                    _mark_failed(
+                        self._current_job_id,
+                        "Client disconnected mid-recording - "
+                        f"only {buffered_seconds:.1f}s of audio was captured, nothing to salvage",
+                    )
+                except Exception as _mf_err:
+                    logger.warning(
+                        "Failed to mark job %s as failed: %s", self._current_job_id, _mf_err
+                    )
+            return
+
+        logger.warning(
+            "Client %s disconnected mid-recording - salvaging %.1fs of buffered audio (job %s)",
+            self.client_name,
+            buffered_seconds,
+            sanitize_log_value(self._current_job_id or "none"),
+        )
+        self._salvage_reason = (
+            "Client disconnected mid-recording - this transcript covers only "
+            "the audio received before the connection dropped"
+        )
+        try:
+            await self.process_transcription()
+        except Exception:
+            # process_transcription() already persists and reports its own
+            # failures; anything escaping it must not abort session teardown.
+            logger.exception("Salvage of interrupted recording failed for %s", self.client_name)
+        finally:
+            self.audio_chunks = []
+
+    def _min_salvage_seconds(self) -> float:
+        """Shortest buffered head worth transcribing, in seconds."""
+        _DEFAULT = 3.0
+        try:
+            from server.config import get_config as _get_config
+
+            return float(
+                _get_config().get("durability", "min_salvage_seconds", default=_DEFAULT) or _DEFAULT
+            )
+        except Exception as _cfg_err:
+            logger.debug("Could not read min_salvage_seconds: %s", repr(_cfg_err))
+            return _DEFAULT
 
     def _release_job(self) -> None:
         """Release the job slot in the job tracker."""
@@ -1186,6 +1318,11 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
     finally:
         # Clean up session
         if session:
+            # GH-239: rescue whatever the client already streamed BEFORE
+            # cleanup() runs - cleanup() calls _release_job(), which clears
+            # _current_job_id and hands the single job slot to the next
+            # session, leaving the salvaged result with no row to land in.
+            await session.finalize_interrupted_recording()
             await session.cleanup()
             async with _sessions_lock:
                 if session.session_id in _connected_sessions:

--- a/server/backend/tests/test_cancel_wiring.py
+++ b/server/backend/tests/test_cancel_wiring.py
@@ -76,6 +76,33 @@ def test_cancellation_check_consults_the_job_tracker(module: str) -> None:
         )
 
 
+def test_websocket_disconnect_signal_is_muted_for_a_salvage() -> None:
+    """GH-239: the disconnect term must stay, and must stay salvage-aware.
+
+    ``_client_disconnected`` reads like dead code on this path, and today it is:
+    the receive loop that sets it is blocked inside ``handle_client_message``
+    for the whole of ``process_transcription``, so it cannot flip mid-run. That
+    is a property of the loop being synchronous, not a guarantee - ``preview``
+    already runs as a background task, and any future change that stops the
+    loop blocking makes this signal live again.
+
+    So it is kept deliberately, and this pins BOTH halves of the expression:
+    remove the disconnect term and a future non-blocking loop silently loses its
+    abort signal; remove the salvage mute and the GH-239 salvage cancels itself
+    on its first poll, re-losing exactly the audio it exists to rescue.
+    """
+    for call in _transcribe_calls(ROUTES / "websocket.py"):
+        src = _cancellation_source(call) or ""
+        assert "_client_disconnected" in src, (
+            f"cancellation_check={src!r} dropped the disconnect signal - see this "
+            "test's docstring before deleting it as unused"
+        )
+        assert "_salvage_reason" in src, (
+            f"cancellation_check={src!r} no longer mutes the disconnect signal "
+            "during a salvage, so the GH-239 salvage will cancel itself"
+        )
+
+
 def test_diarization_dispatch_forwards_cancellation_to_the_engine() -> None:
     """The GH-258 wrapper is only as cancellable as what it passes down.
 

--- a/server/backend/tests/test_p0_durability.py
+++ b/server/backend/tests/test_p0_durability.py
@@ -58,6 +58,8 @@ def _make_session(
     # GH-258: set by __init__ / start_recording, which this factory bypasses.
     session.diarization_enabled = False
     session.expected_speakers = None
+    # GH-239: None means "not a salvage run" - process_transcription reads it.
+    session._salvage_reason = None
     session.capabilities = SimpleNamespace(
         supports_binary_audio=True,
         preferred_sample_rate=sample_rate,

--- a/server/backend/tests/test_websocket_disconnect_salvage.py
+++ b/server/backend/tests/test_websocket_disconnect_salvage.py
@@ -1,0 +1,484 @@
+"""Tests for salvaging buffered head audio on a mid-recording WS disconnect (GH-239).
+
+A longform ``/ws`` session buffers client-streamed PCM but only ever transcribes
+it in ``process_transcription()``, which used to run exclusively on the ``stop``
+message. A mid-recording disconnect therefore discarded everything the user had
+already streamed, and left the job row stuck in 'processing' until the orphan
+sweep reaped it.
+
+Invariants covered here:
+  1. ``send_message`` reports whether the frame actually reached the client, and
+     a job is only marked delivered when it did. Otherwise a result nobody
+     received is hidden from the ``/recent`` recovery list.
+  2. A mid-recording disconnect with usable audio finalizes durably, flagged
+     ``partial`` so the UI can say the transcript is truncated.
+  3. The junk-job guard: a connect-then-drop with (almost) no audio must not
+     produce a saved result, and must reach a terminal state immediately.
+  4. Salvage must not cancel itself - ``_client_disconnected`` is True by
+     definition on this path, and it feeds the backend's ``cancellation_check``.
+
+Run:  ../../build/.venv/bin/pytest tests/test_websocket_disconnect_salvage.py -v --tb=short
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from server.api.routes import websocket as ws_mod
+from server.core import model_manager as mm_mod
+from starlette.websockets import WebSocketState
+
+
+@dataclass
+class _FakeResult:
+    """Duck-typed TranscriptionResult (avoids the torch/webrtcvad import chain)."""
+
+    text: str = "hello world"
+    segments: list[dict[str, Any]] = field(default_factory=list)
+    words: list[dict[str, Any]] = field(default_factory=list)
+    language: str | None = "en"
+    language_probability: float = 0.9
+    duration: float = 2.0
+    num_speakers: int = 0
+    partial: bool = False
+    partial_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "text": self.text,
+            "segments": self.segments,
+            "words": self.words,
+            "language": self.language,
+            "language_probability": self.language_probability,
+            "duration": self.duration,
+            "num_speakers": self.num_speakers,
+            "total_words": len(self.words),
+            "partial": self.partial,
+            "partial_reason": self.partial_reason,
+            "metadata": {"num_segments": len(self.segments)},
+        }
+
+
+def _pcm(seconds: float, sample_rate: int = 16000) -> bytes:
+    """`seconds` of Int16 mono PCM at `sample_rate`."""
+    return b"\x00\x01" * int(seconds * sample_rate)
+
+
+def _make_session(
+    *,
+    job_id: str | None = "job-001",
+    is_recording: bool = True,
+    audio_seconds: float = 5.0,
+    real_send: bool = False,
+):
+    """Build a TranscriptionSession without running the heavy __init__."""
+    session = object.__new__(ws_mod.TranscriptionSession)
+    session.websocket = MagicMock()
+    session.websocket.client_state = WebSocketState.CONNECTED
+    session.websocket.send_json = AsyncMock()
+    session.client_name = "test-client"
+    session.session_id = "sess-001"
+    session.is_recording = is_recording
+    session.language = None
+    session.audio_chunks = [_pcm(audio_seconds)] if audio_seconds else []
+    session.sample_rate = 16000
+    session.temp_file = None
+    session.translation_enabled = False
+    session.translation_target_language = "en"
+    session._preview_in_progress = False
+    session._preview_task = None
+    session._client_disconnected = True  # the whole point of this path
+    session._current_job_id = job_id
+    session._realtime_engine = None
+    session._use_realtime_engine = False
+    session.auto_add_to_notebook = False
+    session.diarization_enabled = False
+    session.expected_speakers = None
+    session._salvage_reason = None
+    if not real_send:
+        session.send_message = AsyncMock()
+    return session
+
+
+def _patch_transcription(monkeypatch, tmp_path, *, result: _FakeResult | None = None):
+    """Patch everything process_transcription() touches. Returns the fake engine."""
+    fake_engine = MagicMock()
+    fake_engine.model_name = "large-v3"
+    fake_engine.transcribe_file.return_value = result or _FakeResult()
+
+    fake_manager = MagicMock()
+    fake_manager.ensure_transcription_loaded.return_value = fake_engine
+    fake_manager.job_tracker.is_cancelled.return_value = False
+    fake_manager.job_tracker.get_status.return_value = {}
+    fake_manager.gpu_device_index = 0
+    monkeypatch.setattr(mm_mod, "get_model_manager", lambda: fake_manager)
+
+    monkeypatch.setattr(ws_mod, "_save_result", MagicMock())
+    monkeypatch.setattr(ws_mod, "_mark_delivered", MagicMock())
+    monkeypatch.setattr(ws_mod, "_mark_failed", MagicMock())
+    monkeypatch.setattr(ws_mod, "_set_audio_path", MagicMock())
+
+    import server.config as cfg_mod
+
+    fake_cfg = MagicMock()
+    fake_cfg.get.side_effect = lambda *a, **kw: (
+        str(tmp_path) if a[:2] == ("durability", "recordings_dir") else kw.get("default")
+    )
+    monkeypatch.setattr(cfg_mod, "get_config", lambda: fake_cfg)
+
+    import server.core.webhook as wh_mod
+
+    monkeypatch.setattr(wh_mod, "dispatch", AsyncMock())
+
+    return fake_engine
+
+
+def _saved_payload() -> dict[str, Any]:
+    """The result_json handed to _save_result, decoded."""
+    import json
+
+    return json.loads(ws_mod._save_result.call_args.kwargs["result_json"])
+
+
+# ── 1. send_message reports real delivery ──────────────────────────────────
+
+
+def test_send_message_reports_success():
+    session = _make_session(real_send=True)
+
+    assert asyncio.run(session.send_message("final", {"text": "hi"})) is True
+
+
+def test_send_message_reports_failure_when_socket_is_closed():
+    session = _make_session(real_send=True)
+    session.websocket.client_state = WebSocketState.DISCONNECTED
+
+    assert asyncio.run(session.send_message("final", {"text": "hi"})) is False
+
+
+def test_send_message_reports_failure_when_the_send_raises():
+    """starlette only flips client_state inside receive(), so a dead socket can
+    still read CONNECTED - the send itself is the only honest signal."""
+    session = _make_session(real_send=True)
+    session.websocket.send_json = AsyncMock(side_effect=RuntimeError("socket gone"))
+
+    assert asyncio.run(session.send_message("final", {"text": "hi"})) is False
+
+
+# ── 2. mark_delivered only on a real delivery ──────────────────────────────
+
+
+def test_undelivered_result_is_not_marked_delivered(monkeypatch, tmp_path):
+    """A result the client never received must stay delivered=0 so it surfaces
+    in the /recent recovery list instead of being silently buried."""
+    _patch_transcription(monkeypatch, tmp_path)
+    session = _make_session()
+    session.send_message = AsyncMock(return_value=False)
+
+    asyncio.run(session.process_transcription())
+
+    ws_mod._save_result.assert_called_once()
+    ws_mod._mark_delivered.assert_not_called()
+
+
+def test_delivered_result_is_still_marked_delivered(monkeypatch, tmp_path):
+    """The happy path must not regress."""
+    _patch_transcription(monkeypatch, tmp_path)
+    session = _make_session()
+    session.send_message = AsyncMock(return_value=True)
+
+    asyncio.run(session.process_transcription())
+
+    ws_mod._mark_delivered.assert_called_once_with("job-001")
+
+
+# ── 3. Salvage on a mid-recording disconnect ───────────────────────────────
+
+
+def test_disconnect_mid_recording_salvages_the_buffered_audio(monkeypatch, tmp_path):
+    """The GH-239 bug: this discarded the head audio and saved nothing."""
+    _patch_transcription(monkeypatch, tmp_path)
+    session = _make_session(audio_seconds=5.0)
+
+    asyncio.run(session.finalize_interrupted_recording())
+
+    ws_mod._save_result.assert_called_once()
+    assert ws_mod._save_result.call_args.kwargs["job_id"] == "job-001"
+    assert ws_mod._save_result.call_args.kwargs["result_text"] == "hello world"
+
+
+def test_salvaged_result_is_flagged_partial(monkeypatch, tmp_path):
+    """The transcript covers only what arrived before the drop - say so."""
+    _patch_transcription(monkeypatch, tmp_path)
+    session = _make_session(audio_seconds=5.0)
+
+    asyncio.run(session.finalize_interrupted_recording())
+
+    payload = _saved_payload()
+    assert payload["partial"] is True
+    assert "disconnect" in (payload["partial_reason"] or "").lower()
+
+
+def test_salvage_keeps_a_pre_existing_partial_reason(monkeypatch, tmp_path):
+    """A chunking backend that already gave up partway must not lose its reason."""
+    _patch_transcription(
+        monkeypatch,
+        tmp_path,
+        result=_FakeResult(partial=True, partial_reason="chunk 3 timed out"),
+    )
+    session = _make_session(audio_seconds=5.0)
+
+    asyncio.run(session.finalize_interrupted_recording())
+
+    reason = _saved_payload()["partial_reason"] or ""
+    assert "chunk 3 timed out" in reason
+    assert "disconnect" in reason.lower()
+
+
+def test_salvage_does_not_cancel_itself(monkeypatch, tmp_path):
+    """_client_disconnected is True by definition here and feeds the backend's
+    cancellation_check - left unguarded, the salvage aborts on its first poll."""
+    engine = _patch_transcription(monkeypatch, tmp_path)
+    session = _make_session(audio_seconds=5.0)
+
+    asyncio.run(session.finalize_interrupted_recording())
+
+    cancellation_check = engine.transcribe_file.call_args.kwargs["cancellation_check"]
+    assert cancellation_check() is False
+
+
+def test_salvage_still_honours_an_explicit_cancel(monkeypatch, tmp_path):
+    """POST /cancel must keep working during a salvage."""
+    engine = _patch_transcription(monkeypatch, tmp_path)
+    mm_mod.get_model_manager().job_tracker.is_cancelled.return_value = True
+    session = _make_session(audio_seconds=5.0)
+
+    asyncio.run(session.finalize_interrupted_recording())
+
+    cancellation_check = engine.transcribe_file.call_args.kwargs["cancellation_check"]
+    assert cancellation_check() is True
+
+
+def test_salvage_stops_the_realtime_engine_first(monkeypatch, tmp_path):
+    """VAD sessions keep a recorder running; it must be stopped before the
+    buffer is transcribed, exactly as the clean stop_recording() path does."""
+    _patch_transcription(monkeypatch, tmp_path)
+    session = _make_session(audio_seconds=5.0)
+    session._realtime_engine = MagicMock()
+
+    asyncio.run(session.finalize_interrupted_recording())
+
+    session._realtime_engine.stop_recording.assert_called_once()
+
+
+# ── 4. Junk-job guard ──────────────────────────────────────────────────────
+
+
+def test_connect_then_drop_saves_no_result(monkeypatch, tmp_path):
+    """Below the minimum, a salvage would only manufacture an empty job."""
+    _patch_transcription(monkeypatch, tmp_path)
+    session = _make_session(audio_seconds=0.5)
+
+    asyncio.run(session.finalize_interrupted_recording())
+
+    ws_mod._save_result.assert_not_called()
+
+
+def test_connect_then_drop_reaches_a_terminal_state(monkeypatch, tmp_path):
+    """Leaving the row in 'processing' means waiting on the orphan sweep to
+    guess. The disconnect is not a guess - fail it now, with the real reason."""
+    _patch_transcription(monkeypatch, tmp_path)
+    session = _make_session(audio_seconds=0.5)
+
+    asyncio.run(session.finalize_interrupted_recording())
+
+    ws_mod._mark_failed.assert_called_once()
+    assert ws_mod._mark_failed.call_args[0][0] == "job-001"
+    assert "disconnect" in ws_mod._mark_failed.call_args[0][1].lower()
+
+
+def test_no_audio_at_all_is_handled(monkeypatch, tmp_path):
+    _patch_transcription(monkeypatch, tmp_path)
+    session = _make_session(audio_seconds=0)
+
+    asyncio.run(session.finalize_interrupted_recording())
+
+    ws_mod._save_result.assert_not_called()
+    ws_mod._mark_failed.assert_called_once()
+
+
+def test_min_salvage_seconds_is_configurable(monkeypatch, tmp_path):
+    """An 8s head is salvaged by default, but not when the operator raises the
+    floor above it."""
+    _patch_transcription(monkeypatch, tmp_path)
+    import server.config as cfg_mod
+
+    fake_cfg = MagicMock()
+    fake_cfg.get.side_effect = lambda *a, **kw: (
+        str(tmp_path)
+        if a[:2] == ("durability", "recordings_dir")
+        else 30.0
+        if a[:2] == ("durability", "min_salvage_seconds")
+        else kw.get("default")
+    )
+    monkeypatch.setattr(cfg_mod, "get_config", lambda: fake_cfg)
+    session = _make_session(audio_seconds=8.0)
+
+    asyncio.run(session.finalize_interrupted_recording())
+
+    ws_mod._save_result.assert_not_called()
+
+
+# ── 5. No double-finalize ──────────────────────────────────────────────────
+
+
+def test_clean_stop_is_not_salvaged_again(monkeypatch, tmp_path):
+    """stop_recording() clears is_recording before transcribing, so the
+    teardown that follows must not run a second transcription."""
+    _patch_transcription(monkeypatch, tmp_path)
+    session = _make_session(is_recording=False, audio_seconds=5.0)
+
+    asyncio.run(session.finalize_interrupted_recording())
+
+    ws_mod._save_result.assert_not_called()
+    ws_mod._mark_failed.assert_not_called()
+
+
+def test_salvage_clears_is_recording(monkeypatch, tmp_path):
+    """Guards against a re-entrant second salvage."""
+    _patch_transcription(monkeypatch, tmp_path)
+    session = _make_session(audio_seconds=5.0)
+
+    asyncio.run(session.finalize_interrupted_recording())
+
+    assert session.is_recording is False
+
+
+def test_drop_without_a_job_row_saves_nothing(monkeypatch, tmp_path):
+    """No job_id means create_job failed at start - there is nothing to attach
+    a result to, and mark_failed has no row to touch."""
+    _patch_transcription(monkeypatch, tmp_path)
+    session = _make_session(job_id=None, audio_seconds=0.5)
+
+    asyncio.run(session.finalize_interrupted_recording())
+
+    ws_mod._save_result.assert_not_called()
+    ws_mod._mark_failed.assert_not_called()
+
+
+# ── 6. Salvage must never break connection teardown ────────────────────────
+
+
+def test_salvage_failure_does_not_propagate(monkeypatch, tmp_path):
+    """This runs in the endpoint's finally block. An exception escaping here
+    would skip session cleanup and leak the job slot."""
+    _patch_transcription(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        ws_mod.TranscriptionSession,
+        "process_transcription",
+        AsyncMock(side_effect=RuntimeError("boom")),
+    )
+    session = _make_session(audio_seconds=5.0)
+
+    asyncio.run(session.finalize_interrupted_recording())  # must not raise
+
+
+# ── 7. Endpoint wiring ─────────────────────────────────────────────────────
+
+
+def _endpoint_finally_calls() -> list[str]:
+    """Awaited method names in websocket_endpoint's finally block, in order."""
+    import ast
+    from pathlib import Path
+
+    source = (Path(ws_mod.__file__)).read_text()
+    tree = ast.parse(source)
+    endpoint = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "websocket_endpoint"
+    )
+    handler = next(
+        node for node in ast.walk(endpoint) if isinstance(node, ast.Try) and node.finalbody
+    )
+    return [
+        node.func.attr
+        for stmt in handler.finalbody
+        for node in ast.walk(stmt)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    ]
+
+
+def test_endpoint_salvages_before_releasing_the_job_slot():
+    """cleanup() calls _release_job(), which drops _current_job_id - salvage
+    after it would persist the result nowhere."""
+    calls = _endpoint_finally_calls()
+
+    assert "finalize_interrupted_recording" in calls, (
+        "websocket_endpoint's finally must salvage the buffered audio (GH-239)"
+    )
+    assert calls.index("finalize_interrupted_recording") < calls.index("cleanup")
+
+
+def _drive_endpoint(monkeypatch, session_holder: dict, order: list[str]):
+    """Run websocket_endpoint against a socket that drops immediately."""
+    auth = MagicMock()
+    auth.client_name = "test-client"
+    auth.is_admin = False
+    auth.is_localhost_bypass = False
+    monkeypatch.setattr(ws_mod, "authenticate_websocket_from_message", AsyncMock(return_value=auth))
+
+    async def _record_salvage(self):
+        order.append("salvage")
+
+    async def _record_cleanup(self):
+        order.append("cleanup")
+
+    monkeypatch.setattr(
+        ws_mod.TranscriptionSession, "finalize_interrupted_recording", _record_salvage
+    )
+    monkeypatch.setattr(ws_mod.TranscriptionSession, "cleanup", _record_cleanup)
+
+    websocket = MagicMock()
+    websocket.accept = AsyncMock()
+    websocket.headers = {}
+    websocket.query_params = {}
+    websocket.client = MagicMock(host="127.0.0.1")
+    websocket.client_state = WebSocketState.DISCONNECTED  # sends become no-ops
+    websocket.receive = AsyncMock(return_value={"type": "websocket.disconnect"})
+
+    asyncio.run(ws_mod.websocket_endpoint(websocket))
+    session_holder["sessions"] = dict(ws_mod._connected_sessions)
+
+
+def test_endpoint_runs_the_salvage_hook_on_a_drop(monkeypatch):
+    """AST order is necessary but not sufficient - prove the call actually fires."""
+    order: list[str] = []
+    _drive_endpoint(monkeypatch, {}, order)
+
+    assert order == ["salvage", "cleanup"]
+
+
+def test_endpoint_deregisters_the_session_after_a_drop(monkeypatch):
+    """A salvage that leaked the session would keep it in _connected_sessions."""
+    holder: dict = {}
+    _drive_endpoint(monkeypatch, holder, [])
+
+    assert holder["sessions"] == {}
+
+
+@pytest.mark.parametrize("audio_seconds", [5.0, 0.5])
+def test_salvage_releases_the_buffer(monkeypatch, tmp_path, audio_seconds):
+    """A long recording's PCM buffer can be ~100 MB; the session object may
+    outlive this call in _connected_sessions until the endpoint's finally
+    removes it."""
+    _patch_transcription(monkeypatch, tmp_path)
+    session = _make_session(audio_seconds=audio_seconds)
+
+    asyncio.run(session.finalize_interrupted_recording())
+
+    assert session.audio_chunks == []

--- a/server/backend/tests/test_websocket_notebook_autoadd.py
+++ b/server/backend/tests/test_websocket_notebook_autoadd.py
@@ -81,6 +81,8 @@ def _make_session(*, auto_add: bool = False, job_id: str | None = "job-001"):
     # GH-258: set by __init__ / start_recording, which this factory bypasses.
     session.diarization_enabled = False
     session.expected_speakers = None
+    # GH-239: None means "not a salvage run" - process_transcription reads it.
+    session._salvage_reason = None
     session.send_message = AsyncMock()
     return session
 

--- a/server/config.yaml
+++ b/server/config.yaml
@@ -762,6 +762,15 @@ durability:
     # Default: 30
     orphan_sweep_interval_minutes: 30
 
+    # GH-239: when a recording session's connection drops before the client
+    # sends `stop`, the server transcribes and saves whatever audio it already
+    # received, flagged as a partial result. This is the shortest buffered head
+    # worth doing that for, in seconds - below it the audio is discarded and the
+    # job is marked failed, so a client that connects and immediately drops does
+    # not litter the job history with empty results.
+    # Default: 3
+    min_salvage_seconds: 3
+
 # Issue #104, Sprint 4 — auto-summary and auto-export coordinator settings.
 auto_actions:
     # How often (in seconds) the deferred-export sweeper re-checks rows whose


### PR DESCRIPTION
Closes #239.

A longform `/ws` session buffers client-streamed PCM but only ever transcribed it on the `stop` message. A mid-recording disconnect discarded everything the user had already streamed and left the job row in `processing` until the orphan sweep reaped it. #238 made the client fail loudly instead of truncating silently; this is the server half that makes the head recoverable.

## How the salvage works

`TranscriptionSession.finalize_interrupted_recording()` runs from the endpoint's `finally`, **before** `cleanup()` releases the job slot and clears `_current_job_id`.

It deliberately reuses the ordinary `process_transcription()` path instead of a parallel one. That path writes the PCM to `recordings_dir` and records `audio_path` before its first `await`, so even a server that dies mid-salvage leaves a job the user can drive through `POST /retry/{job_id}`. Holding the job slot for the duration also means it cannot race a second job onto the single-slot tracker, and the orphan sweep's `is_busy()` guard skips the row while it runs.

The result is stamped `partial` with a reason, which SessionView already renders as its amber truncation banner. A pre-existing partial reason (chunking backend gave up) is kept alongside it rather than overwritten.

## Two traps this had to clear

**The salvage would have cancelled itself.** `cancellation_check` reads `_client_disconnected`, which is True by definition on this path. Left alone, the salvage aborts on its first poll and re-loses exactly the audio it exists to rescue. `_salvage_reason` mutes it; an explicit `POST /cancel` still stops the run. One field serves as both the "salvage in progress" marker and the `partial_reason` text, so the two cannot drift.

**The result would have been marked delivered to nobody.** `send_message()` swallowed the send failure and returned `None`, so callers could not tell. starlette flips `client_state` to DISCONNECTED only inside `receive()`, so a socket whose peer has vanished still reads CONNECTED and the failure surfaces as a raised send. Treating that as delivered set `delivered=1` and hid the result from the `/recent` recovery list. `send_message()` now returns whether the frame went out, and `mark_delivered` is gated on it.

That gate is what makes the salvage discoverable with no special case: it sends into a dead socket, fails the gate, and stays `delivered=0`. Note this also changes the normal delivery path, which is the widest-reaching part of the diff and worth a close look.

## Junk-job guard

`durability.min_salvage_seconds` (default 3) is the shortest buffered head worth transcribing. Below it the audio is discarded and the job is marked failed with the real reason, rather than left for the orphan sweep to infer one minutes later. A connect-then-drop client cannot litter the job history with empty results.

## Client side

- A mid-recording drop with a known `job_id` now polls `GET /result/{job_id}` and loads the partial when it lands. The interruption is still announced and the reconnect is still halted, so no zombie session is spawned (#237). A drop with no `job_id` keeps the terminal error: there is no row to salvage into.
- The poll budget is now a wall-clock deadline instead of a ten-attempt cap, which gave up after 30 seconds, far short of the time needed to transcribe a real recording. Network errors keep their own small budget, since an unreachable server will not produce a result however long we wait.
- The recovery path carries `num_speakers` and `diarization` through, matching the `result_ready` path, and clears the red banner on success so it does not sit beside a recovered transcript.

## Two follow-ups folded in

**The recovery banner went stale after mount.** It was fetched exactly once, so a result that landed afterwards stayed invisible until the view was remounted, which this change makes reachable in normal use. It now re-checks when a session ends in error and when the window regains focus, and it filters out the job whose transcript is already on screen.

**The disconnect term is pinned, with its reasoning.** `_client_disconnected` reads like dead code in `cancellation_check`, and today it is: the receive loop that sets it is blocked inside `handle_client_message` for the whole of `process_transcription`, so it cannot flip mid-run. That is a property of the loop being synchronous, not a guarantee, since `preview` already runs as a background task. The guard in `test_cancel_wiring.py` pins both halves and explains why, so neither is removed as unused. Both regressions were reproduced against the guard before it was trusted.

## Known interaction

The salvage holds the single job slot while it runs, so a user who hits Start again immediately gets `session_busy`. That is the honest answer, and the recovery state on screen discourages it.

## Verification

| Check | Result |
| --- | --- |
| Backend pytest (full suite) | 2368 passed, 4 skipped |
| Dashboard vitest (full suite) | 139 files, 2010 passed |
| tsc, eslint, ruff format + check | clean |
| ui-contract validate + test | passed (22 checks) |

New tests: 24 backend covering the salvage, the junk guard, the delivery gate and the endpoint wiring, plus 9 vitest for the client recovery and 6 for the banner refresh.

The GH-237 fail-loudly test now asserts the recoverable status, with a note on why the terminal one was the old contract.

## Smoke test checklist (not yet run)

jsdom cannot cut a real WebSocket, so these need hardware:

- [ ] Start a recording, let it run about 30 seconds, then kill the network (or stop the container). The transcript should come back on its own with the amber "incomplete" banner and a working Retry.
- [ ] Same, but with a long recording (several minutes), to confirm the poll budget outlasts the transcription.
- [ ] Connect and drop within a second. No result should be saved; the job should show as failed with the "nothing to salvage" reason, not sit in `processing`.
- [ ] Drop mid-recording, then press Start again immediately. Expect `session_busy` until the salvage finishes.
- [ ] Drop with diarization enabled, and confirm the speaker labels survive into the salvaged transcript.
- [ ] Leave the app during a salvage and come back, to confirm the recovery banner refreshes on focus.
