### PR TITLE
feat(server, dashboard): retroactive diarization for saved notes and Markdown export (GH-279)

### DIFF
--- a/dashboard/components/__tests__/NoteActionMenu.test.tsx
+++ b/dashboard/components/__tests__/NoteActionMenu.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * NoteActionMenu — Diarize + Export Markdown wiring (GH-279).
+ *
+ * The calendar-card context menu must:
+ *   1. Offer an enabled Diarize item for a non-diarized note WITH word
+ *      timestamps, and clicking it must start the retro-diarize job and
+ *      close the menu.
+ *   2. Disable Diarize (with an explanatory title tooltip) when the note has
+ *      no word-level timestamps (wordCount === 0).
+ *   3. Hide Diarize entirely once the note is diarized.
+ *   4. Offer Export Markdown wired to getExportUrl(id, 'md').
+ */
+
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks (mirror NotebookView.test.tsx — the module graph is shared) ──────
+
+vi.mock('../../src/hooks/useCalendar', () => ({
+  useCalendar: () => ({
+    days: {},
+    totalRecordings: 0,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/hooks/useSearch', () => ({
+  useSearch: () => ({ results: [], count: 0, loading: false, error: null, search: vi.fn() }),
+}));
+
+vi.mock('../../src/hooks/useLanguages', () => ({
+  useLanguages: () => ({
+    languages: [{ code: 'en', name: 'English' }],
+    backendType: 'whisper',
+    loading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('../../src/hooks/useAdminStatus', () => ({
+  useAdminStatus: () => ({ status: null, loading: false, error: null, refresh: vi.fn() }),
+}));
+
+vi.mock('../../src/hooks/useNotebookWatcher', () => ({
+  useNotebookWatcher: () => ({
+    notebookWatchPath: '',
+    notebookWatchActive: false,
+    notebookWatchAccessible: true,
+    setNotebookWatchPath: vi.fn(),
+    toggleNotebookWatch: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/stores/importQueueStore', () => ({
+  useImportQueueStore: (selector: (s: Record<string, unknown>) => unknown) => {
+    const state = {
+      jobs: [],
+      isPaused: false,
+      notebookCallbacks: {},
+      updateNotebookCallbacks: vi.fn(),
+      updateNotebookConfig: vi.fn(),
+      enqueueFiles: vi.fn(),
+      enqueueNotebookFiles: vi.fn(),
+    };
+    return typeof selector === 'function' ? selector(state) : state;
+  },
+  selectNotebookJobs: () => [],
+  selectPendingCount: () => 0,
+  selectCompletedCount: () => 0,
+  selectErrorCount: () => 0,
+  selectIsProcessing: () => false,
+}));
+
+const mockGetExportUrl = vi.fn().mockReturnValue('http://localhost/export');
+
+vi.mock('../../src/api/client', () => ({
+  apiClient: {
+    getCalendar: vi.fn().mockResolvedValue({ days: {}, total_recordings: 0 }),
+    getAdminStatus: vi.fn().mockResolvedValue(null),
+    search: vi.fn().mockResolvedValue({ results: [], count: 0 }),
+    updateRecordingTitle: vi.fn(),
+    deleteRecording: vi.fn(),
+    getExportUrl: (...args: unknown[]) => mockGetExportUrl(...args),
+  },
+}));
+
+vi.mock('../../src/config/store', () => ({
+  getConfig: vi.fn().mockResolvedValue(undefined),
+  setConfig: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../src/utils/transcriptionBackend', () => ({
+  supportsExplicitWordTimestampToggle: () => true,
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('../../src/hooks/useConfirm', () => ({
+  useConfirm: () => ({ confirm: vi.fn().mockResolvedValue(true), dialog: null }),
+}));
+
+vi.mock('zustand/react/shallow', () => ({
+  useShallow: (selector: unknown) => selector,
+}));
+
+const mockDiarizeAndWait = vi.fn();
+
+vi.mock('../../src/services/retroDiarize', () => ({
+  diarizeRecordingAndWait: (...args: unknown[]) => mockDiarizeAndWait(...args),
+}));
+
+// ── Import after mocks ────────────────────────────────────────────────────
+
+import { NoteActionMenu } from '../views/NotebookView';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function renderMenu(overrides: Partial<React.ComponentProps<typeof NoteActionMenu>> = {}) {
+  const onClose = vi.fn();
+  const onRefresh = vi.fn();
+  render(
+    React.createElement(NoteActionMenu, {
+      trigger: { type: 'point' as const, x: 10, y: 10 },
+      onClose,
+      noteEventId: '5',
+      recordingId: 5,
+      noteTitle: 'Test Note',
+      wordCount: 12,
+      hasDiarization: false,
+      onRefresh,
+      onPlay: vi.fn(),
+      ...overrides,
+    }),
+  );
+  return { onClose, onRefresh };
+}
+
+function findMenuButton(label: string): HTMLButtonElement | null {
+  const buttons = Array.from(document.body.querySelectorAll('button'));
+  return (buttons.find((b) => b.textContent?.trim() === label) as HTMLButtonElement) ?? null;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('NoteActionMenu — Diarize + Export Markdown wiring (GH-279)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDiarizeAndWait.mockResolvedValue({ job_id: 'abc12345', recording_id: 5 });
+    mockGetExportUrl.mockReturnValue('http://localhost/export');
+    document.body.innerHTML = '';
+  });
+
+  it('offers an enabled Diarize item that starts the job and closes the menu', async () => {
+    const { onClose } = renderMenu();
+
+    const diarize = findMenuButton('Diarize');
+    expect(diarize).toBeTruthy();
+    expect(diarize?.disabled).toBe(false);
+
+    await act(async () => {
+      fireEvent.click(diarize as Element);
+    });
+    expect(mockDiarizeAndWait).toHaveBeenCalledWith(5);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('refreshes the calendar once the diarize job resolves successfully', async () => {
+    let resolveJob: (v: unknown) => void = () => undefined;
+    mockDiarizeAndWait.mockReturnValue(
+      new Promise((resolve) => {
+        resolveJob = resolve;
+      }),
+    );
+    const { onRefresh } = renderMenu();
+
+    await act(async () => {
+      fireEvent.click(findMenuButton('Diarize') as Element);
+    });
+    expect(onRefresh).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveJob({ job_id: 'abc12345', recording_id: 5 });
+      await Promise.resolve();
+    });
+    expect(onRefresh).toHaveBeenCalled();
+  });
+
+  it('disables Diarize with a tooltip when the note has no word timestamps', async () => {
+    renderMenu({ wordCount: 0 });
+
+    const diarize = findMenuButton('Diarize');
+    expect(diarize).toBeTruthy();
+    expect(diarize?.disabled).toBe(true);
+    expect(diarize?.title).toMatch(/word-level timestamps/);
+
+    await act(async () => {
+      fireEvent.click(diarize as Element);
+    });
+    expect(mockDiarizeAndWait).not.toHaveBeenCalled();
+  });
+
+  it('hides Diarize for an already-diarized note', () => {
+    renderMenu({ hasDiarization: true });
+
+    expect(findMenuButton('Diarize')).toBeNull();
+    // The rest of the menu is intact.
+    expect(findMenuButton('Export TXT')).toBeTruthy();
+    expect(findMenuButton('Delete')).toBeTruthy();
+  });
+
+  it('offers Export Markdown wired to the md export URL', async () => {
+    const windowOpen = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const { onClose } = renderMenu();
+
+    const exportMd = findMenuButton('Export Markdown');
+    expect(exportMd).toBeTruthy();
+    await act(async () => {
+      fireEvent.click(exportMd as Element);
+    });
+    expect(mockGetExportUrl).toHaveBeenCalledWith(5, 'md');
+    expect(windowOpen).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+    windowOpen.mockRestore();
+  });
+});

--- a/dashboard/components/views/AudioNoteModal.tsx
+++ b/dashboard/components/views/AudioNoteModal.tsx
@@ -29,6 +29,7 @@ import {
   Copy,
   MoreHorizontal,
   Download,
+  Users,
 } from 'lucide-react';
 import { Button } from '../ui/Button';
 import { StatusLight } from '../ui/StatusLight';
@@ -37,6 +38,7 @@ import { useRecording } from '../../src/hooks/useRecording';
 import { apiClient } from '../../src/api/client';
 import { FindReplaceTextEditor } from '../editor/FindReplaceTextEditor';
 import { flattenSegmentsToText } from '../../src/services/transcriptFlatten';
+import { diarizeRecordingAndWait } from '../../src/services/retroDiarize';
 import { toast } from 'sonner';
 import { useConfirm } from '../../src/hooks/useConfirm';
 import { ConfidenceChip } from '../recording/ConfidenceChip';
@@ -578,6 +580,16 @@ export const AudioNoteModal: React.FC<AudioNoteModalProps> = ({
   // the modal header. Mirrors the row-level NoteActionMenu in NotebookView so
   // users can manage the recording without closing the modal first.
   const [optionsMenuOpen, setOptionsMenuOpen] = useState(false);
+  // GH-279 — retroactive diarization in-flight flag (disables the menu item).
+  const [diarizeRunning, setDiarizeRunning] = useState(false);
+  // GH-279 — the modal instance survives note switches (no key prop), so an
+  // in-flight diarize job must know whether the note it started for is still
+  // the one on screen before touching shared useRecording state.
+  const activeRecordingIdRef = useRef<number | null>(null);
+  useEffect(() => {
+    activeRecordingIdRef.current = note?.recordingId ?? null;
+    setDiarizeRunning(false);
+  }, [note?.recordingId]);
   const [recordingRenameDialog, setRecordingRenameDialog] = useState<{
     currentTitle: string;
   } | null>(null);
@@ -1730,7 +1742,7 @@ export const AudioNoteModal: React.FC<AudioNoteModalProps> = ({
 
   /** Open the recording export download for the requested format. */
   const handleRecordingExport = useCallback(
-    (format: 'txt' | 'srt' | 'ass') => {
+    (format: 'txt' | 'srt' | 'ass' | 'md') => {
       setOptionsMenuOpen(false);
       if (!note?.recordingId) return;
       const url = apiClient.getExportUrl(note.recordingId, format);
@@ -1746,6 +1758,42 @@ export const AudioNoteModal: React.FC<AudioNoteModalProps> = ({
   );
 
   /**
+   * GH-279 — retroactively diarize this recording. Waits for the server job
+   * and reloads the transcript so the speaker turns appear in place.
+   *
+   * The completion path only touches useRecording state while the note it
+   * started for is still the active one: the modal instance is shared across
+   * notes, so a stale `refresh()` after a note switch would clobber the
+   * currently-open note's transcript with this recording's data.
+   */
+  const handleDiarize = useCallback(async () => {
+    setOptionsMenuOpen(false);
+    const startedForId = note?.recordingId;
+    if (!startedForId || diarizeRunning) return;
+    setDiarizeRunning(true);
+    toast.info('Diarization started — identifying speakers.');
+    try {
+      const result = await diarizeRecordingAndWait(startedForId);
+      if (result.error) {
+        toast.error(`Diarization failed: ${result.error}`);
+        return;
+      }
+      toast.success(result.message || 'Diarization complete.');
+      onRecordingMutated?.();
+      if (activeRecordingIdRef.current === startedForId) {
+        refresh();
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Diarization failed.';
+      toast.error(message);
+    } finally {
+      if (activeRecordingIdRef.current === startedForId) {
+        setDiarizeRunning(false);
+      }
+    }
+  }, [note?.recordingId, diarizeRunning, refresh, onRecordingMutated]);
+
+  /**
    * Issue #104, Story 3.5 — download the FR9-format plain-text transcript
    * via the native OS file-save dialog. Uses the new `format=plaintext`
    * branch on the export route (StreamingResponse, paragraph per speaker
@@ -1754,7 +1802,7 @@ export const AudioNoteModal: React.FC<AudioNoteModalProps> = ({
   const handleDownloadPlaintextTranscript = useCallback(async () => {
     setOptionsMenuOpen(false);
     if (!note?.recordingId) return;
-    const url = apiClient.getExportUrl(note.recordingId, 'plaintext' as never);
+    const url = apiClient.getExportUrl(note.recordingId, 'plaintext');
     if (url === null) {
       toast.error('Remote host not configured. Open Settings → Connection.');
       return;
@@ -2058,6 +2106,30 @@ export const AudioNoteModal: React.FC<AudioNoteModalProps> = ({
                           >
                             <Edit2 size={14} /> Rename
                           </button>
+                          {/* GH-279 — retroactive diarization. Hidden once
+                              diarized; disabled with a tooltip when the note
+                              has no word-level timestamps to align against. */}
+                          {!hasDiarizationTranscript && (
+                            <button
+                              onClick={handleDiarize}
+                              disabled={!hasWordTimestamps || diarizeRunning}
+                              title={
+                                !hasWordTimestamps
+                                  ? 'Diarization requires word-level timestamps, which this note was transcribed without.'
+                                  : diarizeRunning
+                                    ? 'Diarization in progress.'
+                                    : undefined
+                              }
+                              className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-slate-300 hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-slate-300"
+                            >
+                              {diarizeRunning ? (
+                                <Loader2 size={14} className="animate-spin" />
+                              ) : (
+                                <Users size={14} />
+                              )}
+                              {diarizeRunning ? 'Diarizing…' : 'Diarize'}
+                            </button>
+                          )}
                           {/* Issue #104, Story 3.5 — Download transcript /
                               Download summary use the new plain-text streaming
                               format + native save dialog. The verbose Export
@@ -2100,6 +2172,12 @@ export const AudioNoteModal: React.FC<AudioNoteModalProps> = ({
                             className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-slate-300 hover:bg-white/10 hover:text-white"
                           >
                             <Download size={14} /> Export ASS
+                          </button>
+                          <button
+                            onClick={() => handleRecordingExport('md')}
+                            className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-slate-300 hover:bg-white/10 hover:text-white"
+                          >
+                            <Download size={14} /> Export Markdown
                           </button>
                           <div className="my-1 h-px bg-white/10"></div>
                           <button

--- a/dashboard/components/views/NotebookView.tsx
+++ b/dashboard/components/views/NotebookView.tsx
@@ -27,6 +27,7 @@ import {
   Pause,
   FolderOpen,
   WifiOff,
+  Users,
 } from 'lucide-react';
 import { GlassCard } from '../ui/GlassCard';
 import { Button } from '../ui/Button';
@@ -52,6 +53,7 @@ import { apiClient } from '../../src/api/client';
 import type { AdminStatus, Recording } from '../../src/api/types';
 import { jobTrackerFromAdminStatus } from '../../src/api/types';
 import { describeJobProgress } from '../../src/services/jobProgress';
+import { diarizeRecordingAndWait } from '../../src/services/retroDiarize';
 import { supportsExplicitWordTimestampToggle as supportsExplicitWordTimestampToggleForModel } from '../../src/utils/transcriptionBackend';
 import {
   isCanaryModel,
@@ -255,16 +257,24 @@ interface MenuProps {
   noteEventId: string;
   recordingId: number | null;
   noteTitle: string;
+  // GH-279 — Diarize gating: hidden when already diarized, disabled with a
+  // tooltip when the note has no word-level timestamps (wordCount === 0).
+  wordCount: number;
+  hasDiarization: boolean;
   onRefresh: () => void | Promise<void>;
   onPlay: (id: string) => void;
 }
 
-const NoteActionMenu: React.FC<MenuProps> = ({
+// Exported for direct component testing (NoteActionMenu.test.tsx) — the menu
+// is otherwise reachable only through the full calendar render tree.
+export const NoteActionMenu: React.FC<MenuProps> = ({
   trigger,
   onClose,
   noteEventId,
   recordingId,
   noteTitle,
+  wordCount,
+  hasDiarization,
   onRefresh,
   onPlay,
 }) => {
@@ -312,7 +322,7 @@ const NoteActionMenu: React.FC<MenuProps> = ({
     onClose();
   };
 
-  const handleExport = (format: 'txt' | 'srt' | 'ass') => {
+  const handleExport = (format: 'txt' | 'srt' | 'ass' | 'md') => {
     const targetId = getValidRecordingId();
     if (targetId === null) {
       toast.error('Invalid recording ID.');
@@ -326,6 +336,32 @@ const NoteActionMenu: React.FC<MenuProps> = ({
       return;
     }
     window.open(url, '_blank');
+    onClose();
+  };
+
+  // GH-279 — fire-and-forget: the poll survives the menu unmount, and the
+  // captured onRefresh repaints the calendar when the job completes.
+  const handleDiarize = () => {
+    const targetId = getValidRecordingId();
+    if (targetId === null) {
+      toast.error('Invalid recording ID.');
+      onClose();
+      return;
+    }
+    toast.info(`Diarization started for "${noteTitle}" — identifying speakers.`);
+    diarizeRecordingAndWait(targetId)
+      .then(async (result) => {
+        if (result.error) {
+          toast.error(`Diarization failed: ${result.error}`);
+          return;
+        }
+        await Promise.resolve(onRefresh());
+        toast.success(result.message || `Diarization complete for "${noteTitle}".`);
+      })
+      .catch((err) => {
+        const message = err instanceof Error ? err.message : 'Diarization failed.';
+        toast.error(message);
+      });
     onClose();
   };
 
@@ -500,6 +536,21 @@ const NoteActionMenu: React.FC<MenuProps> = ({
                 Rename
               </button>
             )}
+            {!hasDiarization && (
+              <button
+                onClick={handleDiarize}
+                disabled={wordCount === 0}
+                title={
+                  wordCount === 0
+                    ? 'Diarization requires word-level timestamps, which this note was transcribed without.'
+                    : undefined
+                }
+                className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-xs text-slate-300 transition-colors hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-slate-300"
+              >
+                <Users size={14} />
+                Diarize
+              </button>
+            )}
             <button
               onClick={() => handleExport('txt')}
               className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-xs text-slate-300 transition-colors hover:bg-white/10 hover:text-white"
@@ -520,6 +571,13 @@ const NoteActionMenu: React.FC<MenuProps> = ({
             >
               <Download size={14} />
               Export ASS
+            </button>
+            <button
+              onClick={() => handleExport('md')}
+              className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-xs text-slate-300 transition-colors hover:bg-white/10 hover:text-white"
+            >
+              <Download size={14} />
+              Export Markdown
             </button>
             <div className="mx-2 my-1 h-px bg-white/5"></div>
             <button
@@ -675,6 +733,10 @@ interface EventData {
   tag?: string;
   startTime: number;
   recordingId?: number;
+  // GH-279 — gate the context-menu Diarize action without a per-note fetch.
+  // wordCount > 0 means word-level timestamps exist in the words table.
+  wordCount?: number;
+  hasDiarization?: boolean;
 }
 
 const TimeSection: React.FC<{
@@ -711,6 +773,8 @@ const TimeSection: React.FC<{
     id: string;
     recordingId: number | null;
     title: string;
+    wordCount: number;
+    hasDiarization: boolean;
     trigger: MenuTrigger;
   } | null>(null);
   const isCompact = visibleSlots >= 4;
@@ -806,6 +870,8 @@ const TimeSection: React.FC<{
       id: evt.id,
       recordingId: evt.recordingId ?? null,
       title: evt.title,
+      wordCount: evt.wordCount ?? 0,
+      hasDiarization: evt.hasDiarization ?? false,
       trigger: { type: 'point', x: e.clientX, y: e.clientY },
     });
   };
@@ -928,6 +994,8 @@ const TimeSection: React.FC<{
                                     id: evt.id,
                                     recordingId: evt.recordingId ?? null,
                                     title: evt.title,
+                                    wordCount: evt.wordCount ?? 0,
+                                    hasDiarization: evt.hasDiarization ?? false,
                                     trigger: { type: 'rect', rect },
                                   });
                                 }}
@@ -983,6 +1051,8 @@ const TimeSection: React.FC<{
           noteEventId={activeMenu.id}
           recordingId={activeMenu.recordingId}
           noteTitle={activeMenu.title}
+          wordCount={activeMenu.wordCount}
+          hasDiarization={activeMenu.hasDiarization}
           onRefresh={onRefresh}
           onPlay={(id) => {
             const evt = events.find((e) => e.id === id);
@@ -1015,6 +1085,8 @@ const recordingToEvent = (rec: Recording): EventData => {
     duration: formatDuration(rec.duration_seconds),
     tag: rec.has_diarization ? 'Diarized' : undefined,
     recordingId: rec.id,
+    wordCount: rec.word_count ?? 0,
+    hasDiarization: Boolean(rec.has_diarization),
   };
 };
 
@@ -1089,6 +1161,17 @@ const CalendarTab: React.FC<{
 
   // Live calendar data from API
   const calendar = useCalendar(year, month);
+
+  // GH-279 — latest-ref wrapper for menu-triggered refreshes. Menu actions
+  // (rename, delete, and especially the long-running Diarize completion)
+  // capture onRefresh in closures that may resolve after the user navigated
+  // to another month; calling the captured calendar.refresh directly would
+  // refetch the OLD month and overwrite the current month's day data.
+  const calendarRefreshRef = useRef(calendar.refresh);
+  useEffect(() => {
+    calendarRefreshRef.current = calendar.refresh;
+  }, [calendar.refresh]);
+  const refreshCurrentMonth = useCallback(() => calendarRefreshRef.current(), []);
 
   // Build calendar grid: day-of-month (1-indexed) → array of recording summaries
   const eventsByDay: Record<number, EventData[]> = useMemo(() => {
@@ -1320,7 +1403,7 @@ const CalendarTab: React.FC<{
             onNoteClick={onNoteClick}
             onAddNote={(hour) => onAddNote(hour, addNoteDateKey)}
             onDropFilesAtSlot={handleDropAtHour}
-            onRefresh={calendar.refresh}
+            onRefresh={refreshCurrentMonth}
           />
           <TimeSection
             title="Afternoon"
@@ -1334,7 +1417,7 @@ const CalendarTab: React.FC<{
             onNoteClick={onNoteClick}
             onAddNote={(hour) => onAddNote(hour, addNoteDateKey)}
             onDropFilesAtSlot={handleDropAtHour}
-            onRefresh={calendar.refresh}
+            onRefresh={refreshCurrentMonth}
           />
         </div>
         <HistoryPicker

--- a/dashboard/components/views/__tests__/AudioNoteModal.diarize.test.tsx
+++ b/dashboard/components/views/__tests__/AudioNoteModal.diarize.test.tsx
@@ -1,0 +1,333 @@
+/**
+ * AudioNoteModal — Diarize + Export Markdown menu wiring (GH-279).
+ *
+ * The options dropdown must:
+ *   1. Offer an enabled Diarize item for a non-diarized note WITH word
+ *      timestamps, and clicking it must invoke the retroDiarize service.
+ *   2. Disable Diarize (with an explanatory title tooltip) when the note has
+ *      no word-level timestamps.
+ *   3. Hide Diarize entirely once the note is diarized.
+ *   4. Offer Export Markdown, wired to getExportUrl(id, 'md').
+ */
+
+import React from 'react';
+import { render, act, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// ── Hoisted controllable state ────────────────────────────────────────────
+
+let mockRecording: Record<string, unknown> | null = null;
+let mockSegments: Array<Record<string, unknown>> = [];
+const mockDiarizeAndWait = vi.fn();
+const mockGetExportUrl = vi.fn().mockReturnValue('http://localhost/export');
+const mockRefresh = vi.fn();
+
+// ── Heavy mocks (mirror AudioNoteModal hook surface) ───────────────────────
+
+vi.mock('../../../src/hooks/useRecording', () => ({
+  useRecording: () => ({
+    recording: mockRecording,
+    transcription: { recording_id: 1, segments: mockSegments },
+    loading: false,
+    error: null,
+    refresh: mockRefresh,
+    audioUrl: null,
+  }),
+}));
+
+vi.mock('../../../src/hooks/useDiarizationConfidence', () => ({
+  useDiarizationConfidence: () => ({
+    turns: [],
+    byTurn: new Map(),
+    loading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('../../../src/hooks/useDiarizationReview', () => ({
+  useDiarizationReview: () => ({
+    state: { recording_id: 1, status: null, reviewed_turns_json: null },
+    refresh: vi.fn(),
+    triggerOpen: vi.fn(),
+    triggerComplete: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../src/hooks/useRecordingAliases', () => ({
+  useRecordingAliases: () => ({
+    aliases: [],
+    aliasMap: new Map(),
+    setAliases: vi.fn().mockResolvedValue(undefined),
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../src/hooks/useWordHighlighter', () => ({
+  useWordHighlighter: () => ({ activeWordIndex: -1, registerWord: vi.fn(), scrollTo: vi.fn() }),
+}));
+
+vi.mock('../../../src/hooks/useConfirm', () => ({
+  useConfirm: () => ({ confirm: vi.fn().mockResolvedValue(true), dialog: null }),
+}));
+
+vi.mock('../../../src/hooks/useAutoActionRetry', () => ({
+  useAutoActionRetry: () => ({ mutate: vi.fn(), isPending: false, error: null }),
+}));
+
+vi.mock('../../../src/stores/activeProfileStore', () => ({
+  useActiveProfileStore: (selector?: (s: { activeProfileId: number | null }) => unknown) => {
+    const state = { activeProfileId: null };
+    return typeof selector === 'function' ? selector(state) : state;
+  },
+}));
+
+vi.mock('../../../src/hooks/useAriaAnnouncer', () => ({
+  useAriaAnnouncer: () => vi.fn(),
+}));
+
+vi.mock('../../../src/services/retroDiarize', () => ({
+  diarizeRecordingAndWait: (...args: unknown[]) => mockDiarizeAndWait(...args),
+}));
+
+vi.mock('../../../src/api/client', () => ({
+  apiClient: {
+    listConversations: vi.fn().mockResolvedValue([]),
+    getMessages: vi.fn().mockResolvedValue([]),
+    getConversation: vi.fn().mockResolvedValue({ id: 0, title: '', messages: [] }),
+    createConversation: vi.fn().mockResolvedValue({ id: 1, title: 'New Chat' }),
+    updateConversation: vi.fn().mockResolvedValue(undefined),
+    deleteConversation: vi.fn().mockResolvedValue(undefined),
+    deleteMessagesFrom: vi.fn().mockResolvedValue(undefined),
+    generateConversationTitle: vi.fn().mockResolvedValue({ title: '' }),
+    chat: vi.fn(),
+    summarizeRecordingStream: vi.fn(),
+    summarizeRecording: vi.fn().mockResolvedValue({ summary: '' }),
+    getAudioUrl: vi.fn().mockReturnValue(null),
+    getAvailableModels: vi.fn().mockResolvedValue({ models: [] }),
+    getLLMModels: vi.fn().mockResolvedValue([]),
+    getLLMStatus: vi.fn().mockResolvedValue({ active: false, model: null }),
+    deleteRecording: vi.fn().mockResolvedValue(undefined),
+    updateRecordingTitle: vi.fn().mockResolvedValue(undefined),
+    updateRecordingDate: vi.fn().mockResolvedValue(undefined),
+    updateRecordingSummary: vi.fn().mockResolvedValue(undefined),
+    getExportUrl: (...args: unknown[]) => mockGetExportUrl(...args),
+    retryAutoAction: vi.fn().mockResolvedValue({ status: 'retry_initiated' }),
+  },
+}));
+
+vi.mock('../../../src/config/store', () => ({
+  getConfig: vi.fn().mockResolvedValue(undefined),
+  setConfig: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}));
+
+// react-markdown bundles ESM-only deps that vitest can't transform out of the box.
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', null, children),
+}));
+vi.mock('remark-gfm', () => ({ default: () => undefined }));
+
+// ── Imports after mocks ───────────────────────────────────────────────────
+
+import { AudioNoteModal } from '../AudioNoteModal';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function createWrapper(): ({ children }: { children: React.ReactNode }) => React.ReactElement {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children) as React.ReactElement;
+}
+
+const NOTE = {
+  title: 'Test Recording',
+  date: '2026-05-04',
+  duration: '00:60',
+  recordingId: 1,
+};
+
+const BASE_RECORDING = {
+  id: 1,
+  filename: 'test.wav',
+  filepath: '/data/test.wav',
+  title: 'Test Recording',
+  duration_seconds: 60,
+  recorded_at: '2026-05-04T12:00:00Z',
+  imported_at: null,
+  word_count: 5,
+  has_diarization: false,
+  summary: null,
+  summary_model: null,
+  transcription_backend: 'whisper',
+};
+
+const SEGMENT_WITH_WORDS = {
+  text: 'hello there',
+  start: 0.0,
+  end: 1.2,
+  speaker: null,
+  words: [
+    { word: 'hello', start: 0.0, end: 0.5 },
+    { word: 'there', start: 0.6, end: 1.2 },
+  ],
+};
+
+const SEGMENT_WITHOUT_WORDS = {
+  text: 'hello there',
+  start: 0.0,
+  end: 1.2,
+  speaker: null,
+  words: [],
+};
+
+async function renderAndOpenMenu(): Promise<ReturnType<typeof render>> {
+  const view = render(
+    React.createElement(AudioNoteModal, { isOpen: true, onClose: vi.fn(), note: NOTE }),
+    { wrapper: createWrapper() },
+  );
+
+  await act(async () => {
+    // Portal container + double-rAF open animation gate (see the
+    // auto-actions test for the rationale).
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((r) => requestAnimationFrame(r));
+    await new Promise((r) => requestAnimationFrame(r));
+    await Promise.resolve();
+  });
+
+  const optionsButton = document.body.querySelector('button[title="More options"]');
+  expect(optionsButton).toBeTruthy();
+  await act(async () => {
+    fireEvent.click(optionsButton as Element);
+  });
+  return view;
+}
+
+function findMenuButton(label: string): HTMLButtonElement | null {
+  const buttons = Array.from(document.body.querySelectorAll('button'));
+  return (buttons.find((b) => b.textContent?.trim() === label) as HTMLButtonElement) ?? null;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('AudioNoteModal — Diarize + Export Markdown wiring (GH-279)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRecording = { ...BASE_RECORDING };
+    mockSegments = [SEGMENT_WITH_WORDS];
+    mockDiarizeAndWait.mockResolvedValue({ job_id: 'abc12345', recording_id: 1 });
+    mockGetExportUrl.mockReturnValue('http://localhost/export');
+    document.body.innerHTML = '';
+  });
+
+  it('offers an enabled Diarize item and invokes the service on click', async () => {
+    await renderAndOpenMenu();
+
+    const diarize = findMenuButton('Diarize');
+    expect(diarize).toBeTruthy();
+    expect(diarize?.disabled).toBe(false);
+
+    await act(async () => {
+      fireEvent.click(diarize as Element);
+    });
+    expect(mockDiarizeAndWait).toHaveBeenCalledWith(1);
+  });
+
+  it('disables Diarize with a tooltip when word timestamps are absent', async () => {
+    mockSegments = [SEGMENT_WITHOUT_WORDS];
+
+    await renderAndOpenMenu();
+
+    const diarize = findMenuButton('Diarize');
+    expect(diarize).toBeTruthy();
+    expect(diarize?.disabled).toBe(true);
+    expect(diarize?.title).toMatch(/word-level timestamps/);
+
+    await act(async () => {
+      fireEvent.click(diarize as Element);
+    });
+    expect(mockDiarizeAndWait).not.toHaveBeenCalled();
+  });
+
+  it('hides Diarize once the recording is diarized', async () => {
+    mockRecording = { ...BASE_RECORDING, has_diarization: true };
+    mockSegments = [{ ...SEGMENT_WITH_WORDS, speaker: 'SPEAKER_00' }];
+
+    await renderAndOpenMenu();
+
+    expect(findMenuButton('Diarize')).toBeNull();
+  });
+
+  it('does not apply a stale refresh when the note switches mid-diarize', async () => {
+    // GH-279 review finding: the modal instance is shared across notes, so a
+    // diarize job finishing for note A must not refresh while note B is open
+    // (the stale refresh would clobber B's displayed transcript with A's data).
+    let resolveJob: (v: unknown) => void = () => undefined;
+    mockDiarizeAndWait.mockReturnValue(
+      new Promise((resolve) => {
+        resolveJob = resolve;
+      }),
+    );
+
+    const view = await renderAndOpenMenu();
+    await act(async () => {
+      fireEvent.click(findMenuButton('Diarize') as Element);
+    });
+
+    // Switch the modal to a DIFFERENT note while the job is in flight.
+    view.rerender(
+      React.createElement(AudioNoteModal, {
+        isOpen: true,
+        onClose: vi.fn(),
+        note: { ...NOTE, recordingId: 2, title: 'Other Recording' },
+      }),
+    );
+
+    await act(async () => {
+      resolveJob({ job_id: 'abc12345', recording_id: 1 });
+      await Promise.resolve();
+    });
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  it('applies the refresh when the same note is still open on completion', async () => {
+    let resolveJob: (v: unknown) => void = () => undefined;
+    mockDiarizeAndWait.mockReturnValue(
+      new Promise((resolve) => {
+        resolveJob = resolve;
+      }),
+    );
+
+    await renderAndOpenMenu();
+    await act(async () => {
+      fireEvent.click(findMenuButton('Diarize') as Element);
+    });
+
+    await act(async () => {
+      resolveJob({ job_id: 'abc12345', recording_id: 1 });
+      await Promise.resolve();
+    });
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+
+  it('offers Export Markdown wired to the md export URL', async () => {
+    const windowOpen = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+    await renderAndOpenMenu();
+
+    const exportMd = findMenuButton('Export Markdown');
+    expect(exportMd).toBeTruthy();
+    await act(async () => {
+      fireEvent.click(exportMd as Element);
+    });
+    expect(mockGetExportUrl).toHaveBeenCalledWith(1, 'md');
+    expect(windowOpen).toHaveBeenCalled();
+    windowOpen.mockRestore();
+  });
+});

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -840,6 +840,16 @@ export class APIClient {
   }
 
   /**
+   * POST /api/notebook/recordings/{id}/diarize — GH-279.
+   * Retroactively diarize an already-transcribed recording using its stored
+   * audio + word timestamps (no re-transcription). Returns 202 Accepted with
+   * { job_id }; poll /api/admin/status for the result.
+   */
+  async diarizeRecording(recordingId: number): Promise<{ job_id: string }> {
+    return this.post(`/api/notebook/recordings/${recordingId}/diarize`);
+  }
+
+  /**
    * POST /api/notebook/recordings/{id}/auto-actions/retry — Issue #104, Stories 6.6 + 6.9.
    * Idempotent retry of a failed/deferred/empty/truncated auto-action.
    * Returns:

--- a/dashboard/src/api/types.ts
+++ b/dashboard/src/api/types.ts
@@ -254,6 +254,8 @@ export interface JobTrackerResult {
     performed: boolean;
     reason: string | null;
   };
+  // GH-279 — set by the retro-diarize job on success.
+  num_speakers?: number;
   error?: string;
 }
 
@@ -298,7 +300,9 @@ export interface TimeslotResponse {
   is_full: boolean;
 }
 
-export type ExportFormat = 'txt' | 'srt' | 'ass';
+// 'plaintext' is the FR9 streaming transcript (Story 3.4); 'md' is the
+// Markdown conversation export (GH-279).
+export type ExportFormat = 'txt' | 'srt' | 'ass' | 'plaintext' | 'md';
 
 // ─── File Import (Session) ────────────────────────────────────────────────────
 

--- a/dashboard/src/services/__tests__/retroDiarize.test.ts
+++ b/dashboard/src/services/__tests__/retroDiarize.test.ts
@@ -1,0 +1,119 @@
+/**
+ * retroDiarize service (GH-279) — start + poll-until-done semantics.
+ *
+ * The service mirrors the import queue's poll-/api/admin/status loop, so the
+ * tests pin the same completion contract: matching tracker result resolves,
+ * an idle tracker with a foreign result means the job was lost, and transient
+ * poll errors are retried.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockDiarizeRecording = vi.fn();
+const mockGetAdminStatus = vi.fn();
+
+vi.mock('../../api/client', () => ({
+  apiClient: {
+    diarizeRecording: (...args: unknown[]) => mockDiarizeRecording(...args),
+    getAdminStatus: (...args: unknown[]) => mockGetAdminStatus(...args),
+  },
+}));
+
+import { diarizeRecordingAndWait } from '../retroDiarize';
+
+const JOB_ID = 'abc12345';
+
+function adminStatus(jobTracker: Record<string, unknown>): Record<string, unknown> {
+  return { status: 'ok', models: { job_tracker: jobTracker }, config: {} };
+}
+
+describe('diarizeRecordingAndWait', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockDiarizeRecording.mockReset().mockResolvedValue({ job_id: JOB_ID });
+    mockGetAdminStatus.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts the job and resolves with the matching tracker result', async () => {
+    mockGetAdminStatus
+      .mockResolvedValueOnce(adminStatus({ is_busy: true, active_job_id: JOB_ID, result: null }))
+      .mockResolvedValueOnce(
+        adminStatus({
+          is_busy: false,
+          active_job_id: null,
+          result: { job_id: JOB_ID, recording_id: 7, num_speakers: 2 },
+        }),
+      );
+
+    const promise = diarizeRecordingAndWait(7);
+    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    await expect(promise).resolves.toEqual({
+      job_id: JOB_ID,
+      recording_id: 7,
+      num_speakers: 2,
+    });
+    expect(mockDiarizeRecording).toHaveBeenCalledWith(7);
+  });
+
+  it('resolves with the error-bearing result so the caller can branch', async () => {
+    mockGetAdminStatus.mockResolvedValueOnce(
+      adminStatus({
+        is_busy: false,
+        active_job_id: null,
+        result: { job_id: JOB_ID, error: 'CUDA out of memory' },
+      }),
+    );
+
+    const promise = diarizeRecordingAndWait(7);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    await expect(promise).resolves.toEqual({ job_id: JOB_ID, error: 'CUDA out of memory' });
+  });
+
+  it('rejects when the tracker is idle with a foreign result (job lost)', async () => {
+    mockGetAdminStatus.mockResolvedValueOnce(
+      adminStatus({
+        is_busy: false,
+        active_job_id: null,
+        result: { job_id: 'other999' },
+      }),
+    );
+
+    const promise = diarizeRecordingAndWait(7);
+    const assertion = expect(promise).rejects.toThrow(/job lost/);
+    await vi.advanceTimersByTimeAsync(5000);
+    await assertion;
+  });
+
+  it('retries after a transient poll error', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    mockGetAdminStatus.mockRejectedValueOnce(new Error('network hiccup')).mockResolvedValueOnce(
+      adminStatus({
+        is_busy: false,
+        active_job_id: null,
+        result: { job_id: JOB_ID, recording_id: 7 },
+      }),
+    );
+
+    const promise = diarizeRecordingAndWait(7);
+    await vi.advanceTimersByTimeAsync(5000);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    await expect(promise).resolves.toEqual({ job_id: JOB_ID, recording_id: 7 });
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('propagates a start failure without polling', async () => {
+    mockDiarizeRecording.mockRejectedValueOnce(new Error('409: already diarized'));
+
+    await expect(diarizeRecordingAndWait(7)).rejects.toThrow('409');
+    expect(mockGetAdminStatus).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/src/services/retroDiarize.ts
+++ b/dashboard/src/services/retroDiarize.ts
@@ -1,0 +1,50 @@
+/**
+ * Retroactive diarization job service (GH-279).
+ *
+ * Starts a diarize job on an already-transcribed notebook recording and
+ * resolves when the server-side job finishes. Uses the same
+ * poll-/api/admin/status pattern as the import queue (importQueueStore):
+ * the server has no push channel for notebook jobs, and the job tracker
+ * result slot is cleared when the NEXT job starts, so polling every few
+ * seconds is both necessary and sufficient.
+ */
+import { apiClient } from '../api/client';
+import { jobTrackerFromAdminStatus } from '../api/types';
+import type { JobTrackerResult } from '../api/types';
+
+const POLL_INTERVAL_MS = 5000;
+const MAX_POLL_HOURS = 24;
+const MAX_POLLS = Math.ceil((MAX_POLL_HOURS * 60 * 60 * 1000) / POLL_INTERVAL_MS);
+
+/**
+ * Start retroactive diarization for a recording and wait for completion.
+ *
+ * Resolves with the job tracker result (check `.error` for job-level
+ * failure). Rejects when the job cannot be started (HTTP error from the
+ * diarize endpoint), when the job is lost (server restart), or on timeout.
+ */
+export async function diarizeRecordingAndWait(recordingId: number): Promise<JobTrackerResult> {
+  const { job_id: serverJobId } = await apiClient.diarizeRecording(recordingId);
+
+  for (let i = 0; i < MAX_POLLS; i++) {
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+
+    try {
+      const status = await apiClient.getAdminStatus();
+      const jobTracker = jobTrackerFromAdminStatus(status);
+
+      if (jobTracker?.is_busy && jobTracker?.active_job_id === serverJobId) continue;
+
+      const result = jobTracker?.result ?? undefined;
+      if (result && result.job_id === serverJobId) return result;
+
+      if (!jobTracker?.is_busy && (!result || result.job_id !== serverJobId)) {
+        throw new Error('Diarization job lost — server may have restarted');
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('job lost')) throw err;
+      console.warn('Diarize poll error (will retry):', err);
+    }
+  }
+  throw new Error(`Diarization timed out after ${MAX_POLL_HOURS} hours`);
+}

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.16.0",
-  "contract_sha256": "87229e8d0df2be2f5abcb1a08d0ddf0966145161ab5586cc2db87edd82cd9808",
-  "updated_at": "2026-08-02T10:21:20.184Z"
+  "spec_version": "1.16.2",
+  "contract_sha256": "c6e0b6296db48892595aedae9357d55ea50b67f74a046e2220787bf32a0db582",
+  "updated_at": "2026-08-04T14:27:28.266Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.16.0
+  spec_version: 1.16.2
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -13,6 +13,7 @@ meta:
       - components/__tests__/CustomSelect.test.tsx
       - components/__tests__/HfTokenExplainer.test.tsx
       - components/__tests__/LogsView.test.tsx
+      - components/__tests__/NoteActionMenu.test.tsx
       - components/__tests__/NotebookView.canary-language.test.tsx
       - components/__tests__/NotebookView.profile-id.test.tsx
       - components/__tests__/NotebookView.test.tsx
@@ -27,6 +28,7 @@ meta:
       - components/__tests__/SessionView.client-link-stop.test.tsx
       - components/__tests__/SessionView.diarization.test.tsx
       - components/__tests__/SessionView.greek-sigma.test.tsx
+      - components/__tests__/SessionView.recovery-refresh.test.tsx
       - components/__tests__/SessionView.retry-failed.test.tsx
       - components/__tests__/SessionView.test.tsx
       - components/__tests__/StartupActivityInline.test.tsx
@@ -98,6 +100,7 @@ meta:
       - components/ui/UpdateBanner.tsx
       - components/ui/UpdateModal.tsx
       - components/views/__tests__/AudioNoteModal.auto-actions.test.tsx
+      - components/views/__tests__/AudioNoteModal.diarize.test.tsx
       - components/views/__tests__/AudioNoteModal.summary.test.tsx
       - components/views/__tests__/GpuDiagnosticModal.test.tsx
       - components/views/__tests__/GpuHealthCard.test.tsx
@@ -133,7 +136,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-08-02T10:20:32.229Z
+    generated_at: 2026-08-04T14:27:10.407Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:

--- a/docs/api-contracts-server.md
+++ b/docs/api-contracts-server.md
@@ -62,9 +62,10 @@
 | GET | `/api/notebook/recordings/{id}/audio` | user (+`?token=`) | Stream audio with HTTP Range (206) |
 | GET | `/api/notebook/recordings/{id}/transcription` | user | Transcription as segments-with-embedded-words |
 | POST | `/api/notebook/transcribe/upload` | user | Upload + background transcribe + save to notebook; 202 + `job_id`; supports diarization, `profile_id` |
+| POST | `/api/notebook/recordings/{id}/diarize` | user | **NEW** (GH-279) — retroactively diarize a saved recording from its stored audio + word timestamps (no re-transcription); 202 + `job_id`, poll `/api/admin/status`; 400 without word timestamps, 409 if already diarized / audio missing / job slot busy |
 | GET | `/api/notebook/calendar` | user | Recordings grouped by day for a `year`/`month` |
 | GET | `/api/notebook/timeslot` | user | Time-slot occupancy for `date`+`hour` |
-| GET | `/api/notebook/recordings/{id}/export` | user (+`?token=`) | Export transcript: `txt`/`plaintext`/`srt`/`ass` (alias-substituted) |
+| GET | `/api/notebook/recordings/{id}/export` | user (+`?token=`) | Export transcript: `txt`/`plaintext`/`md`/`srt`/`ass` (alias-substituted; `md` is the GH-279 Markdown conversation format) |
 | POST | `/api/notebook/recordings/{id}/reexport` | user | **NEW** — re-render plaintext export with a `profile_id` to its destination folder |
 | POST | `/api/notebook/recordings/{id}/auto-actions/retry` | user | **NEW** — idempotent retry of `auto_summary`/`auto_export`/`webhook` |
 | GET | `/api/notebook/backups` | user | List database backups |

--- a/server/backend/api/routes/notebook.py
+++ b/server/backend/api/routes/notebook.py
@@ -1280,6 +1280,97 @@ async def upload_and_transcribe(
     return {"job_id": job_id[:8]}
 
 
+class DiarizeRequest(BaseModel):
+    """Body for ``POST /recordings/{id}/diarize`` (GH-279). All fields optional."""
+
+    expected_speakers: int | None = None
+
+
+@router.post(
+    "/recordings/{recording_id}/diarize",
+    response_model=AcceptedResponse,
+    status_code=202,
+)
+async def diarize_recording(
+    recording_id: int,
+    request: Request,
+    body: DiarizeRequest | None = None,
+) -> dict[str, Any]:
+    """
+    Retroactively diarize an already-transcribed recording (GH-279).
+
+    Diarizes the stored audio file WITHOUT re-running transcription, then
+    aligns the speaker turns onto the recording's stored word timestamps.
+    Returns 202 Accepted with a job_id; clients poll GET /api/admin/status
+    for completion, exactly like /transcribe/upload.
+
+    Preconditions (checked before the job slot is taken):
+    - the recording exists and is not already diarized
+    - word-level timestamps exist (the alignment substrate)
+    - the original audio file is still present on disk
+
+    Returns 409 Conflict if another transcription job is already running.
+    """
+    recording = get_recording(recording_id)
+    if not recording:
+        raise HTTPException(status_code=404, detail="Recording not found")
+
+    if bool(recording.get("has_diarization")):
+        raise HTTPException(
+            status_code=409,
+            detail="Recording is already diarized.",
+        )
+
+    words = get_words(recording_id)
+    if not words:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Diarization requires word-level timestamps, which this recording "
+                "was transcribed without."
+            ),
+        )
+
+    audio_path = Path(recording.get("filepath") or "")
+    if not audio_path.exists():
+        raise HTTPException(
+            status_code=409,
+            detail="Original audio file not found on disk.",
+        )
+
+    expected_speakers = body.expected_speakers if body else None
+    if expected_speakers is not None and not (1 <= expected_speakers <= 10):
+        raise HTTPException(
+            status_code=400,
+            detail="expected_speakers must be between 1 and 10",
+        )
+
+    model_manager = request.app.state.model_manager
+    client_name = get_client_name(request)
+
+    success, job_id, active_user = model_manager.job_tracker.try_start_job(client_name)
+    if not success:
+        raise HTTPException(
+            status_code=409,
+            detail=f"A transcription is already running for {active_user}",
+        )
+
+    from server.core.retro_diarize import run_retro_diarization
+
+    loop = asyncio.get_running_loop()
+    loop.create_task(
+        asyncio.to_thread(
+            run_retro_diarization,
+            model_manager=model_manager,
+            recording_id=recording_id,
+            job_id=job_id,
+            expected_speakers=expected_speakers,
+        )
+    )
+
+    return {"job_id": job_id[:8]}
+
+
 @router.get("/calendar")
 async def get_calendar_data(
     year: int = Query(..., description="Year"),
@@ -1349,7 +1440,7 @@ async def export_recording(
     recording_id: int,
     format: str = Query(
         "txt",
-        description="Export format: 'txt', 'srt', 'ass', or 'plaintext'",
+        description="Export format: 'txt', 'srt', 'ass', 'plaintext', or 'md'",
     ),
 ) -> Response:
     """
@@ -1366,14 +1457,45 @@ async def export_recording(
     - plaintext: FR9 streaming format — paragraph-per-speaker-turn, no
       subtitle timestamps, no metadata header. Used by the Sprint 2
       "Download transcript" button (Issue #104, Story 3.4).
+    - md: Markdown conversation (GH-279) — title + date header, then one
+      "**Speaker N** *[MM:SS]*: text" line per speaker turn. Degrades to
+      plain paragraphs for recordings without diarization.
     - srt: SubRip subtitle format
     - ass: Advanced SubStation Alpha subtitle format
     """
     requested_format = format.strip().lower()
-    if requested_format not in {"txt", "srt", "ass", "plaintext"}:
+    if requested_format not in {"txt", "srt", "ass", "plaintext", "md"}:
         raise HTTPException(
             status_code=400,
-            detail="Unsupported export format. Supported formats: txt, plaintext, srt, ass.",
+            detail="Unsupported export format. Supported formats: txt, plaintext, md, srt, ass.",
+        )
+
+    # GH-279 — markdown streams like plaintext: early branch, alias-aware,
+    # available for every recording (non-diarized notes degrade to plain
+    # paragraphs under the same title/date header).
+    if requested_format == "md":
+        recording = get_recording(recording_id)
+        if not recording:
+            raise HTTPException(status_code=404, detail="Recording not found")
+        from server.core.alias_substitution import apply_aliases
+        from server.core.markdown_export import stream_markdown
+        from server.database import alias_repository
+        from server.database.database import iter_segments
+
+        title = recording.get("title") or recording.get("filename") or "Recording"
+        rendered_filename = (
+            f"{title.replace(' ', '_')}.md" if title else f"recording_{recording_id}.md"
+        )
+        aliases = alias_repository.alias_map(recording_id)
+        return StreamingResponse(
+            stream_markdown(
+                recording,
+                apply_aliases(iter_segments(recording_id), aliases),
+            ),
+            media_type="text/markdown; charset=utf-8",
+            headers={
+                "Content-Disposition": _content_disposition("attachment", rendered_filename),
+            },
         )
 
     # Story 3.4 — plaintext is a streaming response that bypasses the

--- a/server/backend/core/markdown_export.py
+++ b/server/backend/core/markdown_export.py
@@ -1,0 +1,113 @@
+"""Markdown conversation exporter (GH-279).
+
+Yields a Markdown document shaped like the format requested in GH-279::
+
+    # Friday Meeting - Part 2
+
+    **Date:** July 10, 2026 at 02:53 PM
+
+    ---
+
+    **Speaker 3** *[00:44]*: There's not enough memory storage.
+    **Speaker 1** *[00:48]*: Yes, I'll let you decide which one should go in.
+
+One line per speaker turn (consecutive segments with the same ``speaker``
+coalesce), each terminated with a Markdown hard break (two trailing spaces)
+so renderers keep the turns on separate lines. Speaker labels arrive
+pre-substituted — the caller wraps ``iter_segments`` in
+``alias_substitution.apply_aliases`` so numbering matches the dashboard view.
+
+Recordings without diarization degrade to plain paragraphs under the same
+title/date header (no speaker prefix, no timestamps).
+
+Streaming generator like ``plaintext_export.stream_plaintext`` — designed for
+``StreamingResponse`` so long recordings never materialize fully in RAM.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from datetime import datetime
+from typing import Any
+
+
+def format_markdown_timestamp(seconds: float) -> str:
+    """Zero-padded ``MM:SS`` (minutes roll past 59 for recordings over an hour).
+
+    Matches the txt-export timestamp convention in ``notebook.export_recording``
+    — NOT the dashboard's ``formatRecSecs`` (which does not zero-pad minutes).
+    """
+    try:
+        total = max(0, int(float(seconds)))
+    except (TypeError, ValueError):
+        total = 0
+    return f"{total // 60:02d}:{total % 60:02d}"
+
+
+def _format_date(recorded_at: Any) -> str:
+    """Human-readable date, same format as the txt export header."""
+    if not isinstance(recorded_at, str) or not recorded_at:
+        return ""
+    try:
+        rec_dt = datetime.fromisoformat(recorded_at.replace("Z", "+00:00"))
+        return rec_dt.strftime("%B %d, %Y at %I:%M %p")
+    except ValueError:
+        return recorded_at
+
+
+def stream_markdown(
+    recording: dict[str, Any],
+    segments: Iterable[dict[str, Any]],
+) -> Iterator[str]:
+    """Yield Markdown chunks for the given recording's segments.
+
+    ``segments`` must carry display-ready ``speaker`` labels (pass them
+    through ``apply_aliases`` first) plus ``text`` and ``start_time``.
+    """
+    title = recording.get("title") or recording.get("filename") or "Recording"
+    yield f"# {title}\n\n"
+
+    date_str = _format_date(recording.get("recorded_at"))
+    if date_str:
+        yield f"**Date:** {date_str}\n\n"
+
+    yield "---\n\n"
+
+    # Sentinel distinct from any real speaker label so the first segment
+    # always opens a turn (mirrors plaintext_export.stream_plaintext).
+    _SENTINEL = object()
+    current_speaker: object = _SENTINEL
+    turn_start: float = 0.0
+    turn_parts: list[str] = []
+
+    def _flush() -> Iterator[str]:
+        if not turn_parts:
+            return
+        text = " ".join(turn_parts)
+        if current_speaker is None:
+            # No diarization — plain paragraph, blank line between paragraphs.
+            yield f"{text}\n\n"
+        else:
+            ts = format_markdown_timestamp(turn_start)
+            # Two trailing spaces = Markdown hard line break.
+            yield f"**{current_speaker}** *[{ts}]*: {text}  \n"
+
+    for seg in segments:
+        speaker_raw = seg.get("speaker")
+        speaker: str | None = str(speaker_raw).strip() if speaker_raw not in (None, "") else None
+        text = str(seg.get("text") or "").strip()
+        if not text:
+            continue
+
+        if speaker != current_speaker:
+            yield from _flush()
+            turn_parts = []
+            current_speaker = speaker
+            try:
+                turn_start = float(seg.get("start_time") or 0.0)
+            except (TypeError, ValueError):
+                turn_start = 0.0
+
+        turn_parts.append(text)
+
+    yield from _flush()

--- a/server/backend/core/retro_diarize.py
+++ b/server/backend/core/retro_diarize.py
@@ -1,0 +1,187 @@
+"""Retroactive diarization of an already-transcribed recording (GH-279).
+
+Every existing diarization consumer goes through
+``core.diarization_dispatch.transcribe_with_optional_diarization``, which
+always couples diarization to a FRESH transcription pass. This module covers
+the other case: a notebook recording that was transcribed without diarization
+(e.g. a Live-Mode session promotion, or an upload with the toggle off) and
+already has word-level timestamps persisted in the ``words`` table.
+
+Here we diarize the stored audio file alone — no STT engine runs — and align
+the resulting speaker turns onto the stored words via the same DB-layer
+alignment used at import time (``replace_recording_segments_with_diarization``).
+
+Model lifecycle mirrors ``parallel_diarize.transcribe_then_diarize`` phase 2:
+unload the STT model first (frees VRAM), load the diarizer, and in ``finally``
+restore the pre-job state (unload diarizer, reload STT) with guarded calls so
+a restore failure never masks the real outcome.
+
+Failure contract (CLAUDE.md data-loss invariant): if diarization fails at any
+stage — model load, inference, zero turns found, DB write — the recording's
+existing transcript is left completely untouched and the error is surfaced
+through ``job_tracker.end_job`` for client polling.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def run_retro_diarization(
+    *,
+    model_manager: Any,
+    recording_id: int,
+    job_id: str,
+    expected_speakers: int | None = None,
+) -> None:
+    """Diarize an existing recording's stored audio and persist the merge.
+
+    Synchronous worker intended for ``asyncio.to_thread()``. Stores the
+    success or error result in ``model_manager.job_tracker`` so clients can
+    poll GET /api/admin/status for completion — the same contract as
+    ``notebook._run_transcription``.
+    """
+    from server.database.database import (
+        get_recording,
+        get_words,
+        replace_recording_segments_with_diarization,
+    )
+
+    try:
+        recording = get_recording(recording_id)
+        if not recording:
+            raise ValueError(f"Recording {recording_id} not found")
+
+        audio_path = Path(recording.get("filepath") or "")
+        if not audio_path.exists():
+            raise FileNotFoundError(f"Original audio file not found on disk: {audio_path}")
+
+        words = get_words(recording_id)
+        if not words:
+            raise ValueError(
+                "Recording has no word-level timestamps; retroactive diarization "
+                "needs them for speaker alignment"
+            )
+
+        # The diarizing phase includes the model swap — the swap is part of
+        # the wait the user experiences (GH-211).
+        model_manager.job_tracker.set_phase("diarizing")
+        logger.info(
+            "Starting retroactive diarization for recording %d (%s)",
+            recording_id,
+            audio_path.name,
+        )
+
+        model_manager.unload_transcription_model()  # Frees VRAM for the diarizer
+        try:
+            model_manager.load_diarization_model()
+            diar_engine = model_manager.diarization_engine
+            diar_result = diar_engine.diarize_file(str(audio_path), num_speakers=expected_speakers)
+        finally:
+            # Restore the pre-job model state. Guarded: a restore failure must
+            # not replace the real diarization outcome propagating out.
+            try:
+                model_manager.unload_diarization_model()
+            except Exception:
+                logger.warning(
+                    "Failed to unload the diarization model after retro-diarize",
+                    exc_info=True,
+                )
+            try:
+                model_manager.load_transcription_model()
+            except Exception:
+                logger.warning(
+                    "Failed to reload STT model after retro-diarize",
+                    exc_info=True,
+                )
+
+        diar_dicts = [seg.to_dict() for seg in diar_result.segments]
+        if not diar_dicts:
+            raise RuntimeError(
+                "Diarization found no speaker turns; the recording was left unchanged"
+            )
+
+        if not replace_recording_segments_with_diarization(
+            recording_id,
+            diar_dicts,
+            alignment_words=words,
+        ):
+            raise RuntimeError(
+                "Failed to persist diarized segments; the recording was left unchanged"
+            )
+
+        model_manager.job_tracker.end_job(
+            job_id,
+            result={
+                "job_id": job_id[:8],
+                "recording_id": recording_id,
+                "num_speakers": diar_result.num_speakers,
+                "message": (
+                    f"Diarization complete: {diar_result.num_speakers} speaker(s) identified"
+                ),
+            },
+        )
+        logger.info(
+            "Retro-diarize job %s completed: recording_id=%d, %d speakers",
+            job_id[:8],
+            recording_id,
+            diar_result.num_speakers,
+        )
+
+        _run_review_lifecycle_hook(recording_id)
+
+    except Exception as e:
+        logger.error(
+            "Retro-diarize job %s failed for recording %d: %s",
+            job_id[:8],
+            recording_id,
+            e,
+            exc_info=True,
+        )
+        model_manager.job_tracker.end_job(
+            job_id,
+            result={
+                "job_id": job_id[:8],
+                "recording_id": recording_id,
+                "error": str(e),
+            },
+        )
+
+    finally:
+        # Must stay LAST in this finally - nothing may sit behind it.
+        from server.core.audio_utils import post_job_gpu_cleanup
+
+        post_job_gpu_cleanup("notebook retro-diarize", model_manager.gpu_device_index)
+
+
+def _run_review_lifecycle_hook(recording_id: int) -> None:
+    """Open the ADR-009 review lifecycle for the freshly diarized recording.
+
+    Mirrors the post-save block of ``notebook._run_transcription``: compute
+    per-turn confidence and insert a ``pending`` review row when low-confidence
+    turns exist. A recording that was never diarized has no review row, so the
+    None → pending transition is valid. Bookkeeping must never crash the job —
+    the diarized segments are already durably committed.
+    """
+    from server.core.diarization_confidence import (
+        LOW_CONFIDENCE_THRESHOLD,
+        per_turn_confidence,
+    )
+    from server.core.diarization_review_lifecycle import on_transcription_complete
+    from server.database.database import get_segments, get_words
+
+    try:
+        segments_for_conf = get_segments(recording_id)
+        words_for_conf = get_words(recording_id)
+        turns = per_turn_confidence(segments_for_conf, words_for_conf)
+        has_low_conf = any(t["confidence"] < LOW_CONFIDENCE_THRESHOLD for t in turns)
+        on_transcription_complete(recording_id, has_low_conf)
+    except Exception:
+        logger.exception(
+            "diarization-review lifecycle hook failed for recording %d",
+            recording_id,
+        )

--- a/server/backend/database/database.py
+++ b/server/backend/database/database.py
@@ -1783,6 +1783,113 @@ def save_longform_to_database(
             conn.close()
 
 
+def replace_recording_segments_with_diarization(
+    recording_id: int,
+    diarization_segments: list[dict[str, Any]],
+    alignment_words: list[dict[str, Any]],
+) -> bool:
+    """Atomically replace a recording's segments/words with diarized ones (GH-279).
+
+    Retroactive diarization: the recording already has a plain (speaker-less)
+    transcript with word timestamps; a fresh diarization run produced raw
+    speaker turns. Re-insert the stored words under the new speaker segments
+    using the SAME alignment helper the initial-import path uses, so a
+    retroactively diarized recording is indistinguishable from one diarized
+    at import time.
+
+    All mutations run in a single BEGIN IMMEDIATE transaction: delete old
+    words+segments, re-insert, flip ``has_diarization``, refresh
+    ``word_count``. Any failure rolls back — the original transcript is
+    never lost to a failed diarization write.
+
+    Args:
+        recording_id: Existing recording to rewrite.
+        diarization_segments: Raw speaker turns (``start``/``end``/``speaker``).
+        alignment_words: The recording's stored word rows
+            (``word``/``start_time``/``end_time``/``confidence``).
+
+    Returns:
+        True on success, False on any failure (recording left unchanged).
+    """
+    if not diarization_segments:
+        logger.error(
+            "Refusing to replace segments for recording %d: empty diarization segments "
+            "would discard the transcript",
+            recording_id,
+        )
+        return False
+    if not alignment_words:
+        logger.error(
+            "Refusing to replace segments for recording %d: no alignment words",
+            recording_id,
+        )
+        return False
+
+    db_path = get_db_path()
+    if not db_path.exists():
+        logger.warning(f"Database not found at {db_path}.")
+        return False
+
+    conn = None
+    try:
+        conn = sqlite3.connect(
+            db_path,
+            timeout=30.0,
+            check_same_thread=False,
+        )
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+
+        cursor.execute("BEGIN IMMEDIATE")
+        try:
+            cursor.execute("SELECT id FROM recordings WHERE id = ?", (recording_id,))
+            if cursor.fetchone() is None:
+                raise ValueError(f"Recording {recording_id} not found")
+
+            # Delete words BEFORE segments so the words_fts sync triggers see
+            # consistent rows; both cascades would also fire on segment delete,
+            # but explicit ordering keeps the intent auditable.
+            cursor.execute("DELETE FROM words WHERE recording_id = ?", (recording_id,))
+            cursor.execute("DELETE FROM segments WHERE recording_id = ?", (recording_id,))
+
+            _insert_diarization_segments_with_words(
+                cursor,
+                recording_id,
+                diarization_segments,
+                alignment_words=alignment_words,
+                save_words=True,
+            )
+
+            cursor.execute(
+                """
+                UPDATE recordings
+                SET has_diarization = 1,
+                    word_count = (SELECT COUNT(*) FROM words WHERE recording_id = ?)
+                WHERE id = ?
+                """,
+                (recording_id, recording_id),
+            )
+
+            conn.commit()
+            logger.info(f"Recording {recording_id} segments replaced with diarized turns")
+            return True
+
+        except Exception:
+            conn.rollback()
+            raise
+
+    except Exception as e:
+        logger.error(
+            f"Error replacing segments for recording {recording_id}: {e}",
+            exc_info=True,
+        )
+        return False
+
+    finally:
+        if conn:
+            conn.close()
+
+
 def find_recordings_by_audio_hash(
     audio_hash: str,
     limit: int = 10,

--- a/server/backend/tests/test_markdown_export.py
+++ b/server/backend/tests/test_markdown_export.py
@@ -1,0 +1,229 @@
+"""Tests for the Markdown conversation export (GH-279).
+
+Covers the pure generator (core/markdown_export.py) and the ``format=md``
+branch of GET /api/notebook/recordings/{id}/export using the direct-call
+route pattern from test_notebook_export_route.py.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from server.api.routes import notebook
+from server.core.markdown_export import format_markdown_timestamp, stream_markdown
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _render(recording: dict, segments: list[dict]) -> str:
+    return "".join(stream_markdown(recording, iter(segments)))
+
+
+async def _drain(response) -> str:
+    chunks: list[str] = []
+    async for chunk in response.body_iterator:
+        chunks.append(chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk)
+    return "".join(chunks)
+
+
+_RECORDING = {
+    "id": 1,
+    "title": "Friday Meeting - Part 2",
+    "filename": "friday.mp3",
+    "recorded_at": "2026-07-10T14:53:00",
+    "duration_seconds": 120.0,
+    "word_count": 12,
+    "has_diarization": 1,
+}
+
+
+# ── format_markdown_timestamp ────────────────────────────────────────────────
+
+
+class TestFormatMarkdownTimestamp:
+    def test_zero_pads_minutes_and_seconds(self):
+        assert format_markdown_timestamp(44.2) == "00:44"
+
+    def test_minutes_roll_past_59_for_long_recordings(self):
+        assert format_markdown_timestamp(3672.9) == "61:12"
+
+    def test_zero(self):
+        assert format_markdown_timestamp(0.0) == "00:00"
+
+    def test_negative_clamps_to_zero(self):
+        assert format_markdown_timestamp(-3.0) == "00:00"
+
+    def test_non_numeric_defaults_to_zero(self):
+        assert format_markdown_timestamp(None) == "00:00"  # type: ignore[arg-type]
+
+
+# ── stream_markdown ──────────────────────────────────────────────────────────
+
+
+class TestStreamMarkdown:
+    def test_header_title_date_separator(self):
+        out = _render(_RECORDING, [])
+        assert out.startswith("# Friday Meeting - Part 2\n\n")
+        assert "**Date:** July 10, 2026 at 02:53 PM\n\n" in out
+        assert "---\n\n" in out
+
+    def test_speaker_turn_line_format(self):
+        segments = [
+            {"speaker": "Speaker 3", "text": "Not enough memory.", "start_time": 44.2},
+        ]
+        out = _render(_RECORDING, segments)
+        # Hard line break: two trailing spaces before the newline.
+        assert "**Speaker 3** *[00:44]*: Not enough memory.  \n" in out
+
+    def test_consecutive_same_speaker_segments_coalesce(self):
+        segments = [
+            {"speaker": "Speaker 1", "text": "Yes, I will let you decide.", "start_time": 48.0},
+            {"speaker": "Speaker 1", "text": "Which one should go in.", "start_time": 49.5},
+            {"speaker": "Speaker 2", "text": "Okay.", "start_time": 51.0},
+        ]
+        out = _render(_RECORDING, segments)
+        assert (
+            "**Speaker 1** *[00:48]*: Yes, I will let you decide. Which one should go in.  \n"
+            in out
+        )
+        assert "**Speaker 2** *[00:51]*: Okay.  \n" in out
+        # Only one Speaker 1 line — the two segments merged into one turn.
+        assert out.count("**Speaker 1**") == 1
+
+    def test_alternating_speakers_keep_separate_lines(self):
+        segments = [
+            {"speaker": "Speaker 1", "text": "One.", "start_time": 1.0},
+            {"speaker": "Speaker 2", "text": "Two.", "start_time": 2.0},
+            {"speaker": "Speaker 1", "text": "Three.", "start_time": 3.0},
+        ]
+        out = _render(_RECORDING, segments)
+        assert out.count("**Speaker 1**") == 2
+        assert out.count("**Speaker 2**") == 1
+
+    def test_non_diarized_degrades_to_plain_paragraphs(self):
+        segments = [
+            {"speaker": None, "text": "Hello world.", "start_time": 0.0},
+        ]
+        out = _render({"title": "Note"}, segments)
+        assert "# Note\n\n" in out
+        assert "---\n\n" in out
+        assert "Hello world.\n" in out
+        assert "**" not in out.replace("**Date:**", "")
+        assert "*[" not in out
+
+    def test_missing_recorded_at_omits_date_line(self):
+        out = _render({"title": "Note"}, [])
+        assert "**Date:**" not in out
+
+    def test_unparseable_recorded_at_falls_back_to_raw_string(self):
+        out = _render({"title": "Note", "recorded_at": "sometime"}, [])
+        assert "**Date:** sometime\n\n" in out
+
+    def test_empty_text_segments_skipped(self):
+        segments = [
+            {"speaker": "Speaker 1", "text": "   ", "start_time": 1.0},
+            {"speaker": "Speaker 2", "text": "Real text.", "start_time": 2.0},
+        ]
+        out = _render(_RECORDING, segments)
+        assert "**Speaker 1**" not in out
+        assert "**Speaker 2** *[00:02]*: Real text.  \n" in out
+
+    def test_title_falls_back_to_filename_then_default(self):
+        assert _render({"filename": "a.mp3"}, []).startswith("# a.mp3\n\n")
+        assert _render({}, []).startswith("# Recording\n\n")
+
+    def test_null_start_time_renders_zero_timestamp(self):
+        segments = [{"speaker": "Speaker 1", "text": "Hi.", "start_time": None}]
+        out = _render(_RECORDING, segments)
+        assert "**Speaker 1** *[00:00]*: Hi.  \n" in out
+
+
+# ── GET /recordings/{id}/export?format=md ────────────────────────────────────
+
+
+def _patch_md_route_data(
+    monkeypatch,
+    recording: dict,
+    segments: list[dict],
+    aliases: dict[str, str] | None = None,
+) -> None:
+    db_module = importlib.import_module("server.database.database")
+    alias_repo = importlib.import_module("server.database.alias_repository")
+    monkeypatch.setattr(notebook, "get_recording", lambda recording_id: recording)
+    monkeypatch.setattr(db_module, "iter_segments", lambda recording_id: iter(segments))
+    monkeypatch.setattr(alias_repo, "alias_map", lambda recording_id: aliases or {})
+
+
+@pytest.mark.asyncio
+async def test_md_export_streams_markdown_with_headers(monkeypatch) -> None:
+    segments = [
+        {"speaker": "SPEAKER_00", "text": "Hello there.", "start_time": 0.5},
+        {"speaker": "SPEAKER_01", "text": "Hi.", "start_time": 3.0},
+    ]
+    _patch_md_route_data(monkeypatch, _RECORDING, segments)
+
+    response = await notebook.export_recording(1, format="md")
+
+    assert response.status_code == 200
+    assert response.media_type == "text/markdown; charset=utf-8"
+    assert '.md"' in response.headers["Content-Disposition"]
+    content = await _drain(response)
+    assert content.startswith("# Friday Meeting - Part 2\n\n")
+    # Raw diarization labels are substituted to first-appearance numbering.
+    assert "**Speaker 1** *[00:00]*: Hello there.  \n" in content
+    assert "**Speaker 2** *[00:03]*: Hi.  \n" in content
+
+
+@pytest.mark.asyncio
+async def test_md_export_applies_user_aliases(monkeypatch) -> None:
+    segments = [
+        {"speaker": "SPEAKER_00", "text": "Hello.", "start_time": 0.0},
+        {"speaker": "SPEAKER_01", "text": "Hi.", "start_time": 2.0},
+    ]
+    _patch_md_route_data(
+        monkeypatch,
+        _RECORDING,
+        segments,
+        aliases={"SPEAKER_00": "Elena"},
+    )
+
+    response = await notebook.export_recording(1, format="md")
+
+    content = await _drain(response)
+    assert "**Elena** *[00:00]*: Hello.  \n" in content
+    # Unaliased speakers keep first-appearance numbering.
+    assert "**Speaker 1** *[00:02]*: Hi.  \n" in content
+
+
+@pytest.mark.asyncio
+async def test_md_export_allowed_for_pure_note(monkeypatch) -> None:
+    """Unlike SRT/ASS, markdown must work for notes without diarization/words."""
+    recording = {
+        "id": 1,
+        "title": "Pure note",
+        "filename": "pure.mp3",
+        "recorded_at": "2026-01-10T11:00:00",
+        "duration_seconds": 42.0,
+        "word_count": 0,
+        "has_diarization": 0,
+    }
+    segments = [{"speaker": None, "text": "Just text.", "start_time": 0.0}]
+    _patch_md_route_data(monkeypatch, recording, segments)
+
+    response = await notebook.export_recording(1, format="md")
+
+    assert response.status_code == 200
+    content = await _drain(response)
+    assert "Just text.\n" in content
+
+
+@pytest.mark.asyncio
+async def test_md_export_404_when_recording_missing(monkeypatch) -> None:
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(notebook, "get_recording", lambda recording_id: None)
+
+    with pytest.raises(HTTPException) as exc:
+        await notebook.export_recording(999, format="md")
+    assert exc.value.status_code == 404

--- a/server/backend/tests/test_retro_diarize.py
+++ b/server/backend/tests/test_retro_diarize.py
@@ -1,0 +1,549 @@
+"""Tests for retroactive diarization of an existing recording (GH-279).
+
+Three layers:
+- POST /recordings/{id}/diarize precondition matrix (direct-call route pattern)
+- core/retro_diarize.run_retro_diarization worker (model-swap discipline,
+  failure contract, job tracker results)
+- database.replace_recording_segments_with_diarization on a real temp SQLite
+  (atomic replace, rollback-on-failure, FTS sync)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import server.database.database as db
+from fastapi import HTTPException
+from server.api.routes import notebook
+from server.core import retro_diarize
+
+# ── Shared fakes ─────────────────────────────────────────────────────────────
+
+
+class _FakeTracker:
+    def __init__(self, busy: bool = False):
+        self._busy = busy
+        self.phases: list[str] = []
+        self.ended: list[tuple[str, dict | None]] = []
+
+    def try_start_job(self, user: str):
+        if self._busy:
+            return (False, None, "other-client")
+        return (True, "job-uuid-1234567890", None)
+
+    def set_phase(self, phase: str) -> None:
+        self.phases.append(phase)
+
+    def end_job(self, job_id: str, result: dict | None = None) -> bool:
+        self.ended.append((job_id, result))
+        return True
+
+
+class _Turn:
+    def __init__(self, start: float, end: float, speaker: str):
+        self._d = {"start": start, "end": end, "speaker": speaker}
+
+    def to_dict(self) -> dict:
+        return self._d
+
+
+class _FakeModelManager:
+    def __init__(self, diar_result=None, diar_error: Exception | None = None):
+        self.calls: list[str] = []
+        self.job_tracker = _FakeTracker()
+        self.gpu_device_index = 0
+        self._diar_result = diar_result
+        self._diar_error = diar_error
+
+    def unload_transcription_model(self) -> None:
+        self.calls.append("unload_stt")
+
+    def load_transcription_model(self) -> None:
+        self.calls.append("load_stt")
+
+    def load_diarization_model(self) -> None:
+        self.calls.append("load_diar")
+
+    def unload_diarization_model(self) -> None:
+        self.calls.append("unload_diar")
+
+    @property
+    def diarization_engine(self):
+        def _diarize_file(path: str, num_speakers=None):
+            self.calls.append("diarize_file")
+            if self._diar_error is not None:
+                raise self._diar_error
+            return self._diar_result
+
+        return SimpleNamespace(diarize_file=_diarize_file)
+
+
+def _two_turn_result() -> SimpleNamespace:
+    return SimpleNamespace(
+        segments=[_Turn(0.0, 2.0, "SPEAKER_00"), _Turn(2.0, 4.0, "SPEAKER_01")],
+        num_speakers=2,
+    )
+
+
+_WORDS = [
+    {"word": "hello", "start_time": 0.2, "end_time": 0.6, "confidence": 0.9},
+    {"word": "there", "start_time": 0.7, "end_time": 1.1, "confidence": 0.9},
+    {"word": "general", "start_time": 2.2, "end_time": 2.8, "confidence": 0.8},
+    {"word": "kenobi", "start_time": 2.9, "end_time": 3.5, "confidence": 0.8},
+]
+
+
+# ── Route: POST /recordings/{id}/diarize ─────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _patch_client_name(monkeypatch):
+    monkeypatch.setattr(notebook, "get_client_name", lambda _req: "test-client")
+
+
+def _request_with_manager(manager) -> SimpleNamespace:
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(model_manager=manager)))
+
+
+def _recording_row(tmp_path: Path, has_diarization: int = 0) -> dict:
+    audio = tmp_path / "note.mp3"
+    audio.write_bytes(b"fake-audio")
+    return {
+        "id": 7,
+        "filepath": str(audio),
+        "has_diarization": has_diarization,
+        "title": "Note",
+    }
+
+
+class TestDiarizeRoutePreconditions:
+    @pytest.mark.asyncio
+    async def test_404_when_recording_missing(self, monkeypatch):
+        monkeypatch.setattr(notebook, "get_recording", lambda _id: None)
+
+        with pytest.raises(HTTPException) as exc:
+            await notebook.diarize_recording(999, _request_with_manager(_FakeModelManager()))
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_409_when_already_diarized(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            notebook, "get_recording", lambda _id: _recording_row(tmp_path, has_diarization=1)
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            await notebook.diarize_recording(7, _request_with_manager(_FakeModelManager()))
+        assert exc.value.status_code == 409
+        assert "already diarized" in exc.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_400_when_no_word_timestamps(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(notebook, "get_recording", lambda _id: _recording_row(tmp_path))
+        monkeypatch.setattr(notebook, "get_words", lambda _id: [])
+
+        with pytest.raises(HTTPException) as exc:
+            await notebook.diarize_recording(7, _request_with_manager(_FakeModelManager()))
+        assert exc.value.status_code == 400
+        assert "word-level timestamps" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_409_when_audio_file_missing_on_disk(self, monkeypatch, tmp_path):
+        row = _recording_row(tmp_path)
+        Path(row["filepath"]).unlink()
+        monkeypatch.setattr(notebook, "get_recording", lambda _id: row)
+        monkeypatch.setattr(notebook, "get_words", lambda _id: list(_WORDS))
+
+        with pytest.raises(HTTPException) as exc:
+            await notebook.diarize_recording(7, _request_with_manager(_FakeModelManager()))
+        assert exc.value.status_code == 409
+        assert "audio file" in exc.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_400_on_bad_expected_speakers(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(notebook, "get_recording", lambda _id: _recording_row(tmp_path))
+        monkeypatch.setattr(notebook, "get_words", lambda _id: list(_WORDS))
+
+        with pytest.raises(HTTPException) as exc:
+            await notebook.diarize_recording(
+                7,
+                _request_with_manager(_FakeModelManager()),
+                body=notebook.DiarizeRequest(expected_speakers=11),
+            )
+        assert exc.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_409_when_job_slot_busy(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(notebook, "get_recording", lambda _id: _recording_row(tmp_path))
+        monkeypatch.setattr(notebook, "get_words", lambda _id: list(_WORDS))
+        manager = _FakeModelManager()
+        manager.job_tracker = _FakeTracker(busy=True)
+
+        with pytest.raises(HTTPException) as exc:
+            await notebook.diarize_recording(7, _request_with_manager(manager))
+        assert exc.value.status_code == 409
+        assert "other-client" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_202_launches_background_worker(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(notebook, "get_recording", lambda _id: _recording_row(tmp_path))
+        monkeypatch.setattr(notebook, "get_words", lambda _id: list(_WORDS))
+        invoked: dict = {}
+
+        def _fake_worker(**kwargs):
+            invoked.update(kwargs)
+
+        monkeypatch.setattr(retro_diarize, "run_retro_diarization", _fake_worker)
+        manager = _FakeModelManager()
+
+        result = await notebook.diarize_recording(
+            7,
+            _request_with_manager(manager),
+            body=notebook.DiarizeRequest(expected_speakers=3),
+        )
+
+        assert result == {"job_id": "job-uuid"}
+        # Drain the fire-and-forget task so the patched worker actually runs.
+        pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+        await asyncio.gather(*pending)
+        assert invoked["recording_id"] == 7
+        assert invoked["job_id"] == "job-uuid-1234567890"
+        assert invoked["expected_speakers"] == 3
+        assert invoked["model_manager"] is manager
+
+
+# ── Worker: run_retro_diarization ────────────────────────────────────────────
+
+
+@pytest.fixture()
+def _worker_env(monkeypatch, tmp_path):
+    """Patch the worker's DB/audio collaborators; return a mutable env dict."""
+    audio = tmp_path / "note.mp3"
+    audio.write_bytes(b"fake-audio")
+    env = {
+        "recording": {"id": 7, "filepath": str(audio), "title": "Note"},
+        "words": list(_WORDS),
+        "replace_calls": [],
+        "replace_return": True,
+        "cleanup_calls": [],
+        "hook_calls": [],
+    }
+
+    db_module = importlib.import_module("server.database.database")
+    monkeypatch.setattr(db_module, "get_recording", lambda _id: env["recording"])
+    monkeypatch.setattr(db_module, "get_words", lambda _id: env["words"])
+
+    def _fake_replace(recording_id, diar_dicts, alignment_words):
+        env["replace_calls"].append((recording_id, diar_dicts, alignment_words))
+        return env["replace_return"]
+
+    monkeypatch.setattr(db_module, "replace_recording_segments_with_diarization", _fake_replace)
+
+    audio_utils = importlib.import_module("server.core.audio_utils")
+    monkeypatch.setattr(
+        audio_utils,
+        "post_job_gpu_cleanup",
+        lambda label, device: env["cleanup_calls"].append(label),
+    )
+    monkeypatch.setattr(
+        retro_diarize,
+        "_run_review_lifecycle_hook",
+        lambda rid: env["hook_calls"].append(rid),
+    )
+    return env
+
+
+class TestRunRetroDiarization:
+    def test_success_persists_and_reports(self, _worker_env):
+        manager = _FakeModelManager(diar_result=_two_turn_result())
+
+        retro_diarize.run_retro_diarization(
+            model_manager=manager, recording_id=7, job_id="job-abcdefgh"
+        )
+
+        assert manager.job_tracker.phases == ["diarizing"]
+        # Model swap mirrors transcribe_then_diarize phase 2: free the STT
+        # model first, restore both models before the DB write-back.
+        assert manager.calls == [
+            "unload_stt",
+            "load_diar",
+            "diarize_file",
+            "unload_diar",
+            "load_stt",
+        ]
+        assert len(_worker_env["replace_calls"]) == 1
+        rid, diar_dicts, alignment_words = _worker_env["replace_calls"][0]
+        assert rid == 7
+        assert [d["speaker"] for d in diar_dicts] == ["SPEAKER_00", "SPEAKER_01"]
+        assert alignment_words == _WORDS
+        (job_id, result) = manager.job_tracker.ended[0]
+        assert job_id == "job-abcdefgh"
+        assert result["recording_id"] == 7
+        assert result["num_speakers"] == 2
+        assert "error" not in result
+        assert _worker_env["hook_calls"] == [7]
+        assert _worker_env["cleanup_calls"] == ["notebook retro-diarize"]
+
+    def test_zero_turns_is_failure_and_db_untouched(self, _worker_env):
+        manager = _FakeModelManager(diar_result=SimpleNamespace(segments=[], num_speakers=0))
+
+        retro_diarize.run_retro_diarization(
+            model_manager=manager, recording_id=7, job_id="job-abcdefgh"
+        )
+
+        assert _worker_env["replace_calls"] == []
+        (_, result) = manager.job_tracker.ended[0]
+        assert "error" in result
+        assert "no speaker turns" in result["error"]
+        assert _worker_env["hook_calls"] == []
+        # Models restored even on failure.
+        assert "unload_diar" in manager.calls and "load_stt" in manager.calls
+
+    def test_diarization_exception_restores_models_and_reports_error(self, _worker_env):
+        manager = _FakeModelManager(diar_error=RuntimeError("CUDA out of memory"))
+
+        retro_diarize.run_retro_diarization(
+            model_manager=manager, recording_id=7, job_id="job-abcdefgh"
+        )
+
+        assert _worker_env["replace_calls"] == []
+        assert manager.calls == [
+            "unload_stt",
+            "load_diar",
+            "diarize_file",
+            "unload_diar",
+            "load_stt",
+        ]
+        (_, result) = manager.job_tracker.ended[0]
+        assert "CUDA out of memory" in result["error"]
+        assert _worker_env["cleanup_calls"] == ["notebook retro-diarize"]
+
+    def test_replace_failure_reports_error(self, _worker_env):
+        _worker_env["replace_return"] = False
+        manager = _FakeModelManager(diar_result=_two_turn_result())
+
+        retro_diarize.run_retro_diarization(
+            model_manager=manager, recording_id=7, job_id="job-abcdefgh"
+        )
+
+        (_, result) = manager.job_tracker.ended[0]
+        assert "error" in result
+        assert _worker_env["hook_calls"] == []
+
+    def test_missing_audio_fails_before_any_model_swap(self, _worker_env):
+        Path(_worker_env["recording"]["filepath"]).unlink()
+        manager = _FakeModelManager(diar_result=_two_turn_result())
+
+        retro_diarize.run_retro_diarization(
+            model_manager=manager, recording_id=7, job_id="job-abcdefgh"
+        )
+
+        assert manager.calls == []
+        (_, result) = manager.job_tracker.ended[0]
+        assert "error" in result
+        assert _worker_env["cleanup_calls"] == ["notebook retro-diarize"]
+
+    def test_missing_words_fails_before_any_model_swap(self, _worker_env):
+        _worker_env["words"] = []
+        manager = _FakeModelManager(diar_result=_two_turn_result())
+
+        retro_diarize.run_retro_diarization(
+            model_manager=manager, recording_id=7, job_id="job-abcdefgh"
+        )
+
+        assert manager.calls == []
+        (_, result) = manager.job_tracker.ended[0]
+        assert "word-level timestamps" in result["error"]
+
+
+# ── Database: replace_recording_segments_with_diarization ────────────────────
+
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS recordings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    filename TEXT NOT NULL,
+    filepath TEXT NOT NULL UNIQUE,
+    title TEXT,
+    duration_seconds REAL NOT NULL,
+    recorded_at TIMESTAMP NOT NULL,
+    imported_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    word_count INTEGER DEFAULT 0,
+    has_diarization INTEGER DEFAULT 0,
+    summary TEXT,
+    summary_model TEXT,
+    transcription_backend TEXT,
+    audio_hash TEXT,
+    normalized_audio_hash TEXT
+);
+
+CREATE TABLE IF NOT EXISTS segments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    recording_id INTEGER NOT NULL,
+    segment_index INTEGER NOT NULL,
+    speaker TEXT,
+    text TEXT NOT NULL,
+    start_time REAL NOT NULL,
+    end_time REAL NOT NULL,
+    FOREIGN KEY (recording_id) REFERENCES recordings(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS words (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    recording_id INTEGER NOT NULL,
+    segment_id INTEGER NOT NULL,
+    word_index INTEGER NOT NULL,
+    word TEXT NOT NULL,
+    start_time REAL NOT NULL,
+    end_time REAL NOT NULL,
+    confidence REAL,
+    FOREIGN KEY (recording_id) REFERENCES recordings(id) ON DELETE CASCADE,
+    FOREIGN KEY (segment_id) REFERENCES segments(id) ON DELETE CASCADE
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS words_fts USING fts5(
+    word,
+    content='words',
+    content_rowid='id',
+    tokenize='unicode61'
+);
+
+CREATE TRIGGER IF NOT EXISTS words_ai AFTER INSERT ON words BEGIN
+    INSERT INTO words_fts(rowid, word) VALUES (new.id, new.word);
+END;
+
+CREATE TRIGGER IF NOT EXISTS words_ad AFTER DELETE ON words BEGIN
+    INSERT INTO words_fts(words_fts, rowid, word) VALUES('delete', old.id, old.word);
+END;
+
+CREATE TRIGGER IF NOT EXISTS words_au AFTER UPDATE ON words BEGIN
+    INSERT INTO words_fts(words_fts, rowid, word) VALUES('delete', old.id, old.word);
+    INSERT INTO words_fts(rowid, word) VALUES (new.id, new.word);
+END;
+"""
+
+
+@pytest.fixture()
+def _isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    data_dir = tmp_path / "data"
+    db_dir = data_dir / "database"
+    db_dir.mkdir(parents=True)
+    db_path = db_dir / "notebook.db"
+
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(_SCHEMA_SQL)
+    conn.close()
+
+    monkeypatch.setattr(db, "_data_dir", data_dir)
+    monkeypatch.setattr(db, "_db_path", db_path)
+
+
+def _seed_plain_recording(tmp_path: Path) -> int:
+    """Insert a non-diarized recording with word timestamps (the GH-279 target)."""
+    audio = tmp_path / "seed.mp3"
+    audio.write_bytes(b"fake")
+    recording_id = db.save_longform_to_database(
+        audio_path=audio,
+        duration_seconds=4.0,
+        transcription_text="hello there general kenobi",
+        word_timestamps=[
+            {"word": "hello", "start": 0.2, "end": 0.6, "confidence": 0.9},
+            {"word": "there", "start": 0.7, "end": 1.1, "confidence": 0.9},
+            {"word": "general", "start": 2.2, "end": 2.8, "confidence": 0.8},
+            {"word": "kenobi", "start": 2.9, "end": 3.5, "confidence": 0.8},
+        ],
+    )
+    assert recording_id is not None
+    return recording_id
+
+
+_DIAR_TURNS = [
+    {"start": 0.0, "end": 2.0, "speaker": "SPEAKER_00"},
+    {"start": 2.0, "end": 4.0, "speaker": "SPEAKER_01"},
+]
+
+
+class TestReplaceRecordingSegments:
+    def test_replaces_segments_and_flips_flag(self, _isolated_db, tmp_path):
+        rid = _seed_plain_recording(tmp_path)
+        before = db.get_recording(rid)
+        assert not before["has_diarization"]
+        assert before["word_count"] == 4
+
+        ok = db.replace_recording_segments_with_diarization(
+            rid, _DIAR_TURNS, alignment_words=db.get_words(rid)
+        )
+
+        assert ok is True
+        after = db.get_recording(rid)
+        assert after["has_diarization"] == 1
+        assert after["word_count"] == 4
+        segments = db.get_segments(rid)
+        assert [s["speaker"] for s in segments] == ["SPEAKER_00", "SPEAKER_01"]
+        assert segments[0]["text"] == "hello there"
+        assert segments[1]["text"] == "general kenobi"
+        # Words re-linked to the NEW segment ids.
+        words = db.get_words(rid)
+        seg_ids = {s["id"] for s in segments}
+        assert all(w["segment_id"] in seg_ids for w in words)
+
+    def test_fts_stays_in_sync_after_replace(self, _isolated_db, tmp_path):
+        rid = _seed_plain_recording(tmp_path)
+
+        assert db.replace_recording_segments_with_diarization(
+            rid, _DIAR_TURNS, alignment_words=db.get_words(rid)
+        )
+
+        hits = db.search_words("kenobi")
+        assert len(hits) == 1
+        assert hits[0]["speaker"] == "SPEAKER_01"
+
+    def test_empty_turns_refused_and_untouched(self, _isolated_db, tmp_path):
+        rid = _seed_plain_recording(tmp_path)
+
+        ok = db.replace_recording_segments_with_diarization(
+            rid, [], alignment_words=db.get_words(rid)
+        )
+
+        assert ok is False
+        assert not db.get_recording(rid)["has_diarization"]
+        assert len(db.get_words(rid)) == 4
+
+    def test_empty_words_refused_and_untouched(self, _isolated_db, tmp_path):
+        rid = _seed_plain_recording(tmp_path)
+
+        ok = db.replace_recording_segments_with_diarization(rid, _DIAR_TURNS, alignment_words=[])
+
+        assert ok is False
+        assert not db.get_recording(rid)["has_diarization"]
+
+    def test_unknown_recording_refused(self, _isolated_db, tmp_path):
+        ok = db.replace_recording_segments_with_diarization(
+            999, _DIAR_TURNS, alignment_words=list(_WORDS)
+        )
+        assert ok is False
+
+    def test_insert_failure_rolls_back_original_transcript(
+        self, _isolated_db, tmp_path, monkeypatch
+    ):
+        rid = _seed_plain_recording(tmp_path)
+        original_segments = db.get_segments(rid)
+
+        def _boom(*args, **kwargs):
+            raise sqlite3.OperationalError("simulated failure mid-insert")
+
+        monkeypatch.setattr(db, "_insert_diarization_segments_with_words", _boom)
+
+        ok = db.replace_recording_segments_with_diarization(
+            rid, _DIAR_TURNS, alignment_words=db.get_words(rid)
+        )
+
+        assert ok is False
+        # Data-loss invariant: the original transcript survives untouched.
+        assert db.get_segments(rid) == original_segments
+        assert len(db.get_words(rid)) == 4
+        assert not db.get_recording(rid)["has_diarization"]


### PR DESCRIPTION
Implements the two remaining asks from #279: retroactive diarization of already-saved notebook recordings, and a Markdown conversation export.

## Feature A — Diarize an existing note (no re-transcription)

Every existing diarization path couples diarization to a fresh transcription pass. This PR adds the missing standalone path: the stored audio file is diarized with the standalone engine (PyAnnote/Sortformer), and the speaker turns are aligned onto the recording's **already-persisted word timestamps** — the STT engine never runs.

**Server**
- `POST /api/notebook/recordings/{id}/diarize` — 202 + `job_id`, client polls `/api/admin/status` (same contract as `/transcribe/upload`). Preconditions: 404 unknown recording, 409 already diarized, 400 no word timestamps, 409 audio file missing on disk, 409 job slot busy.
- `core/retro_diarize.py` — background worker. Mirrors the `transcribe_then_diarize` phase-2 model-swap discipline: unload STT → load diarizer → diarize → guarded unload/reload in `finally`, `post_job_gpu_cleanup` last. Zero speaker turns is treated as failure (DB untouched).
- `database.replace_recording_segments_with_diarization()` — single `BEGIN IMMEDIATE` transaction: delete old segments/words, re-insert through the same alignment helper the import path uses (`_insert_diarization_segments_with_words`), flip `has_diarization`, refresh `word_count`. Any failure rolls back — the original transcript survives every failure mode (data-loss invariant). FTS triggers keep `words_fts` in sync; a retro-diarized recording is indistinguishable in the DB from one diarized at import time. The ADR-009 review-lifecycle hook fires after commit, same as the import path.

**Dashboard**
- **Diarize** appears in both note menus (calendar-card `NoteActionMenu` + `AudioNoteModal` dropdown): hidden once diarized, disabled with an explanatory hover tooltip when the note has no word-level timestamps (`word_count` is threaded through `EventData`, so the context menu needs no extra fetch).
- `services/retroDiarize.ts` polls admin status until the job settles (import-queue pattern); completion refreshes the calendar / open note and toasts the outcome, failure toasts the server's error.

**Review-hardened:** an adversarial review pass caught two stale-closure hazards in the first cut, both fixed and pinned by tests:
- The shared `AudioNoteModal` instance survives note switches; a diarize completion now only applies `refresh()` if the note it started for is still open (otherwise it would clobber the open note's transcript with the other recording's data).
- Calendar refreshes from menu actions go through a latest-ref wrapper, so a completion that lands after a month navigation refetches the *current* month instead of overwriting it with the stale one.

## Feature B — Markdown export

New `format=md` on `GET /recordings/{id}/export` (streaming, like `plaintext`), wired to **Export Markdown** in both menus:

```markdown
# Friday Meeting - Part 2

**Date:** July 10, 2026 at 02:53 PM

---

**Speaker 3** *[00:44]*: There's not enough memory storage.
**Speaker 1** *[00:48]*: Yes, I'll let you decide which one should go in.
```

- Speaker labels go through the shared alias system (`apply_aliases`), so `Speaker N` numbering and user aliases match the transcript view exactly.
- Consecutive same-speaker segments coalesce into one turn line; timestamps are zero-padded `MM:SS` (minutes roll past 59 for >1h recordings), each line ends with a Markdown hard break.
- Non-diarized notes degrade to plain paragraphs under the same title/date header — `md` is available for every recording, unlike SRT/ASS.
- `ExportFormat` union widened (`'plaintext' | 'md'` added), removing the old `as never` cast.

## Tests

- Backend: full suite **2406 passed** (38 new — route precondition matrix, worker swap-order/failure contract, transactional replace + rollback + FTS sync on a real temp SQLite, markdown format/alias/pure-note/route tests).
- Dashboard: full suite **2026 passed** (16 new — polling semantics incl. job-lost and transient-error retry, Diarize/Export Markdown gating in both menus, stale-refresh guard on note switch). Typecheck + eslint clean.
- ui-contract: resynced (spec 1.16.2), 22 checks green.

## Smoke checklist (hardware)

- [ ] Record without diarization (or promote a Live session), right-click → Diarize: speakers appear after the job, calendar tag flips to DIARIZED, review banner appears on low confidence
- [ ] Diarize a note transcribed **without** word timestamps: menu item grayed out with tooltip
- [ ] Diarize while another transcription is running: 409 toast, note untouched
- [ ] Export Markdown for a diarized note with aliases set: labels match the transcript view
- [ ] Export Markdown for a plain note: title/date header + paragraphs

For #279.
