### PR TITLE
feat(dashboard, ui): prominent progress display for the active Import Queue item

### DIFF
--- a/dashboard/components/views/SessionImportTab.tsx
+++ b/dashboard/components/views/SessionImportTab.tsx
@@ -139,7 +139,7 @@ export const SessionImportTab: React.FC<SessionImportTabProps> = ({ ffmpegAvaila
   // the fast (3s) poll while a job runs; the useAdminStatus call above stays
   // on the default interval (TanStack Query dedupes by queryKey, shortest
   // refetchInterval wins).
-  const { label: progressLabel, stalled } = useJobProgress(isProcessing);
+  const { label: progressLabel, details: progressDetails, stalled } = useJobProgress(isProcessing);
 
   // GH-209: gate the diarization toggle on the server-side feature flag.
   // Computed ONCE at container startup (ModelManager._initialize_diarization_
@@ -330,7 +330,9 @@ export const SessionImportTab: React.FC<SessionImportTabProps> = ({ ffmpegAvaila
     if (hasNew) {
       // rAF: the queue card may be mounting in this very commit on the first drop
       requestAnimationFrame(() => {
-        queueRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        // Optional call: jsdom has no scrollIntoView, and the rAF can fire
+        // after a test unmounts, so a bare call flakes the suite.
+        queueRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'nearest' });
       });
     }
   }, [jobs]);
