### PR TITLE
feat(dashboard, shortcuts): press-and-hold push-to-talk via the GlobalShortcuts portal Deactivated signal

### DIFF
--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -827,6 +827,19 @@ export const SessionView: React.FC<SessionViewProps> = ({
       if (isLive) live.stop();
       else handleStopRecording();
     },
+    onPttStopRecording: () => {
+      // Wayland portal press-and-hold release: only affects the one-shot
+      // session. Live Mode and the processing phase stay untouched, unlike
+      // onStopRecording which also stops Live Mode.
+      if (transcription.status === 'recording') {
+        handleStopRecording();
+      } else if (transcription.status === 'connecting') {
+        // Released before the session came up: no audio was captured yet, so
+        // cancel the pending session instead of leaving the mic hot. Same
+        // treatment as handleStopClient gives the connecting state.
+        transcription.reset();
+      }
+    },
     onCancelRecording: () => handleCancelProcessing(),
     onToggleMute: () => {
       if (transcription.status === 'recording' || transcription.status === 'connecting') {

--- a/dashboard/electron/__tests__/pushToTalk.test.ts
+++ b/dashboard/electron/__tests__/pushToTalk.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment node
+
+/**
+ * Push-to-talk decision logic for the XDG GlobalShortcuts portal.
+ *
+ * Tests the pure helpers in pushToTalk.ts: timestamp normalization,
+ * held-duration resolution (portal clock vs wall clock), hold-vs-tap
+ * classification, and activation_token extraction from signal options.
+ *
+ * D-Bus signal wiring is NOT tested here - see waylandShortcuts.signals.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  PUSH_TO_TALK_HOLD_MS,
+  PRESS_REPEAT_WINDOW_MS,
+  toMillis,
+  heldDurationMs,
+  isPushToTalkHold,
+  mergePress,
+  extractActivationToken,
+  type PendingPress,
+  type ShortcutPress,
+} from '../pushToTalk.js';
+
+function press(portalTimestamp: number, wallClock: number): ShortcutPress {
+  return { portalTimestamp, wallClock };
+}
+
+// ── toMillis ────────────────────────────────────────────────────────────────
+
+describe('[P2] toMillis', () => {
+  it('passes finite numbers through unchanged', () => {
+    expect(toMillis(1234)).toBe(1234);
+    expect(toMillis(0)).toBe(0);
+  });
+
+  it('converts BigInt to number (dbus-next delivers the t type as BigInt)', () => {
+    expect(toMillis(98765n)).toBe(98765);
+    expect(toMillis(0n)).toBe(0);
+  });
+
+  it('returns 0 for undefined, null, NaN, Infinity, and strings', () => {
+    expect(toMillis(undefined)).toBe(0);
+    expect(toMillis(null)).toBe(0);
+    expect(toMillis(Number.NaN)).toBe(0);
+    expect(toMillis(Number.POSITIVE_INFINITY)).toBe(0);
+    expect(toMillis('1234')).toBe(0);
+  });
+});
+
+// ── heldDurationMs ──────────────────────────────────────────────────────────
+
+describe('[P2] heldDurationMs', () => {
+  it('uses the portal timestamp delta when both edges carry timestamps', () => {
+    // Wall clocks deliberately disagree - the portal clock must win because
+    // both edges share the same (undefined) base.
+    expect(heldDurationMs(press(1000, 50_000), press(1800, 99_000))).toBe(800);
+  });
+
+  it('falls back to wall clock when the press has no portal timestamp', () => {
+    expect(heldDurationMs(press(0, 50_000), press(1800, 50_600))).toBe(600);
+  });
+
+  it('falls back to wall clock when the release has no portal timestamp', () => {
+    expect(heldDurationMs(press(1000, 50_000), press(0, 50_300))).toBe(300);
+  });
+
+  it('falls back to wall clock when the portal delta is negative', () => {
+    // A compositor restart can reset the portal clock base mid-hold.
+    expect(heldDurationMs(press(9000, 50_000), press(100, 50_700))).toBe(700);
+  });
+
+  it('clamps a negative wall clock delta to 0', () => {
+    expect(heldDurationMs(press(0, 50_000), press(0, 49_000))).toBe(0);
+  });
+});
+
+// ── isPushToTalkHold ────────────────────────────────────────────────────────
+
+describe('[P2] isPushToTalkHold', () => {
+  it('classifies a short tap as NOT a hold', () => {
+    const held = PUSH_TO_TALK_HOLD_MS - 1;
+    expect(isPushToTalkHold(press(1000, 0), press(1000 + held, held))).toBe(false);
+  });
+
+  it('classifies exactly the threshold as a hold', () => {
+    expect(
+      isPushToTalkHold(press(1000, 0), press(1000 + PUSH_TO_TALK_HOLD_MS, PUSH_TO_TALK_HOLD_MS)),
+    ).toBe(true);
+  });
+
+  it('classifies a long hold as a hold', () => {
+    expect(isPushToTalkHold(press(1000, 0), press(4000, 3000))).toBe(true);
+  });
+
+  it('respects a custom threshold', () => {
+    expect(isPushToTalkHold(press(1000, 0), press(1200, 200), 100)).toBe(true);
+    expect(isPushToTalkHold(press(1000, 0), press(1200, 200), 300)).toBe(false);
+  });
+});
+
+// ── mergePress ──────────────────────────────────────────────────────────────
+
+describe('[P2] mergePress', () => {
+  it('starts a new pending press when none is pending', () => {
+    const incoming = press(1000, 50_000);
+    expect(mergePress(null, incoming)).toEqual({ press: incoming, lastSeen: 50_000 });
+  });
+
+  it('keeps the FIRST press across auto-repeat within the window', () => {
+    // KDE bug 484525: some Plasma versions stream Activated while held.
+    const first = press(1000, 50_000);
+    let pending: PendingPress = mergePress(null, first);
+    pending = mergePress(pending, press(1600, 50_600));
+    expect(pending.press).toEqual(first);
+    expect(pending.lastSeen).toBe(50_600);
+  });
+
+  it('refreshes lastSeen on each repeat so long holds keep merging', () => {
+    const first = press(1000, 50_000);
+    let pending: PendingPress = mergePress(null, first);
+    // Repeats every 600ms for 3 seconds: each is within the window of the
+    // PREVIOUS repeat even though the total exceeds the window.
+    for (let t = 600; t <= 3000; t += 600) {
+      pending = mergePress(pending, press(1000 + t, 50_000 + t));
+    }
+    expect(pending.press).toEqual(first);
+    expect(pending.lastSeen).toBe(53_000);
+  });
+
+  it('starts over when the gap exceeds the repeat window (missed release)', () => {
+    const stale = mergePress(null, press(1000, 50_000));
+    const fresh = press(9000, 50_000 + PRESS_REPEAT_WINDOW_MS + 1);
+    expect(mergePress(stale, fresh)).toEqual({ press: fresh, lastSeen: fresh.wallClock });
+  });
+
+  it('respects a custom repeat window', () => {
+    const pending = mergePress(null, press(1000, 50_000));
+    expect(mergePress(pending, press(1200, 50_200), 100).press).toEqual(press(1200, 50_200));
+    expect(mergePress(pending, press(1200, 50_200), 300).press).toEqual(press(1000, 50_000));
+  });
+});
+
+// ── extractActivationToken ──────────────────────────────────────────────────
+
+describe('[P2] extractActivationToken', () => {
+  it('unwraps a dbus-next Variant-shaped value', () => {
+    expect(extractActivationToken({ activation_token: { signature: 's', value: 'tok-123' } })).toBe(
+      'tok-123',
+    );
+  });
+
+  it('accepts a plain string value', () => {
+    expect(extractActivationToken({ activation_token: 'tok-456' })).toBe('tok-456');
+  });
+
+  it('returns null for an empty token string', () => {
+    expect(extractActivationToken({ activation_token: '' })).toBeNull();
+    expect(extractActivationToken({ activation_token: { signature: 's', value: '' } })).toBeNull();
+  });
+
+  it('returns null when the key is missing or options is not an object', () => {
+    // KDE currently emits an empty options dict, so this is the common case.
+    expect(extractActivationToken({})).toBeNull();
+    expect(extractActivationToken(undefined)).toBeNull();
+    expect(extractActivationToken(null)).toBeNull();
+    expect(extractActivationToken('tok')).toBeNull();
+  });
+
+  it('returns null for non-string token values', () => {
+    expect(extractActivationToken({ activation_token: 42 })).toBeNull();
+    expect(extractActivationToken({ activation_token: { signature: 'u', value: 42 } })).toBeNull();
+  });
+});

--- a/dashboard/electron/__tests__/waylandShortcuts.signals.test.ts
+++ b/dashboard/electron/__tests__/waylandShortcuts.signals.test.ts
@@ -1,0 +1,185 @@
+// @vitest-environment node
+
+/**
+ * Portal signal wiring for push-to-talk (subscribeToSignals).
+ *
+ * Drives Activated/Deactivated pairs through a fake portal proxy and a send
+ * spy - the same fake-object pattern the registerHostAppId tests use - and
+ * asserts the push-to-talk invariants end to end: tap keeps toggle behavior,
+ * a hold sends ptt-stop-recording exactly once, auto-repeat does not reset
+ * the held-duration clock, the KDE empty-options dict is harmless, and
+ * teardown clears the pending press.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { subscribeToSignals, destroyWaylandShortcuts } from '../waylandShortcuts.js';
+import { PUSH_TO_TALK_HOLD_MS } from '../pushToTalk.js';
+
+const SESSION = '/org/freedesktop/portal/desktop/session/1_23/s';
+const START_ID = 'start-recording';
+const STOP_ID = 'stop-transcribe';
+
+class FakePortalProxy {
+  handlers = new Map<string, (...args: unknown[]) => void>();
+  removedListeners: string[] = [];
+
+  on(signalName: string, handler: (...args: unknown[]) => void): void {
+    this.handlers.set(signalName, handler);
+  }
+
+  removeListener(signalName: string): void {
+    this.removedListeners.push(signalName);
+    this.handlers.delete(signalName);
+  }
+
+  emit(signalName: string, ...args: unknown[]): void {
+    this.handlers.get(signalName)?.(...args);
+  }
+}
+
+function setup() {
+  const proxy = new FakePortalProxy();
+  const send = vi.fn();
+  subscribeToSignals(proxy, send);
+  return { proxy, send };
+}
+
+function pttActions(send: ReturnType<typeof vi.fn>): number {
+  return send.mock.calls.filter((c) => c[0] === 'tray:action' && c[1] === 'ptt-stop-recording')
+    .length;
+}
+
+const savedToken = process.env.XDG_ACTIVATION_TOKEN;
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  delete process.env.XDG_ACTIVATION_TOKEN;
+});
+
+afterEach(() => {
+  // Resets pendingStartPress and the unsubscribe closures between tests.
+  destroyWaylandShortcuts();
+  vi.restoreAllMocks();
+  if (savedToken === undefined) delete process.env.XDG_ACTIVATION_TOKEN;
+  else process.env.XDG_ACTIVATION_TOKEN = savedToken;
+});
+
+describe('[P2] subscribeToSignals push-to-talk wiring', () => {
+  it('forwards Activated to the tray action for both shortcuts', () => {
+    const { proxy, send } = setup();
+
+    proxy.emit('Activated', SESSION, START_ID, 1000n, {});
+    proxy.emit('Activated', SESSION, STOP_ID, 2000n, {});
+
+    expect(send).toHaveBeenCalledWith('tray:action', 'start-recording');
+    expect(send).toHaveBeenCalledWith('tray:action', 'stop-recording');
+  });
+
+  it('treats a short tap as a toggle: release sends no ptt action', () => {
+    const { proxy, send } = setup();
+
+    proxy.emit('Activated', SESSION, START_ID, 1000n, {});
+    proxy.emit('Deactivated', SESSION, START_ID, 1000n + BigInt(PUSH_TO_TALK_HOLD_MS - 1), {});
+
+    expect(pttActions(send)).toBe(0);
+  });
+
+  it('sends ptt-stop-recording exactly once for a qualifying hold', () => {
+    const { proxy, send } = setup();
+
+    proxy.emit('Activated', SESSION, START_ID, 1000n, {});
+    proxy.emit('Deactivated', SESSION, START_ID, 1000n + BigInt(PUSH_TO_TALK_HOLD_MS + 200), {});
+    // A duplicate release must not fire again (pending press was consumed).
+    proxy.emit('Deactivated', SESSION, START_ID, 9000n, {});
+
+    expect(pttActions(send)).toBe(1);
+  });
+
+  it('does NOT reset the held-duration clock on key auto-repeat', () => {
+    // KDE bug 484525: Plasma can stream Activated signals while a shortcut is
+    // held. Only the repeat 100ms before the release would be counted without
+    // first-press-wins merging, misclassifying the hold as a tap.
+    const now = vi.spyOn(Date, 'now');
+    const { proxy, send } = setup();
+
+    now.mockReturnValue(10_000);
+    proxy.emit('Activated', SESSION, START_ID, 1000n, {});
+    now.mockReturnValue(10_600);
+    proxy.emit('Activated', SESSION, START_ID, 1600n, {});
+    now.mockReturnValue(10_700);
+    proxy.emit('Deactivated', SESSION, START_ID, 1700n, {});
+
+    expect(pttActions(send)).toBe(1);
+  });
+
+  it('starts a fresh press after the repeat window (missed release)', () => {
+    const now = vi.spyOn(Date, 'now');
+    const { proxy, send } = setup();
+
+    // First press whose release was never delivered (e.g. portal hiccup).
+    now.mockReturnValue(10_000);
+    proxy.emit('Activated', SESSION, START_ID, 1000n, {});
+    // A real tap 10 seconds later must not inherit the stale press, or the
+    // release would misread as a 10-second hold and stop the new recording.
+    now.mockReturnValue(20_000);
+    proxy.emit('Activated', SESSION, START_ID, 11_000n, {});
+    now.mockReturnValue(20_100);
+    proxy.emit('Deactivated', SESSION, START_ID, 11_100n, {});
+
+    expect(pttActions(send)).toBe(0);
+  });
+
+  it('ignores Deactivated for the stop shortcut and unknown ids', () => {
+    const { proxy, send } = setup();
+
+    proxy.emit('Activated', SESSION, STOP_ID, 1000n, {});
+    proxy.emit('Deactivated', SESSION, STOP_ID, 5000n, {});
+    proxy.emit('Deactivated', SESSION, 'bogus-id', 5000n, {});
+    proxy.emit('Activated', SESSION, 'bogus-id', 5000n, {});
+
+    expect(pttActions(send)).toBe(0);
+    expect(send).toHaveBeenCalledTimes(1); // only the stop Activated
+  });
+
+  it('handles the KDE empty-options dict without stashing a token', () => {
+    const { proxy } = setup();
+
+    proxy.emit('Activated', SESSION, START_ID, 1000n, {});
+    proxy.emit('Deactivated', SESSION, START_ID, 2000n, {});
+
+    expect(process.env.XDG_ACTIVATION_TOKEN).toBeUndefined();
+  });
+
+  it('stashes a portal-supplied activation token into the environment', () => {
+    const { proxy } = setup();
+
+    proxy.emit('Activated', SESSION, START_ID, 1000n, {
+      activation_token: { signature: 's', value: 'tok-789' },
+    });
+
+    expect(process.env.XDG_ACTIVATION_TOKEN).toBe('tok-789');
+  });
+
+  it('drops the pending press on teardown so it cannot leak into a new session', () => {
+    const first = setup();
+    first.proxy.emit('Activated', SESSION, START_ID, 1000n, {});
+
+    destroyWaylandShortcuts();
+
+    // New portal session after re-registration: a release with hold-length
+    // timestamps must find no pending press and stay silent.
+    const second = setup();
+    second.proxy.emit('Deactivated', SESSION, START_ID, 9000n, {});
+
+    expect(pttActions(second.send)).toBe(0);
+  });
+
+  it('unsubscribes all three signals on teardown', () => {
+    const { proxy } = setup();
+
+    destroyWaylandShortcuts();
+
+    expect(proxy.removedListeners.sort()).toEqual(['Activated', 'Deactivated', 'ShortcutsChanged']);
+  });
+});

--- a/dashboard/electron/pushToTalk.ts
+++ b/dashboard/electron/pushToTalk.ts
@@ -1,0 +1,113 @@
+/**
+ * Push-to-talk decision logic for the XDG GlobalShortcuts portal.
+ *
+ * The portal emits Activated on shortcut press and Deactivated on release
+ * (interface version 2). Holding the start-recording shortcut past the
+ * threshold turns the release into "stop and transcribe" (push-to-talk),
+ * while a short tap keeps the existing edge-triggered toggle behavior.
+ *
+ * Pure functions only - the D-Bus signal wiring lives in waylandShortcuts.ts.
+ */
+
+/** Minimum held duration for a press/release pair to count as push-to-talk. */
+export const PUSH_TO_TALK_HOLD_MS = 500;
+
+/**
+ * Max gap between Activated edges that still counts as key auto-repeat of the
+ * SAME physical hold. KDE bug 484525: some Plasma versions stream repeated
+ * Activated signals while a portal shortcut is held. KDE repeat delay
+ * defaults to ~600ms, so 1500ms comfortably covers repeats while a fresh
+ * press after a missed release (human timescale, seconds apart) starts over.
+ */
+export const PRESS_REPEAT_WINDOW_MS = 1500;
+
+/** Snapshot of a shortcut press, kept until the matching release arrives. */
+export interface ShortcutPress {
+  /**
+   * Portal-supplied timestamp in ms. The spec leaves the clock base
+   * undefined, but press and release share it, so deltas are meaningful.
+   * 0 when the portal sent none.
+   */
+  portalTimestamp: number;
+  /** Wall-clock ms captured when the signal arrived - the fallback clock. */
+  wallClock: number;
+}
+
+/** A press awaiting its release, tracking auto-repeat refreshes. */
+export interface PendingPress {
+  /** The FIRST press edge of the current physical hold. */
+  press: ShortcutPress;
+  /** Wall-clock ms of the latest Activated edge (first press or a repeat). */
+  lastSeen: number;
+}
+
+/**
+ * Fold an incoming Activated edge into the pending-press state.
+ * An edge arriving within repeatWindowMs of the last one is key auto-repeat
+ * of the same hold: the original press is kept so held duration is measured
+ * from the true press start. A later edge starts a new press (covers a
+ * missed Deactivated, e.g. after a portal restart).
+ */
+export function mergePress(
+  pending: PendingPress | null,
+  incoming: ShortcutPress,
+  repeatWindowMs: number = PRESS_REPEAT_WINDOW_MS,
+): PendingPress {
+  if (pending && incoming.wallClock - pending.lastSeen <= repeatWindowMs) {
+    return { press: pending.press, lastSeen: incoming.wallClock };
+  }
+  return { press: incoming, lastSeen: incoming.wallClock };
+}
+
+/**
+ * Normalize a D-Bus timestamp to a number of milliseconds.
+ * dbus-next delivers the spec's `t` (uint64) type as BigInt; other portals
+ * may omit the value entirely. Anything unusable maps to 0, which
+ * heldDurationMs treats as "no portal timestamp".
+ */
+export function toMillis(timestamp: unknown): number {
+  if (typeof timestamp === 'bigint') return Number(timestamp);
+  if (typeof timestamp === 'number' && Number.isFinite(timestamp)) return timestamp;
+  return 0;
+}
+
+/**
+ * Held duration between press and release. Prefers the portal clock (both
+ * edges share its base); falls back to wall clock when either edge lacks a
+ * portal timestamp or the delta is negative (e.g. a compositor restart
+ * reset the clock base mid-hold).
+ */
+export function heldDurationMs(press: ShortcutPress, release: ShortcutPress): number {
+  const portalDelta = release.portalTimestamp - press.portalTimestamp;
+  if (press.portalTimestamp > 0 && release.portalTimestamp > 0 && portalDelta >= 0) {
+    return portalDelta;
+  }
+  return Math.max(0, release.wallClock - press.wallClock);
+}
+
+/** Whether a press/release pair counts as a push-to-talk hold. */
+export function isPushToTalkHold(
+  press: ShortcutPress,
+  release: ShortcutPress,
+  thresholdMs: number = PUSH_TO_TALK_HOLD_MS,
+): boolean {
+  return heldDurationMs(press, release) >= thresholdMs;
+}
+
+/**
+ * Extract the optional `activation_token` from a portal signal options
+ * vardict. dbus-next wraps vardict values in Variant objects
+ * ({ signature, value }); plain strings are tolerated too. Returns null when
+ * absent, empty, or not a string. xdg-desktop-portal-kde currently emits an
+ * empty options dict (the C++ parameter is literally named `unused`), so on
+ * Plasma this stays null until KDE starts minting tokens.
+ */
+export function extractActivationToken(options: unknown): string | null {
+  if (options == null || typeof options !== 'object') return null;
+  const raw = (options as Record<string, unknown>)['activation_token'];
+  const value =
+    raw != null && typeof raw === 'object' && 'value' in raw
+      ? (raw as { value: unknown }).value
+      : raw;
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}

--- a/dashboard/electron/waylandShortcuts.ts
+++ b/dashboard/electron/waylandShortcuts.ts
@@ -5,14 +5,27 @@
  * to the XDG Desktop Portal, which lets us:
  *   - Set human-readable descriptions ("Start Recording", "Stop & Transcribe")
  *   - Set preferred_trigger from config values
- *   - Listen for Activated / ShortcutsChanged signals
+ *   - Listen for Activated / Deactivated / ShortcutsChanged signals
  *   - Read back actual portal-assigned triggers via ListShortcuts
+ *
+ * Press-and-hold (push-to-talk): the portal emits Activated on press and
+ * Deactivated on release. Holding the start-recording shortcut past
+ * PUSH_TO_TALK_HOLD_MS makes the release stop the recording; a short tap
+ * keeps the original toggle behavior. Decision logic lives in pushToTalk.ts.
  *
  * Uses `@particle/dbus-next` (CJS-only) imported via createRequire since the project is ESM.
  */
 
 import { createRequire } from 'module';
 import type { BrowserWindow } from 'electron';
+import {
+  extractActivationToken,
+  isPushToTalkHold,
+  mergePress,
+  toMillis,
+  type PendingPress,
+  type ShortcutPress,
+} from './pushToTalk.js';
 
 const require = createRequire(import.meta.url);
 
@@ -150,13 +163,20 @@ const SHORTCUT_DEFS: Array<{ id: string; description: string; action: string }> 
  */
 export const PORTAL_APP_ID = 'com.transcriptionsuite.dashboard';
 
+/** The shortcut whose press/release pair drives push-to-talk. */
+const PTT_SHORTCUT_ID = SHORTCUT_DEFS[0].id;
+
 let bus: any = null;
 let portalProxy: any = null;
 let sessionPath: string | null = null;
 let connected = false;
 let activatedUnsubscribe: (() => void) | null = null;
+let deactivatedUnsubscribe: (() => void) | null = null;
 let shortcutsChangedUnsubscribe: (() => void) | null = null;
 let currentGetWindow: (() => BrowserWindow | null) | null = null;
+
+/** Pending press of the start shortcut, awaiting its Deactivated edge. */
+let pendingStartPress: PendingPress | null = null;
 
 // Unique token counter for portal request paths
 let requestCounter = 0;
@@ -533,17 +553,53 @@ async function bindShortcutsFromStore(store: ReadableStore): Promise<boolean> {
 }
 
 /**
- * Subscribe to Activated and ShortcutsChanged signals on the portal.
+ * Stash a portal-supplied activation token into the process environment.
+ * Chromium's Wayland backend consumes XDG_ACTIVATION_TOKEN on its next
+ * window-activation request, so a focus() shortly after a shortcut press can
+ * be honored by the compositor despite focus-stealing prevention. KDE
+ * currently sends an empty options dict, so this is dormant on Plasma.
  */
-function subscribeToSignals(): void {
-  if (!portalProxy) return;
+function stashActivationToken(options: unknown): void {
+  const token = extractActivationToken(options);
+  if (token) {
+    process.env.XDG_ACTIVATION_TOKEN = token;
+  }
+}
+
+/** The subset of the dbus-next interface proxy the signal handlers rely on. */
+export interface PortalSignalSource {
+  on(signalName: string, handler: (...args: any[]) => void): void;
+  removeListener(signalName: string, handler: (...args: any[]) => void): void;
+}
+
+/** Send a payload to the current BrowserWindow, if any. */
+function sendToWindow(channel: string, payload: unknown): void {
+  const win = currentGetWindow?.();
+  if (win) {
+    win.webContents.send(channel, payload);
+  }
+}
+
+/**
+ * Subscribe to Activated, Deactivated, and ShortcutsChanged signals.
+ *
+ * Exported for tests: pass a fake proxy (on/removeListener) and a send spy to
+ * drive Activated/Deactivated pairs without a live session bus, mirroring the
+ * fake-portal-object pattern used by the registerHostAppId tests. Production
+ * callers use the defaults (module portalProxy + BrowserWindow send).
+ */
+export function subscribeToSignals(
+  proxy: PortalSignalSource | null = portalProxy,
+  send: (channel: string, payload: unknown) => void = sendToWindow,
+): void {
+  if (!proxy) return;
 
   // Activated signal: (session_handle, shortcut_id, timestamp, options)
   const onActivated = (
     _sessionHandle: string,
     shortcutId: string,
-    _timestamp: any,
-    _options: any,
+    timestamp: any,
+    options: any,
   ) => {
     const def = SHORTCUT_DEFS.find((d) => d.id === shortcutId);
     if (!def) {
@@ -551,29 +607,63 @@ function subscribeToSignals(): void {
       return;
     }
 
-    console.log(`[WaylandShortcuts] Shortcut activated: ${shortcutId} → ${def.action}`);
-    const win = currentGetWindow?.();
-    if (win) {
-      win.webContents.send('tray:action', def.action);
+    stashActivationToken(options);
+
+    if (shortcutId === PTT_SHORTCUT_ID) {
+      // First-press-wins across key auto-repeat: some Plasma versions stream
+      // Activated signals while a shortcut is held (KDE bug 484525), and each
+      // repeat must NOT reset the held-duration clock. A press arriving after
+      // the repeat window starts over (covers a missed Deactivated).
+      pendingStartPress = mergePress(pendingStartPress, {
+        portalTimestamp: toMillis(timestamp),
+        wallClock: Date.now(),
+      });
     }
+
+    console.log(`[WaylandShortcuts] Shortcut activated: ${shortcutId} → ${def.action}`);
+    send('tray:action', def.action);
+  };
+
+  // Deactivated signal: (session_handle, shortcut_id, timestamp, options).
+  // Same shape as Activated - fired when the shortcut keys are released.
+  const onDeactivated = (
+    _sessionHandle: string,
+    shortcutId: string,
+    timestamp: any,
+    options: any,
+  ) => {
+    if (shortcutId !== PTT_SHORTCUT_ID) return;
+
+    stashActivationToken(options);
+
+    const pending = pendingStartPress;
+    pendingStartPress = null;
+    if (!pending) return;
+
+    const release: ShortcutPress = { portalTimestamp: toMillis(timestamp), wallClock: Date.now() };
+    if (!isPushToTalkHold(pending.press, release)) {
+      // Short tap - keep the original toggle behavior (release does nothing).
+      return;
+    }
+
+    console.log('[WaylandShortcuts] Push-to-talk release → stop recording');
+    send('tray:action', 'ptt-stop-recording');
   };
 
   // ShortcutsChanged signal: (session_handle, shortcuts)
   const onShortcutsChanged = (_sessionHandle: string, shortcuts: any) => {
     console.log('[WaylandShortcuts] Shortcuts changed by portal');
     const bindings = parsePortalShortcuts(shortcuts);
-    const win = currentGetWindow?.();
-    if (win) {
-      win.webContents.send('shortcuts:portalChanged', bindings);
-    }
+    send('shortcuts:portalChanged', bindings);
   };
 
-  portalProxy.on('Activated', onActivated);
-  portalProxy.on('ShortcutsChanged', onShortcutsChanged);
+  proxy.on('Activated', onActivated);
+  proxy.on('Deactivated', onDeactivated);
+  proxy.on('ShortcutsChanged', onShortcutsChanged);
 
-  activatedUnsubscribe = () => portalProxy?.removeListener('Activated', onActivated);
-  shortcutsChangedUnsubscribe = () =>
-    portalProxy?.removeListener('ShortcutsChanged', onShortcutsChanged);
+  activatedUnsubscribe = () => proxy.removeListener('Activated', onActivated);
+  deactivatedUnsubscribe = () => proxy.removeListener('Deactivated', onDeactivated);
+  shortcutsChangedUnsubscribe = () => proxy.removeListener('ShortcutsChanged', onShortcutsChanged);
 }
 
 /**
@@ -654,9 +744,20 @@ export function isPortalConnected(): boolean {
  */
 function cleanup(closeBus = false): void {
   activatedUnsubscribe?.();
+  deactivatedUnsubscribe?.();
   shortcutsChangedUnsubscribe?.();
   activatedUnsubscribe = null;
+  deactivatedUnsubscribe = null;
   shortcutsChangedUnsubscribe = null;
+  if (pendingStartPress) {
+    // Teardown mid-hold (re-registration or bus error): the release edge can
+    // no longer be observed, so a hold-started recording keeps running until
+    // stopped manually. That is the safe failure mode - no audio is lost.
+    console.warn(
+      '[WaylandShortcuts] Portal teardown mid-hold - pending push-to-talk press dropped',
+    );
+  }
+  pendingStartPress = null;
   portalProxy = null;
   sessionPath = null;
   connected = false;

--- a/dashboard/src/hooks/__tests__/useTraySync.ptt.test.tsx
+++ b/dashboard/src/hooks/__tests__/useTraySync.ptt.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * useTraySync push-to-talk action dispatch.
+ *
+ * Verifies that the ptt-stop-recording tray action (sent by the Wayland
+ * portal layer on a held-shortcut release) dispatches to onPttStopRecording
+ * and does NOT fall through to onStopRecording, which would also stop Live
+ * Mode in SessionView.
+ */
+
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+type ActionListener = (action: string, ...args: unknown[]) => void;
+
+let actionListener: ActionListener | null = null;
+
+function installElectronApiStub() {
+  (window as any).electronAPI = {
+    tray: {
+      setMenuState: vi.fn(),
+      setState: vi.fn(),
+      setTooltip: vi.fn(),
+      onAction: vi.fn((cb: ActionListener) => {
+        actionListener = cb;
+        return () => {
+          actionListener = null;
+        };
+      }),
+    },
+  };
+}
+
+// isElectron is computed at module load, so the stub must be installed
+// BEFORE useTraySync is imported — hence the dynamic import.
+let useTraySync: typeof import('../useTraySync').useTraySync;
+
+beforeAll(async () => {
+  installElectronApiStub();
+  ({ useTraySync } = await import('../useTraySync'));
+});
+
+function baseDeps(overrides: Record<string, unknown> = {}) {
+  return {
+    serverStatus: 'active',
+    containerRunning: true,
+    containerHealth: 'healthy',
+    transcriptionStatus: 'idle',
+    liveStatus: 'idle',
+    muted: false,
+    ...overrides,
+  } as any;
+}
+
+describe('[P2] useTraySync push-to-talk dispatch', () => {
+  it('dispatches ptt-stop-recording to onPttStopRecording only', () => {
+    const onPttStopRecording = vi.fn();
+    const onStopRecording = vi.fn();
+
+    renderHook(() => useTraySync(baseDeps({ onPttStopRecording, onStopRecording })));
+
+    expect(actionListener).not.toBeNull();
+    act(() => {
+      actionListener!('ptt-stop-recording');
+    });
+
+    expect(onPttStopRecording).toHaveBeenCalledTimes(1);
+    expect(onStopRecording).not.toHaveBeenCalled();
+  });
+
+  it('keeps dispatching stop-recording to onStopRecording', () => {
+    const onPttStopRecording = vi.fn();
+    const onStopRecording = vi.fn();
+
+    renderHook(() => useTraySync(baseDeps({ onPttStopRecording, onStopRecording })));
+
+    act(() => {
+      actionListener!('stop-recording');
+    });
+
+    expect(onStopRecording).toHaveBeenCalledTimes(1);
+    expect(onPttStopRecording).not.toHaveBeenCalled();
+  });
+
+  it('ignores ptt-stop-recording when no callback is wired', () => {
+    const onStopRecording = vi.fn();
+
+    renderHook(() => useTraySync(baseDeps({ onStopRecording })));
+
+    expect(() => {
+      act(() => {
+        actionListener!('ptt-stop-recording');
+      });
+    }).not.toThrow();
+    expect(onStopRecording).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/src/hooks/useTraySync.ts
+++ b/dashboard/src/hooks/useTraySync.ts
@@ -39,6 +39,13 @@ interface TrySyncDeps {
   /** Callbacks to forward tray context-menu actions */
   onStartRecording?: () => void;
   onStopRecording?: () => void;
+  /**
+   * Push-to-talk release from the Wayland portal layer (start shortcut held
+   * past the hold threshold). Only affects the one-shot session: stops an
+   * active recording or cancels a still-connecting one. Unlike
+   * onStopRecording, Live Mode stays untouched.
+   */
+  onPttStopRecording?: () => void;
   onCancelRecording?: () => void;
   onToggleMute?: () => void;
   onTranscribeFile?: (filePath: string) => void;
@@ -248,6 +255,9 @@ export function useTraySync(deps: TrySyncDeps): void {
           break;
         case 'stop-recording':
           callbacksRef.current.onStopRecording?.();
+          break;
+        case 'ptt-stop-recording':
+          callbacksRef.current.onPttStopRecording?.();
           break;
         case 'cancel-recording':
           callbacksRef.current.onCancelRecording?.();


### PR DESCRIPTION
## Summary

Real press-and-hold push-to-talk on Wayland, using only the XDG GlobalShortcuts portal the app already talks to. The portal emits `Activated` on shortcut press and `Deactivated` on release (interface v2); until now only `Activated` was subscribed, so both shortcuts were edge-triggered toggles.

- Hold the start-recording shortcut (default Alt+Ctrl+Z) for 500ms or more: releasing it stops the recording and transcribes. Walkie-talkie flow with a single shortcut.
- A short tap (under 500ms) behaves exactly as before: recording starts and keeps running until the stop shortcut.
- No new protocol, no new dependency, no UI change, no new store key.

Verified against primary sources: the portal spec defines `Deactivated` with the same signature as `Activated` and an optional `activation_token` in the options vardict of both; xdg-desktop-portal-kde wires them to KGlobalAccel `globalShortcutPressed`/`globalShortcutReleased`, so KWin delivers real press/release pairs.

## Design

- `electron/pushToTalk.ts` (new, pure functions only): hold threshold (`PUSH_TO_TALK_HOLD_MS` = 500), BigInt timestamp normalization (dbus-next delivers the D-Bus `t` type as BigInt), held-duration resolution preferring the portal clock with wall-clock fallback, first-press-wins auto-repeat merge, `activation_token` extraction.
- `electron/waylandShortcuts.ts`: subscribes to `Deactivated`, pairs it with the pending `Activated` edge of the start shortcut, and sends a distinct `ptt-stop-recording` tray action only for a qualifying hold. `subscribeToSignals` is now exported with an injectable proxy and send function (same fake-object pattern as the `registerHostAppId` tests).
- Renderer: `useTraySync` dispatches the new action to an optional `onPttStopRecording` callback; `SessionView` stops an active one-shot recording or cancels a still-connecting session.

Key decisions:
- **Distinct action instead of reusing `stop-recording`**: the existing stop handler also stops Live Mode; a hold-release must never do that.
- **Release during `connecting` cancels the pending session** (`transcription.reset()`, the same treatment `handleStopClient` gives that state): no audio has been captured before the session comes up, so there is nothing to transcribe and the mic must not stay hot.
- **First-press-wins merge across key auto-repeat**: KDE bug 484525 reports Plasma streaming repeated `Activated` signals while a portal shortcut is held. Without the merge, every repeat would reset the hold clock and a genuine hold would classify as a tap. Repeat window 1500ms (KDE repeat delay defaults to ~600ms); a press arriving after the window starts over, covering a missed `Deactivated`.
- **Activation tokens are stashed into `XDG_ACTIVATION_TOKEN`** so the compositor can honor a subsequent window activation. Dormant on KDE today: xdg-desktop-portal-kde emits an empty options dict (the C++ parameter is literally named `unused`).

## Known limitations

- Portal-only: the Electron `globalShortcut` path (X11, Windows, macOS) has no release events, so tap-toggle remains the only mode there.
- Teardown mid-hold (shortcut re-registration or a D-Bus error while the key is held) loses the release edge; the recording keeps running until stopped manually. Deliberate: stopping blindly could cut off an active dictation, while leaving it running loses no audio. A warning is logged.
- A release landing in the tiny async gap before `transcription.start()` flips the status to `connecting` is still a no-op; the realistic connecting window (WS round trip, remote server) is covered.

## Tests

- `pushToTalk.test.ts` (22): threshold boundary, BigInt and garbage timestamps, portal-vs-wall-clock fallback, auto-repeat merge, token extraction including the KDE empty-dict case.
- `waylandShortcuts.signals.test.ts` (10): drives `Activated`/`Deactivated` pairs through a fake portal proxy; tap sends nothing, hold sends `ptt-stop-recording` exactly once, repeats keep the hold clock, teardown drops pending state and unsubscribes all three signals.
- `useTraySync.ptt.test.tsx` (3): the new action dispatches only to `onPttStopRecording` and never falls through to `onStopRecording`.

## Verification

- `npm run typecheck`, `npm run lint`, prettier: clean
- Full vitest suite: 2061 passed (the single unhandled-error notice is the pre-existing jsdom `scrollIntoView` noise from SessionImportTab tests, unrelated)
- `npm run ui:contract:check`: pass (22 checks)

## Smoke checklist (KDE Plasma Wayland)

- [ ] Tap start shortcut: recording starts and keeps running; tap stop shortcut: transcribes (unchanged behavior)
- [ ] Hold start shortcut, speak, release after 1s or more: recording stops and transcribes on release
- [ ] Hold and release while the session is still connecting: session cancels, no hot mic, no empty transcription
- [ ] During Live Mode, hold the start shortcut over 500ms and release: Live Mode unaffected
- [ ] Console shows one "Shortcut activated" per hold; if a stream of them appears (KDE bug 484525 behavior), verify the hold still stops on release