### PR TITLE
feat(dashboard, ui): replace the Main Transcription switches and the Live Mode translate switch with pill toggle buttons

### DIFF
--- a/dashboard/components/__tests__/SessionView.diarization.test.tsx
+++ b/dashboard/components/__tests__/SessionView.diarization.test.tsx
@@ -269,10 +269,10 @@ describe('SessionView - speaker diarization for recordings (GH-258)', () => {
     expect(toggle).toBeTruthy();
   });
 
-  it('stacks Translate and Speaker Diarization as two named toggle rows', async () => {
-    // The two switches share one row style and one control column. Both must
-    // carry an accessible name: they are icon-only switches, so without one a
-    // screen reader announces two anonymous toggles on the same card.
+  it('renders Translate and Speaker Diarization as named toggle buttons on one row', async () => {
+    // The two controls are pill buttons sharing one centered row. Both keep
+    // role switch plus an accessible name, so screen readers announce two
+    // named on/off controls instead of two anonymous buttons on the card.
     render(React.createElement(SessionView, baseProps), { wrapper: createWrapper() });
 
     const diarization = await screen.findByRole('switch', { name: 'Speaker Diarization' });

--- a/dashboard/components/ui/ToggleButton.tsx
+++ b/dashboard/components/ui/ToggleButton.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+interface ToggleButtonProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  /** Visible text inside the button; doubles as the accessible name. */
+  label: string;
+  icon?: React.ReactNode;
+  size?: 'sm' | 'md';
+  disabled?: boolean;
+  /** Tooltip text; also shown while disabled to explain why. */
+  title?: string;
+  /** Accessible name override when the visible label is not enough. */
+  ariaLabel?: string;
+  className?: string;
+}
+
+/**
+ * Pill-style on/off button with a visible pressed state. Keeps the same
+ * semantics as AppleSwitch (role switch plus aria-checked) so the two are
+ * interchangeable for tests and screen readers.
+ *
+ * The title lives on a wrapper span, never on the button itself: Chromium
+ * (the Electron renderer) never shows a native tooltip on a disabled form
+ * control, and the disabled state is exactly when the explanatory tooltip
+ * matters. The disabled button also gets pointer-events-none so hover
+ * always lands on the wrapper.
+ */
+export const ToggleButton: React.FC<ToggleButtonProps> = ({
+  checked,
+  onChange,
+  label,
+  icon,
+  size = 'md',
+  disabled = false,
+  title,
+  ariaLabel,
+  className = '',
+}) => {
+  const sizeClasses = size === 'sm' ? 'h-8 gap-1.5 px-3 text-xs' : 'gap-2 px-4 py-2 text-sm';
+
+  const stateClasses = disabled
+    ? 'pointer-events-none border-white/10 bg-white/5 text-slate-500 opacity-40'
+    : checked
+      ? 'border-accent-cyan/40 bg-accent-cyan/15 text-accent-cyan shadow-[0_0_10px_rgba(34,211,238,0.15)] hover:bg-accent-cyan/25'
+      : 'border-white/10 bg-white/5 text-slate-400 hover:bg-white/10 hover:text-white active:scale-95';
+
+  return (
+    <span title={title} className={`inline-flex ${disabled ? 'cursor-not-allowed' : ''}`}>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        aria-label={ariaLabel ?? label}
+        disabled={disabled}
+        onClick={() => {
+          if (!disabled) onChange(!checked);
+        }}
+        className={`focus:ring-accent-cyan inline-flex items-center justify-center rounded-xl border font-medium transition-all duration-200 focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-900 focus:outline-none ${sizeClasses} ${stateClasses} ${className}`}
+      >
+        {icon}
+        <span className="whitespace-nowrap">{label}</span>
+      </button>
+    </span>
+  );
+};

--- a/dashboard/components/ui/ToggleButton.tsx
+++ b/dashboard/components/ui/ToggleButton.tsx
@@ -12,6 +12,8 @@ interface ToggleButtonProps {
   title?: string;
   /** Accessible name override when the visible label is not enough. */
   ariaLabel?: string;
+  /** Stretch to fill the available width of the parent flex row. */
+  fullWidth?: boolean;
   className?: string;
 }
 
@@ -35,6 +37,7 @@ export const ToggleButton: React.FC<ToggleButtonProps> = ({
   disabled = false,
   title,
   ariaLabel,
+  fullWidth = false,
   className = '',
 }) => {
   const sizeClasses = size === 'sm' ? 'h-8 gap-1.5 px-3 text-xs' : 'gap-2 px-4 py-2 text-sm';
@@ -46,7 +49,10 @@ export const ToggleButton: React.FC<ToggleButtonProps> = ({
       : 'border-white/10 bg-white/5 text-slate-400 hover:bg-white/10 hover:text-white active:scale-95';
 
   return (
-    <span title={title} className={`inline-flex ${disabled ? 'cursor-not-allowed' : ''}`}>
+    <span
+      title={title}
+      className={`inline-flex ${fullWidth ? 'min-w-0 flex-1' : ''} ${disabled ? 'cursor-not-allowed' : ''}`}
+    >
       <button
         type="button"
         role="switch"
@@ -56,7 +62,7 @@ export const ToggleButton: React.FC<ToggleButtonProps> = ({
         onClick={() => {
           if (!disabled) onChange(!checked);
         }}
-        className={`focus:ring-accent-cyan inline-flex items-center justify-center rounded-xl border font-medium transition-all duration-200 focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-900 focus:outline-none ${sizeClasses} ${stateClasses} ${className}`}
+        className={`focus:ring-accent-cyan inline-flex items-center justify-center rounded-xl border font-medium transition-all duration-200 focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-900 focus:outline-none ${fullWidth ? 'w-full' : ''} ${sizeClasses} ${stateClasses} ${className}`}
       >
         {icon}
         <span className="whitespace-nowrap">{label}</span>

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -1942,6 +1942,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
                             checked={mainTranslate && canTranslate}
                             onChange={setMainTranslate}
                             disabled={!canTranslate}
+                            fullWidth
                             label="Translate to English"
                             icon={<Languages size={15} />}
                             title={canTranslate ? '' : 'Current model does not support translation'}
@@ -1953,6 +1954,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
                           checked={effectiveDiarization}
                           onChange={handleDiarizationToggle}
                           disabled={diarizationUnavailable}
+                          fullWidth
                           label="Speaker Diarization"
                           icon={<Users size={15} />}
                           title={

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -23,10 +23,12 @@ import {
   Minimize2,
   AlertTriangle,
   Zap,
+  Users,
 } from 'lucide-react';
 import { GlassCard } from '../ui/GlassCard';
 import { Button } from '../ui/Button';
 import { AppleSwitch } from '../ui/AppleSwitch';
+import { ToggleButton } from '../ui/ToggleButton';
 import { StatusLight } from '../ui/StatusLight';
 import { AudioVisualizer } from '../AudioVisualizer';
 import { CustomSelect } from '../ui/CustomSelect';
@@ -1915,97 +1917,79 @@ export const SessionView: React.FC<SessionViewProps> = ({
                       </div>
                     </div>
 
-                    {/* Per-recording toggles. One row each, label left and
-                      control right-aligned in a shared fixed-width column, so
-                      every control shares a right edge with the Source Language
-                      dropdown above (this block's px-1 matches that block's
-                      p-1). The width is fixed rather than content-driven
-                      because it also sizes the Canary bidirectional dropdown
-                      that replaces the Translate switch. */}
-                    <div className="space-y-2 border-t border-white/5 px-1 pt-3">
-                      <div
-                        className="flex items-center gap-6"
-                        title={canTranslate ? '' : 'Current model does not support translation'}
-                      >
-                        <span
-                          className={`min-w-0 flex-1 text-sm font-medium ${canTranslate ? 'text-white/90' : 'text-slate-500 line-through'}`}
-                        >
-                          {isCanaryMainBidi ? 'Translate to' : 'Translate to English'}
-                        </span>
-                        <div className="flex w-34 items-center justify-end">
-                          {isCanaryMainBidi ? (
+                    {/* Per-recording toggles as two pill buttons on one
+                      centered row. The speaker-count stepper appears on its
+                      own centered row below, but only while diarization is
+                      on, so clicking the button always means toggle and the
+                      stepper never fights it for the click. Canary
+                      bidirectional models swap the Translate button for the
+                      target-language dropdown. */}
+                    <div className="border-t border-white/5 px-1 pt-3">
+                      <div className="flex flex-wrap items-center justify-center gap-2">
+                        {isCanaryMainBidi ? (
+                          <div className="flex items-center gap-2">
+                            <span className="text-sm font-medium text-white/90">Translate to</span>
                             <CustomSelect
                               value={mainBidiTarget}
                               onChange={setMainBidiTarget}
                               options={['Off', ...CANARY_TRANSLATION_TARGETS]}
                               accentColor="magenta"
-                              className="focus:ring-accent-magenta w-full rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-sm text-slate-300 outline-none focus:ring-1"
+                              className="focus:ring-accent-magenta w-28 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-sm text-slate-300 outline-none focus:ring-1"
                             />
-                          ) : (
-                            <AppleSwitch
-                              checked={mainTranslate && canTranslate}
-                              onChange={setMainTranslate}
-                              size="sm"
-                              disabled={!canTranslate}
-                              ariaLabel="Translate to English"
-                            />
-                          )}
-                        </div>
-                      </div>
-
-                      {/* GH-258: speaker diarization for this recording. Off by
-                        default so plain dictation is untouched; the count row
-                        only appears once it is on. */}
-                      <div
-                        className="flex items-center gap-6"
-                        title={
-                          diarizationUnavailable
-                            ? diarizationFeature?.reason === 'token_missing'
-                              ? 'Diarization needs a HuggingFace token. Add one in Settings and restart the server.'
-                              : 'Diarization is unavailable on this server.'
-                            : 'Label who said what in the finished transcript.'
-                        }
-                      >
-                        <span className="min-w-0 flex-1 text-sm font-medium text-white/90">
-                          Speaker Diarization
-                        </span>
-                        <div className="flex w-34 items-center justify-end">
-                          <AppleSwitch
-                            checked={effectiveDiarization}
-                            onChange={handleDiarizationToggle}
-                            disabled={diarizationUnavailable}
-                            ariaLabel="Speaker Diarization"
+                          </div>
+                        ) : (
+                          <ToggleButton
+                            checked={mainTranslate && canTranslate}
+                            onChange={setMainTranslate}
+                            disabled={!canTranslate}
+                            label="Translate to English"
+                            icon={<Languages size={15} />}
+                            title={canTranslate ? '' : 'Current model does not support translation'}
                           />
-                        </div>
+                        )}
+                        {/* GH-258: speaker diarization for this recording.
+                          Off by default so plain dictation is untouched. */}
+                        <ToggleButton
+                          checked={effectiveDiarization}
+                          onChange={handleDiarizationToggle}
+                          disabled={diarizationUnavailable}
+                          label="Speaker Diarization"
+                          icon={<Users size={15} />}
+                          title={
+                            diarizationUnavailable
+                              ? diarizationFeature?.reason === 'token_missing'
+                                ? 'Diarization needs a HuggingFace token. Add one in Settings and restart the server.'
+                                : 'Diarization is unavailable on this server.'
+                              : 'Label who said what in the finished transcript.'
+                          }
+                        />
                       </div>
                       {effectiveDiarization && (
-                        <div className="flex items-center gap-6">
-                          <span className="min-w-0 flex-1 text-xs text-slate-400">Speakers</span>
-                          <div className="flex w-34 items-center justify-end gap-2">
-                            <button
-                              type="button"
-                              aria-label="Fewer speakers"
-                              onClick={() =>
-                                handleSpeakerCountChange(constrainSpeakers ? numSpeakers - 1 : 0)
-                              }
-                              className="flex h-6 w-6 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-slate-300 transition-colors hover:bg-white/10"
-                            >
-                              &minus;
-                            </button>
-                            <span className="w-14 text-center text-xs text-slate-300">
-                              {constrainSpeakers ? numSpeakers : 'Auto'}
-                            </span>
-                            <button
-                              type="button"
-                              aria-label="More speakers"
-                              onClick={() =>
-                                handleSpeakerCountChange(constrainSpeakers ? numSpeakers + 1 : 2)
-                              }
-                              className="flex h-6 w-6 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-slate-300 transition-colors hover:bg-white/10"
-                            >
-                              +
-                            </button>
-                          </div>
+                        <div className="mt-3 flex items-center justify-center gap-2">
+                          <span className="mr-1 text-xs text-slate-400">Speakers</span>
+                          <button
+                            type="button"
+                            aria-label="Fewer speakers"
+                            onClick={() =>
+                              handleSpeakerCountChange(constrainSpeakers ? numSpeakers - 1 : 0)
+                            }
+                            className="flex h-6 w-6 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-slate-300 transition-colors hover:bg-white/10"
+                          >
+                            &minus;
+                          </button>
+                          <span className="w-14 text-center text-xs text-slate-300">
+                            {constrainSpeakers ? numSpeakers : 'Auto'}
+                          </span>
+                          <button
+                            type="button"
+                            aria-label="More speakers"
+                            onClick={() =>
+                              handleSpeakerCountChange(constrainSpeakers ? numSpeakers + 1 : 2)
+                            }
+                            className="flex h-6 w-6 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-slate-300 transition-colors hover:bg-white/10"
+                          >
+                            +
+                          </button>
                         </div>
                       )}
                     </div>
@@ -2703,25 +2687,28 @@ export const SessionView: React.FC<SessionViewProps> = ({
                               canTranslateLive ? '' : 'Current model does not support translation'
                             }
                           >
-                            <span
-                              className={`text-[9px] font-bold tracking-widest whitespace-nowrap uppercase ${canTranslateLive ? 'text-slate-500' : 'text-slate-600 line-through'}`}
-                            >
-                              {isCanaryLiveBidi ? 'Translate to' : 'Translate to English'}
-                            </span>
                             {isCanaryLiveBidi ? (
-                              <CustomSelect
-                                value={liveBidiTarget}
-                                onChange={setLiveBidiTarget}
-                                options={['Off', ...CANARY_TRANSLATION_TARGETS]}
-                                accentColor="magenta"
-                                className="focus:ring-accent-magenta h-full min-w-25 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-sm text-slate-300 outline-none focus:ring-1"
-                              />
+                              <>
+                                <span className="text-[9px] font-bold tracking-widest whitespace-nowrap text-slate-500 uppercase">
+                                  Translate to
+                                </span>
+                                <CustomSelect
+                                  value={liveBidiTarget}
+                                  onChange={setLiveBidiTarget}
+                                  options={['Off', ...CANARY_TRANSLATION_TARGETS]}
+                                  accentColor="magenta"
+                                  className="focus:ring-accent-magenta h-full min-w-25 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-sm text-slate-300 outline-none focus:ring-1"
+                                />
+                              </>
                             ) : (
-                              <AppleSwitch
+                              <ToggleButton
+                                size="sm"
                                 checked={liveTranslate && canTranslateLive}
                                 onChange={setLiveTranslate}
-                                size="sm"
                                 disabled={!canTranslateLive}
+                                label="Translate to English"
+                                ariaLabel="Translate to English (Live Mode)"
+                                icon={<Languages size={13} />}
                               />
                             )}
                           </div>
@@ -2826,25 +2813,28 @@ export const SessionView: React.FC<SessionViewProps> = ({
                         className="flex h-8 shrink-0 items-center gap-2"
                         title={canTranslateLive ? '' : 'Current model does not support translation'}
                       >
-                        <span
-                          className={`text-[9px] font-bold tracking-widest whitespace-nowrap uppercase ${canTranslateLive ? 'text-slate-500' : 'text-slate-600 line-through'}`}
-                        >
-                          {isCanaryLiveBidi ? 'Translate to' : 'Translate to English'}
-                        </span>
                         {isCanaryLiveBidi ? (
-                          <CustomSelect
-                            value={liveBidiTarget}
-                            onChange={setLiveBidiTarget}
-                            options={['Off', ...CANARY_TRANSLATION_TARGETS]}
-                            accentColor="magenta"
-                            className="focus:ring-accent-magenta h-full min-w-25 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-sm text-slate-300 outline-none focus:ring-1"
-                          />
+                          <>
+                            <span className="text-[9px] font-bold tracking-widest whitespace-nowrap text-slate-500 uppercase">
+                              Translate to
+                            </span>
+                            <CustomSelect
+                              value={liveBidiTarget}
+                              onChange={setLiveBidiTarget}
+                              options={['Off', ...CANARY_TRANSLATION_TARGETS]}
+                              accentColor="magenta"
+                              className="focus:ring-accent-magenta h-full min-w-25 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-sm text-slate-300 outline-none focus:ring-1"
+                            />
+                          </>
                         ) : (
-                          <AppleSwitch
+                          <ToggleButton
+                            size="sm"
                             checked={liveTranslate && canTranslateLive}
                             onChange={setLiveTranslate}
-                            size="sm"
                             disabled={!canTranslateLive}
+                            label="Translate to English"
+                            ariaLabel="Translate to English (Live Mode)"
+                            icon={<Languages size={13} />}
                           />
                         )}
                       </div>

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.16.4",
-  "contract_sha256": "3fd59f26ea0f60b01a6ab09de34b3f988585b27aa5187e77ebcaffe4ea3b850e",
-  "updated_at": "2026-08-07T10:33:45.984Z"
+  "spec_version": "1.16.5",
+  "contract_sha256": "b102993c07367d2e18839cc260a8eb60122b581b739b3e7e58060eb1ae55e87e",
+  "updated_at": "2026-08-07T14:46:24.364Z"
 }

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.16.2",
-  "contract_sha256": "c6e0b6296db48892595aedae9357d55ea50b67f74a046e2220787bf32a0db582",
-  "updated_at": "2026-08-04T14:27:28.266Z"
+  "spec_version": "1.16.4",
+  "contract_sha256": "3fd59f26ea0f60b01a6ab09de34b3f988585b27aa5187e77ebcaffe4ea3b850e",
+  "updated_at": "2026-08-07T10:33:45.984Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.16.4
+  spec_version: 1.16.5
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -137,7 +137,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-08-07T10:33:13.810Z
+    generated_at: 2026-08-07T14:45:56.173Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.16.2
+  spec_version: 1.16.4
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -97,6 +97,7 @@ meta:
       - components/ui/ShortcutCapture.tsx
       - components/ui/StatusLight.test.tsx
       - components/ui/StatusLight.tsx
+      - components/ui/ToggleButton.tsx
       - components/ui/UpdateBanner.tsx
       - components/ui/UpdateModal.tsx
       - components/views/__tests__/AudioNoteModal.auto-actions.test.tsx
@@ -136,7 +137,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-08-04T14:27:10.407Z
+    generated_at: 2026-08-07T10:33:13.810Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -314,6 +315,7 @@ foundation:
       classes:
         - shadow
         - shadow-[0_0_10px_#22d3ee]
+        - shadow-[0_0_10px_rgba(34,211,238,0.15)]
         - shadow-[0_0_12px_rgba(192,132,252,0.2)]
         - shadow-[0_0_12px_rgba(203,213,225,0.2)]
         - shadow-[0_0_12px_rgba(232,121,249,0.2)]
@@ -423,6 +425,7 @@ foundation:
         - min-w-[5rem]
         - p-[3px]
         - shadow-[0_0_10px_#22d3ee]
+        - shadow-[0_0_10px_rgba(34,211,238,0.15)]
         - shadow-[0_0_12px_rgba(192,132,252,0.2)]
         - shadow-[0_0_12px_rgba(203,213,225,0.2)]
         - shadow-[0_0_12px_rgba(232,121,249,0.2)]
@@ -810,6 +813,7 @@ utility_allowlist:
     - hover:bg-accent-cyan
     - hover:bg-accent-cyan/10
     - hover:bg-accent-cyan/20
+    - hover:bg-accent-cyan/25
     - hover:bg-accent-cyan/30
     - hover:bg-accent-cyan/5
     - hover:bg-amber-400/20
@@ -1218,10 +1222,10 @@ utility_allowlist:
     - w-2
     - w-2.5
     - w-24
+    - w-28
     - w-3
     - w-3.5
     - w-32
-    - w-34
     - w-35
     - w-4
     - w-4.5
@@ -1274,6 +1278,7 @@ utility_allowlist:
     - min-w-[5rem]
     - p-[3px]
     - shadow-[0_0_10px_#22d3ee]
+    - shadow-[0_0_10px_rgba(34,211,238,0.15)]
     - shadow-[0_0_12px_rgba(192,132,252,0.2)]
     - shadow-[0_0_12px_rgba(203,213,225,0.2)]
     - shadow-[0_0_12px_rgba(232,121,249,0.2)]
@@ -3106,6 +3111,23 @@ component_contracts:
         rule: Compact mode behavior is governed by visibleSlots threshold and keeps AI/duration collapse behavior.
   ToastCard:
     file: components/ui/NotificationToasts.tsx
+    required_tokens:
+      - colors
+      - motion
+      - radii
+      - shadows
+    allowed_variants: {}
+    structural_invariants:
+      - id: structure-stable
+        rule: Preserve current structural layout and region hierarchy for this component.
+    behavior_rules:
+      - id: motion-locked
+        rule: Use only approved motion tokens and classes from foundation token registry.
+    state_rules:
+      - id: closed-set-styles
+        rule: Do not introduce unregistered utility, arbitrary, or inline style values.
+  ToggleButton:
+    file: components/ui/ToggleButton.tsx
     required_tokens:
       - colors
       - motion


### PR DESCRIPTION
## Summary

The Main Transcription card used two Apple-style switches stacked as label rows (Translate to English, Speaker Diarization). This PR replaces them with two pill-style toggle buttons sharing one centered row, and reuses the exact same button for the Translate to English option in both Live Mode toolbars (inline and pop-out) so the design stays consistent across the two surfaces.

## Changes

- **New `ToggleButton` component** (`dashboard/components/ui/ToggleButton.tsx`)
  - Pill button with icon + label, cyan checked state matching the AppleSwitch on-color and the active input-source highlight.
  - Keeps `role="switch"` + `aria-checked`, so it is a drop-in replacement for AppleSwitch as far as tests and screen readers are concerned.
  - The `title` tooltip lives on a wrapper span, not the button: Chromium never shows native tooltips on disabled form controls, and the disabled state is exactly when the explanation (missing HF token, model without translation) matters. The disabled button also gets `pointer-events-none` so hover always lands on the wrapper.
  - House focus ring (`focus:ring-accent-cyan` etc.), same convention as AppleSwitch/CustomSelect.
- **Main Transcription card**: the two toggle rows collapse into one centered row of two buttons. The speaker-count stepper (- / Auto|N / +) moves to its own centered row below and only renders while diarization is on, so a click on the button is always an on/off toggle and never fights the stepper. Canary bidirectional models keep the target-language dropdown in place of the Translate button.
- **Live Mode** (both toolbar copies): the translate AppleSwitch becomes the same `ToggleButton` (size sm, fits the h-8 toolbar row). It carries a distinct accessible name ("Translate to English (Live Mode)") so the main-card switch stays uniquely queryable.
- **ui-contract**: re-extracted, `spec_version` 1.16.2 → 1.16.4, baseline updated.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] Full vitest suite: 142 files / 2026 tests pass (the stray unhandled-error count is pre-existing flake, reproduced on main)
- [x] `npm run ui:contract:check` clean (22 checks)
- [ ] Hardware smoke: centered button row renders correctly in the Main Transcription card; speakers stepper appears/disappears with the diarization button
- [ ] Hardware smoke: disabled-state tooltips show on hover in the packaged Electron app (translate with a non-translating model, diarization without HF token)
- [ ] Hardware smoke: Live Mode translate button toggles in both the inline and pop-out toolbars