@@ -681,55 +683,117 @@ export const SessionImportTab: React.FC<SessionImportTabProps> = ({ ffmpegAvaila
             }
           >
             <div className="max-h-60 space-y-2 overflow-y-auto">
-              {jobs.map((job) => (
-                <div
-                  key={job.id}
-                  className="flex items-center gap-3 rounded-lg bg-white/5 px-3 py-2 transition-colors hover:bg-white/8"
-                >
-                  {statusIcon(job)}
-                  {(job.type === 'session-auto' || job.type === 'notebook-auto') && (
-                    <span title="Auto-watch">
-                      <Eye size={14} className="shrink-0 text-slate-500" />
-                    </span>
-                  )}
-                  <span className="flex-1 truncate text-sm text-white">
-                    {typeof job.file === 'string' ? job.file.split('/').pop() : job.file.name}
-                  </span>
-                  <span
-                    className={`text-xs whitespace-nowrap ${
-                      job.status === 'success' && job.outputPath
-                        ? 'cursor-pointer text-green-400 hover:text-green-300'
-                        : 'text-slate-400'
-                    }`}
-                    onClick={
-                      job.status === 'success' && job.outputPath
-                        ? () => handleOpenOutputPath(job.outputPath!)
-                        : undefined
-                    }
-                    title={job.status === 'success' && job.outputPath ? 'Open folder' : undefined}
+              {jobs.map((job) =>
+                job.status === 'processing' ? (
+                  /* Expanded rendering for the one job being transcribed:
+                     progress bar + big percent so progress is obvious at a
+                     glance, instead of the tiny one-line label. */
+                  <div
+                    key={job.id}
+                    className="border-accent-cyan/20 bg-accent-cyan/5 rounded-lg border px-3 py-2.5"
                   >
-                    {statusLabel(job)}
-                  </span>
-                  {job.status === 'error' && (
-                    <button
-                      onClick={() => retryJob(job.id)}
-                      className="hover:text-accent-cyan p-1 text-slate-400 transition-colors"
-                      title="Retry"
+                    <div className="flex items-center gap-3">
+                      {statusIcon(job)}
+                      {(job.type === 'session-auto' || job.type === 'notebook-auto') && (
+                        <span title="Auto-watch">
+                          <Eye size={14} className="shrink-0 text-slate-500" />
+                        </span>
+                      )}
+                      <span className="flex-1 truncate text-sm font-medium text-white">
+                        {typeof job.file === 'string' ? job.file.split('/').pop() : job.file.name}
+                      </span>
+                      {progressDetails.percent !== null ? (
+                        <span className="text-accent-cyan text-lg leading-none font-semibold tabular-nums">
+                          {progressDetails.percent}%
+                        </span>
+                      ) : (
+                        <span className="text-accent-cyan text-sm font-medium">
+                          {progressDetails.phaseLabel}...
+                        </span>
+                      )}
+                    </div>
+                    <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-white/10">
+                      {progressDetails.percent !== null ? (
+                        <div
+                          className="bg-accent-cyan h-full rounded-full transition-all duration-300"
+                          style={{ width: `${progressDetails.percent}%` }}
+                        />
+                      ) : (
+                        <div className="bg-accent-cyan h-full w-1/3 animate-pulse rounded-full" />
+                      )}
+                    </div>
+                    <div className="mt-1.5 flex items-center justify-between gap-3 text-xs text-slate-400">
+                      <span className="truncate">
+                        {progressDetails.percent !== null
+                          ? progressDetails.phaseLabel
+                          : progressDetails.phaseLabel + '...'}
+                        {progressDetails.positionText && (
+                          <span className="text-slate-300"> {progressDetails.positionText}</span>
+                        )}
+                      </span>
+                      <span className="whitespace-nowrap">
+                        {progressDetails.elapsedText && `elapsed ${progressDetails.elapsedText}`}
+                        {progressDetails.etaText && (
+                          <span className="text-slate-300"> · ETA {progressDetails.etaText}</span>
+                        )}
+                      </span>
+                    </div>
+                    {stalled && (
+                      <p className="mt-1.5 text-xs text-amber-400">
+                        No recent progress, the job may be stalled
+                      </p>
+                    )}
+                  </div>
+                ) : (
+                  <div
+                    key={job.id}
+                    className="flex items-center gap-3 rounded-lg bg-white/5 px-3 py-2 transition-colors hover:bg-white/8"
+                  >
+                    {statusIcon(job)}
+                    {(job.type === 'session-auto' || job.type === 'notebook-auto') && (
+                      <span title="Auto-watch">
+                        <Eye size={14} className="shrink-0 text-slate-500" />
+                      </span>
+                    )}
+                    <span className="flex-1 truncate text-sm text-white">
+                      {typeof job.file === 'string' ? job.file.split('/').pop() : job.file.name}
+                    </span>
+                    <span
+                      className={`text-xs whitespace-nowrap ${
+                        job.status === 'success' && job.outputPath
+                          ? 'cursor-pointer text-green-400 hover:text-green-300'
+                          : 'text-slate-400'
+                      }`}
+                      onClick={
+                        job.status === 'success' && job.outputPath
+                          ? () => handleOpenOutputPath(job.outputPath!)
+                          : undefined
+                      }
+                      title={job.status === 'success' && job.outputPath ? 'Open folder' : undefined}
                     >
-                      <RotateCcw size={18} />
-                    </button>
-                  )}
-                  {job.status !== 'processing' && job.status !== 'writing' && (
-                    <button
-                      onClick={() => removeJob(job.id)}
-                      className="p-1 text-slate-500 transition-colors hover:text-red-400"
-                      title="Remove"
-                    >
-                      <XCircle size={18} />
-                    </button>
-                  )}
-                </div>
-              ))}
+                      {statusLabel(job)}
+                    </span>
+                    {job.status === 'error' && (
+                      <button
+                        onClick={() => retryJob(job.id)}
+                        className="hover:text-accent-cyan p-1 text-slate-400 transition-colors"
+                        title="Retry"
+                      >
+                        <RotateCcw size={18} />
+                      </button>
+                    )}
+                    {job.status !== 'writing' && (
+                      <button
+                        onClick={() => removeJob(job.id)}
+                        className="p-1 text-slate-500 transition-colors hover:text-red-400"
+                        title="Remove"
+                      >
+                        <XCircle size={18} />
+                      </button>
+                    )}
+                  </div>
+                ),
+              )}
             </div>
           </GlassCard>
         </div>

--- a/dashboard/src/hooks/useJobProgress.ts
+++ b/dashboard/src/hooks/useJobProgress.ts
@@ -1,16 +1,21 @@
 import { useEffect, useRef, useState } from 'react';
 import { useAdminStatus } from './useAdminStatus';
 import { jobTrackerFromAdminStatus } from '../api/types';
-import { describeJobProgress } from '../services/jobProgress';
+import { describeJobProgress, summarizeJobProgress } from '../services/jobProgress';
+import type { JobProgressDetails } from '../services/jobProgress';
 
 const STALL_AFTER_SECONDS = 120;
 
 /**
- * Live label + stall flag for the single active server job (GH-211).
- * Polls faster (3s) while a job is running; the stall flag trips after 120s
- * without any change in (current, total, phase).
+ * Live label + structured details + stall flag for the single active server
+ * job (GH-211). Polls faster (3s) while a job is running; the stall flag
+ * trips after 120s without any change in (current, total, phase).
  */
-export function useJobProgress(active: boolean): { label: string; stalled: boolean } {
+export function useJobProgress(active: boolean): {
+  label: string;
+  details: JobProgressDetails;
+  stalled: boolean;
+} {
   const admin = useAdminStatus(active ? 3_000 : 10_000);
   const tracker = jobTrackerFromAdminStatus(admin.status);
   const [, forceTick] = useState(0);
@@ -34,5 +39,6 @@ export function useJobProgress(active: boolean): { label: string; stalled: boole
   }
   const stalled = active && now - lastChangeRef.current.at > STALL_AFTER_SECONDS;
   const label = describeJobProgress(tracker?.progress ?? null, tracker?.started_at ?? null, now);
-  return { label, stalled: !!stalled };
+  const details = summarizeJobProgress(tracker?.progress ?? null, tracker?.started_at ?? null, now);
+  return { label, details, stalled: !!stalled };
 }

--- a/dashboard/src/services/jobProgress.test.ts
+++ b/dashboard/src/services/jobProgress.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { describeJobProgress, formatClock } from './jobProgress';
+import { describeJobProgress, formatClock, summarizeJobProgress } from './jobProgress';
 
 describe('formatClock', () => {
   it('formats mm:ss under an hour', () => {
@@ -80,5 +80,94 @@ describe('describeJobProgress (GH-211)', () => {
 
   it('null progress and null startedAt -> plain Processing...', () => {
     expect(describeJobProgress(null, null, now)).toBe('Processing...');
+  });
+});
+
+describe('summarizeJobProgress', () => {
+  const now = 1_000_000;
+
+  it('duration phase exposes percent, position, elapsed and ETA', () => {
+    const d = summarizeJobProgress(
+      { current: 760, total: 2295, message: '', phase: 'transcribing' },
+      now - 120,
+      now,
+    );
+    expect(d).toEqual({
+      kind: 'duration',
+      phaseLabel: 'Transcribing',
+      percent: 33,
+      positionText: '12:40 / 38:15',
+      elapsedText: '2:00',
+      etaText: '4:02',
+    });
+  });
+
+  it('transcribing_diarizing uses the combined verb', () => {
+    const d = summarizeJobProgress(
+      { current: 760, total: 2295, message: '', phase: 'transcribing_diarizing' },
+      now - 120,
+      now,
+    );
+    expect(d.kind).toBe('duration');
+    expect(d.phaseLabel).toBe('Transcribing + identifying speakers');
+  });
+
+  it('loading_model is indeterminate with its own label', () => {
+    const d = summarizeJobProgress(
+      { current: 0, total: 0, message: '', phase: 'loading_model' },
+      now - 5,
+      now,
+    );
+    expect(d.kind).toBe('loading');
+    expect(d.phaseLabel).toBe('Loading model');
+    expect(d.percent).toBeNull();
+    expect(d.positionText).toBeNull();
+    expect(d.etaText).toBeNull();
+  });
+
+  it('diarizing is indeterminate but keeps elapsed', () => {
+    const d = summarizeJobProgress(
+      { current: 2295, total: 2295, message: '', phase: 'diarizing' },
+      now - 300,
+      now,
+    );
+    expect(d.kind).toBe('phase');
+    expect(d.phaseLabel).toBe('Identifying speakers');
+    expect(d.percent).toBeNull();
+    expect(d.elapsedText).toBe('5:00');
+  });
+
+  it('omits the ETA during the first seconds of a phase', () => {
+    const d = summarizeJobProgress(
+      { current: 10, total: 100, message: '', phase: 'transcribing' },
+      now - 3,
+      now,
+    );
+    expect(d.percent).toBe(10);
+    expect(d.etaText).toBeNull();
+  });
+
+  it('progress without a phase but with totals renders a generic position', () => {
+    const d = summarizeJobProgress(
+      { current: 30, total: 300, message: '', phase: null },
+      now - 60,
+      now,
+    );
+    expect(d.kind).toBe('position');
+    expect(d.phaseLabel).toBe('Processing');
+    expect(d.positionText).toBe('0:30 / 5:00');
+    expect(d.percent).toBeNull();
+  });
+
+  it('null progress and null startedAt -> generic with null fields', () => {
+    const d = summarizeJobProgress(null, null, now);
+    expect(d).toEqual({
+      kind: 'generic',
+      phaseLabel: 'Processing',
+      percent: null,
+      positionText: null,
+      elapsedText: null,
+      etaText: null,
+    });
   });
 });

--- a/dashboard/src/services/jobProgress.ts
+++ b/dashboard/src/services/jobProgress.ts
@@ -12,11 +12,109 @@ export function formatClock(totalSeconds: number): string {
 }
 
 const PHASE_LABELS: Record<string, string> = {
-  loading_model: 'Loading model...',
+  loading_model: 'Loading model',
   transcribing: 'Transcribing',
   diarizing: 'Identifying speakers',
   transcribing_diarizing: 'Transcribing + identifying speakers',
 };
+
+/**
+ * Job progress broken into renderable parts.
+ * kind drives the layout: 'duration' has a real percent + position,
+ * 'loading'/'phase' are indeterminate, 'position' has totals but no phase,
+ * 'generic' has nothing but elapsed (at best).
+ */
+export interface JobProgressDetails {
+  kind: 'loading' | 'duration' | 'phase' | 'position' | 'generic';
+  phaseLabel: string;
+  percent: number | null;
+  positionText: string | null;
+  elapsedText: string | null;
+  etaText: string | null;
+}
+
+/**
+ * Structured progress for an in-flight transcription job. Single source of
+ * truth for both the compact label (describeJobProgress) and the expanded
+ * active-row rendering in the Import Queue.
+ */
+export function summarizeJobProgress(
+  progress: JobTrackerProgress | null | undefined,
+  startedAt: number | null | undefined,
+  nowSeconds: number,
+): JobProgressDetails {
+  const elapsed = startedAt ? Math.max(0, nowSeconds - startedAt) : null;
+  const elapsedText = elapsed !== null ? formatClock(elapsed) : null;
+  const phase = progress?.phase ?? null;
+
+  if (phase === 'loading_model') {
+    return {
+      kind: 'loading',
+      phaseLabel: PHASE_LABELS.loading_model,
+      percent: null,
+      positionText: null,
+      elapsedText,
+      etaText: null,
+    };
+  }
+
+  if (
+    (phase === 'transcribing' || phase === 'transcribing_diarizing') &&
+    progress &&
+    progress.total > 0
+  ) {
+    const pct = Math.min(100, Math.round((progress.current / progress.total) * 100));
+    let etaText: string | null = null;
+    if (
+      elapsed !== null &&
+      elapsed > 5 &&
+      progress.current > 0 &&
+      progress.current < progress.total
+    ) {
+      const remaining = ((progress.total - progress.current) * elapsed) / progress.current;
+      etaText = formatClock(remaining);
+    }
+    return {
+      kind: 'duration',
+      phaseLabel: PHASE_LABELS[phase],
+      percent: pct,
+      positionText: `${formatClock(progress.current)} / ${formatClock(progress.total)}`,
+      elapsedText,
+      etaText,
+    };
+  }
+
+  if (phase && PHASE_LABELS[phase]) {
+    return {
+      kind: 'phase',
+      phaseLabel: PHASE_LABELS[phase],
+      percent: null,
+      positionText: null,
+      elapsedText,
+      etaText: null,
+    };
+  }
+
+  if (progress && progress.total > 0) {
+    return {
+      kind: 'position',
+      phaseLabel: 'Processing',
+      percent: null,
+      positionText: `${formatClock(progress.current)} / ${formatClock(progress.total)}`,
+      elapsedText,
+      etaText: null,
+    };
+  }
+
+  return {
+    kind: 'generic',
+    phaseLabel: 'Processing',
+    percent: null,
+    positionText: null,
+    elapsedText,
+    etaText: null,
+  };
+}
 
 /**
  * Human label for an in-flight transcription job (GH-211).
@@ -30,38 +128,22 @@ export function describeJobProgress(
   startedAt: number | null | undefined,
   nowSeconds: number,
 ): string {
-  const elapsed = startedAt ? Math.max(0, nowSeconds - startedAt) : null;
-  const elapsedPart = elapsed !== null ? ` (elapsed ${formatClock(elapsed)})` : '';
-  const phase = progress?.phase ?? null;
+  const d = summarizeJobProgress(progress, startedAt, nowSeconds);
+  const elapsedPart = d.elapsedText !== null ? ` (elapsed ${d.elapsedText})` : '';
 
-  if (phase === 'loading_model') return 'Loading model...';
-
-  if (
-    (phase === 'transcribing' || phase === 'transcribing_diarizing') &&
-    progress &&
-    progress.total > 0
-  ) {
-    const pct = Math.min(100, Math.round((progress.current / progress.total) * 100));
-    let eta = '';
-    if (
-      elapsed !== null &&
-      elapsed > 5 &&
-      progress.current > 0 &&
-      progress.current < progress.total
-    ) {
-      const remaining = ((progress.total - progress.current) * elapsed) / progress.current;
-      eta = `, ETA ${formatClock(remaining)}`;
+  switch (d.kind) {
+    case 'loading':
+      return 'Loading model...';
+    case 'duration': {
+      const elapsed = d.elapsedText !== null ? `, elapsed ${d.elapsedText}` : '';
+      const eta = d.etaText !== null ? `, ETA ${d.etaText}` : '';
+      return `${d.phaseLabel} ${d.positionText} (${d.percent}%${elapsed}${eta})`;
     }
-    const verb = PHASE_LABELS[phase];
-    return `${verb} ${formatClock(progress.current)} / ${formatClock(progress.total)} (${pct}%${
-      elapsed !== null ? `, elapsed ${formatClock(elapsed)}` : ''
-    }${eta})`;
+    case 'phase':
+      return `${d.phaseLabel}...${elapsedPart}`;
+    case 'position':
+      return `Processing ${d.positionText}${elapsedPart}`;
+    case 'generic':
+      return `Processing...${elapsedPart}`;
   }
-
-  if (phase && PHASE_LABELS[phase]) return `${PHASE_LABELS[phase]}...${elapsedPart}`;
-
-  if (progress && progress.total > 0) {
-    return `Processing ${formatClock(progress.current)} / ${formatClock(progress.total)}${elapsedPart}`;
-  }
-  return `Processing...${elapsedPart}`;
 }

--- a/dashboard/ui-contract/contract-baseline.json
+++ b/dashboard/ui-contract/contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.16.5",
-  "contract_sha256": "b102993c07367d2e18839cc260a8eb60122b581b739b3e7e58060eb1ae55e87e",
-  "updated_at": "2026-08-07T14:46:24.364Z"
+  "spec_version": "1.17.0",
+  "contract_sha256": "68e98d173020ca3f12f604148948f96d9949907f768564e2be0529a21e796af3",
+  "updated_at": "2026-08-09T14:34:54.163Z"
 }

--- a/dashboard/ui-contract/transcription-suite-ui.contract.yaml
+++ b/dashboard/ui-contract/transcription-suite-ui.contract.yaml
@@ -1,5 +1,5 @@
 meta:
-  spec_version: 1.16.5
+  spec_version: 1.17.0
   contract_mode: closed_set
   source_scope: mockup_repo
   validation_method: static_source_scan
@@ -137,7 +137,7 @@ meta:
       - index.tsx
       - src/index.css
       - types.ts
-    generated_at: 2026-08-07T14:45:56.173Z
+    generated_at: 2026-08-09T14:34:16.500Z
     notes: Canonicalized from live source scan for React+TypeScript+Tailwind mockup.
 foundation:
   color_space:
@@ -1331,6 +1331,7 @@ inline_style_allowlist:
     - ${100 / visibleSlots}%
     - ${item.progress}%
     - ${percent}%
+    - ${progressDetails.percent}%
     - "0"
     - "0.16"
     - "0.3"


### PR DESCRIPTION
## Summary

The Import Queue row for the file currently being transcribed was a one-line entry whose only progress feedback was a small grey text label (`Transcribing 35:04 / 58:28 (60%, elapsed 1:51, ETA 1:14)`). This PR expands that one row - and only that row - into a highlighted progress block so the state of the active job is obvious at a glance:

- Cyan-tinted bordered card instead of the flat compact row.
- A real progress bar (same visual language as the notification toasts) with a large percent readout on the right of the filename.
- A detail line underneath: phase + audio position (e.g. `Transcribing 35:04 / 58:28`) on the left, `elapsed 1:51 · ETA 1:14` on the right.
- While no percentage is known (model load, diarization, the first seconds of transcription) the bar renders as an indeterminate pulse with the phase label.
- The GH-211 stall detection now renders as its own amber warning line instead of being appended to the label text.

Queued / done / failed rows are unchanged.

## Implementation

- `jobProgress.ts`: new `summarizeJobProgress()` returns structured parts (`kind`, `phaseLabel`, `percent`, `positionText`, `elapsedText`, `etaText`). `describeJobProgress()` is now derived from it, so the compact label (still used by NotebookView and by non-duration phases) and the expanded row can never drift apart. All 8 pre-existing label tests pass unchanged, pinning the label output byte-for-byte.
- `useJobProgress` additionally returns the structured `details` object; the `{label, stalled}` contract is untouched.
- `SessionImportTab`: the `jobs.map` branch renders the expanded block for `status === 'processing'`; the compact row keeps handling everything else. The now-unreachable `!== 'processing'` guard on the Remove button was dropped (TS narrowing flags it).
- Drive-by test-stability fix: the GH-210 `scrollIntoView` call inside `requestAnimationFrame` is now an optional call - jsdom does not implement it and the rAF can fire after a test unmounts, which intermittently failed the suite with an unhandled `TypeError`.
- ui-contract rebuilt for the new `${progressDetails.percent}%` inline width literal, `spec_version` 1.16.5 -> 1.17.0, baseline updated.

## Test plan

- [x] `vitest`: 147 files / 2102 tests green, including 7 new `summarizeJobProgress` unit tests (duration, loading, diarizing, ETA warm-up window, phaseless totals, null tracker)
- [x] `tsc --noEmit` clean, `eslint` clean on touched files
- [x] `npm run ui:contract:check` green (22 checks)
- [ ] Smoke: import a long file, confirm the active row shows bar + percent, position, elapsed/ETA, and the indeterminate bar during model load / diarization
- [ ] Smoke: stall path (amber line) and queued/done/failed rows unchanged