### PR TITLE
feat(dashboard, ui): fold the Session Import tab into the Main Transcription card and add Markdown import output

### DIFF
--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { Eye, EyeOff } from 'lucide-react';
-import { View, NotebookTab, SessionTab } from './types';
+import { View, NotebookTab } from './types';
 import { Sidebar } from './components/Sidebar';
 import { SessionView } from './components/views/SessionView';
 import { NotebookView } from './components/views/NotebookView';
@@ -74,7 +74,6 @@ function isComposeEnvFlagEnabled(value: string | null | undefined): boolean {
 const AppInner: React.FC = () => {
   const [currentView, setCurrentView] = useState<View>(View.SESSION);
   const [notebookTab, setNotebookTab] = useState<NotebookTab>(NotebookTab.CALENDAR);
-  const [sessionTab, setSessionTab] = useState<SessionTab>(SessionTab.MAIN);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isAboutOpen, setIsAboutOpen] = useState(false);
   const [isBugReportOpen, setIsBugReportOpen] = useState(false);
@@ -780,8 +779,6 @@ const AppInner: React.FC = () => {
         onChangeView={setCurrentView}
         notebookTab={notebookTab}
         onChangeNotebookTab={setNotebookTab}
-        sessionTab={sessionTab}
-        onChangeSessionTab={setSessionTab}
         onOpenSettings={() => setIsSettingsOpen(true)}
         onOpenAbout={() => setIsAboutOpen(true)}
         onOpenBugReport={() => setIsBugReportOpen(true)}
@@ -841,8 +838,6 @@ const AppInner: React.FC = () => {
                 startupFlowPending={startupFlowPending}
                 isUploading={isUploading}
                 live={live}
-                sessionTab={sessionTab}
-                onChangeSessionTab={setSessionTab}
               />
             </ErrorBoundary>
           </div>

--- a/dashboard/components/Sidebar.tsx
+++ b/dashboard/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useLayoutEffect, useRef, useState, useEffect } from 'react';
-import { View, NotebookTab, SessionTab } from '../types';
+import { View, NotebookTab } from '../types';
 import {
   Bell,
   Mic2,
@@ -27,8 +27,6 @@ interface SidebarProps {
   onChangeView: (view: View) => void;
   notebookTab: NotebookTab;
   onChangeNotebookTab: (tab: NotebookTab) => void;
-  sessionTab: SessionTab;
-  onChangeSessionTab: (tab: SessionTab) => void;
   onOpenSettings: () => void;
   onOpenAbout: () => void;
   onOpenBugReport: () => void;
@@ -61,8 +59,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
   onChangeView,
   notebookTab,
   onChangeNotebookTab,
-  sessionTab,
-  onChangeSessionTab,
   onOpenSettings,
   onOpenAbout,
   onOpenBugReport,
@@ -196,9 +192,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
     { id: NotebookTab.IMPORT, icon: <Upload size={14} />, label: 'Import' },
   ];
 
-  // Sub-items shown indented below the Session nav item
-  const sessionSubItems = [{ id: SessionTab.IMPORT, icon: <Upload size={14} />, label: 'Import' }];
-
   const activeIndex = navItems.findIndex((item) => item.id === currentView);
 
   // Ref-based pill positioning — measures actual button positions
@@ -299,7 +292,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 onClick={() => {
                   onChangeView(item.id);
                   if (item.id === View.NOTEBOOK) onChangeNotebookTab(NotebookTab.CALENDAR);
-                  if (item.id === View.SESSION) onChangeSessionTab(SessionTab.MAIN);
                 }}
                 className={`relative z-10 flex w-full items-center focus:ring-0 focus:outline-none ${collapsed ? 'justify-center px-0' : 'px-4'} h-12 rounded-xl transition-colors duration-200 ${
                   isActive ? 'text-white' : 'text-slate-400 hover:bg-white/5 hover:text-white'
@@ -333,41 +325,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
               </button>
 
               {/* Session sub-tabs: always visible */}
-              {item.id === View.SESSION && (
-                <div className="flex flex-col gap-2">
-                  {sessionSubItems.map((subItem) => {
-                    const isSubActive = currentView === View.SESSION && sessionTab === subItem.id;
-                    return (
-                      <button
-                        key={subItem.id}
-                        onClick={() => {
-                          onChangeView(View.SESSION);
-                          onChangeSessionTab(subItem.id);
-                        }}
-                        className={`relative z-10 flex w-full items-center focus:ring-0 focus:outline-none ${collapsed ? 'justify-center px-0' : 'pr-4 pl-9'} h-9 rounded-xl transition-colors duration-200 ${
-                          isSubActive
-                            ? 'bg-white/6 text-slate-200'
-                            : 'text-slate-500 hover:bg-white/5 hover:text-slate-400'
-                        }`}
-                      >
-                        <div className="flex items-center gap-3">
-                          <span
-                            className={`transition-colors duration-200 ${isSubActive ? 'text-accent-cyan/70' : ''}`}
-                          >
-                            {subItem.icon}
-                          </span>
-                          <span
-                            className={`text-xs font-medium whitespace-nowrap transition-all duration-200 ${collapsed ? 'hidden w-0 opacity-0' : 'opacity-100'}`}
-                          >
-                            {subItem.label}
-                          </span>
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              )}
-
               {/* Notebook sub-tabs: always visible */}
               {item.id === View.NOTEBOOK && (
                 <div className="flex flex-col gap-2">

--- a/dashboard/components/__tests__/SessionImportTab.output-format.test.tsx
+++ b/dashboard/components/__tests__/SessionImportTab.output-format.test.tsx
@@ -274,8 +274,17 @@ describe('SessionImportTab — explicit output-format selector (GH-212)', () => 
     await pickOutputFormat('Plain text (.txt)');
     expect(querySubtitleFormatButton()).toBeNull();
 
-    await pickOutputFormat('Both');
+    await pickOutputFormat('Text + subtitles');
     expect(querySubtitleFormatButton()).not.toBeNull();
+  });
+
+  it('hides the Subtitle format select for Markdown and persists the md format', async () => {
+    await renderTab();
+
+    await pickOutputFormat('Markdown (.md)');
+
+    expect(querySubtitleFormatButton()).toBeNull();
+    expect(mockSetConfig).toHaveBeenCalledWith('sessionImport.outputFormat', 'md');
   });
 
   it('persists the selection under sessionImport.outputFormat', async () => {

--- a/dashboard/components/__tests__/SessionView.canary-language.test.tsx
+++ b/dashboard/components/__tests__/SessionView.canary-language.test.tsx
@@ -197,7 +197,6 @@ vi.mock('../../src/types/runtime', () => ({
 }));
 
 import { SessionView } from '../views/SessionView';
-import { SessionTab } from '../../types';
 import { useTraySync } from '../../src/hooks/useTraySync';
 import { apiClient } from '../../src/api/client';
 
@@ -242,8 +241,6 @@ const baseProps = {
   startupFlowPending: false,
   isUploading: false,
   live: baseLiveState,
-  sessionTab: SessionTab.MAIN,
-  onChangeSessionTab: vi.fn(),
 };
 
 const NEMO_LANGUAGES_FOR_TEST: Array<{ code: string; name: string }> = [

--- a/dashboard/components/__tests__/SessionView.client-link-stop.test.tsx
+++ b/dashboard/components/__tests__/SessionView.client-link-stop.test.tsx
@@ -163,7 +163,6 @@ vi.mock('../../src/types/runtime', () => ({
 }));
 
 import { SessionView } from '../views/SessionView';
-import { SessionTab } from '../../types';
 import type { LiveModeState } from '../../src/hooks/useLiveMode';
 
 function createWrapper() {
@@ -207,8 +206,6 @@ const baseProps = {
   startupFlowPending: false,
   isUploading: false,
   live: baseLiveState,
-  sessionTab: SessionTab.MAIN,
-  onChangeSessionTab: vi.fn(),
 };
 
 const ORIGINAL_NAVIGATOR_PLATFORM = navigator.platform;

--- a/dashboard/components/__tests__/SessionView.diarization.test.tsx
+++ b/dashboard/components/__tests__/SessionView.diarization.test.tsx
@@ -192,7 +192,6 @@ vi.mock('../../src/types/runtime', () => ({
 }));
 
 import { SessionView } from '../views/SessionView';
-import { SessionTab } from '../../types';
 
 function createWrapper() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -235,8 +234,6 @@ const baseProps = {
   startupFlowPending: false,
   isUploading: false,
   live: baseLiveState,
-  sessionTab: SessionTab.MAIN,
-  onChangeSessionTab: vi.fn(),
 };
 
 describe('SessionView - speaker diarization for recordings (GH-258)', () => {

--- a/dashboard/components/__tests__/SessionView.greek-sigma.test.tsx
+++ b/dashboard/components/__tests__/SessionView.greek-sigma.test.tsx
@@ -186,7 +186,6 @@ vi.mock('../../src/types/runtime', () => ({
 }));
 
 import { SessionView } from '../views/SessionView';
-import { SessionTab } from '../../types';
 
 function createWrapper() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -229,8 +228,6 @@ const baseProps = {
   startupFlowPending: false,
   isUploading: false,
   live: baseLiveState,
-  sessionTab: SessionTab.MAIN,
-  onChangeSessionTab: vi.fn(),
 };
 
 function setPersistedLanguages(main: string | undefined, live?: string | undefined) {

--- a/dashboard/components/__tests__/SessionView.recovery-refresh.test.tsx
+++ b/dashboard/components/__tests__/SessionView.recovery-refresh.test.tsx
@@ -215,7 +215,6 @@ vi.mock('../../src/types/runtime', () => ({
 }));
 
 import { SessionView } from '../views/SessionView';
-import { SessionTab } from '../../types';
 
 function createWrapper() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -256,8 +255,6 @@ const baseProps = {
     clearHistory: vi.fn(),
     getText: vi.fn().mockReturnValue(''),
   },
-  sessionTab: SessionTab.MAIN,
-  onChangeSessionTab: vi.fn(),
 };
 
 function renderSessionView() {

--- a/dashboard/components/__tests__/SessionView.retry-failed.test.tsx
+++ b/dashboard/components/__tests__/SessionView.retry-failed.test.tsx
@@ -209,7 +209,6 @@ vi.mock('../../src/types/runtime', () => ({
 }));
 
 import { SessionView } from '../views/SessionView';
-import { SessionTab } from '../../types';
 
 function createWrapper() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -250,8 +249,6 @@ const baseProps = {
     clearHistory: vi.fn(),
     getText: vi.fn().mockReturnValue(''),
   },
-  sessionTab: SessionTab.MAIN,
-  onChangeSessionTab: vi.fn(),
 };
 
 function renderSessionView() {

--- a/dashboard/components/__tests__/SessionView.test.tsx
+++ b/dashboard/components/__tests__/SessionView.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -184,6 +184,12 @@ vi.mock('../views/FullscreenVisualizer', () => ({
   FullscreenVisualizer: () => null,
 }));
 
+// The embedded import surface has its own test suite; stub it so this file
+// only exercises the Transcribe File disclosure wiring in SessionView.
+vi.mock('../views/SessionImportTab', () => ({
+  SessionImportTab: () => React.createElement('div', { 'data-testid': 'session-import-surface' }),
+}));
+
 vi.mock('../AudioVisualizer', () => ({
   AudioVisualizer: () => React.createElement('div', { 'data-testid': 'audio-visualizer' }),
 }));
@@ -194,7 +200,6 @@ vi.mock('../../src/types/runtime', () => ({
 }));
 
 import { SessionView } from '../views/SessionView';
-import { SessionTab } from '../../types';
 import { isModelDisabled } from '../../src/services/modelSelection';
 import { useNotificationsStore } from '../../src/stores/notificationsStore';
 
@@ -240,8 +245,6 @@ const baseProps = {
   startupFlowPending: false,
   isUploading: false,
   live: baseLiveState,
-  sessionTab: SessionTab.MAIN,
-  onChangeSessionTab: vi.fn(),
 };
 
 // ── Tests ───────────────────────────────────────────────────────────────���──
@@ -306,6 +309,26 @@ describe('[P2] SessionView', () => {
     // Copy and Download buttons may appear more than once in the DOM
     expect(screen.getAllByText('Copy').length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText('Download').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('expands the Transcribe File import surface from the Main Transcription card', () => {
+    render(React.createElement(SessionView, baseProps), { wrapper: createWrapper() });
+
+    // The surface stays MOUNTED while collapsed (hidden attribute, not a
+    // conditional render) so the folder watcher it owns keeps running.
+    const surface = screen.getByTestId('session-import-surface');
+    const toggle = screen.getByRole('button', { name: /transcribe file/i });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(surface).not.toBeVisible();
+
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(surface).toBeVisible();
+
+    fireEvent.click(toggle);
+    expect(surface).not.toBeVisible();
+    expect(screen.getByTestId('session-import-surface')).toBeDefined();
   });
 });
 

--- a/dashboard/components/views/SessionImportTab.tsx
+++ b/dashboard/components/views/SessionImportTab.tsx
@@ -569,7 +569,7 @@ export const SessionImportTab: React.FC<SessionImportTabProps> = ({ ffmpegAvaila
     typeof window !== 'undefined' && Boolean((window as any).electronAPI?.fileIO);
 
   return (
-    <div className="mx-auto mt-10 max-w-2xl space-y-8">
+    <div className="space-y-4">
       <input
         ref={fileInputRef}
         type="file"
@@ -881,9 +881,11 @@ export const SessionImportTab: React.FC<SessionImportTabProps> = ({ ffmpegAvaila
         <p className="text-xs leading-relaxed text-slate-500">
           {outputFormat === 'txt'
             ? 'Transcriptions are saved as .txt (plain text) to the output folder.'
-            : outputFormat === 'both'
-              ? `Transcriptions are saved as .txt plus .${diarizedFormat} to the output folder.`
-              : `Transcriptions are saved as .${diarizedFormat} subtitles to the output folder.`}
+            : outputFormat === 'md'
+              ? 'Transcriptions are saved as .md (Markdown) to the output folder.'
+              : outputFormat === 'both'
+                ? `Transcriptions are saved as .txt plus .${diarizedFormat} to the output folder.`
+                : `Transcriptions are saved as .${diarizedFormat} subtitles to the output folder.`}
         </p>
       </div>
 
@@ -903,16 +905,17 @@ export const SessionImportTab: React.FC<SessionImportTabProps> = ({ ffmpegAvaila
                 setOutputFormat(format);
                 void setConfig('sessionImport.outputFormat', format);
               }}
-              options={['txt', 'subtitles', 'both']}
+              options={['txt', 'subtitles', 'md', 'both']}
               optionLabel={{
                 txt: 'Plain text (.txt)',
                 subtitles: 'Subtitles (.srt/.ass)',
-                both: 'Both',
+                md: 'Markdown (.md)',
+                both: 'Text + subtitles',
               }}
               className="focus:ring-accent-cyan w-52 rounded-lg border border-white/10 bg-white/5 px-2.5 py-1.5 text-sm text-white transition-all outline-none hover:border-white/20 focus:ring-1"
             />
           </div>
-          {outputFormat !== 'txt' && (
+          {(outputFormat === 'subtitles' || outputFormat === 'both') && (
             <div className="flex items-center justify-between gap-4 pl-1">
               <div className="min-w-0">
                 <p className="text-sm font-medium text-white">Subtitle format</p>
@@ -939,7 +942,7 @@ export const SessionImportTab: React.FC<SessionImportTabProps> = ({ ffmpegAvaila
                 ? diarizationFeature?.reason === 'token_missing'
                   ? 'Unavailable: no HuggingFace token configured. Add one in Settings, then restart the server.'
                   : 'Unavailable on this server.'
-                : 'Identify distinct speakers. Speaker labels appear in subtitle output; plain text output is unaffected.'
+                : 'Identify distinct speakers. Speaker labels appear in subtitle and Markdown output; plain text output is unaffected.'
             }
           />
           {effectiveDiarization && (

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -24,6 +24,8 @@ import {
   AlertTriangle,
   Zap,
   Users,
+  FileAudio,
+  ChevronDown,
 } from 'lucide-react';
 import { GlassCard } from '../ui/GlassCard';
 import { Button } from '../ui/Button';
@@ -64,7 +66,6 @@ import {
   CANARY_TRANSLATION_TARGETS,
 } from '../../src/services/modelCapabilities';
 import { isModelDisabled } from '../../src/services/modelSelection';
-import { SessionTab } from '../../types';
 import { SessionImportTab } from './SessionImportTab';
 import { useImportQueueStore } from '../../src/stores/importQueueStore';
 import { useNotificationsStore } from '../../src/stores/notificationsStore';
@@ -131,8 +132,6 @@ interface SessionViewProps {
   startupFlowPending: boolean;
   isUploading?: boolean;
   live: LiveModeState;
-  sessionTab: SessionTab;
-  onChangeSessionTab: (tab: SessionTab) => void;
 }
 
 export const SessionView: React.FC<SessionViewProps> = ({
@@ -143,8 +142,6 @@ export const SessionView: React.FC<SessionViewProps> = ({
   startupFlowPending,
   isUploading,
   live,
-  sessionTab,
-  onChangeSessionTab,
 }) => {
   // Global State
   const [isFullscreenVisualizerOpen, setIsFullscreenVisualizerOpen] = useState(false);
@@ -476,6 +473,11 @@ export const SessionView: React.FC<SessionViewProps> = ({
 
   // Output formatting
   const [hideTimestamps, setHideTimestamps] = useState(false);
+
+  // Transcribe File expander: the former Session Import tab now lives at the
+  // bottom of the Main Transcription card, collapsed by default because the
+  // import surface carries many controls.
+  const [transcribeFileOpen, setTranscribeFileOpen] = useState(false);
 
   // Live Mode State (`isLive` hoisted above for use by recordingDisabledReason)
   const [liveLanguage, setLiveLanguage] = useState('English');
@@ -1506,19 +1508,6 @@ export const SessionView: React.FC<SessionViewProps> = ({
     backgroundAttachment: 'fixed',
   };
 
-  if (sessionTab === SessionTab.IMPORT) {
-    return (
-      <div className="custom-scrollbar h-full w-full overflow-y-auto">
-        <div className="mx-auto max-w-7xl py-6 pr-3 pl-6">
-          <div className="mb-6 flex flex-col space-y-2">
-            <h1 className="text-3xl font-bold tracking-tight text-white">Session</h1>
-          </div>
-          <SessionImportTab ffmpegAvailable={serverConnection.details?.ffmpeg_available} />
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="mx-auto flex h-full w-full max-w-7xl flex-col py-6 pr-3 pl-6">
       {/* 1. Header (Fixed) */}
@@ -2287,6 +2276,37 @@ export const SessionView: React.FC<SessionViewProps> = ({
                         )}
                       </div>
                     )}
+
+                    {/* Transcribe File: the former Session Import tab, folded
+                      into this card behind a disclosure button. The divider
+                      mirrors the one above the per-recording toggles. */}
+                    <div className="border-t border-white/5 px-1 pt-3">
+                      <button
+                        type="button"
+                        aria-expanded={transcribeFileOpen}
+                        onClick={() => setTranscribeFileOpen((open) => !open)}
+                        className="flex w-full items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2.5 text-sm font-medium text-slate-300 transition-colors hover:border-white/20 hover:bg-white/10 hover:text-white"
+                      >
+                        <FileAudio size={15} />
+                        <span>Transcribe File</span>
+                        <ChevronDown
+                          size={14}
+                          className={`transition-transform duration-200 ${transcribeFileOpen ? 'rotate-180' : ''}`}
+                        />
+                      </button>
+                      {/* Collapse hides via the hidden attribute instead of
+                        unmounting: SessionImportTab owns the folder-watch
+                        lifecycle (useSessionWatcher stops the watcher in its
+                        effect cleanup), so unmounting on collapse would
+                        silently stop an active watch. Always mounting also
+                        re-arms a persisted watch at app start instead of on
+                        first visit. */}
+                      <div hidden={!transcribeFileOpen} className="mt-4">
+                        <SessionImportTab
+                          ffmpegAvailable={serverConnection.details?.ffmpeg_available}
+                        />
+                      </div>
+                    </div>
                   </div>
                 </GlassCard>
 

--- a/dashboard/src/services/transcriptionFormatters.test.ts
+++ b/dashboard/src/services/transcriptionFormatters.test.ts
@@ -6,6 +6,7 @@ import {
   renderSrt,
   renderAss,
   renderTxt,
+  renderMarkdown,
   resolveTranscriptionOutput,
   resolveTranscriptionOutputs,
 } from './transcriptionFormatters';
@@ -89,6 +90,43 @@ describe('renderAss', () => {
     const ass = renderAss(diarizedResponse, 'Test');
     expect(ass).toContain('[Speaker 1]');
     expect(ass).toContain('[Speaker 2]');
+  });
+});
+
+describe('renderMarkdown', () => {
+  it('renders speaker turns with normalized labels and MM:SS timestamps', () => {
+    const md = renderMarkdown(diarizedResponse, 'memo');
+    expect(md).toContain('# memo');
+    expect(md).toContain('---');
+    expect(md).toContain('**Speaker 1** *[00:00]*: Hello world.');
+    expect(md).toContain('**Speaker 2** *[00:02]*: Goodbye world.');
+  });
+
+  it('coalesces consecutive segments from the same speaker into one turn', () => {
+    const coalesced: TranscriptionResponse = {
+      ...diarizedResponse,
+      segments: [
+        { text: 'Hello world.', start: 0, end: 1.5, speaker: 'SPEAKER_00' },
+        { text: 'Still me.', start: 1.6, end: 2.0, speaker: 'SPEAKER_00' },
+        { text: 'Goodbye world.', start: 2.0, end: 3.5, speaker: 'SPEAKER_01' },
+      ],
+    };
+    const md = renderMarkdown(coalesced, 'memo');
+    // One turn line per speaker, terminated with a Markdown hard break.
+    expect(md).toContain('**Speaker 1** *[00:00]*: Hello world. Still me.  \n');
+    expect(md).toContain('**Speaker 2** *[00:02]*: Goodbye world.  \n');
+  });
+
+  it('degrades to plain paragraphs when no speaker labels are present', () => {
+    const md = renderMarkdown(timedResponse, 'memo');
+    expect(md).toContain('# memo');
+    expect(md).not.toContain('**');
+    expect(md).toContain('Hello world. Goodbye world.');
+  });
+
+  it('degrades to the transcript text when there are no usable segments', () => {
+    const md = renderMarkdown(textOnlyResponse, 'memo');
+    expect(md).toBe('# memo\n\n---\n\nHello world. Goodbye world.\n');
   });
 });
 
@@ -212,6 +250,27 @@ describe('resolveTranscriptionOutputs (explicit format, GH-212)', () => {
       subtitleFormat: 'srt',
     });
     expect(outs.map((o) => o.outputFilename)).toEqual(['memo.txt', 'memo.srt']);
+  });
+
+  it('outputFormat=md → single .md file with the markdown document', () => {
+    const outs = resolveTranscriptionOutputs('memo.m4a', diarizedResponse, {
+      outputFormat: 'md',
+      subtitleFormat: 'srt',
+    });
+    expect(outs).toHaveLength(1);
+    expect(outs[0].outputFilename).toBe('memo.md');
+    expect(outs[0].content).toContain('# memo');
+    expect(outs[0].content).toContain('**Speaker 1**');
+  });
+
+  it('outputFormat=md without segments still writes .md, not the .txt fallback', () => {
+    const outs = resolveTranscriptionOutputs('memo.m4a', textOnlyResponse, {
+      outputFormat: 'md',
+      subtitleFormat: 'srt',
+    });
+    expect(outs).toHaveLength(1);
+    expect(outs[0].outputFilename).toBe('memo.md');
+    expect(outs[0].content).toContain('Hello world. Goodbye world.');
   });
 
   it('falls back to .txt only when the response has no usable segments, regardless of format', () => {

--- a/dashboard/src/services/transcriptionFormatters.ts
+++ b/dashboard/src/services/transcriptionFormatters.ts
@@ -142,6 +142,72 @@ export function renderTxt(response: TranscriptionResponse): string {
 }
 
 /**
+ * Format seconds as a zero-padded MM:SS Markdown turn timestamp (minutes roll
+ * past 59 for recordings over an hour).
+ * Matches format_markdown_timestamp() in server/backend/core/markdown_export.py.
+ */
+function formatMarkdownTimestamp(seconds: number): string {
+  const total = Math.max(0, Math.floor(Number.isFinite(seconds) ? seconds : 0));
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+}
+
+/**
+ * Render transcription as a Markdown conversation document.
+ *
+ * Mirrors stream_markdown() in server/backend/core/markdown_export.py (GH-279)
+ * so a Session import and a Notebook export produce the same shape: a title
+ * header, a horizontal rule, then one line per speaker turn (consecutive
+ * segments with the same speaker coalesce) prefixed with the normalized
+ * speaker label and the turn start time, terminated with a Markdown hard
+ * break. Segments without a speaker label degrade to plain paragraphs; a
+ * response with no usable segments degrades to the plain transcript text
+ * under the same header.
+ */
+export function renderMarkdown(response: TranscriptionResponse, title = 'Transcription'): string {
+  const safeTitle = title.replace(/\n/g, ' ').trim() || 'Transcription';
+  const chunks: string[] = [`# ${safeTitle}\n\n`, '---\n\n'];
+
+  const segments = (response.segments ?? []).filter((s) => s.text.trim().length > 0);
+  if (segments.length === 0) {
+    const text = response.text.trim();
+    return chunks.join('') + (text ? `${text}\n` : '');
+  }
+
+  const speakerMap = buildSpeakerMap(response);
+
+  let currentSpeaker: string | null | undefined;
+  let turnStart = 0;
+  let turnParts: string[] = [];
+
+  const flush = () => {
+    if (turnParts.length === 0) return;
+    const text = turnParts.join(' ');
+    if (currentSpeaker == null) {
+      chunks.push(`${text}\n\n`);
+    } else {
+      const label = speakerMap.get(currentSpeaker) ?? currentSpeaker;
+      chunks.push(`**${label}** *[${formatMarkdownTimestamp(turnStart)}]*: ${text}  \n`);
+    }
+  };
+
+  for (const seg of segments) {
+    const speaker = seg.speaker && seg.speaker.trim() ? seg.speaker : null;
+    if (speaker !== currentSpeaker || currentSpeaker === undefined) {
+      flush();
+      turnParts = [];
+      currentSpeaker = speaker;
+      turnStart = seg.start ?? 0;
+    }
+    turnParts.push(seg.text.trim());
+  }
+  flush();
+
+  return chunks.join('');
+}
+
+/**
  * Determine the output filename and rendered content for a transcription result.
  *
  * Centralizes the hideTimestamps / diarization / format branching that was
@@ -174,7 +240,7 @@ export function resolveTranscriptionOutput(
   return { outputFilename: `${stem}.txt`, content: renderTxt(transcription) };
 }
 
-export type SessionOutputFormat = 'txt' | 'subtitles' | 'both';
+export type SessionOutputFormat = 'txt' | 'subtitles' | 'md' | 'both';
 
 export interface ResolvedOutput {
   outputFilename: string;
@@ -194,6 +260,12 @@ export function resolveTranscriptionOutputs(
 ): ResolvedOutput[] {
   const stem = filename.replace(/\.[^.]+$/, '');
   const txt: ResolvedOutput = { outputFilename: `${stem}.txt`, content: renderTxt(transcription) };
+
+  // Markdown never falls back to .txt: renderMarkdown degrades internally to
+  // the plain transcript under the same header when segments are unusable.
+  if (options.outputFormat === 'md') {
+    return [{ outputFilename: `${stem}.md`, content: renderMarkdown(transcription, stem) }];
+  }
 
   const hasSegments =
     transcription.segments && transcription.segments.some((s) => s.text.trim().length > 0);

--- a/dashboard/src/stores/importQueueStore.ts
+++ b/dashboard/src/stores/importQueueStore.ts
@@ -241,6 +241,8 @@ export function describePlannedFormat(
   switch (cfg.outputFormat ?? 'subtitles') {
     case 'txt':
       return '.txt';
+    case 'md':
+      return '.md';
     case 'both':
       return `.txt + ${sub}`;
     default:

--- a/dashboard/types.ts
+++ b/dashboard/types.ts
@@ -12,11 +12,6 @@ export enum NotebookTab {
   IMPORT = 'IMPORT',
 }
 
-export enum SessionTab {
-  MAIN = 'MAIN',
-  IMPORT = 'IMPORT',
-}
-
 export interface StatusIndicatorProps {
   status: 'active' | 'inactive' | 'warning' | 'error' | 'loading';
   label?: string;


### PR DESCRIPTION
## Summary

Session redesign: the separate **Session > Import** sidebar sub-tab is gone. The whole import surface now lives inside the **Main Transcription** card behind a collapsible **Transcribe File** button, and the import Output Format selector gains **Markdown (.md)** for parity with the Notebook Markdown export (GH-279).

### Transcribe File disclosure
- A divider (matching the existing one above the Translate / Diarization toggles) plus a full-width **Transcribe File** button now sits at the bottom of the Main Transcription card. Clicking it expands the former Import tab surface in place (drop zone, import queue, output location, folder watch, import options), unchanged.
- The `SessionTab` enum and its prop plumbing (App, Sidebar, SessionView, 7 test files) were removed as dead code.
- **Collapse hides via the `hidden` attribute instead of unmounting.** `useSessionWatcher` stops the chokidar watcher in its effect cleanup, so unmounting on collapse would silently kill an active folder watch (caught in review). Side benefit over the old tab: the import surface now mounts with SessionView at app start, so a persisted folder watch **re-arms on launch** instead of waiting for the first visit to the Import tab, and folder-watch jobs honor the persisted option toggles from boot.

### Markdown output format
- `renderMarkdown()` in `transcriptionFormatters.ts` mirrors the server-side `markdown_export.py` (GH-279) so a Session import and a Notebook export produce the same document shape: title header, horizontal rule, one line per coalesced speaker turn (`**Speaker N** *[MM:SS]*: text` with a Markdown hard break), plain-paragraph degrade without speakers, plain-transcript degrade without usable segments.
- `SessionOutputFormat` gains `'md'`; `resolveTranscriptionOutputs` writes `stem.md` (never the .txt fallback); `describePlannedFormat` stamps `Queued (.md)`.
- The subtitle-format row now shows only for `subtitles` / `both` (the old `!== 'txt'` check would have wrongly shown it for Markdown); the `both` option label is now **Text + subtitles**; info note and diarization description updated.

## Test plan
- [x] `npm run check` green (typecheck, eslint, prettier, ui-contract 22 checks; contract class inventory unchanged, no baseline bump needed)
- [x] Full vitest suite: 142 files / 2034 tests green (the single `macVariantUpdater` stream test failed once under parallel load, passes 3/3 in isolation; pre-existing flake)
- [x] New tests: SessionView disclosure wiring (mounted-but-hidden collapse), Markdown selector path + `sessionImport.outputFormat` persistence, `renderMarkdown` (speaker labels, turn coalescing, MM:SS format, both degrades), `resolveTranscriptionOutputs` md cases
- [ ] Hardware smoke: expand Transcribe File, import a diarized file with Output Format = Markdown, verify the .md matches a Notebook Markdown export of the same audio
- [ ] Hardware smoke: enable folder watch, collapse the Transcribe File panel, drop a file into the watched folder, confirm it still imports