### PR TITLE
feat(server,dashboard): session ephemeral retention - no permanent entries from the Session tab

### DIFF
--- a/dashboard/components/views/SettingsModal.tsx
+++ b/dashboard/components/views/SettingsModal.tsx
@@ -56,7 +56,6 @@ import { ModelProfilesPanel } from '../profiles/ModelProfilesPanel';
 import { useLanguages } from '../../src/hooks/useLanguages';
 import { MAIN_MODEL_PRESETS } from '../../src/services/modelSelection';
 import { CANARY_TRANSLATION_TARGETS } from '../../src/services/modelCapabilities';
-import type { DuplicatePolicy } from '../../src/stores/importQueueStore';
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -70,20 +69,6 @@ const DEFAULT_SHORTCUTS = {
 } as const;
 const MAIN_MODEL_CUSTOM_OPTION = 'Custom (HuggingFace repo)';
 const MODEL_DEFAULT_LOADING_PLACEHOLDER = 'Loading server default...';
-// GH-120 — Folder Watch duplicate-handling policy. Display order + labels for
-// the App-tab dropdown; values map to importQueueStore's DuplicatePolicy.
-// ('skip' is intentionally not offered — see DuplicatePolicy docs: it could
-// drop a file with no retrievable transcript, violating the data-loss invariant.)
-const DUPLICATE_POLICY_ORDER: DuplicatePolicy[] = ['create_new', 'ask'];
-const DUPLICATE_POLICY_LABELS: Record<DuplicatePolicy, string> = {
-  create_new: 'Always create a new entry',
-  ask: 'Ask each time',
-};
-/** Coerce any stored/legacy value (e.g. a removed 'skip') to a valid policy so
- *  a corrupt config never blanks the dropdown — defaults to 'create_new'. */
-function normalizeDuplicatePolicy(raw: unknown): DuplicatePolicy {
-  return raw === 'ask' ? 'ask' : 'create_new';
-}
 
 function normalizeConfigString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
@@ -212,7 +197,6 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
     pasteAtCursor: false,
     blurEffectsEnabled: true,
     idleAnimationsEnabled: false, // GH #87 — default OFF (see idleAnimationsBoot)
-    duplicatePolicy: 'create_new' as DuplicatePolicy, // GH-120 — Folder Watch
   });
   // Issue #87 — track the LAST SAVED Blur effects value so we can revert any
   // unsaved live-preview DOM changes if the modal closes via X without Save.
@@ -455,7 +439,6 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
                 pasteAtCursor: (cfg['app.pasteAtCursor'] as boolean) ?? prev.pasteAtCursor,
                 blurEffectsEnabled: loadedBlurEffectsEnabled,
                 idleAnimationsEnabled: loadedIdleAnimationsEnabled,
-                duplicatePolicy: normalizeDuplicatePolicy(cfg['folderWatch.duplicatePolicy']),
               }));
               setShortcutSettings((prev) => ({
                 ...prev,
@@ -576,7 +559,6 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
         ['app.pasteAtCursor', appSettings.pasteAtCursor],
         ['ui.blurEffectsEnabled', appSettings.blurEffectsEnabled],
         ['ui.idleAnimationsEnabled', appSettings.idleAnimationsEnabled],
-        ['folderWatch.duplicatePolicy', appSettings.duplicatePolicy],
         ['shortcuts.startRecording', shortcutSettings.startRecording.trim()],
         ['shortcuts.stopTranscribe', shortcutSettings.stopTranscribe.trim()],
       ];
@@ -956,26 +938,6 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
           }}
           label="Start minimized to system tray"
         />
-      </Section>
-      <Section title="Folder Watch">
-        <label className="mb-1.5 block text-xs font-medium tracking-wider text-slate-500 uppercase">
-          When a duplicate is detected
-        </label>
-        <CustomSelect
-          value={DUPLICATE_POLICY_LABELS[appSettings.duplicatePolicy]}
-          onChange={(v) => {
-            const policy =
-              DUPLICATE_POLICY_ORDER.find((p) => DUPLICATE_POLICY_LABELS[p] === v) ?? 'create_new';
-            setAppSettings((prev) => ({ ...prev, duplicatePolicy: policy }));
-            setIsDirty(true);
-          }}
-          options={DUPLICATE_POLICY_ORDER.map((p) => DUPLICATE_POLICY_LABELS[p])}
-        />
-        <p className="mt-2 text-xs text-slate-500">
-          Folder Watch transcribes batches unattended. Choose how it handles a file whose audio
-          matches an existing transcription, instead of pausing to ask for every file. Manual
-          imports always ask.
-        </p>
       </Section>
       <Section title="Appearance">
         <AppleSwitch

--- a/dashboard/electron/main.ts
+++ b/dashboard/electron/main.ts
@@ -555,10 +555,6 @@ const store = new Store({
     'folderWatch.notebookPath': '',
     'folderWatch.sessionWatchActive': false,
     'folderWatch.notebookWatchActive': false,
-    // GH-120 — how Folder Watch resolves a detected duplicate without blocking
-    // the import queue on the interactive modal. 'create_new' | 'ask'.
-    // Default 'create_new': unattended batch never stalls and never drops a file.
-    'folderWatch.duplicatePolicy': 'create_new',
   },
 });
 

--- a/dashboard/src/api/types.ts
+++ b/dashboard/src/api/types.ts
@@ -213,16 +213,10 @@ export interface UploadResponse {
 
 /** Returned by POST /api/notebook/transcribe/upload (202 Accepted) */
 export interface TranscriptionAccepted {
+  /** FULL job id — session imports poll GET /api/transcribe/result/{job_id}
+   *  with it (session ephemeral retention, 2026-08-09 spec). The old
+   *  dedup_matches field is gone: session imports never dedup any more. */
   job_id: string;
-  /**
-   * Issue #104 / Story 2.4 — populated by /api/transcribe/import when a
-   * prior job's audio_hash matches this upload. Empty list = J1 happy path
-   * (no duplicate). Notebook upload (`/api/notebook/transcribe/upload`)
-   * doesn't currently populate this field; it's reserved for future cross-
-   * flow dedup. Default-empty keeps the response shape backwards-compatible
-   * for callers that ignore it.
-   */
-  dedup_matches?: DedupMatch[];
 }
 
 /** A prior item that shares this upload's audio_hash or normalized_audio_hash.

--- a/dashboard/src/stores/importQueueStore.test.ts
+++ b/dashboard/src/stores/importQueueStore.test.ts
@@ -6,6 +6,7 @@ vi.mock('../api/client', () => ({
     importAndTranscribe: vi.fn(),
     uploadAndTranscribe: vi.fn(),
     getAdminStatus: vi.fn(),
+    fetchTranscriptionResult: vi.fn(),
     cancelTranscription: vi.fn().mockResolvedValue(undefined),
   },
 }));
@@ -52,7 +53,6 @@ import { toast } from 'sonner';
 import { apiClient } from '../api/client';
 import {
   useImportQueueStore,
-  resolveDuplicateChoice,
   selectPendingCount,
   selectCompletedCount,
   selectErrorCount,
@@ -64,8 +64,6 @@ import {
 import type { UnifiedImportJob } from './importQueueStore';
 import { useDedupChoiceStore } from './dedupChoiceStore';
 import { getConfig } from '../config/store';
-import type { DedupMatch } from '../api/types';
-import type { DedupChoice } from '../../components/import/DedupPromptModal';
 
 function resetStore() {
   useImportQueueStore.setState({
@@ -111,6 +109,11 @@ function resetStore() {
 
 function getState() {
   return useImportQueueStore.getState();
+}
+
+/** Minimal Response stand-in for the /result poll (session ephemeral retention). */
+function httpResult(status: number, body?: unknown): Response {
+  return { status, json: async () => body } as unknown as Response;
 }
 
 function makeJob(overrides: Partial<UnifiedImportJob> = {}): UnifiedImportJob {
@@ -565,9 +568,13 @@ describe('importQueueStore', () => {
     }
 
     function mockPollResult(result: Record<string, unknown>) {
-      vi.mocked(apiClient.getAdminStatus).mockResolvedValue({
-        models: { job_tracker: { is_busy: false, result: { job_id: 'server-job-1', ...result } } },
-      } as never);
+      vi.mocked(apiClient.fetchTranscriptionResult).mockResolvedValue(
+        httpResult(200, {
+          job_id: 'server-job-1',
+          status: 'completed',
+          result: { job_id: 'server-job-1', ...result },
+        }),
+      );
     }
 
     async function runQueue() {
@@ -826,78 +833,141 @@ describe('importQueueStore', () => {
     });
   });
 
-  // ── resolveDuplicateChoice (GH-120 — Folder Watch duplicate policy) ────
+  // ── Session ephemeral retention (2026-08-09 spec) ──────────────────────
   //
-  // The dedup gate must NOT block unattended Folder Watch (session-auto) jobs
-  // on the interactive modal. session-auto jobs resolve duplicates per the
-  // configured folderWatch.duplicatePolicy; manual (session-normal) jobs always
-  // prompt. Default policy is 'create_new' so batch runs unattended out of the
-  // box without ever silently dropping a file (data-loss invariant).
+  // The server no longer sends dedup_matches and the client must never
+  // prompt. Session results are fetched from GET /result/{job_id} instead of
+  // the in-memory job tracker: 202 keep polling, 200 done, 410 failed with
+  // the error detail, 404 job lost.
 
-  describe('resolveDuplicateChoice (GH-120 — Folder Watch duplicate policy)', () => {
-    const MATCHES: DedupMatch[] = [
-      {
-        recording_id: 'c3b4c22a',
-        name: 'prior.mp3',
-        created_at: '2026-05-07T00:00:00Z',
-        source: 'transcription_job',
-      },
-    ];
-    let requestChoiceSpy: Mock<(matches: DedupMatch[]) => Promise<DedupChoice>>;
+  describe('session imports never prompt for duplicates', () => {
+    const sessionTranscription = {
+      text: 'Hello world.',
+      segments: [{ text: 'Hello world.', start: 0, end: 1.5 }],
+      words: [],
+      language_probability: 0.99,
+      duration: 1.5,
+      num_speakers: 0,
+    };
+
+    let writeText: Mock;
 
     beforeEach(() => {
-      // Override the dedup-choice store's interactive resolver so we can assert
-      // whether the modal would have been raised.
-      requestChoiceSpy = vi.fn(
-        (_m: DedupMatch[]): Promise<DedupChoice> => Promise.resolve('create_new'),
-      );
-      useDedupChoiceStore.setState({ requestChoice: requestChoiceSpy });
+      writeText = vi.fn().mockResolvedValue(undefined);
+      (window as any).electronAPI = { fileIO: { writeText } };
       vi.mocked(getConfig).mockReset();
+      vi.mocked(getConfig).mockImplementation(
+        (key: string) =>
+          Promise.resolve(key === 'sessionImport.outputFormat' ? 'txt' : undefined) as never,
+      );
     });
 
-    it('session-auto with no policy set defaults to create_new WITHOUT prompting (the GH-120 fix)', async () => {
-      vi.mocked(getConfig).mockResolvedValue(undefined);
-      const choice = await resolveDuplicateChoice('session-auto', MATCHES);
-      expect(choice).toBe('create_new');
+    afterEach(() => {
+      delete (window as any).electronAPI;
+    });
+
+    it('ignores a legacy dedup_matches field and completes the job without a prompt', async () => {
+      const requestChoiceSpy = vi.fn();
+      useDedupChoiceStore.setState({ requestChoice: requestChoiceSpy as never });
+      // A LEGACY server may still include dedup_matches — the client must
+      // silently ignore it and proceed as a normal new entry.
+      vi.mocked(apiClient.importAndTranscribe).mockResolvedValue({
+        job_id: 'server-job-1',
+        dedup_matches: [{ recording_id: 'old', name: 'old.wav', created_at: '2026-01-01' }],
+      } as never);
+      vi.mocked(apiClient.fetchTranscriptionResult).mockResolvedValue(
+        httpResult(200, {
+          job_id: 'server-job-1',
+          status: 'completed',
+          result: {
+            job_id: 'server-job-1',
+            transcription: sessionTranscription,
+            diarization: { requested: false, performed: false, reason: null },
+          },
+        }),
+      );
+
+      getState().updateSessionConfig({ outputDir: '/out' });
+      getState().addFiles([new File(['x'], 'dup.wav')], 'session-normal');
+      await vi.advanceTimersByTimeAsync(10_000);
+
       expect(requestChoiceSpy).not.toHaveBeenCalled();
+      expect(getState().jobs[0].status).toBe('success');
+    });
+  });
+
+  describe('pollForSessionResult HTTP outcomes', () => {
+    const sessionTranscription = {
+      text: 'Hello world.',
+      segments: [{ text: 'Hello world.', start: 0, end: 1.5 }],
+      words: [],
+      language_probability: 0.99,
+      duration: 1.5,
+      num_speakers: 0,
+    };
+
+    let writeText: Mock;
+
+    beforeEach(() => {
+      writeText = vi.fn().mockResolvedValue(undefined);
+      (window as any).electronAPI = { fileIO: { writeText } };
+      vi.mocked(getConfig).mockReset();
+      vi.mocked(getConfig).mockImplementation(
+        (key: string) =>
+          Promise.resolve(key === 'sessionImport.outputFormat' ? 'txt' : undefined) as never,
+      );
+      vi.mocked(apiClient.importAndTranscribe).mockResolvedValue({
+        job_id: 'server-job-1',
+      } as never);
     });
 
-    it("session-auto with policy 'create_new' resolves create_new without prompting", async () => {
-      vi.mocked(getConfig).mockResolvedValue('create_new');
-      const choice = await resolveDuplicateChoice('session-auto', MATCHES);
-      expect(choice).toBe('create_new');
-      expect(requestChoiceSpy).not.toHaveBeenCalled();
+    afterEach(() => {
+      delete (window as any).electronAPI;
     });
 
-    it("session-auto with policy 'ask' prompts the user via the interactive modal", async () => {
-      vi.mocked(getConfig).mockResolvedValue('ask');
-      const choice = await resolveDuplicateChoice('session-auto', MATCHES);
-      expect(requestChoiceSpy).toHaveBeenCalledWith(MATCHES);
-      expect(choice).toBe('create_new'); // whatever the modal returned
+    it('surfaces the 410 error detail as the job error', async () => {
+      vi.mocked(apiClient.fetchTranscriptionResult).mockResolvedValue(
+        httpResult(410, { detail: 'CUDA out of memory' }),
+      );
+
+      getState().addFiles([new File(['x'], 'oom.wav')], 'session-normal');
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(getState().jobs[0].status).toBe('error');
+      expect(getState().jobs[0].error).toContain('CUDA out of memory');
     });
 
-    it('session-auto with an unknown/legacy policy value falls back to create_new (never re-blocks, never skips)', async () => {
-      // e.g. a 'skip' value persisted by an earlier build, or a corrupt manual edit.
-      // Must NOT fall through to the modal (that would re-introduce GH-120) and must
-      // NOT skip transcription (that would risk data loss).
-      vi.mocked(getConfig).mockResolvedValue('skip' as never);
-      const choice = await resolveDuplicateChoice('session-auto', MATCHES);
-      expect(choice).toBe('create_new');
-      expect(requestChoiceSpy).not.toHaveBeenCalled();
+    it('treats 404 as a lost job', async () => {
+      vi.mocked(apiClient.fetchTranscriptionResult).mockResolvedValue(httpResult(404));
+
+      getState().addFiles([new File(['x'], 'lost.wav')], 'session-normal');
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(getState().jobs[0].status).toBe('error');
+      expect(getState().jobs[0].error).toContain('lost');
     });
 
-    it('session-auto defaults to create_new when the config read throws (no error cascade)', async () => {
-      vi.mocked(getConfig).mockRejectedValue(new Error('IPC unavailable'));
-      const choice = await resolveDuplicateChoice('session-auto', MATCHES);
-      expect(choice).toBe('create_new');
-      expect(requestChoiceSpy).not.toHaveBeenCalled();
-    });
+    it('keeps polling on 202 then resolves on 200', async () => {
+      vi.mocked(apiClient.fetchTranscriptionResult)
+        .mockResolvedValueOnce(httpResult(202, { status: 'processing', job_id: 'server-job-1' }))
+        .mockResolvedValue(
+          httpResult(200, {
+            job_id: 'server-job-1',
+            status: 'completed',
+            result: {
+              job_id: 'server-job-1',
+              transcription: sessionTranscription,
+              diarization: { requested: false, performed: false, reason: null },
+            },
+          }),
+        );
 
-    it('session-normal (manual import) always prompts, ignoring the folder-watch policy', async () => {
-      vi.mocked(getConfig).mockResolvedValue('create_new');
-      const choice = await resolveDuplicateChoice('session-normal', MATCHES);
-      expect(requestChoiceSpy).toHaveBeenCalledWith(MATCHES);
-      expect(choice).toBe('create_new');
+      getState().updateSessionConfig({ outputDir: '/out' });
+      getState().addFiles([new File(['x'], 'slow.wav')], 'session-normal');
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      expect(getState().jobs[0].status).toBe('success');
+      expect(writeText).toHaveBeenCalled();
     });
   });
 

--- a/dashboard/src/stores/importQueueStore.ts
+++ b/dashboard/src/stores/importQueueStore.ts
@@ -14,7 +14,6 @@ import type {
   FileImportJobResult,
   JobTrackerResult,
   UploadResponse,
-  DedupMatch,
 } from '../api/types';
 import {
   resolveTranscriptionOutputs,
@@ -22,9 +21,6 @@ import {
 } from '../services/transcriptionFormatters';
 import { supportsAutoDetect } from '../services/modelCapabilities';
 import { getConfig } from '../config/store';
-import { useDedupChoiceStore } from './dedupChoiceStore';
-import { useAriaAnnouncerStore } from './ariaAnnouncerStore';
-import type { DedupChoice } from '../../components/import/DedupPromptModal';
 import {
   notifyJobProcessing,
   notifyJobSuccess,
@@ -250,77 +246,49 @@ export function describePlannedFormat(
   }
 }
 
-// ─── Duplicate resolution (GH-120) ───────────────────────────────────────────
-
-/** How Folder Watch (session-auto) jobs resolve a server-detected duplicate
- *  without blocking the import queue on the interactive modal.
- *
- *  Only two values are offered. A 'skip'/use-existing policy is deliberately
- *  NOT supported: a session-import dedup match is a bare audio-hash anchor with
- *  no retrievable transcript in the DB (the /import worker writes results to the
- *  in-memory job tracker, never to the durability row — see _run_file_import in
- *  server/backend/api/routes/transcription.py), so auto-skipping could leave a
- *  file with no transcript and violate the data-loss invariant. Unattended jobs
- *  therefore only ever create a new entry or ask. */
-export type DuplicatePolicy = 'ask' | 'create_new';
-
-/** Default when `folderWatch.duplicatePolicy` is unset, unknown, or unreadable:
- *  create a new entry so an unattended batch never stalls AND never silently
- *  drops a file (the data-loss invariant). */
-const DEFAULT_DUPLICATE_POLICY: DuplicatePolicy = 'create_new';
-
-/**
- * Decide how to resolve a server-detected duplicate for a session import.
- *
- * Manual imports (`session-normal`) always prompt the user via the interactive
- * DedupPromptModal. Folder Watch imports (`session-auto`) follow the configured
- * `folderWatch.duplicatePolicy` so a batch runs unattended (GH-120). Only the
- * explicit `'ask'` policy falls back to the modal; every other case — the
- * `'create_new'` default, an unknown/legacy stored value (e.g. a removed
- * `'skip'`), or an IPC read failure — creates a new entry, so a corrupt config
- * can never re-block the queue or skip a file.
- */
-export async function resolveDuplicateChoice(
-  jobType: ImportJobType,
-  matches: DedupMatch[],
-): Promise<DedupChoice> {
-  if (jobType === 'session-auto') {
-    const policy =
-      (await getConfig<DuplicatePolicy>('folderWatch.duplicatePolicy').catch(() => undefined)) ??
-      DEFAULT_DUPLICATE_POLICY;
-    if (policy !== 'ask') return 'create_new';
-    // policy === 'ask' → fall through to the interactive prompt below.
-  }
-  return useDedupChoiceStore.getState().requestChoice(matches);
-}
-
 const POLL_INTERVAL_MS = 5_000;
 const MAX_POLLS = (24 * 60 * 60 * 1000) / POLL_INTERVAL_MS; // 24 hours
 
 // ─── Polling ─────────────────────────────────────────────────────────────────
 
+// Session imports poll the durability row directly (GET /api/transcribe/result/
+// {job_id}): 202 processing, 200 completed (the server purges the row after
+// this response — session ephemeral retention), 410 failed with the error
+// detail, 404 job lost. Must go through apiClient's absolute base URL — a
+// relative fetch resolves against the packaged file:// origin and never
+// reaches the backend (GH #202).
 async function pollForSessionResult(serverJobId: string): Promise<FileImportJobResult> {
   for (let i = 0; i < MAX_POLLS; i++) {
     if (_abort) throw new Error('Import queue aborted');
     await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
 
+    let resp: Response;
     try {
-      const status = await apiClient.getAdminStatus();
-      const jobTracker = (status?.models as any)?.job_tracker;
-
-      if (jobTracker?.is_busy && jobTracker?.active_job_id === serverJobId) continue;
-
-      const result = jobTracker?.result as FileImportJobResult | undefined;
-      if (result && result.job_id === serverJobId) return result;
-
-      if (!jobTracker?.is_busy && (!result || result.job_id !== serverJobId)) {
-        throw new Error('Transcription job lost — server may have restarted');
-      }
+      resp = await apiClient.fetchTranscriptionResult(serverJobId);
     } catch (err) {
-      if (err instanceof Error && err.message.includes('job lost')) throw err;
-      if (err instanceof Error && err.message.includes('aborted')) throw err;
       console.warn('Poll error (will retry):', err);
+      continue;
     }
+
+    if (resp.status === 202) continue;
+    if (resp.status === 200) {
+      const body = (await resp.json()) as { result?: FileImportJobResult };
+      return body.result ?? ({ job_id: serverJobId } as FileImportJobResult);
+    }
+    if (resp.status === 410) {
+      let detail = 'Transcription failed';
+      try {
+        detail = ((await resp.json()) as { detail?: string }).detail ?? detail;
+      } catch {
+        // keep the generic message when the body is not JSON
+      }
+      throw new Error(detail);
+    }
+    if (resp.status === 404) {
+      throw new Error('Transcription job lost — server may have restarted');
+    }
+    if (resp.status === 403) throw new Error('Access denied for this transcription job');
+    console.warn(`Poll got HTTP ${resp.status} (will retry)`);
   }
   throw new Error('Transcription timed out after 24 hours');
 }
@@ -374,41 +342,11 @@ async function processSessionJob(
     fileObj = file;
   }
 
+  // Session ephemeral retention (2026-08-09 spec): the server no longer
+  // hashes or dedup-checks session imports, so there is nothing to resolve
+  // here — a legacy server's dedup_matches field is deliberately ignored.
   const importResponse = await apiClient.importAndTranscribe(fileObj, job.options);
   const { job_id: serverJobId } = importResponse;
-
-  // Issue #104, Story 2.4 + Sprint 2 Item 4 — full DedupPromptModal flow.
-  // When the server reports prior matches, resolve the duplicate. Manual
-  // imports await the user's choice via the interactive modal; Folder Watch
-  // (session-auto) jobs follow folderWatch.duplicatePolicy so a batch runs
-  // unattended instead of blocking the queue on the modal (GH-120).
-  if (importResponse.dedup_matches?.length) {
-    const first = importResponse.dedup_matches[0];
-    const choice = await resolveDuplicateChoice(job.type, importResponse.dedup_matches);
-
-    if (choice === 'use_existing' || choice === 'cancel') {
-      // User picked "Use existing" (or pressed Esc / closed): cancel the
-      // server-side job and skip this queue entry. The cancel API is
-      // best-effort — if the job already completed it's a harmless no-op.
-      try {
-        await apiClient.cancelTranscription();
-      } catch {
-        // Swallow: skip-the-local-entry is the user-visible contract.
-      }
-      useAriaAnnouncerStore.getState().announce(`Duplicate skipped: ${first.name}`, 'polite');
-      // Mark this queue entry as success-with-no-output so the user sees
-      // the queue advance rather than freeze on a "processing" state.
-      // We deliberately do NOT mark as 'error' — the user chose this.
-      store.setState((s) => ({
-        jobs: s.jobs.map((j) =>
-          j.id === job.id ? { ...j, status: 'success' as const, outputFilename: undefined } : j,
-        ),
-      }));
-      return;
-    }
-    // 'create_new': continue with the existing happy path.
-    toast.warning(`Duplicate of '${first.name}' detected — creating a new entry.`);
-  }
 
   const result = await pollForSessionResult(serverJobId);
 

--- a/docs/api-contracts-server.md
+++ b/docs/api-contracts-server.md
@@ -36,12 +36,12 @@
 | POST | `/api/transcribe/audio` | user | Full transcription (text + segments + words + optional diarization); supports `multitrack`, `profile_id`; persists before delivery |
 | POST | `/api/transcribe/quick` | user | Fast text-only transcription (Record view) |
 | POST | `/api/transcribe/cancel` | user | Cancel the active job |
-| POST | `/api/transcribe/import` | user | Background transcribe (no DB/notebook); 202 + `job_id` + inline `dedup_matches`; supports `multitrack` |
+| POST | `/api/transcribe/import` | user | Background transcribe (no notebook entry); 202 + full `job_id`; result persisted to the durability row — poll `GET /api/transcribe/result/{job_id}` (202/410/200; a 200 purges the row — session ephemeral retention); supports `multitrack` |
 | POST | `/api/transcribe/import/dedup-check` | user | **NEW** — look up prior jobs/recordings sharing an audio hash (no side effects) |
-| GET | `/api/transcribe/result/{job_id}` | user | **NEW** — fetch saved result (200 done / 202 processing / 404 / 410 failed); marks delivered; ownership check |
+| GET | `/api/transcribe/result/{job_id}` | user | **NEW** — fetch saved result (200 done / 202 processing / 404 / 410 failed); marks delivered; ownership check. Session sources (`websocket`, `file_import`): 200 also purges row + audio (repeat fetches 404); 410 on a failed `file_import` purges the row |
 | POST | `/api/transcribe/retry/{job_id}` | user | **NEW** — re-transcribe a failed job from preserved audio |
 | GET | `/api/transcribe/recent` | user | **NEW** — up to 5 recently completed-but-undelivered jobs (post-restart recovery banner) |
-| POST | `/api/transcribe/result/{job_id}/dismiss` | user | **NEW** — mark a result delivered without transferring payload |
+| POST | `/api/transcribe/result/{job_id}/dismiss` | user | **NEW** — mark a result delivered without transferring payload; purges completed session-source rows |
 | GET | `/api/transcribe/languages` | user | Supported languages for active backend, `auto_detect`, `supports_translation` |
 
 ### Audio Notebook (`/api/notebook`)

--- a/docs/data-models-server.md
+++ b/docs/data-models-server.md
@@ -256,6 +256,18 @@ Located in `server/backend/database/migrations/versions/`. Run automatically on 
 3. **Wave 3 — Orphan recovery:** on startup, `recover_orphaned_jobs()` marks stale `processing` jobs as
    `failed`; periodic orphan sweep re-checks (guarded by `job_tracker.is_busy()`).
 
+### Session Ephemeral Retention (2026-08-09 spec)
+
+Session-source rows (`source` = `websocket` or `file_import`) are deleted — together with
+their audio file — immediately after the result is confirmed delivered (inline WS final,
+`GET /result` fetch, or dismiss), via `job_repository.delete_job()`. Failed mic
+(`websocket`) jobs keep row + WAV indefinitely for `/retry`; failed imports (which never
+retain audio) are purged once the client has received the 410 error, or by the cleanup
+sweep. A one-time startup purge (`purge_legacy_session_rows()`) removes pre-existing bare
+/import dedup anchors and already-delivered session rows. Rows from other sources (e.g.
+`audio_upload`) keep the pre-existing behavior: row kept forever, audio garbage-collected
+after `audio_retention_days`.
+
 ### Job Lifecycle
 
 ```

--- a/docs/superpowers/plans/2026-08-09-session-ephemeral-retention.md
+++ b/docs/superpowers/plans/2026-08-09-session-ephemeral-retention.md
@@ -1,0 +1,1758 @@
+# Session Ephemeral Retention Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Session-tab transcriptions (mic + file imports) leave no server-side trace once confirmed delivered; the duplicate dialog never appears in any Session flow; the `/import` durability bug is fixed.
+
+**Architecture:** Extend the existing durability pipeline (`transcription_jobs` table) with a post-delivery purge step scoped to session sources (`'websocket'`, `'file_import'`). The `/import` worker joins the persist-before-deliver pipeline (`save_result`/`mark_failed`); the dashboard polls `GET /api/transcribe/result/{job_id}` instead of scraping the in-memory job tracker. Dedup hashing is removed from `/import` entirely. A backstop sweep and a one-time startup cleanup catch stragglers and legacy rows.
+
+**Tech Stack:** FastAPI + SQLite (server/backend), Zustand + vitest (dashboard), pytest via the build venv.
+
+**Spec:** `docs/superpowers/specs/2026-08-09-session-ephemeral-retention-design.md`
+
+**Branch:** `feat/session-ephemeral-retention` (already created; the spec is committed there).
+
+---
+
+## Ground rules for the executor
+
+- Backend tests: `cd server/backend && ../../build/.venv/bin/pytest tests/ -v --tb=short` — always finish with the FULL suite, not just the new files.
+- Dashboard tests need Node 22: `cd dashboard && nvm use && npx vitest run src/stores/importQueueStore.test.ts`.
+- Per CLAUDE.md: run GitNexus `impact` before editing each symbol, `detect_changes` before each commit. No AI attribution anywhere. Commit style: `type(area): summary` + bullet body, long lines NOT broken.
+- The three WS session test-factories break on new session **attributes** — this plan deliberately adds none (purge state is method-local).
+- `server/backend/api/routes/transcription.py` already imports at module top: `create_job`, `save_result`, `mark_failed`, `find_duplicates_anywhere`, `sanitize_for_json`, `_json`, `sanitize_log_value`. Verify with grep before adding duplicate imports.
+
+---
+
+### Task 1: `delete_job` + `SESSION_SOURCES` in the job repository
+
+**Files:**
+- Modify: `server/backend/database/job_repository.py`
+- Test: `server/backend/tests/test_session_ephemeral_retention.py` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `server/backend/tests/test_session_ephemeral_retention.py`:
+
+```python
+"""Tests for session ephemeral retention (2026-08-09 spec).
+
+Covers the repository purge primitives (delete_job, backstop queries,
+legacy-row query) and the extended cleanup task. Uses a real temporary
+SQLite DB via the same get_connection monkeypatch pattern as
+test_job_repository_imports.py.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+repo = importlib.import_module("server.database.job_repository")
+
+
+@pytest.fixture()
+def db(tmp_path, monkeypatch):
+    """Real SQLite DB with the transcription_jobs columns this feature touches."""
+    db_path = tmp_path / "jobs.db"
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE transcription_jobs (
+            id TEXT PRIMARY KEY,
+            status TEXT NOT NULL DEFAULT 'processing',
+            source TEXT,
+            client_name TEXT,
+            language TEXT,
+            task TEXT,
+            translation_target TEXT,
+            job_profile_snapshot TEXT,
+            snapshot_schema_version TEXT,
+            audio_hash TEXT,
+            normalized_audio_hash TEXT,
+            audio_path TEXT,
+            result_text TEXT,
+            result_json TEXT,
+            result_language TEXT,
+            duration_seconds REAL,
+            error_message TEXT,
+            delivered INTEGER NOT NULL DEFAULT 0,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            completed_at TIMESTAMP
+        )
+        """
+    )
+    conn.commit()
+
+    @contextmanager
+    def _get_connection():
+        yield conn
+
+    monkeypatch.setattr(repo, "get_connection", _get_connection)
+    yield conn
+    conn.close()
+
+
+def _insert(
+    conn,
+    job_id: str,
+    *,
+    source: str = "file_import",
+    status: str = "processing",
+    delivered: int = 0,
+    audio_path: str | None = None,
+    result_text: str | None = None,
+    created_at: str = "2020-01-01 00:00:00",
+    completed_at: str | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO transcription_jobs
+            (id, status, source, delivered, audio_path, result_text,
+             created_at, completed_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (job_id, status, source, delivered, audio_path, result_text, created_at, completed_at),
+    )
+    conn.commit()
+
+
+def _row(conn, job_id: str):
+    return conn.execute(
+        "SELECT * FROM transcription_jobs WHERE id = ?", (job_id,)
+    ).fetchone()
+
+
+class TestDeleteJob:
+    def test_deletes_row_and_audio_file(self, db, tmp_path):
+        wav = tmp_path / "job1.wav"
+        wav.write_bytes(b"RIFF")
+        _insert(db, "job1", audio_path=str(wav))
+
+        repo.delete_job("job1")
+
+        assert _row(db, "job1") is None
+        assert not wav.exists()
+
+    def test_missing_audio_file_still_deletes_row(self, db, tmp_path):
+        _insert(db, "job2", audio_path=str(tmp_path / "gone.wav"))
+
+        repo.delete_job("job2")
+
+        assert _row(db, "job2") is None
+
+    def test_null_audio_path_deletes_row(self, db):
+        _insert(db, "job3", audio_path=None)
+
+        repo.delete_job("job3")
+
+        assert _row(db, "job3") is None
+
+    def test_nonexistent_job_is_noop(self, db):
+        repo.delete_job("missing")  # must not raise
+
+    def test_never_raises_on_db_error(self, monkeypatch):
+        @contextmanager
+        def _broken():
+            raise RuntimeError("db locked")
+            yield  # pragma: no cover
+
+        monkeypatch.setattr(repo, "get_connection", _broken)
+        repo.delete_job("whatever")  # must not raise
+
+
+class TestSessionSources:
+    def test_exactly_websocket_and_file_import(self):
+        assert set(repo.SESSION_SOURCES) == {"websocket", "file_import"}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_session_ephemeral_retention.py -v --tb=short`
+Expected: FAIL — `AttributeError: module ... has no attribute 'delete_job'` / `'SESSION_SOURCES'`.
+
+- [ ] **Step 3: Implement in `job_repository.py`**
+
+Add `from pathlib import Path` to the module imports. After `get_jobs_for_cleanup`, add:
+
+```python
+# ─── Session ephemeral retention (2026-08-09 spec) ───────────────────────────
+
+# Sources whose rows are purged after confirmed delivery. Rows from any other
+# source (e.g. 'audio_upload', notebook uploads) are NEVER purged — only these
+# two values may ever reach delete_job via the session lifecycle.
+SESSION_SOURCES = ("websocket", "file_import")
+
+
+def delete_job(job_id: str) -> None:
+    """Delete a job row and its audio file (session ephemeral retention).
+
+    Best-effort by contract: every failure is logged as a warning and
+    swallowed — a purge must never break delivery or session teardown.
+    The backstop sweep in audio_cleanup catches stragglers.
+    """
+    try:
+        row = get_job(job_id)
+        if row is None:
+            return
+        audio_path = row.get("audio_path")
+        if audio_path:
+            try:
+                Path(audio_path).unlink(missing_ok=True)
+            except Exception:
+                logger.warning(
+                    "delete_job: failed to unlink audio for %s",
+                    sanitize_log_value(job_id),
+                    exc_info=True,
+                )
+        with get_connection() as conn:
+            conn.execute("DELETE FROM transcription_jobs WHERE id = ?", (job_id,))
+            conn.commit()
+    except Exception:
+        logger.warning(
+            "delete_job: failed to purge job %s", sanitize_log_value(job_id), exc_info=True
+        )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_session_ephemeral_retention.py -v --tb=short`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/backend/database/job_repository.py server/backend/tests/test_session_ephemeral_retention.py
+git commit -m "feat(server): add delete_job purge primitive and SESSION_SOURCES for session ephemeral retention"
+```
+
+---
+
+### Task 2: Backstop + legacy queries in the job repository
+
+**Files:**
+- Modify: `server/backend/database/job_repository.py`
+- Test: `server/backend/tests/test_session_ephemeral_retention.py`
+
+- [ ] **Step 1: Write the failing tests** (append to the new test file)
+
+```python
+class TestGetPurgeableSessionJobs:
+    def test_returns_old_delivered_session_rows_only(self, db):
+        _insert(db, "ws-old", source="websocket", status="completed", delivered=1,
+                completed_at="2020-01-01T00:00:00+00:00")
+        _insert(db, "imp-old", source="file_import", status="completed", delivered=1,
+                completed_at="2020-01-02T00:00:00+00:00")
+        # Excluded: wrong source, undelivered, failed, too recent
+        _insert(db, "upload-old", source="audio_upload", status="completed", delivered=1,
+                completed_at="2020-01-01T00:00:00+00:00")
+        _insert(db, "ws-undelivered", source="websocket", status="completed", delivered=0,
+                completed_at="2020-01-01T00:00:00+00:00")
+        _insert(db, "ws-failed", source="websocket", status="failed", delivered=0)
+        _insert(db, "ws-recent", source="websocket", status="completed", delivered=1,
+                completed_at="2099-01-01T00:00:00+00:00")
+
+        ids = {j["id"] for j in repo.get_purgeable_session_jobs(max_age_days=7)}
+
+        assert ids == {"ws-old", "imp-old"}
+
+
+class TestGetStaleFailedImports:
+    def test_returns_only_aged_failed_imports_without_audio(self, db, tmp_path):
+        _insert(db, "imp-fail-old", source="file_import", status="failed",
+                created_at="2020-01-01 00:00:00")
+        # Excluded: has audio (hypothetical future), wrong source, recent, not failed
+        _insert(db, "imp-fail-audio", source="file_import", status="failed",
+                audio_path=str(tmp_path / "kept.wav"), created_at="2020-01-01 00:00:00")
+        _insert(db, "ws-fail-old", source="websocket", status="failed",
+                created_at="2020-01-01 00:00:00")
+        _insert(db, "imp-fail-recent", source="file_import", status="failed",
+                created_at="2099-01-01 00:00:00")
+        _insert(db, "imp-done", source="file_import", status="completed",
+                created_at="2020-01-01 00:00:00")
+
+        ids = {j["id"] for j in repo.get_stale_failed_imports(max_age_days=7)}
+
+        assert ids == {"imp-fail-old"}
+
+
+class TestGetLegacySessionRows:
+    def test_returns_bare_anchors_and_delivered_session_rows(self, db, tmp_path):
+        # Bare /import dedup anchors — any status, no result, no audio
+        _insert(db, "anchor-proc", source="file_import", status="processing")
+        _insert(db, "anchor-failed", source="file_import", status="failed")
+        # Delivered session rows
+        _insert(db, "ws-done", source="websocket", status="completed", delivered=1,
+                result_text="hello", audio_path=str(tmp_path / "a.wav"))
+        _insert(db, "imp-done", source="file_import", status="completed", delivered=1,
+                result_text="hello")
+        # Kept: undelivered / failed-with-content / non-session
+        _insert(db, "ws-undelivered", source="websocket", status="completed", delivered=0,
+                result_text="precious")
+        _insert(db, "ws-failed-wav", source="websocket", status="failed",
+                audio_path=str(tmp_path / "b.wav"))
+        _insert(db, "upload-done", source="audio_upload", status="completed", delivered=1,
+                result_text="hello")
+
+        ids = {j["id"] for j in repo.get_legacy_session_rows()}
+
+        assert ids == {"anchor-proc", "anchor-failed", "ws-done", "imp-done"}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_session_ephemeral_retention.py -v --tb=short`
+Expected: new classes FAIL with `AttributeError` (functions missing); Task 1 classes still PASS.
+
+- [ ] **Step 3: Implement the three queries** (append to `job_repository.py`, after `delete_job`)
+
+```python
+def get_purgeable_session_jobs(max_age_days: int, limit: int = 100) -> list[dict]:
+    """Return completed+delivered session-source jobs older than max_age_days.
+
+    Backstop for rows that missed their immediate post-delivery purge (e.g. a
+    crash between mark_delivered and delete_job). completed_at is isoformat —
+    see get_jobs_for_cleanup for the cutoff-format note.
+    """
+    from datetime import timedelta
+
+    cutoff = (datetime.now(UTC) - timedelta(days=max_age_days)).isoformat()
+    placeholders = ",".join("?" for _ in SESSION_SOURCES)
+    with get_connection() as conn:
+        cursor = conn.execute(
+            f"""
+            SELECT * FROM transcription_jobs
+            WHERE status = 'completed'
+              AND delivered = 1
+              AND source IN ({placeholders})
+              AND completed_at < ?
+            ORDER BY completed_at ASC
+            LIMIT ?
+            """,
+            (*SESSION_SOURCES, cutoff, limit),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
+
+def get_stale_failed_imports(max_age_days: int, limit: int = 100) -> list[dict]:
+    """Return aged failed file_import rows with no preserved audio.
+
+    A failed import keeps no audio (the /import temp file is always deleted),
+    so nothing is retryable — the row exists only to deliver its error message
+    via GET /result/{job_id} (410). When the client never polls (e.g. the
+    dashboard crashed), this query lets the backstop sweep purge the row.
+
+    created_at is written by SQLite CURRENT_TIMESTAMP (space separator), so
+    the cutoff must use strftime — see get_orphaned_jobs for the format note.
+    """
+    from datetime import timedelta
+
+    cutoff = (datetime.now(UTC) - timedelta(days=max_age_days)).strftime("%Y-%m-%d %H:%M:%S")
+    with get_connection() as conn:
+        cursor = conn.execute(
+            """
+            SELECT * FROM transcription_jobs
+            WHERE status = 'failed'
+              AND source = 'file_import'
+              AND audio_path IS NULL
+              AND created_at < ?
+            ORDER BY created_at ASC
+            LIMIT ?
+            """,
+            (cutoff, limit),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
+
+def get_legacy_session_rows(limit: int = 1000) -> list[dict]:
+    """One-time startup cleanup query (session-ephemeral-retention migration).
+
+    Returns rows that predate the ephemeral lifecycle:
+    - bare /import dedup anchors — source='file_import' with neither result
+      text nor audio, ANY status. These rows were written purely so the old
+      dedup check could find re-imports; they are what triggers the duplicate
+      dialog and hold nothing recoverable.
+    - already-delivered session rows — completed + delivered=1 for any session
+      source. The result reached the client; under the new lifecycle these
+      would have been purged at delivery time.
+
+    Failed or undelivered rows WITH content are never returned. Runs at
+    startup before any request is served, so no live 'processing' row can be
+    caught by the anchor arm.
+    """
+    placeholders = ",".join("?" for _ in SESSION_SOURCES)
+    with get_connection() as conn:
+        cursor = conn.execute(
+            f"""
+            SELECT * FROM transcription_jobs
+            WHERE (source = 'file_import'
+                   AND result_text IS NULL
+                   AND audio_path IS NULL)
+               OR (source IN ({placeholders})
+                   AND status = 'completed'
+                   AND delivered = 1)
+            ORDER BY created_at ASC
+            LIMIT ?
+            """,
+            (*SESSION_SOURCES, limit),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_session_ephemeral_retention.py -v --tb=short`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/backend/database/job_repository.py server/backend/tests/test_session_ephemeral_retention.py
+git commit -m "feat(server): add backstop and legacy-row queries for session ephemeral retention"
+```
+
+---
+
+### Task 3: Extend the cleanup task + one-time legacy purge
+
+**Files:**
+- Modify: `server/backend/database/audio_cleanup.py`
+- Modify: `server/backend/api/main.py` (lifespan, right after `recover_orphaned_jobs`)
+- Test: `server/backend/tests/test_session_ephemeral_retention.py`
+
+- [ ] **Step 1: Write the failing tests** (append to the test file)
+
+```python
+class TestCleanupOldRecordingsPurgesRows:
+    def _run(self, monkeypatch, db):
+        """Run cleanup_old_recordings against the patched repo module."""
+        import asyncio
+
+        from server.database import audio_cleanup
+
+        asyncio.run(audio_cleanup.cleanup_old_recordings("/data/recordings", max_age_days=7))
+
+    def test_purges_aged_delivered_session_rows(self, db, monkeypatch, tmp_path):
+        wav = tmp_path / "ws.wav"
+        wav.write_bytes(b"RIFF")
+        _insert(db, "ws-old", source="websocket", status="completed", delivered=1,
+                audio_path=str(wav), completed_at="2020-01-01T00:00:00+00:00")
+
+        self._run(monkeypatch, db)
+
+        assert _row(db, "ws-old") is None
+        assert not wav.exists()
+
+    def test_purges_aged_failed_imports(self, db, monkeypatch):
+        _insert(db, "imp-fail-old", source="file_import", status="failed",
+                created_at="2020-01-01 00:00:00")
+
+        self._run(monkeypatch, db)
+
+        assert _row(db, "imp-fail-old") is None
+
+    def test_keeps_non_session_rows_deletes_only_their_audio(self, db, monkeypatch, tmp_path):
+        wav = tmp_path / "up.wav"
+        wav.write_bytes(b"RIFF")
+        _insert(db, "upload-old", source="audio_upload", status="completed", delivered=1,
+                audio_path=str(wav), completed_at="2020-01-01T00:00:00+00:00")
+
+        self._run(monkeypatch, db)
+
+        assert _row(db, "upload-old") is not None  # row kept (status quo)
+        assert not wav.exists()  # WAV still garbage-collected
+
+    def test_keeps_failed_websocket_rows(self, db, monkeypatch, tmp_path):
+        wav = tmp_path / "retryable.wav"
+        wav.write_bytes(b"RIFF")
+        _insert(db, "ws-failed", source="websocket", status="failed",
+                audio_path=str(wav), created_at="2020-01-01 00:00:00")
+
+        self._run(monkeypatch, db)
+
+        assert _row(db, "ws-failed") is not None
+        assert wav.exists()
+
+    def test_retention_zero_skips_everything(self, db, monkeypatch):
+        import asyncio
+
+        from server.database import audio_cleanup
+
+        _insert(db, "ws-old", source="websocket", status="completed", delivered=1,
+                completed_at="2020-01-01T00:00:00+00:00")
+
+        asyncio.run(audio_cleanup.cleanup_old_recordings("/data/recordings", max_age_days=0))
+
+        assert _row(db, "ws-old") is not None
+
+
+class TestPurgeLegacySessionRows:
+    def test_purges_anchors_and_delivered_rows_keeps_the_rest(self, db, monkeypatch, tmp_path):
+        import asyncio
+
+        from server.database import audio_cleanup
+
+        wav = tmp_path / "done.wav"
+        wav.write_bytes(b"RIFF")
+        _insert(db, "anchor", source="file_import", status="failed")
+        _insert(db, "ws-done", source="websocket", status="completed", delivered=1,
+                result_text="x", audio_path=str(wav))
+        _insert(db, "ws-undelivered", source="websocket", status="completed", delivered=0,
+                result_text="precious")
+
+        asyncio.run(audio_cleanup.purge_legacy_session_rows())
+
+        assert _row(db, "anchor") is None
+        assert _row(db, "ws-done") is None
+        assert not wav.exists()
+        assert _row(db, "ws-undelivered") is not None
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_session_ephemeral_retention.py -v --tb=short`
+Expected: new classes FAIL (`purge_legacy_session_rows` missing; row-purge assertions fail against the current WAV-only cleanup).
+
+- [ ] **Step 3: Implement in `audio_cleanup.py`**
+
+Update the module docstring (it currently says "The job DB row is always kept") to:
+
+```python
+"""
+Audio cleanup module for transcription durability (Wave 2) and session
+ephemeral retention (2026-08-09 spec).
+
+For non-session jobs (e.g. source='audio_upload'): deletes only the raw audio
+file of completed+delivered jobs older than the retention window — the DB row
+is kept as a record that a transcription happened.
+
+For session-source jobs ('websocket', 'file_import'): the backstop passes also
+delete the DB ROW — the Session tab is ephemeral, and rows here only survive
+their immediate post-delivery purge after a crash. Aged failed file_import
+rows (which never have audio, so nothing is retryable) are purged too.
+
+Never deletes audio for failed or undelivered jobs, and never touches failed
+mic ('websocket') rows — their WAV is what makes /retry possible.
+"""
+```
+
+Extend `cleanup_old_recordings` — after the existing per-job WAV deletion loop and before the final summary `logger.info`, add:
+
+```python
+    # Session ephemeral retention backstops. Immediate purge normally removes
+    # session rows at delivery time; these passes only catch crash-window
+    # stragglers and failed imports whose client never polled the error.
+    from .job_repository import (
+        delete_job,
+        get_purgeable_session_jobs,
+        get_stale_failed_imports,
+    )
+
+    purged_rows = 0
+    try:
+        stragglers = await asyncio.to_thread(get_purgeable_session_jobs, max_age_days)
+        stale_imports = await asyncio.to_thread(get_stale_failed_imports, max_age_days)
+        for job in [*stragglers, *stale_imports]:
+            await asyncio.to_thread(delete_job, job["id"])
+            purged_rows += 1
+    except Exception:
+        logger.exception("Audio cleanup: session-row backstop purge failed")
+```
+
+and extend the summary log line to include `purged_rows`:
+
+```python
+    logger.info(
+        "Audio cleanup complete: %d file(s) deleted, %d skipped, %d session row(s) purged "
+        "(retention=%d days, dir=%s)",
+        deleted,
+        skipped,
+        purged_rows,
+        max_age_days,
+        recordings_dir,
+    )
+```
+
+Note: the early `if not jobs: return` guard in the current implementation must NOT short-circuit the new passes — restructure so the WAV pass and the row-purge passes both always run (keep the `max_age_days <= 0` early return as the only skip). Concretely: replace `if not jobs: ... return` with `if not jobs: logger.debug(...)` and initialize `deleted = skipped = 0` before the loop.
+
+Then add the one-time startup purge at the end of the module:
+
+```python
+async def purge_legacy_session_rows() -> None:
+    """One-time startup migration for session ephemeral retention.
+
+    Purges rows accumulated under the old lifecycle: bare /import dedup
+    anchors (the rows behind the duplicate dialog) and already-delivered
+    session rows. Anything failed or undelivered with content is untouched.
+    Safe to run every startup — once drained it finds nothing.
+    """
+    from .job_repository import delete_job, get_legacy_session_rows
+
+    total = 0
+    while True:
+        try:
+            rows = await asyncio.to_thread(get_legacy_session_rows)
+        except Exception:
+            logger.exception("Legacy session-row purge: query failed")
+            return
+        if not rows:
+            break
+        for row in rows:
+            await asyncio.to_thread(delete_job, row["id"])
+        total += len(rows)
+        if len(rows) < 1000:  # last page
+            break
+    if total:
+        logger.info("Legacy session-row purge: %d row(s) removed", total)
+```
+
+- [ ] **Step 4: Wire the startup call in `api/main.py`**
+
+Immediately after `await recover_orphaned_jobs(_orphan_timeout)` / `_log_time("orphan job recovery complete")` (around line 436), add:
+
+```python
+    # One-time legacy purge for session ephemeral retention (2026-08-09 spec).
+    # Runs before any request is served, so no live job can be caught.
+    from server.database.audio_cleanup import purge_legacy_session_rows
+
+    await purge_legacy_session_rows()
+    _log_time("legacy session-row purge complete")
+```
+
+- [ ] **Step 5: Run the tests to verify they pass, plus neighbors**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_session_ephemeral_retention.py tests/test_main_lifespan_sweeper.py -v --tb=short`
+Expected: PASS. If `test_main_lifespan_sweeper.py` mocks lifespan internals and breaks on the new call, patch `purge_legacy_session_rows` the same way it patches `recover_orphaned_jobs`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/backend/database/audio_cleanup.py server/backend/api/main.py server/backend/tests/test_session_ephemeral_retention.py
+git commit -m "feat(server): extend cleanup sweep with session-row purges and one-time legacy cleanup at startup"
+```
+
+---
+
+### Task 4: Purge on `/result` fetch and dismiss
+
+**Files:**
+- Modify: `server/backend/api/routes/transcription.py` (`get_transcription_result`, `dismiss_transcription_result`)
+- Test: `server/backend/tests/test_transcription_durability_routes.py`
+
+- [ ] **Step 1: Write the failing tests** (append inside the existing classes; follow the direct-call pattern already in the file)
+
+In `TestGetTranscriptionResult`:
+
+```python
+    def test_200_purges_session_source_job(self, repo, monkeypatch):
+        purged: list[str] = []
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {
+                "status": "completed",
+                "client_name": None,
+                "source": "file_import",
+                "result_json": '{"text": "hi"}',
+            },
+        )
+        monkeypatch.setattr(repo, "delete_job", lambda jid: purged.append(jid))
+
+        resp = asyncio.run(transcription.get_transcription_result("job-imp", _request()))
+
+        assert resp.status_code == 200
+        assert purged == ["job-imp"]
+
+    def test_200_keeps_non_session_job(self, repo, monkeypatch):
+        purged: list[str] = []
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {
+                "status": "completed",
+                "client_name": None,
+                "source": "audio_upload",
+                "result_json": '{"text": "hi"}',
+            },
+        )
+        monkeypatch.setattr(repo, "delete_job", lambda jid: purged.append(jid))
+
+        resp = asyncio.run(transcription.get_transcription_result("job-up", _request()))
+
+        assert resp.status_code == 200
+        assert purged == []
+
+    def test_410_purges_failed_import_without_audio(self, repo, monkeypatch):
+        purged: list[str] = []
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {
+                "status": "failed",
+                "client_name": None,
+                "source": "file_import",
+                "audio_path": None,
+                "error_message": "boom",
+            },
+        )
+        monkeypatch.setattr(repo, "delete_job", lambda jid: purged.append(jid))
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(transcription.get_transcription_result("job-if", _request()))
+
+        assert exc.value.status_code == 410
+        assert purged == ["job-if"]
+
+    def test_410_keeps_failed_websocket_job(self, repo, monkeypatch):
+        purged: list[str] = []
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {
+                "status": "failed",
+                "client_name": None,
+                "source": "websocket",
+                "audio_path": "/data/recordings/x.wav",
+                "error_message": "boom",
+            },
+        )
+        monkeypatch.setattr(repo, "delete_job", lambda jid: purged.append(jid))
+
+        with pytest.raises(HTTPException):
+            asyncio.run(transcription.get_transcription_result("job-ws", _request()))
+
+        assert purged == []
+```
+
+In the dismiss test class (`TestDismissTranscriptionResult` or equivalent — match the existing class name):
+
+```python
+    def test_dismiss_purges_completed_session_job(self, repo, monkeypatch):
+        purged: list[str] = []
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {"status": "completed", "client_name": None, "source": "websocket"},
+        )
+        monkeypatch.setattr(repo, "delete_job", lambda jid: purged.append(jid))
+
+        resp = asyncio.run(transcription.dismiss_transcription_result("job-d", _request()))
+
+        assert resp.status_code == 200
+        assert purged == ["job-d"]
+
+    def test_dismiss_keeps_non_session_job(self, repo, monkeypatch):
+        purged: list[str] = []
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {"status": "completed", "client_name": None, "source": "audio_upload"},
+        )
+        monkeypatch.setattr(repo, "delete_job", lambda jid: purged.append(jid))
+
+        resp = asyncio.run(transcription.dismiss_transcription_result("job-d2", _request()))
+
+        assert resp.status_code == 200
+        assert purged == []
+```
+
+- [ ] **Step 2: Run to verify the new tests fail**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_transcription_durability_routes.py -v --tb=short`
+Expected: new tests FAIL (`delete_job` never called); all pre-existing tests PASS.
+
+- [ ] **Step 3: Implement the route changes**
+
+In `get_transcription_result`, change the function-local import to:
+
+```python
+    from ...database.job_repository import SESSION_SOURCES, delete_job, get_job, mark_delivered
+```
+
+Replace the failed branch:
+
+```python
+    if job["status"] == "failed":
+        detail = job.get("error_message") or "Transcription failed"
+        # Session ephemeral retention: a failed import keeps no audio, so
+        # nothing is retryable — the row's only purpose was delivering this
+        # error message, which just happened. Failed 'websocket' jobs keep
+        # their row + WAV so /retry stays possible.
+        if job.get("source") == "file_import" and not job.get("audio_path"):
+            delete_job(job_id)
+        raise HTTPException(status_code=410, detail=detail)
+```
+
+After the `mark_delivered` try/except in the completed branch (result data is already in memory at that point), add before the `return JSONResponse(...)`:
+
+```python
+    # Session ephemeral retention: a delivered session job leaves no
+    # server-side trace. delete_job never raises (warning-only contract).
+    if job.get("source") in SESSION_SOURCES:
+        delete_job(job_id)
+```
+
+In `dismiss_transcription_result`, change the import to include `SESSION_SOURCES, delete_job` and after `mark_delivered(job_id)` add:
+
+```python
+    # Dismiss means "I don't want it" — purge session jobs like a delivery.
+    if job.get("status") == "completed" and job.get("source") in SESSION_SOURCES:
+        delete_job(job_id)
+```
+
+- [ ] **Step 4: Run to verify everything passes**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_transcription_durability_routes.py -v --tb=short`
+Expected: PASS (all — old tests use rows without `source`, `dict.get("source")` returns None, no purge, unchanged behavior).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/backend/api/routes/transcription.py server/backend/tests/test_transcription_durability_routes.py
+git commit -m "feat(server): purge session-source jobs on result fetch, failed-import 410, and dismiss"
+```
+
+---
+
+### Task 5: `/import` route — remove dedup, mandatory durability row, full job_id
+
+**Files:**
+- Modify: `server/backend/api/routes/transcription.py` (`ImportAcceptedResponse`, `import_and_transcribe`)
+- Test: `server/backend/tests/test_import_ephemeral_route.py` (new)
+
+- [ ] **Step 1: Grep for existing contract tests**
+
+Run: `grep -rln "dedup_matches" server/backend/tests/`
+Any test asserting `/import` returns `dedup_matches` or writes hashes must be updated in this task (delete the assertion or repurpose per the new contract). `test_dedup_check_endpoint.py` and `test_create_job_audio_hash.py` target surfaces that KEEP working (the standalone dedup-check endpoint and the repo function) — leave them alone unless they call the `/import` route itself.
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `server/backend/tests/test_import_ephemeral_route.py`:
+
+```python
+"""Tests for the /import route under session ephemeral retention.
+
+Direct-call pattern (see test_transcription_durability_routes.py):
+- monkeypatch repo functions on server.database.job_repository is NOT enough
+  here — /import imports create_job at module top, so patch it on the
+  transcription route module itself.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from starlette.datastructures import UploadFile
+
+from server.api.routes import transcription
+
+
+class _Tracker:
+    def __init__(self):
+        self.ended: list[str] = []
+
+    def try_start_job(self, user):
+        return (True, "full-job-id-1234", None)
+
+    def end_job(self, job_id, result=None):
+        self.ended.append(job_id)
+        return True
+
+
+def _request(tracker):
+    config = SimpleNamespace(get=lambda *a, **k: k.get("default"))
+    state = SimpleNamespace(
+        model_manager=SimpleNamespace(job_tracker=tracker),
+        config=config,
+    )
+    return SimpleNamespace(app=SimpleNamespace(state=state))
+
+
+def _upload() -> UploadFile:
+    return UploadFile(filename="test.wav", file=io.BytesIO(b"RIFF0000WAVE"))
+
+
+@pytest.fixture(autouse=True)
+def _quiet_route(monkeypatch):
+    monkeypatch.setattr(transcription, "get_client_name", lambda _req: "test-client")
+    monkeypatch.setattr(transcription, "_assert_main_model_selected", lambda _req: None)
+    monkeypatch.setattr(
+        transcription, "resolve_parallel_diarization_default", lambda _cfg: False
+    )
+    # The route ends with loop.create_task(asyncio.to_thread(_run_file_import, ...));
+    # neuter the worker so no real transcription starts.
+    monkeypatch.setattr(transcription, "_run_file_import", lambda **kw: None)
+
+
+def _call(tracker):
+    return asyncio.run(
+        transcription.import_and_transcribe(
+            _request(tracker),
+            file=_upload(),
+            language=None,
+            translation_enabled=False,
+            translation_target_language=None,
+            enable_diarization=False,
+            enable_word_timestamps=True,
+            expected_speakers=None,
+            parallel_diarization=None,
+            diarization_engine=None,
+            multitrack=False,
+        )
+    )
+
+
+class TestImportRoute:
+    def test_returns_full_job_id_and_no_dedup_matches(self, monkeypatch):
+        created: list[dict] = []
+        monkeypatch.setattr(
+            transcription, "create_job", lambda **kw: created.append(kw)
+        )
+
+        resp = _call(_Tracker())
+
+        assert resp["job_id"] == "full-job-id-1234"
+        assert "dedup_matches" not in resp
+        assert created[0]["source"] == "file_import"
+        # No hashes computed or stored any more
+        assert "audio_hash" not in created[0]
+        assert "normalized_audio_hash" not in created[0]
+
+    def test_create_job_failure_aborts_with_500_and_releases_slot(self, monkeypatch):
+        def _boom(**kw):
+            raise RuntimeError("db locked")
+
+        monkeypatch.setattr(transcription, "create_job", _boom)
+        tracker = _Tracker()
+
+        with pytest.raises(HTTPException) as exc:
+            _call(tracker)
+
+        assert exc.value.status_code == 500
+        assert tracker.ended == ["full-job-id-1234"]
+```
+
+- [ ] **Step 3: Run to verify they fail**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_import_ephemeral_route.py -v --tb=short`
+Expected: FAIL — response carries `job_id` == short id + `dedup_matches`; create_job failure currently swallowed.
+
+- [ ] **Step 4: Implement**
+
+Replace `ImportAcceptedResponse` (keep `DedupMatch` — the standalone dedup-check endpoint still uses it):
+
+```python
+class ImportAcceptedResponse(BaseModel):
+    """Response model for accepted file import job (202).
+
+    ``job_id`` is the FULL job id: the client polls
+    GET /api/transcribe/result/{job_id} with it (202 processing / 410 failed /
+    200 completed). Session ephemeral retention (2026-08-09 spec) removed the
+    dedup_matches field — session imports no longer hash or dedup-check.
+    """
+
+    job_id: str
+```
+
+In `import_and_transcribe`:
+1. Delete the whole hashing block (the `audio_hash`/`normalized_audio_hash` computation and its try/except) and the `dedup_matches` list comprehension.
+2. Make the durability row mandatory — replace the `try: create_job(...) except: warn` block with:
+
+```python
+    # Session ephemeral retention: the durability row is the delivery channel
+    # for the import result (the client polls GET /result/{job_id}). Without
+    # the row the outcome would be unreachable, so a failed insert aborts the
+    # request instead of running a transcription nobody can fetch.
+    try:
+        create_job(
+            job_id=job_id,
+            source="file_import",
+            client_name=client_name,
+            language=language,
+            task="translate" if translation_enabled else "transcribe",
+            translation_target=(translation_target_language if translation_enabled else None),
+        )
+    except Exception as _e:
+        logger.error(
+            "Failed to create durability row for import job %s: %s", job_id[:8], _e
+        )
+        model_manager.job_tracker.end_job(job_id)
+        try:
+            tmp_path.unlink()
+        except Exception:
+            logger.warning("Failed to remove temp upload %s after aborted import", tmp_path)
+        raise HTTPException(
+            status_code=500, detail="Could not create job record — import aborted"
+        ) from _e
+```
+
+3. Change the return to `return {"job_id": job_id}` and update the route docstring: clients poll `GET /api/transcribe/result/{job_id}` (202/410/200), the result is persisted server-side before it is fetchable, and the row is purged after confirmed delivery.
+
+- [ ] **Step 5: Run to verify they pass**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_import_ephemeral_route.py tests/test_dedup_check_endpoint.py -v --tb=short`
+Expected: PASS. The dedup-check endpoint suite must stay green (endpoint untouched).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/backend/api/routes/transcription.py server/backend/tests/test_import_ephemeral_route.py
+git commit -m "feat(server): drop dedup hashing from /import, make durability row mandatory, return full job_id"
+```
+
+---
+
+### Task 6: `_run_file_import` joins the durability pipeline
+
+**Files:**
+- Modify: `server/backend/api/routes/transcription.py` (`_run_file_import` + new `_persist_import_result` helper)
+- Test: `server/backend/tests/test_import_ephemeral_route.py`
+
+- [ ] **Step 1: Write the failing tests** (append to `test_import_ephemeral_route.py`)
+
+```python
+class TestRunFileImportDurability:
+    """_run_file_import must persist BEFORE the in-memory job_tracker hand-off."""
+
+    def _model_manager(self):
+        calls: list[tuple] = []
+
+        class _JT:
+            def set_phase(self, *_a):
+                pass
+
+            def update_progress(self, *_a):
+                pass
+
+            def is_cancelled(self):
+                return False
+
+            def end_job(self, job_id, result=None):
+                calls.append(("end_job", job_id, result))
+                return True
+
+        mm = SimpleNamespace(
+            job_tracker=_JT(),
+            gpu_device_index=0,
+            ensure_transcription_loaded=lambda: SimpleNamespace(model_name="m"),
+        )
+        mm.job_tracker.set_phase = mm.job_tracker.set_phase  # keep mypy quiet
+        return mm, calls
+
+    @pytest.fixture(autouse=True)
+    def _no_gpu_cleanup(self, monkeypatch):
+        import server.core.audio_utils as audio_utils
+
+        monkeypatch.setattr(audio_utils, "post_job_gpu_cleanup", lambda *_a, **_k: None)
+
+    def _run(self, monkeypatch, tmp_path, *, dispatch):
+        import server.core.diarization_dispatch as dd
+
+        monkeypatch.setattr(dd, "transcribe_with_optional_diarization", dispatch)
+        mm, calls = self._model_manager()
+        wav = tmp_path / "in.wav"
+        wav.write_bytes(b"RIFF")
+        transcription._run_file_import(
+            model_manager=mm,
+            tmp_path=wav,
+            filename="in.wav",
+            language=None,
+            translation_enabled=False,
+            translation_target_language=None,
+            enable_diarization=False,
+            enable_word_timestamps=True,
+            expected_speakers=None,
+            parallel_diarization=None,
+            use_parallel_default=False,
+            multitrack=False,
+            job_id="job-import-1",
+            event_loop=None,
+        )
+        return calls
+
+    def test_success_persists_before_end_job(self, monkeypatch, tmp_path):
+        order: list[str] = []
+        saved: list[dict] = []
+
+        def _dispatch(**kw):
+            result = SimpleNamespace(
+                to_dict=lambda: {"text": "hello", "language": "en", "duration": 1.0}
+            )
+            outcome = SimpleNamespace(
+                to_dict=lambda: {"requested": False, "performed": False, "reason": None}
+            )
+            return SimpleNamespace(result=result, outcome=outcome)
+
+        def _save(**kw):
+            order.append("save_result")
+            saved.append(kw)
+
+        monkeypatch.setattr(transcription, "save_result", _save)
+        calls = self._run(monkeypatch, tmp_path, dispatch=_dispatch)
+        order.extend(name for name, *_ in calls)
+
+        assert order == ["save_result", "end_job"]
+        assert saved[0]["job_id"] == "job-import-1"
+        assert saved[0]["result_text"] == "hello"
+        import json as _j
+
+        payload = _j.loads(saved[0]["result_json"])
+        assert payload["transcription"]["text"] == "hello"
+        assert payload["text"] == "hello"  # top-level mirror for /recent previews
+
+    def test_failure_calls_mark_failed(self, monkeypatch, tmp_path):
+        failed: list[tuple] = []
+
+        def _dispatch(**kw):
+            raise RuntimeError("decode error")
+
+        monkeypatch.setattr(
+            transcription, "mark_failed", lambda jid, msg: failed.append((jid, msg))
+        )
+        self._run(monkeypatch, tmp_path, dispatch=_dispatch)
+
+        assert failed and failed[0][0] == "job-import-1"
+        assert "decode error" in failed[0][1]
+
+    def test_cancel_calls_mark_failed_with_cancel_message(self, monkeypatch, tmp_path):
+        from server.core.model_manager import TranscriptionCancelledError
+
+        failed: list[tuple] = []
+
+        def _dispatch(**kw):
+            raise TranscriptionCancelledError("cancelled")
+
+        monkeypatch.setattr(
+            transcription, "mark_failed", lambda jid, msg: failed.append((jid, msg))
+        )
+        self._run(monkeypatch, tmp_path, dispatch=_dispatch)
+
+        assert failed and "cancelled" in failed[0][1].lower()
+
+    def test_save_result_failure_marks_failed(self, monkeypatch, tmp_path):
+        failed: list[tuple] = []
+
+        def _dispatch(**kw):
+            result = SimpleNamespace(
+                to_dict=lambda: {"text": "hello", "language": "en", "duration": 1.0}
+            )
+            outcome = SimpleNamespace(
+                to_dict=lambda: {"requested": False, "performed": False, "reason": None}
+            )
+            return SimpleNamespace(result=result, outcome=outcome)
+
+        def _boom(**kw):
+            raise RuntimeError("disk full")
+
+        monkeypatch.setattr(transcription, "save_result", _boom)
+        monkeypatch.setattr(
+            transcription, "mark_failed", lambda jid, msg: failed.append((jid, msg))
+        )
+        self._run(monkeypatch, tmp_path, dispatch=_dispatch)
+
+        assert failed and "persist" in failed[0][1].lower()
+```
+
+Note for the executor: `_run_file_import` resolves `TranscriptionCancelledError` and `save_result`/`mark_failed` — check how the module imports them (module top vs function-local) and patch at the binding the function actually uses. If `save_result` is imported inside `_run_file_import` from `...database.job_repository`, patch `server.database.job_repository.save_result` instead of `transcription.save_result`. Adjust the monkeypatch targets accordingly — the assertions stay the same.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_import_ephemeral_route.py -v --tb=short`
+Expected: new class FAILS (no persistence calls happen today).
+
+- [ ] **Step 3: Implement**
+
+Add a module-level helper above `_run_file_import`:
+
+```python
+def _persist_import_result(
+    job_id: str, payload: dict[str, Any], result_dict: dict[str, Any]
+) -> None:
+    """Persist an import result to its durability row BEFORE the in-memory
+    job_tracker hand-off (persist-before-deliver, CLAUDE.md invariant).
+
+    The row is the import path's ONLY delivery channel — the dashboard polls
+    GET /result/{job_id} — so a failed write escalates to mark_failed: the
+    client then receives an actionable 410 instead of polling 202 forever
+    until the orphan sweep mislabels the job.
+    """
+    from server.core.json_utils import sanitize_for_json
+
+    try:
+        sanitized = sanitize_for_json(payload)
+        save_result(
+            job_id=job_id,
+            result_text=result_dict.get("text", "") or "",
+            result_json=_json.dumps(sanitized, ensure_ascii=False),
+            result_language=result_dict.get("language"),
+            duration_seconds=result_dict.get("duration"),
+        )
+    except Exception:
+        logger.critical(
+            "Failed to persist import result for job %s — the transcription exists "
+            "only in the in-memory job tracker and is lost on restart",
+            sanitize_log_value(job_id),
+            exc_info=True,
+        )
+        try:
+            mark_failed(
+                job_id,
+                "Persistence failed — the transcription completed but could not be "
+                "saved. Check the server logs.",
+            )
+        except Exception:
+            logger.warning(
+                "Failed to mark import job %s as failed after persistence failure",
+                sanitize_log_value(job_id),
+                exc_info=True,
+            )
+```
+
+(If `save_result`/`mark_failed` are not already module-top imports in `transcription.py`, add them to the existing `job_repository` import.)
+
+In `_run_file_import`:
+
+1. **Multitrack success path** — replace the inline `end_job(... result={...})` with:
+
+```python
+            result_dict = result.to_dict()
+            payload = {
+                "job_id": job_id[:8],
+                "transcription": result_dict,
+                "diarization": {
+                    "requested": False,
+                    "performed": False,
+                    "reason": "multitrack",
+                },
+                # Top-level text mirror so /recent previews and the recovery
+                # banner render this row without knowing the import shape.
+                "text": result_dict.get("text", ""),
+            }
+            _persist_import_result(job_id, payload, result_dict)
+            model_manager.job_tracker.end_job(job_id, result=payload)
+```
+
+(The webhook dispatch after it keeps using `result_dict` — unchanged.)
+
+2. **Normal success path** — same pattern:
+
+```python
+        result_dict = result.to_dict()
+        payload = {
+            "job_id": job_id[:8],
+            "transcription": result_dict,
+            "diarization": diarization_outcome,
+            "text": result_dict.get("text", ""),
+        }
+        _persist_import_result(job_id, payload, result_dict)
+        model_manager.job_tracker.end_job(job_id, result=payload)
+```
+
+3. **Cancel branch** — before the existing `end_job`, add:
+
+```python
+        try:
+            mark_failed(job_id, "Transcription cancelled by user")
+        except Exception:
+            logger.warning(
+                "Failed to mark cancelled import job %s", sanitize_log_value(job_id), exc_info=True
+            )
+```
+
+4. **Error branch** — after composing `error_payload`, add (remedy included when present):
+
+```python
+        _row_error = str(e) if dep_error is None else f"{e}. {dep_error.remedy}"
+        try:
+            mark_failed(job_id, _row_error)
+        except Exception:
+            logger.warning(
+                "Failed to mark import job %s as failed", sanitize_log_value(job_id), exc_info=True
+            )
+```
+
+5. Update the `_run_file_import` docstring: it now persists results to the durability row (persist-before-deliver) and keeps `job_tracker` for progress reporting; also update the Issue #104 comment block in `import_and_transcribe` if any stale text remains about NULL result columns.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_import_ephemeral_route.py -v --tb=short`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/backend/api/routes/transcription.py server/backend/tests/test_import_ephemeral_route.py
+git commit -m "fix(server): persist file-import results to the durability row before job_tracker hand-off"
+```
+
+---
+
+### Task 7: WebSocket post-delivery purge
+
+**Files:**
+- Modify: `server/backend/api/routes/websocket.py` (import block lines ~39-48; auto-add block lines ~641-665)
+- Test: `server/backend/tests/test_websocket_session_purge.py` (new)
+
+- [ ] **Step 1: Read the existing WS test factories first**
+
+Read `server/backend/tests/test_persist_before_deliver_matrix.py` and `test_websocket_notebook_autoadd.py` to reuse their session factory + monkeypatch pattern verbatim (they already fake `_save_result`, `_mark_delivered`, `send_message`, engine, and dispatch). Copy the factory into the new test file (or import it if it is shared via a fixtures module) — do NOT add attributes to the session class.
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `server/backend/tests/test_websocket_session_purge.py` with four cases, using the borrowed factory. The assertions that matter:
+
+```python
+# 1. Happy path: persisted + delivered inline + no auto-add → purged
+assert purged == [job_id]
+
+# 2. result_ready reference path (>1MB payload) → NOT purged here
+assert purged == []
+
+# 3. auto-add ON and _save_session_to_notebook returns a recording id → purged
+assert purged == [job_id]
+
+# 4. auto-add ON and _save_session_to_notebook returns None (or raises) → NOT purged
+assert purged == []
+```
+
+Each case monkeypatches `websocket._delete_job` with `lambda jid: purged.append(jid)` (plus `websocket._save_result`, `websocket._mark_delivered`, `websocket._save_session_to_notebook` per the factory pattern). For case 2 make the payload >1MB via a long `result.text` (or monkeypatch `json.dumps` length behavior — prefer the long text, it is what production sees).
+
+- [ ] **Step 3: Run to verify they fail**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_websocket_session_purge.py -v --tb=short`
+Expected: FAIL — `websocket` has no `_delete_job` attribute.
+
+- [ ] **Step 4: Implement**
+
+Add to the existing `job_repository` import block in `websocket.py`:
+
+```python
+    delete_job as _delete_job,
+```
+
+Replace the auto-add block (currently `if self.auto_add_to_notebook:` ... through the `except Exception as nb_err:` handler) with:
+
+```python
+            # Auto-add to the Audio Notebook (GH #199). Runs AFTER the result is
+            # persisted and delivered: the notebook entry is a derived artifact,
+            # so a failure here must never cost the user their transcript. Runs
+            # in a thread, since the MP3 encode would otherwise block the event
+            # loop. _autoadd_ok gates the ephemeral purge below — a failed
+            # notebook save keeps row + WAV so nothing is lost.
+            _autoadd_ok = True
+            if self.auto_add_to_notebook:
+                _autoadd_ok = False
+                try:
+                    recording_id = await asyncio.to_thread(
+                        _save_session_to_notebook,
+                        audio_path=self.temp_file,
+                        duration_seconds=result.duration,
+                        result=result,
+                        model_name=getattr(engine, "model_name", None),
+                        diarization_segments=dispatched.speaker_segments,
+                    )
+                    if recording_id:
+                        _autoadd_ok = True
+                        logger.info("Saved session recording to notebook: id=%s", recording_id)
+                    else:
+                        _warn_notebook_autoadd_failed(
+                            "Could not save the recording to the Audio Notebook."
+                        )
+                except Exception as nb_err:
+                    logger.error("Failed to add recording to notebook: %s", nb_err, exc_info=True)
+                    _warn_notebook_autoadd_failed(
+                        f"Could not save the recording to the Audio Notebook: {nb_err}"
+                    )
+
+            # Session ephemeral retention (2026-08-09 spec): a session job whose
+            # result reached the client keeps no server-side trace — purge the
+            # row and its WAV. Fires only on confirmed inline delivery; the
+            # result_ready reference path purges inside GET /result/{job_id}
+            # instead, and a failed notebook auto-add cancels the purge (row +
+            # WAV stay as the recovery copy). Guarded so a purge error can
+            # never surface as a post-delivery "transcription failed" banner.
+            if (
+                self._current_job_id
+                and _result_persisted
+                and not _sent_as_reference
+                and _final_delivered
+                and _autoadd_ok
+            ):
+                try:
+                    _delete_job(self._current_job_id)
+                except Exception as _purge_err:
+                    logger.warning(
+                        "Post-delivery purge failed for job %s: %s",
+                        self._current_job_id,
+                        _purge_err,
+                    )
+```
+
+- [ ] **Step 5: Run the new file + the WS neighbors**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/test_websocket_session_purge.py tests/test_persist_before_deliver_matrix.py tests/test_websocket_notebook_autoadd.py tests/test_websocket_disconnect_salvage.py tests/test_websocket_longform_payload.py -v --tb=short`
+Expected: PASS. If a matrix/salvage test drives the success path without patching `_delete_job`, it now hits the real one, which no-ops on a missing row and never raises — but patch `websocket._delete_job` to a no-op in those files' shared fixtures anyway so no test touches the real DB.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/backend/api/routes/websocket.py server/backend/tests/test_websocket_session_purge.py
+git commit -m "feat(server): purge mic-session jobs after confirmed delivery with notebook auto-add gating"
+```
+
+---
+
+### Task 8: Full backend suite
+
+- [ ] **Step 1: Run everything**
+
+Run: `cd server/backend && ../../build/.venv/bin/pytest tests/ -v --tb=short`
+Expected: PASS. Likely stragglers to fix here: any `/import` contract test still expecting `dedup_matches` or the short job id; lifespan tests needing a `purge_legacy_session_rows` patch; websocket fixtures needing `_delete_job` no-ops. Fix implementation only if the test reveals a real bug; otherwise update the test to the new contract.
+
+- [ ] **Step 2: Commit any test fixes**
+
+```bash
+git add -A server/backend/tests
+git commit -m "test(server): align existing suites with the session ephemeral retention contract"
+```
+
+---
+
+### Task 9: Dashboard — poll `/result` instead of the job tracker; remove session dedup
+
+**Files:**
+- Modify: `dashboard/src/api/types.ts` (remove `dedup_matches` from `TranscriptionAccepted`)
+- Modify: `dashboard/src/stores/importQueueStore.ts`
+- Test: `dashboard/src/stores/importQueueStore.test.ts`
+
+- [ ] **Step 1: Update the test harness and write failing tests**
+
+In `importQueueStore.test.ts`:
+
+1. Extend the apiClient mock (top of file):
+
+```typescript
+vi.mock('../api/client', () => ({
+  apiClient: {
+    importAndTranscribe: vi.fn(),
+    uploadAndTranscribe: vi.fn(),
+    getAdminStatus: vi.fn(),
+    fetchTranscriptionResult: vi.fn(),
+    cancelTranscription: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+```
+
+2. Add a Response helper next to the other helpers:
+
+```typescript
+function httpResult(status: number, body?: unknown): Response {
+  return { status, json: async () => body } as unknown as Response;
+}
+```
+
+3. For every session-job test that currently mocks `apiClient.getAdminStatus` to deliver the session result, replace the mock with:
+
+```typescript
+vi.mocked(apiClient.fetchTranscriptionResult).mockResolvedValue(
+  httpResult(200, {
+    job_id: 'server-job-1',
+    status: 'completed',
+    result: {
+      job_id: 'server-j',
+      transcription: sessionTranscription,
+      diarization: { requested: false, performed: false, reason: null },
+    },
+  }),
+);
+```
+
+(Notebook-job tests keep `getAdminStatus` — that path is unchanged.)
+
+4. Delete the `resolveDuplicateChoice` import and the whole GH-120 dedup describe block. Replace with:
+
+```typescript
+  // Session ephemeral retention: the server no longer sends dedup_matches and
+  // the client must never prompt. A LEGACY server that still includes the
+  // field gets silently ignored — the import proceeds as a normal new entry.
+  describe('session imports never prompt for duplicates', () => {
+    it('ignores a legacy dedup_matches field and completes the job', async () => {
+      const requestChoiceSpy = vi.fn();
+      useDedupChoiceStore.setState({ requestChoice: requestChoiceSpy as never });
+      vi.mocked(apiClient.importAndTranscribe).mockResolvedValue({
+        job_id: 'server-job-1',
+        dedup_matches: [
+          { recording_id: 'old', name: 'old.wav', created_at: '2026-01-01' },
+        ],
+      } as never);
+      vi.mocked(apiClient.fetchTranscriptionResult).mockResolvedValue(
+        httpResult(200, {
+          job_id: 'server-job-1',
+          status: 'completed',
+          result: {
+            job_id: 'server-j',
+            transcription: sessionTranscription,
+            diarization: { requested: false, performed: false, reason: null },
+          },
+        }),
+      );
+
+      getState().addFiles([new File(['x'], 'dup.wav')], 'session-normal');
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(requestChoiceSpy).not.toHaveBeenCalled();
+      expect(getState().jobs[0].status).toBe('success');
+    });
+  });
+```
+
+(Reuse the file's existing fake-timer + electronAPI conventions from the GH-212 describe; `sessionTranscription` may need to be hoisted or duplicated into this describe.)
+
+5. Add polling-outcome tests in a new describe:
+
+```typescript
+  describe('pollForSessionResult HTTP outcomes', () => {
+    it('surfaces the 410 error detail as the job error', async () => {
+      vi.mocked(apiClient.importAndTranscribe).mockResolvedValue({
+        job_id: 'server-job-1',
+      } as never);
+      vi.mocked(apiClient.fetchTranscriptionResult).mockResolvedValue(
+        httpResult(410, { detail: 'CUDA out of memory' }),
+      );
+
+      getState().addFiles([new File(['x'], 'oom.wav')], 'session-normal');
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(getState().jobs[0].status).toBe('error');
+      expect(getState().jobs[0].error).toContain('CUDA out of memory');
+    });
+
+    it('treats 404 as a lost job', async () => {
+      vi.mocked(apiClient.importAndTranscribe).mockResolvedValue({
+        job_id: 'server-job-1',
+      } as never);
+      vi.mocked(apiClient.fetchTranscriptionResult).mockResolvedValue(httpResult(404));
+
+      getState().addFiles([new File(['x'], 'lost.wav')], 'session-normal');
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(getState().jobs[0].status).toBe('error');
+      expect(getState().jobs[0].error).toContain('lost');
+    });
+
+    it('keeps polling on 202 then resolves on 200', async () => {
+      vi.mocked(apiClient.importAndTranscribe).mockResolvedValue({
+        job_id: 'server-job-1',
+      } as never);
+      vi.mocked(apiClient.fetchTranscriptionResult)
+        .mockResolvedValueOnce(httpResult(202, { status: 'processing' }))
+        .mockResolvedValue(
+          httpResult(200, {
+            job_id: 'server-job-1',
+            status: 'completed',
+            result: {
+              job_id: 'server-j',
+              transcription: sessionTranscription,
+              diarization: { requested: false, performed: false, reason: null },
+            },
+          }),
+        );
+
+      getState().addFiles([new File(['x'], 'slow.wav')], 'session-normal');
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      expect(getState().jobs[0].status).toBe('success');
+    });
+  });
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd dashboard && nvm use && npx vitest run src/stores/importQueueStore.test.ts`
+Expected: FAIL — `fetchTranscriptionResult` never called by the store; dedup describe compile errors surface any missed import cleanup.
+
+- [ ] **Step 3: Implement in `importQueueStore.ts`**
+
+1. Remove imports: `DedupMatch` (types), `useDedupChoiceStore`, `DedupChoice`, `useAriaAnnouncerStore` (verify with grep it has no other use in this file before removing).
+2. Delete the whole "Duplicate resolution (GH-120)" section: `DuplicatePolicy`, `DEFAULT_DUPLICATE_POLICY`, `resolveDuplicateChoice`.
+3. Replace `pollForSessionResult` (keep `POLL_INTERVAL_MS`/`MAX_POLLS`):
+
+```typescript
+// Session imports poll the durability row directly (GET /api/transcribe/result/
+// {job_id}): 202 processing, 200 completed (the server purges the row after
+// this response), 410 failed with the error detail, 404 job lost. Must go
+// through apiClient's absolute base URL — a relative fetch resolves against
+// the packaged file:// origin and never reaches the backend (GH #202).
+async function pollForSessionResult(serverJobId: string): Promise<FileImportJobResult> {
+  for (let i = 0; i < MAX_POLLS; i++) {
+    if (_abort) throw new Error('Import queue aborted');
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+
+    let resp: Response;
+    try {
+      resp = await apiClient.fetchTranscriptionResult(serverJobId);
+    } catch (err) {
+      console.warn('Poll error (will retry):', err);
+      continue;
+    }
+
+    if (resp.status === 202) continue;
+    if (resp.status === 200) {
+      const body = (await resp.json()) as { result?: FileImportJobResult };
+      return body.result ?? {};
+    }
+    if (resp.status === 410) {
+      let detail = 'Transcription failed';
+      try {
+        detail = ((await resp.json()) as { detail?: string }).detail ?? detail;
+      } catch {
+        // keep the generic message when the body is not JSON
+      }
+      throw new Error(detail);
+    }
+    if (resp.status === 404) {
+      throw new Error('Transcription job lost — server may have restarted');
+    }
+    if (resp.status === 403) throw new Error('Access denied for this transcription job');
+    console.warn(`Poll got HTTP ${resp.status} (will retry)`);
+  }
+  throw new Error('Transcription timed out after 24 hours');
+}
+```
+
+`FileImportJobResult` fields are all optional except `job_id` — check the interface; if `job_id` is required, type the return as `FileImportJobResult` via `body.result ?? ({ job_id: serverJobId } as FileImportJobResult)`.
+
+4. In `processSessionJob`, delete the entire `if (importResponse.dedup_matches?.length) { ... }` block (keep the `const { job_id: serverJobId } = importResponse;` line and the `pollForSessionResult(serverJobId)` call; the `result.error` / `!result.transcription` guards stay).
+5. In `types.ts`, remove the `dedup_matches` field and its doc comment from `TranscriptionAccepted` (keep `DedupMatch` and `DedupCheckResponse` — the dedup-check endpoint and `DedupPromptModal` remain).
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `cd dashboard && nvm use && npx vitest run src/stores/importQueueStore.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/src/stores/importQueueStore.ts dashboard/src/stores/importQueueStore.test.ts dashboard/src/api/types.ts
+git commit -m "feat(dashboard): poll /result for session imports and remove the session dedup prompt flow"
+```
+
+---
+
+### Task 10: Remove the Folder Watch duplicate-policy setting
+
+**Files:**
+- Modify: `dashboard/components/views/SettingsModal.tsx`
+- Modify: `dashboard/electron/main.ts`
+- Contract: `dashboard/ui-contract/` (extract → build → bump → baseline → check)
+
+- [ ] **Step 1: SettingsModal removals** (all reference the current line numbers; re-locate by content)
+
+1. Line ~59: delete `import type { DuplicatePolicy } from '../../src/stores/importQueueStore';` (the type no longer exists — TS will force this).
+2. Lines ~73-87: delete the `DUPLICATE_POLICY_ORDER`, `DUPLICATE_POLICY_LABELS`, `normalizeDuplicatePolicy` constants + their GH-120 comment block.
+3. Line ~215: delete the `duplicatePolicy: 'create_new' as DuplicatePolicy,` field from the `appSettings` initial state.
+4. Line ~458: delete the `duplicatePolicy: normalizeDuplicatePolicy(cfg['folderWatch.duplicatePolicy']),` load mapping.
+5. Line ~579: delete the `['folderWatch.duplicatePolicy', appSettings.duplicatePolicy],` save entry.
+6. Lines ~960-979: delete the whole `<Section title="Folder Watch">...</Section>` block (label, `CustomSelect`, helper `<p>`).
+
+- [ ] **Step 2: electron/main.ts** — delete the default and its comment (lines ~558-561):
+
+```typescript
+    // GH-120 — how Folder Watch resolves a detected duplicate without blocking
+    // the import queue on the interactive modal. 'create_new' | 'ask'.
+    // Default 'create_new': unattended batch never stalls and never drops a file.
+    'folderWatch.duplicatePolicy': 'create_new',
+```
+
+A stale stored value in the user's config file is simply never read again — electron-store ignores unknown keys (no migration needed).
+
+- [ ] **Step 3: Typecheck + tests**
+
+Run: `cd dashboard && nvm use && npx tsc --noEmit -p . && npx vitest run`
+Expected: clean compile; full vitest suite PASS (fix any test still importing `DuplicatePolicy`).
+
+- [ ] **Step 4: UI contract** (SettingsModal CSS classes changed — full flow, in this order)
+
+```bash
+cd dashboard
+npm run ui:contract:extract
+npm run ui:contract:build
+# 1. hand-normalize repo_path in the extracted YAML if it stamped the worktree path
+# 2. bump meta.spec_version (minor) in the contract YAML — BEFORE the baseline update
+node ../scripts/ui-contract/validate-contract.mjs --update-baseline
+npm run ui:contract:check
+```
+
+(Verify the validate script location first: `ls scripts/ui-contract/` from repo root — memory says it lives under the top-level `scripts/`, adjust the relative path accordingly.)
+Expected: `ui:contract:check` green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/components/views/SettingsModal.tsx dashboard/electron/main.ts dashboard/ui-contract
+git commit -m "chore(ui): remove the Folder Watch duplicate-policy setting made obsolete by session ephemeral retention"
+```
+
+---
+
+### Task 11: Docs alignment
+
+**Files:**
+- Modify: `docs/api-contracts-server.md` (grep `dedup_matches`, `/import`, `admin/status` polling guidance)
+- Modify: `docs/data-models-server.md` (durability/retention section)
+
+- [ ] **Step 1: Update `docs/api-contracts-server.md`**
+
+- `/import` response: `{"job_id": "<full id>"}` — no `dedup_matches`; note "poll `GET /api/transcribe/result/{job_id}`" replacing any "poll /api/admin/status" instruction.
+- Add to the `/result/{job_id}` entry: "For session-source jobs (`websocket`, `file_import`) a 200 also purges the row and its audio — repeat fetches return 404. A 410 on a failed `file_import` job purges the row as well."
+- `/import/dedup-check` stays documented as-is.
+
+- [ ] **Step 2: Update `docs/data-models-server.md`** — in the `transcription_jobs` section, replace any "rows are never deleted" claim with a short "Session ephemeral retention" paragraph:
+
+> Session-source rows (`source` = `websocket` or `file_import`) are deleted — together with their audio file — immediately after the result is confirmed delivered (inline WS final, `GET /result` fetch, or dismiss). Failed mic jobs keep row + WAV indefinitely for `/retry`; failed imports (which never retain audio) are purged once the client has received the 410 error, or by the cleanup sweep. Rows from other sources (e.g. `audio_upload`) keep the pre-existing behavior: row kept forever, audio garbage-collected after `audio_retention_days`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/api-contracts-server.md docs/data-models-server.md
+git commit -m "docs(server): document session ephemeral retention lifecycle and the new /import contract"
+```
+
+---
+
+### Task 12: Final verification + PR
+
+- [ ] **Step 1: Full backend suite**: `cd server/backend && ../../build/.venv/bin/pytest tests/ --tb=short` → PASS
+- [ ] **Step 2: Full dashboard suite**: `cd dashboard && nvm use && npx vitest run && npx tsc --noEmit -p . && npm run ui:contract:check` → PASS
+- [ ] **Step 3: GitNexus** `detect_changes` — verify only the expected symbols/flows changed; report blast radius.
+- [ ] **Step 4: Push + PR** targeting `main`, body summarizing: ephemeral session lifecycle, dedup removal (dialog gone), /import durability fix, legacy cleanup, smoke checklist:
+  - [ ] Session mic recording → transcript delivered → `transcription_jobs` row gone, WAV gone
+  - [ ] Session mic recording with auto-add ON → notebook entry exists, row + WAV gone
+  - [ ] Session file import of a previously-imported file → NO duplicate dialog
+  - [ ] Import completes with dashboard closed → reopen → recovery banner offers it → fetch → row gone
+  - [ ] Failed import → queue row shows the real error, no false "job lost"
+  - [ ] Failed mic job → retry works (WAV preserved)
+  - [ ] Packaged build: >1 MB import result fetch works (GH #202 regression check)
+  - [ ] Server restart after upgrade: log shows legacy purge count once, second restart shows nothing
+
+---
+
+## Self-review notes (spec coverage)
+
+- Spec §1 lifecycle → Tasks 1, 4, 7. Purge scoped to `SESSION_SOURCES` only (spec's "session-source" definition; `audio_upload` proven untouched by tests in Tasks 2/3/4).
+- Spec §2 import durability → Tasks 5, 6, 9 (poll switch). GH #202 risk covered: `fetchTranscriptionResult` already builds absolute URLs.
+- Spec §3 dedup removal → Tasks 5 (server), 9 (store), 10 (settings). `DedupPromptModal`/`dedupChoiceStore`/`DedupChoiceContainer` deliberately kept per spec.
+- Spec §4 safety net → Tasks 2, 4 (failed-mic keeps row+WAV; failed-import purge-on-410; `/recent` untouched).
+- Spec §5 backstop sweep → Task 3.
+- Spec §6 legacy cleanup → Tasks 2, 3.
+- Error-handling table → delete_job never-raise contract (Task 1), `_autoadd_ok` gate (Task 7), `_persist_import_result` escalation (Task 6).
+- Testing section → Tasks 1-9 test files; WS factories get no new session attributes (Task 7 uses locals only); ui-contract flow in Task 10; electron-store default removal is migration-free (Task 10).

--- a/docs/superpowers/specs/2026-08-09-session-ephemeral-retention-design.md
+++ b/docs/superpowers/specs/2026-08-09-session-ephemeral-retention-design.md
@@ -1,0 +1,213 @@
+# Session Ephemeral Retention — Design Spec
+
+**Date:** 2026-08-09
+**Status:** Approved (design review with user), pending implementation plan
+
+## Problem
+
+The Session tab is meant to be ephemeral: transcribe, hand the result to the client, keep
+nothing. Two things currently violate that intent:
+
+1. **The duplicate dialog.** Re-importing a previously transcribed file through the
+   Session tab pops `DedupPromptModal` ("Possible duplicate detected… Create new /
+   Use existing"). Root cause: `POST /api/transcribe/import` hashes the upload and writes
+   a `transcription_jobs` row that exists *purely* as a dedup anchor
+   (`server/backend/api/routes/transcription.py:936-940`). No code path ever deletes
+   `transcription_jobs` rows, so every past import matches forever. Worse, the dialog's
+   "Use existing" button is not actually wired to load anything — a session dedup match
+   is a bare hash anchor with no retrievable transcript
+   (`dashboard/src/stores/importQueueStore.ts:255-264`).
+
+2. **Permanent retention of session artifacts.** Mic session recordings keep their WAV in
+   `durability.recordings_dir` (deleted only after 7 days, and only when delivered) and
+   their full `result_text`/`result_json` in the DB **forever** — DB rows are never
+   deleted (`server/backend/database/audio_cleanup.py:5-8`).
+
+A related known bug is folded into this work: `_run_file_import` never calls
+`save_result`/`mark_failed` on its durability row, so import results live only in the
+in-memory `job_tracker` (lost on restart, violating the persist-before-deliver
+invariant), and the orphan sweep later flips completed imports to a false
+`status='failed'` (`transcription.py:684-875`, `api/main.py:172-175`).
+
+## Goals
+
+1. A Session-tab transcription (mic recording **or** file import) leaves **no server-side
+   trace** — no DB row, no audio file — once its result has been **confirmed delivered**
+   to the client. The only permanent copy is the Audio Notebook entry, and only when
+   auto-add-to-notebook is enabled (mic recordings only).
+2. The duplicate dialog never appears in any Session flow.
+3. The durability invariant is fully preserved: nothing is deleted before confirmed
+   delivery; failed and undelivered jobs are untouched (salvage banner, `/recent`,
+   `/result`, `/retry` all keep working exactly as today).
+4. The `/import` durability bug is fixed as part of the same lifecycle change.
+
+## Non-goals
+
+- Notebook flows (notebook import, its dedup prompt, manual add, retro-diarize) are
+  unchanged.
+- Live Mode and the rolling preview are unchanged.
+- Auto-add-to-notebook stays **mic-only** (user decision 2026-08-09): session file
+  imports are always ephemeral; permanent file imports go through the Notebook import.
+- No new UI for browsing/retrying failed jobs.
+
+## User decisions (2026-08-09)
+
+- Scope: the **whole Session tab** (mic + file imports), not just the import flow.
+- Auto-add-to-notebook remains mic-only.
+- Approach chosen: full durability-pipeline integration ("Approach A"), over
+  dialog-suppression-only or no-DB-row-at-all alternatives.
+
+## Design
+
+### 1. Unified session job lifecycle
+
+"Session-source" means exactly: `source='file_import'` rows plus rows created by the WS
+mic-session path (whatever `source` value `websocket.py` passes to `create_job` —
+implementation must scope purge to these two values only, so rows created by any other
+route, e.g. a notebook import, are never touched).
+
+For session-source jobs:
+
+```
+create_job (processing)
+  → transcribe
+  → save_result (completed, delivered=0)      # always BEFORE delivery — unchanged
+  → deliver to client
+  → confirmed → mark_delivered (delivered=1)
+  → [auto-add ON, mic only: notebook save must have succeeded]
+  → purge: delete audio file (if any) + DELETE the transcription_jobs row
+```
+
+Purge is the only new step. It fires **only** on `delivered=1`.
+
+- **WS mic path:** purge runs during session teardown after `mark_delivered` succeeds
+  (`websocket.py:609-616` sets it only when the final actually reached the client) and,
+  when auto-add is ON, only after `_save_session_to_notebook` completed successfully. If
+  the notebook save fails, purge is **cancelled** — row + WAV are kept so nothing is
+  lost, and the existing `_warn_notebook_autoadd_failed` warning fires.
+- **Recovery paths:** `GET /result/{job_id}` already calls `mark_delivered` on a 200;
+  it now also purges session-source jobs after marking delivered.
+  `POST /result/{job_id}/dismiss` (recovery-banner dismiss) now purges as well —
+  dismiss means "I don't want it", so nothing needs to remain.
+- **Retry:** a successful `/retry` leaves `delivered=0` on purpose so the result
+  re-surfaces via `/recent`; it purges like any other job once the client fetches or
+  dismisses it.
+
+New repository function `delete_job(job_id)` (DELETE the row; unlink `audio_path` first,
+`missing_ok=True`). Purge failures are log-warning only — delivery never fails because
+cleanup failed; the backstop sweep (§5) catches stragglers.
+
+### 2. Import path joins the durability pipeline
+
+- `_run_file_import` calls `save_result(...)` on success and `mark_failed(...)` on
+  failure/cancel, before touching the in-memory `job_tracker`. This honors
+  persist-before-deliver and stops the orphan sweep's false `failed` flips for
+  completed imports.
+- The dashboard's `pollForSessionResult` stops reading results out of
+  `/api/admin/status`'s `job_tracker` snapshot. It polls `GET /api/transcribe/result/{job_id}`
+  instead: 202 while processing, 410 + error on failure, 200 (+ `mark_delivered` + purge)
+  on success. `job_tracker`/admin-status remains for **progress reporting only**.
+- Net durability win: an import that completes while the dashboard is down survives a
+  server restart and is recoverable — today it is silently lost with the in-memory
+  tracker.
+
+### 3. Dedup removed from session imports
+
+- `/import` stops computing `audio_hash`/`normalized_audio_hash` and stops calling
+  `find_duplicates_anywhere`; `dedup_matches` disappears from its response (the
+  normalized-PCM hash decodes the entire file, so this also speeds up import startup).
+  `create_job` for imports no longer stores hashes.
+- Dashboard: session flows (`session-normal`, `session-auto`) never prompt.
+  `resolveDuplicateChoice`'s session branches, the `DuplicatePolicy` type, and the
+  `folderWatch.duplicatePolicy` config key (+ its Settings UI) are removed — the policy
+  existed only to keep unattended Folder Watch batches from blocking on this dialog
+  (GH-120), which can no longer happen. `DedupPromptModal` itself stays: the Notebook
+  import dedup (real, retrievable entries in `recordings`) is unchanged.
+
+### 4. Safety net unchanged for anything not delivered
+
+- Completed, `delivered=0` (WS drop, salvage, >1MB reference): kept; recovery banner via
+  `/recent` exactly as today. Recover → fetch → purge. Dismiss → purge.
+- Failed **mic** jobs (WAV on disk): row + WAV retained indefinitely (status quo) so
+  `/retry/{job_id}` keeps working. Successful retry → redelivery → purge.
+- Failed **import** jobs have no recoverable audio (`/import` always unlinks its temp
+  file), so nothing retryable remains. The row is purged as soon as the polling client
+  receives the failure (`GET /result/{job_id}` → 410): the error has been delivered and
+  only an error message would be lost. A failed import whose client never polls (e.g.
+  dashboard crash) is left in place and cleaned by the backstop sweep.
+- The orphan sweep is unchanged (and, with §2, stops mislabeling imports).
+
+### 5. Backstop sweep
+
+`cleanup_old_recordings` currently deletes only the WAV of
+`completed AND delivered=1` jobs older than `audio_retention_days`. It is extended
+(session sources only) to also delete the **row**, and to delete aged
+`failed AND source='file_import'` rows (no audio, nothing retryable — covers a failed
+import whose client never polled). With immediate purge in place this sweep only catches
+crash-window stragglers (e.g. a crash between `mark_delivered` and purge). Existing
+config keys keep their meaning; no new config is added.
+
+### 6. One-time legacy cleanup
+
+On startup (folded into the same cleanup task), purge what has already accumulated:
+
+- All `source='file_import'` rows with `result_text IS NULL AND audio_path IS NULL` —
+  bare dedup anchors, nothing recoverable, any status. This removes the rows that
+  trigger today's dialog.
+- All session-source rows with `status='completed' AND delivered=1` — already handed
+  over; row + WAV purged.
+- Anything failed or undelivered is **not** touched.
+
+## Error handling summary
+
+| Failure | Behavior |
+|---|---|
+| Purge fails (DB or unlink) | Warning log; delivery unaffected; backstop sweep retries later |
+| Crash between mark_delivered and purge | Backstop sweep deletes row + WAV |
+| Notebook auto-add save fails | Purge cancelled; row + WAV kept; existing warning surfaces |
+| Import fails | `mark_failed`; row purged once the client polls the 410 (nothing retryable — imports keep no audio); backstop sweep if never polled |
+| Client never fetches import result | Row stays `completed/delivered=0`; recovery banner offers it; purge on fetch/dismiss |
+
+## Testing
+
+- **Backend** (direct-call route-test pattern, full suite via build venv):
+  import success → `save_result` called, row completed; import failure → `mark_failed`;
+  `/result` fetch of a session job → row gone + WAV gone; dismiss → purged;
+  retry → redeliver → purged; notebook-save failure → not purged; legacy sweep deletes
+  anchors + delivered rows but never failed/undelivered; backstop sweep row deletion.
+- **Dashboard** (vitest, Node 22): `importQueueStore` polls `/result`, handles
+  202/410/200; no dedup prompt on any session flow; Folder Watch unaffected by config
+  key removal.
+- **Traps:** the three WS session test-factories break on any new session attribute;
+  `ui:contract:check` after touching SettingsModal; electron-store defaulted keys never
+  read back as `undefined` (removing the `duplicatePolicy` default is safe — stale stored
+  values are simply ignored).
+
+## Risks
+
+- **GH #202:** the >1MB recovery fetch resolves to `file://` in packaged builds. Import
+  polling must go through the standard `apiClient` base-URL plumbing (same as
+  `getAdminStatus`), not the code path with that bug; verify large-result import fetch
+  in a packaged build during smoke.
+- Moving import delivery from admin-status polling to `/result` changes timing/shape of
+  the import happy path — the import queue tests and the PR #285 progress block both
+  touch `pollForSessionResult`; coordinate to avoid conflicts.
+- Deleting delivered rows removes the "ask the DB later" last-resort for session jobs.
+  Accepted by design: the Session tab is ephemeral; permanent copies belong to the
+  Notebook.
+
+## Key code references
+
+- Dialog: `dashboard/components/import/DedupPromptModal.tsx`,
+  `dashboard/src/stores/dedupChoiceStore.ts`,
+  `dashboard/src/stores/importQueueStore.ts:283-295, 356-413`
+- Import route: `server/backend/api/routes/transcription.py:878-1032` (handler),
+  `:684-875` (`_run_file_import`)
+- Dedup query: `server/backend/database/dedup_query.py:28-87`
+- Job repo: `server/backend/database/job_repository.py` (`save_result:152`,
+  `mark_delivered:189`, `mark_failed:203`, `get_jobs_for_cleanup:352`)
+- WS persist/deliver ordering: `server/backend/api/routes/websocket.py:563-620`;
+  auto-add: `:645-665`, `_save_session_to_notebook:99-176`
+- Cleanup: `server/backend/database/audio_cleanup.py`, `server/backend/api/main.py:465-482`
+- Recovery endpoints: `transcription.py:1088-1128` (`/result`), `:1488-1515` (`/recent`),
+  `:1518-1538` (dismiss), `:1131-1207` (`/retry`)

--- a/server/backend/api/main.py
+++ b/server/backend/api/main.py
@@ -436,6 +436,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     await recover_orphaned_jobs(_orphan_timeout)
     _log_time("orphan job recovery complete")
 
+    # One-time legacy purge for session ephemeral retention (2026-08-09 spec).
+    # Runs before any request is served, so no live job can be caught.
+    from server.database.audio_cleanup import purge_legacy_session_rows
+
+    await purge_legacy_session_rows()
+    _log_time("legacy session-row purge complete")
+
     # Schedule backup check in background (non-blocking)
     backup_config = config.config.get("backup", {})
     backup_enabled = backup_config.get("enabled", True)

--- a/server/backend/api/routes/transcription.py
+++ b/server/backend/api/routes/transcription.py
@@ -1095,7 +1095,7 @@ async def get_transcription_result(job_id: str, request: Request) -> JSONRespons
         404: Job not found.
         410: Job failed (includes error_message).
     """
-    from ...database.job_repository import get_job, mark_delivered
+    from ...database.job_repository import SESSION_SOURCES, delete_job, get_job, mark_delivered
 
     job = get_job(job_id)
     if job is None:
@@ -1106,9 +1106,14 @@ async def get_transcription_result(job_id: str, request: Request) -> JSONRespons
     if job["status"] == "processing":
         return JSONResponse(status_code=202, content={"status": "processing", "job_id": job_id})
     if job["status"] == "failed":
-        raise HTTPException(
-            status_code=410, detail=job.get("error_message") or "Transcription failed"
-        )
+        detail = job.get("error_message") or "Transcription failed"
+        # Session ephemeral retention: a failed import keeps no audio, so
+        # nothing is retryable — the row's only purpose was delivering this
+        # error message, which just happened. Failed 'websocket' jobs keep
+        # their row + WAV so /retry stays possible.
+        if job.get("source") == "file_import" and not job.get("audio_path"):
+            delete_job(job_id)
+        raise HTTPException(status_code=410, detail=detail)
     # completed
     if job.get("result_json"):
         try:
@@ -1122,6 +1127,11 @@ async def get_transcription_result(job_id: str, request: Request) -> JSONRespons
         mark_delivered(job_id)
     except Exception as e:
         logger.warning("Failed to mark job %s as delivered: %s", sanitize_log_value(job_id), e)
+    # Session ephemeral retention: a delivered session job leaves no
+    # server-side trace. delete_job never raises (warning-only contract);
+    # the response payload is already in memory at this point.
+    if job.get("source") in SESSION_SOURCES:
+        delete_job(job_id)
     return JSONResponse(
         status_code=200,
         content={"job_id": job_id, "status": "completed", "result": result_data},
@@ -1526,7 +1536,7 @@ async def dismiss_transcription_result(job_id: str, request: Request) -> JSONRes
         403: Job belongs to a different client.
         404: Job not found.
     """
-    from ...database.job_repository import get_job, mark_delivered
+    from ...database.job_repository import SESSION_SOURCES, delete_job, get_job, mark_delivered
 
     job = get_job(job_id)
     if job is None:
@@ -1535,6 +1545,12 @@ async def dismiss_transcription_result(job_id: str, request: Request) -> JSONRes
     if job.get("client_name") is not None and job["client_name"] != client_name:
         raise HTTPException(status_code=403, detail="Access denied")
     mark_delivered(job_id)
+    # Session ephemeral retention: dismiss means "I don't want it" — purge
+    # session jobs like a delivery. Only completed rows can be dismissed from
+    # the recovery banner; the status guard keeps a hypothetical failed-row
+    # dismiss from deleting a retryable WAV.
+    if job.get("status") == "completed" and job.get("source") in SESSION_SOURCES:
+        delete_job(job_id)
     return JSONResponse(status_code=200, content={"job_id": job_id})
 
 

--- a/server/backend/api/routes/transcription.py
+++ b/server/backend/api/routes/transcription.py
@@ -671,14 +671,13 @@ class DedupMatch(BaseModel):
 class ImportAcceptedResponse(BaseModel):
     """Response model for accepted file import job (202).
 
-    ``dedup_matches`` (Issue #104, Story 2.4) carries any prior jobs whose
-    ``audio_hash`` matches this upload. Empty list when no prior match
-    (J1 happy-path silently proceeds — AC2.4.AC3). Default-empty keeps the
-    response shape backwards compatible for clients that ignore the field.
+    ``job_id`` is the FULL job id — the client polls
+    GET /api/transcribe/result/{job_id} with it (202 processing / 410 failed /
+    200 completed). Session ephemeral retention (2026-08-09 spec) removed the
+    dedup_matches field: session imports no longer hash or dedup-check.
     """
 
     job_id: str
-    dedup_matches: list[DedupMatch] = []
 
 
 def _run_file_import(
@@ -892,13 +891,15 @@ async def import_and_transcribe(
     """
     Import an audio file and transcribe it in the background.
 
-    Unlike the notebook upload, this does NOT save to the database or convert
-    to MP3. The full transcription result is stored in job_tracker for the
-    client to retrieve, format (SRT/TXT), and save to disk.
+    Unlike the notebook upload, this does NOT save a notebook entry or convert
+    to MP3. The result is persisted to the transcription_jobs durability row
+    (persist-before-deliver) and the client retrieves it via
+    GET /api/transcribe/result/{job_id}: 202 while processing, 410 + error on
+    failure, 200 with the result on success. Fetching the result purges the
+    row — session imports are ephemeral (2026-08-09 spec). job_tracker keeps
+    the in-memory copy for progress reporting via /api/admin/status only.
 
-    Returns 202 Accepted immediately with a job_id. Clients should poll
-    GET /api/admin/status to check job_tracker.result for completion.
-
+    Returns 202 Accepted immediately with the full job_id.
     Returns 409 Conflict if another transcription job is already running.
     """
     _assert_main_model_selected(request)
@@ -933,30 +934,11 @@ async def import_and_transcribe(
         tmp.write(content)
         tmp_path = Path(tmp.name)
 
-    # Issue #104, Story 2.2 — durability row for the /import flow exists
-    # purely so the dedup-check endpoint can find re-imports of the same
-    # audio. The /import worker still uses model_manager.job_tracker for
-    # results (in-memory), so result_text/result_json on this row stay NULL.
-    # See sprint-2-design.md §1 for the override rationale.
-    # Sprint 2 Item 3 — also compute the normalized PCM hash for
-    # format-agnostic dedup. Either value can be NULL on its own.
-    audio_hash: str | None = None
-    normalized_audio_hash: str | None = None
-    try:
-        from server.core.audio_utils import (
-            compute_normalized_pcm_hash as _norm_sha,
-        )
-        from server.core.audio_utils import sha256_streaming as _sha
-
-        audio_hash = _sha(tmp_path)
-        normalized_audio_hash = _norm_sha(tmp_path)
-    except Exception as _hash_err:
-        logger.warning(
-            "Failed to compute audio_hash for import job %s: %s",
-            job_id[:8],
-            _hash_err,
-        )
-    dedup_matches: list[DedupMatch] = []
+    # Session ephemeral retention: the durability row is the delivery channel
+    # for the import result (the client polls GET /result/{job_id}). Without
+    # the row the outcome would be unreachable, so a failed insert aborts the
+    # request instead of running a transcription nobody can fetch. No hashes
+    # are computed any more — session imports never dedup (2026-08-09 spec).
     try:
         create_job(
             job_id=job_id,
@@ -965,33 +947,17 @@ async def import_and_transcribe(
             language=language,
             task="translate" if translation_enabled else "transcribe",
             translation_target=(translation_target_language if translation_enabled else None),
-            audio_hash=audio_hash,
-            normalized_audio_hash=normalized_audio_hash,
         )
-        # Story 2.4 + Sprint 2 Item 2 + Item 3 — surface prior matches across
-        # BOTH transcription_jobs AND recordings on EITHER hash. Exclude the
-        # just-created jobs row by id.
-        if audio_hash or normalized_audio_hash:
-            dedup_matches = [
-                DedupMatch(
-                    recording_id=m["id"],
-                    name=m["name"],
-                    created_at=m["created_at"],
-                    source=m["source"],
-                )
-                for m in find_duplicates_anywhere(
-                    audio_hash or "",
-                    limit=10,
-                    normalized_audio_hash=normalized_audio_hash,
-                )
-                if not (m["source"] == "transcription_job" and m["id"] == job_id)
-            ]
     except Exception as _e:
-        logger.warning(
-            "Failed to create durability row for import job %s: %s",
-            job_id[:8],
-            _e,
-        )
+        logger.error("Failed to create durability row for import job %s: %s", job_id[:8], _e)
+        model_manager.job_tracker.end_job(job_id)
+        try:
+            tmp_path.unlink()
+        except Exception:
+            logger.warning("Failed to remove temp upload %s after aborted import", tmp_path)
+        raise HTTPException(
+            status_code=500, detail="Could not create job record — import aborted"
+        ) from _e
 
     # Resolve parallel diarization default from config before entering background thread
     config = request.app.state.config
@@ -1025,11 +991,9 @@ async def import_and_transcribe(
         )
     )
 
-    # Return immediately — client polls /api/admin/status for result.
-    # dedup_matches carries any prior jobs with the same audio_hash so the
-    # dashboard can show the dedup prompt (Story 2.4) without a follow-up
-    # round-trip. Empty list = J1 happy path (no duplicate found).
-    return {"job_id": job_id[:8], "dedup_matches": dedup_matches}
+    # Return immediately — the client polls GET /result/{job_id} with the
+    # FULL id (the durability row's primary key).
+    return {"job_id": job_id}
 
 
 class DedupCheckRequest(BaseModel):

--- a/server/backend/api/routes/transcription.py
+++ b/server/backend/api/routes/transcription.py
@@ -680,6 +680,49 @@ class ImportAcceptedResponse(BaseModel):
     job_id: str
 
 
+def _persist_import_result(
+    job_id: str, payload: dict[str, Any], result_dict: dict[str, Any]
+) -> None:
+    """Persist an import result to its durability row BEFORE the in-memory
+    job_tracker hand-off (persist-before-deliver, CLAUDE.md invariant).
+
+    The row is the import path's ONLY delivery channel — the dashboard polls
+    GET /result/{job_id} — so a failed write escalates to mark_failed: the
+    client then receives an actionable 410 instead of polling 202 forever
+    until the orphan sweep mislabels the job.
+    """
+    from server.core.json_utils import sanitize_for_json
+
+    try:
+        sanitized = sanitize_for_json(payload)
+        save_result(
+            job_id=job_id,
+            result_text=result_dict.get("text", "") or "",
+            result_json=_json.dumps(sanitized, ensure_ascii=False),
+            result_language=result_dict.get("language"),
+            duration_seconds=result_dict.get("duration"),
+        )
+    except Exception:
+        logger.critical(
+            "Failed to persist import result for job %s — the transcription exists "
+            "only in the in-memory job tracker and is lost on restart",
+            sanitize_log_value(job_id),
+            exc_info=True,
+        )
+        try:
+            mark_failed(
+                job_id,
+                "Persistence failed — the transcription completed but could not be "
+                "saved. Check the server logs.",
+            )
+        except Exception:
+            logger.warning(
+                "Failed to mark import job %s as failed after persistence failure",
+                sanitize_log_value(job_id),
+                exc_info=True,
+            )
+
+
 def _run_file_import(
     *,
     model_manager: Any,
@@ -707,8 +750,10 @@ def _run_file_import(
     - Convert to MP3
     - Save to database
 
-    It stores the full transcription result in job_tracker so the client
-    can format and save the output file locally.
+    It persists the result to the transcription_jobs durability row
+    (persist-before-deliver) and mirrors it into job_tracker for progress
+    reporting. The client fetches the result via GET /result/{job_id},
+    formats it (SRT/TXT), and saves the output file locally.
     """
     try:
         # Progress callback to update job tracker with chunk progress
@@ -739,18 +784,20 @@ def _run_file_import(
             )
 
             result_dict = result.to_dict()
-            model_manager.job_tracker.end_job(
-                job_id,
-                result={
-                    "job_id": job_id[:8],
-                    "transcription": result_dict,
-                    "diarization": {
-                        "requested": False,
-                        "performed": False,
-                        "reason": "multitrack",
-                    },
+            payload = {
+                "job_id": job_id[:8],
+                "transcription": result_dict,
+                "diarization": {
+                    "requested": False,
+                    "performed": False,
+                    "reason": "multitrack",
                 },
-            )
+                # Top-level text mirror so /recent previews and the recovery
+                # banner render this row without knowing the import shape.
+                "text": result_dict.get("text", ""),
+            }
+            _persist_import_result(job_id, payload, result_dict)
+            model_manager.job_tracker.end_job(job_id, result=payload)
             logger.info("File import job %s completed (multitrack): %s", job_id[:8], filename)
 
             if event_loop is not None:
@@ -800,16 +847,18 @@ def _run_file_import(
         result = dispatched.result
         diarization_outcome = dispatched.outcome.to_dict()
 
-        # Store successful result for client polling
+        # Persist for the /result poll, then mirror into job_tracker.
         result_dict = result.to_dict()
-        model_manager.job_tracker.end_job(
-            job_id,
-            result={
-                "job_id": job_id[:8],
-                "transcription": result_dict,
-                "diarization": diarization_outcome,
-            },
-        )
+        payload = {
+            "job_id": job_id[:8],
+            "transcription": result_dict,
+            "diarization": diarization_outcome,
+            # Top-level text mirror so /recent previews and the recovery
+            # banner render this row without knowing the import shape.
+            "text": result_dict.get("text", ""),
+        }
+        _persist_import_result(job_id, payload, result_dict)
+        model_manager.job_tracker.end_job(job_id, result=payload)
         logger.info("File import job %s completed: %s", job_id[:8], filename)
 
         # Fire outgoing webhook (background thread — use fire-and-forget)
@@ -831,6 +880,14 @@ def _run_file_import(
 
     except TranscriptionCancelledError:
         logger.info("File import job %s cancelled by user", job_id[:8])
+        try:
+            mark_failed(job_id, "Transcription cancelled by user")
+        except Exception:
+            logger.warning(
+                "Failed to mark cancelled import job %s",
+                sanitize_log_value(job_id),
+                exc_info=True,
+            )
         model_manager.job_tracker.end_job(
             job_id,
             result={
@@ -856,6 +913,17 @@ def _run_file_import(
         if dep_error is not None:
             error_payload["remedy"] = dep_error.remedy
             error_payload["backend_type"] = dep_error.backend_type
+        # Persist the failure so the /result poll gets an actionable 410
+        # (remedy included when one exists).
+        _row_error = str(e) if dep_error is None else f"{e}. {dep_error.remedy}"
+        try:
+            mark_failed(job_id, _row_error)
+        except Exception:
+            logger.warning(
+                "Failed to mark import job %s as failed",
+                sanitize_log_value(job_id),
+                exc_info=True,
+            )
         model_manager.job_tracker.end_job(
             job_id,
             result=error_payload,

--- a/server/backend/api/routes/websocket.py
+++ b/server/backend/api/routes/websocket.py
@@ -39,6 +39,9 @@ from server.database.job_repository import (
     create_job as _create_job,
 )
 from server.database.job_repository import (
+    delete_job as _delete_job,
+)
+from server.database.job_repository import (
     mark_delivered as _mark_delivered,
 )
 from server.database.job_repository import (
@@ -641,8 +644,12 @@ class TranscriptionSession:
             # Auto-add to the Audio Notebook (GH #199). Runs AFTER the result is
             # persisted and delivered: the notebook entry is a derived artifact,
             # so a failure here must never cost the user their transcript. Runs
-            # in a thread, since the MP3 encode would otherwise block the event loop.
+            # in a thread, since the MP3 encode would otherwise block the event
+            # loop. _autoadd_ok gates the ephemeral purge below — a failed
+            # notebook save keeps row + WAV so nothing is lost.
+            _autoadd_ok = True
             if self.auto_add_to_notebook:
+                _autoadd_ok = False
                 try:
                     recording_id = await asyncio.to_thread(
                         _save_session_to_notebook,
@@ -653,6 +660,7 @@ class TranscriptionSession:
                         diarization_segments=dispatched.speaker_segments,
                     )
                     if recording_id:
+                        _autoadd_ok = True
                         logger.info("Saved session recording to notebook: id=%s", recording_id)
                     else:
                         _warn_notebook_autoadd_failed(
@@ -662,6 +670,29 @@ class TranscriptionSession:
                     logger.error("Failed to add recording to notebook: %s", nb_err, exc_info=True)
                     _warn_notebook_autoadd_failed(
                         f"Could not save the recording to the Audio Notebook: {nb_err}"
+                    )
+
+            # Session ephemeral retention (2026-08-09 spec): a session job whose
+            # result reached the client keeps no server-side trace — purge the
+            # row and its WAV. Fires only on confirmed inline delivery; the
+            # result_ready reference path purges inside GET /result/{job_id}
+            # instead, and a failed notebook auto-add cancels the purge (row +
+            # WAV stay as the recovery copy). Guarded so a purge error can
+            # never surface as a post-delivery "transcription failed" banner.
+            if (
+                self._current_job_id
+                and _result_persisted
+                and not _sent_as_reference
+                and _final_delivered
+                and _autoadd_ok
+            ):
+                try:
+                    _delete_job(self._current_job_id)
+                except Exception as _purge_err:
+                    logger.warning(
+                        "Post-delivery purge failed for job %s: %s",
+                        self._current_job_id,
+                        _purge_err,
                     )
 
             # Fire outgoing webhook (separate guard so failures don't

--- a/server/backend/database/audio_cleanup.py
+++ b/server/backend/database/audio_cleanup.py
@@ -1,11 +1,18 @@
 """
-Audio cleanup module for transcription durability (Wave 2).
+Audio cleanup module for transcription durability (Wave 2) and session
+ephemeral retention (2026-08-09 spec).
 
-Deletes raw audio files for completed+delivered transcription jobs that are
-older than the configured retention window. The job DB row is always kept —
-it records that a transcription happened. Only the audio file is removed.
+For non-session jobs (e.g. source='audio_upload'): deletes only the raw audio
+file of completed+delivered jobs older than the retention window — the DB row
+is kept as a record that a transcription happened.
 
-Never deletes audio for failed or undelivered jobs.
+For session-source jobs ('websocket', 'file_import'): the backstop passes also
+delete the DB ROW — the Session tab is ephemeral, and rows here only survive
+their immediate post-delivery purge after a crash. Aged failed file_import
+rows (which never have audio, so nothing is retryable) are purged too.
+
+Never deletes audio for failed or undelivered jobs, and never touches failed
+mic ('websocket') rows — their WAV is what makes /retry possible.
 """
 
 import asyncio
@@ -69,22 +76,26 @@ async def cleanup_old_recordings(recordings_dir: str, max_age_days: int) -> None
         )
         return
 
-    from .job_repository import get_jobs_for_cleanup
+    from .job_repository import (
+        delete_job,
+        get_jobs_for_cleanup,
+        get_purgeable_session_jobs,
+        get_stale_failed_imports,
+    )
 
+    deleted = 0
+    skipped = 0
     try:
         jobs = await asyncio.to_thread(get_jobs_for_cleanup, max_age_days)
     except Exception as exc:
         logger.error("Audio cleanup: failed to query expired jobs: %s", exc)
-        return
+        jobs = []
 
     if not jobs:
         logger.debug(
             "Audio cleanup: no expired recordings found (older than %d days)", max_age_days
         )
-        return
 
-    deleted = 0
-    skipped = 0
     for job in jobs:
         audio_path = job.get("audio_path")
         if not audio_path:
@@ -97,10 +108,53 @@ async def cleanup_old_recordings(recordings_dir: str, max_age_days: int) -> None
             logger.warning("Failed to delete audio file %s: %s", audio_path, exc)
             skipped += 1
 
+    # Session ephemeral retention backstops. Immediate purge normally removes
+    # session rows at delivery time; these passes only catch crash-window
+    # stragglers and failed imports whose client never polled the error.
+    purged_rows = 0
+    try:
+        stragglers = await asyncio.to_thread(get_purgeable_session_jobs, max_age_days)
+        stale_imports = await asyncio.to_thread(get_stale_failed_imports, max_age_days)
+        for job in [*stragglers, *stale_imports]:
+            await asyncio.to_thread(delete_job, job["id"])
+            purged_rows += 1
+    except Exception:
+        logger.exception("Audio cleanup: session-row backstop purge failed")
+
     logger.info(
-        "Audio cleanup complete: %d file(s) deleted, %d skipped (retention=%d days, dir=%s)",
+        "Audio cleanup complete: %d file(s) deleted, %d skipped, %d session row(s) purged "
+        "(retention=%d days, dir=%s)",
         deleted,
         skipped,
+        purged_rows,
         max_age_days,
         recordings_dir,
     )
+
+
+async def purge_legacy_session_rows() -> None:
+    """One-time startup migration for session ephemeral retention.
+
+    Purges rows accumulated under the old lifecycle: bare /import dedup
+    anchors (the rows behind the duplicate dialog) and already-delivered
+    session rows. Anything failed or undelivered with content is untouched.
+    Safe to run every startup — once drained it finds nothing.
+    """
+    from .job_repository import delete_job, get_legacy_session_rows
+
+    total = 0
+    while True:
+        try:
+            rows = await asyncio.to_thread(get_legacy_session_rows)
+        except Exception:
+            logger.exception("Legacy session-row purge: query failed")
+            return
+        if not rows:
+            break
+        for row in rows:
+            await asyncio.to_thread(delete_job, row["id"])
+        total += len(rows)
+        if len(rows) < 1000:  # last page
+            break
+    if total:
+        logger.info("Legacy session-row purge: %d row(s) removed", total)

--- a/server/backend/database/job_repository.py
+++ b/server/backend/database/job_repository.py
@@ -6,6 +6,7 @@ Provides CRUD operations for the transcription_jobs table.
 
 import logging
 from datetime import UTC, datetime
+from pathlib import Path
 
 from server.logging import sanitize_log_value
 
@@ -390,3 +391,133 @@ def get_jobs_for_cleanup(max_age_days: int, limit: int = 100) -> list[dict]:
         )
         rows = cursor.fetchall()
         return [dict(row) for row in rows]
+
+
+# ─── Session ephemeral retention (2026-08-09 spec) ───────────────────────────
+
+# Sources whose rows are purged after confirmed delivery. Rows from any other
+# source (e.g. 'audio_upload', notebook uploads) are NEVER purged — only these
+# two values may ever reach delete_job via the session lifecycle.
+SESSION_SOURCES = ("websocket", "file_import")
+
+
+def delete_job(job_id: str) -> None:
+    """Delete a job row and its audio file (session ephemeral retention).
+
+    Best-effort by contract: every failure is logged as a warning and
+    swallowed — a purge must never break delivery or session teardown.
+    The backstop sweep in audio_cleanup catches stragglers.
+    """
+    try:
+        row = get_job(job_id)
+        if row is None:
+            return
+        audio_path = row.get("audio_path")
+        if audio_path:
+            try:
+                Path(audio_path).unlink(missing_ok=True)
+            except Exception:
+                logger.warning(
+                    "delete_job: failed to unlink audio for %s",
+                    sanitize_log_value(job_id),
+                    exc_info=True,
+                )
+        with get_connection() as conn:
+            conn.execute("DELETE FROM transcription_jobs WHERE id = ?", (job_id,))
+            conn.commit()
+    except Exception:
+        logger.warning(
+            "delete_job: failed to purge job %s", sanitize_log_value(job_id), exc_info=True
+        )
+
+
+def get_purgeable_session_jobs(max_age_days: int, limit: int = 100) -> list[dict]:
+    """Return completed+delivered session-source jobs older than max_age_days.
+
+    Backstop for rows that missed their immediate post-delivery purge (e.g. a
+    crash between mark_delivered and delete_job). completed_at is isoformat —
+    see get_jobs_for_cleanup for the cutoff-format note.
+    """
+    from datetime import timedelta
+
+    cutoff = (datetime.now(UTC) - timedelta(days=max_age_days)).isoformat()
+    placeholders = ",".join("?" for _ in SESSION_SOURCES)
+    with get_connection() as conn:
+        cursor = conn.execute(
+            f"""
+            SELECT * FROM transcription_jobs
+            WHERE status = 'completed'
+              AND delivered = 1
+              AND source IN ({placeholders})
+              AND completed_at < ?
+            ORDER BY completed_at ASC
+            LIMIT ?
+            """,
+            (*SESSION_SOURCES, cutoff, limit),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
+
+def get_stale_failed_imports(max_age_days: int, limit: int = 100) -> list[dict]:
+    """Return aged failed file_import rows with no preserved audio.
+
+    A failed import keeps no audio (the /import temp file is always deleted),
+    so nothing is retryable — the row exists only to deliver its error message
+    via GET /result/{job_id} (410). When the client never polls (e.g. the
+    dashboard crashed), this query lets the backstop sweep purge the row.
+
+    created_at is written by SQLite CURRENT_TIMESTAMP (space separator), so
+    the cutoff must use strftime — see get_orphaned_jobs for the format note.
+    """
+    from datetime import timedelta
+
+    cutoff = (datetime.now(UTC) - timedelta(days=max_age_days)).strftime("%Y-%m-%d %H:%M:%S")
+    with get_connection() as conn:
+        cursor = conn.execute(
+            """
+            SELECT * FROM transcription_jobs
+            WHERE status = 'failed'
+              AND source = 'file_import'
+              AND audio_path IS NULL
+              AND created_at < ?
+            ORDER BY created_at ASC
+            LIMIT ?
+            """,
+            (cutoff, limit),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
+
+def get_legacy_session_rows(limit: int = 1000) -> list[dict]:
+    """One-time startup cleanup query (session-ephemeral-retention migration).
+
+    Returns rows that predate the ephemeral lifecycle:
+    - bare /import dedup anchors — source='file_import' with neither result
+      text nor audio, ANY status. These rows were written purely so the old
+      dedup check could find re-imports; they are what triggered the duplicate
+      dialog and hold nothing recoverable.
+    - already-delivered session rows — completed + delivered=1 for any session
+      source. The result reached the client; under the new lifecycle these
+      would have been purged at delivery time.
+
+    Failed or undelivered rows WITH content are never returned. Runs at
+    startup before any request is served, so no live 'processing' row can be
+    caught by the anchor arm.
+    """
+    placeholders = ",".join("?" for _ in SESSION_SOURCES)
+    with get_connection() as conn:
+        cursor = conn.execute(
+            f"""
+            SELECT * FROM transcription_jobs
+            WHERE (source = 'file_import'
+                   AND result_text IS NULL
+                   AND audio_path IS NULL)
+               OR (source IN ({placeholders})
+                   AND status = 'completed'
+                   AND delivered = 1)
+            ORDER BY created_at ASC
+            LIMIT ?
+            """,
+            (*SESSION_SOURCES, limit),
+        )
+        return [dict(row) for row in cursor.fetchall()]

--- a/server/backend/tests/test_import_ephemeral_route.py
+++ b/server/backend/tests/test_import_ephemeral_route.py
@@ -1,0 +1,98 @@
+"""Tests for the /import route under session ephemeral retention.
+
+Direct-call pattern (see test_transcription_durability_routes.py). The route
+imports create_job / save_result / mark_failed into its own module namespace,
+so patches target server.api.routes.transcription, not the repo module.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from server.api.routes import transcription
+from starlette.datastructures import UploadFile
+
+
+class _Tracker:
+    def __init__(self):
+        self.ended: list[str] = []
+
+    def try_start_job(self, user):
+        return (True, "full-job-id-1234", None)
+
+    def end_job(self, job_id, result=None):
+        self.ended.append(job_id)
+        return True
+
+
+def _request(tracker):
+    config = SimpleNamespace(get=lambda *a, **k: k.get("default"))
+    state = SimpleNamespace(
+        model_manager=SimpleNamespace(job_tracker=tracker),
+        config=config,
+    )
+    return SimpleNamespace(app=SimpleNamespace(state=state))
+
+
+def _upload() -> UploadFile:
+    return UploadFile(filename="test.wav", file=io.BytesIO(b"RIFF0000WAVE"))
+
+
+@pytest.fixture(autouse=True)
+def _quiet_route(monkeypatch):
+    monkeypatch.setattr(transcription, "get_client_name", lambda _req: "test-client")
+    monkeypatch.setattr(transcription, "_assert_main_model_selected", lambda _req: None)
+    monkeypatch.setattr(transcription, "resolve_parallel_diarization_default", lambda _cfg: False)
+    # The route ends with loop.create_task(asyncio.to_thread(_run_file_import, ...));
+    # neuter the worker so no real transcription starts.
+    monkeypatch.setattr(transcription, "_run_file_import", lambda **kw: None)
+
+
+def _call(tracker):
+    return asyncio.run(
+        transcription.import_and_transcribe(
+            _request(tracker),
+            file=_upload(),
+            language=None,
+            translation_enabled=False,
+            translation_target_language=None,
+            enable_diarization=False,
+            enable_word_timestamps=True,
+            expected_speakers=None,
+            parallel_diarization=None,
+            diarization_engine=None,
+            multitrack=False,
+        )
+    )
+
+
+class TestImportRoute:
+    def test_returns_full_job_id_and_no_dedup_matches(self, monkeypatch):
+        created: list[dict] = []
+        monkeypatch.setattr(transcription, "create_job", lambda **kw: created.append(kw))
+
+        resp = _call(_Tracker())
+
+        assert resp["job_id"] == "full-job-id-1234"
+        assert "dedup_matches" not in resp
+        assert created[0]["source"] == "file_import"
+        # No hashes computed or stored any more
+        assert "audio_hash" not in created[0]
+        assert "normalized_audio_hash" not in created[0]
+
+    def test_create_job_failure_aborts_with_500_and_releases_slot(self, monkeypatch):
+        def _boom(**kw):
+            raise RuntimeError("db locked")
+
+        monkeypatch.setattr(transcription, "create_job", _boom)
+        tracker = _Tracker()
+
+        with pytest.raises(HTTPException) as exc:
+            _call(tracker)
+
+        assert exc.value.status_code == 500
+        assert tracker.ended == ["full-job-id-1234"]

--- a/server/backend/tests/test_import_ephemeral_route.py
+++ b/server/backend/tests/test_import_ephemeral_route.py
@@ -42,16 +42,6 @@ def _upload() -> UploadFile:
     return UploadFile(filename="test.wav", file=io.BytesIO(b"RIFF0000WAVE"))
 
 
-@pytest.fixture(autouse=True)
-def _quiet_route(monkeypatch):
-    monkeypatch.setattr(transcription, "get_client_name", lambda _req: "test-client")
-    monkeypatch.setattr(transcription, "_assert_main_model_selected", lambda _req: None)
-    monkeypatch.setattr(transcription, "resolve_parallel_diarization_default", lambda _cfg: False)
-    # The route ends with loop.create_task(asyncio.to_thread(_run_file_import, ...));
-    # neuter the worker so no real transcription starts.
-    monkeypatch.setattr(transcription, "_run_file_import", lambda **kw: None)
-
-
 def _call(tracker):
     return asyncio.run(
         transcription.import_and_transcribe(
@@ -71,6 +61,20 @@ def _call(tracker):
 
 
 class TestImportRoute:
+    @pytest.fixture(autouse=True)
+    def _quiet_route(self, monkeypatch):
+        """Route-level stubs. Class-scoped on purpose: patching _run_file_import
+        to a no-op here must NOT leak into TestRunFileImportDurability, which
+        exercises the real worker."""
+        monkeypatch.setattr(transcription, "get_client_name", lambda _req: "test-client")
+        monkeypatch.setattr(transcription, "_assert_main_model_selected", lambda _req: None)
+        monkeypatch.setattr(
+            transcription, "resolve_parallel_diarization_default", lambda _cfg: False
+        )
+        # The route ends with loop.create_task(asyncio.to_thread(_run_file_import, ...));
+        # neuter the worker so no real transcription starts.
+        monkeypatch.setattr(transcription, "_run_file_import", lambda **kw: None)
+
     def test_returns_full_job_id_and_no_dedup_matches(self, monkeypatch):
         created: list[dict] = []
         monkeypatch.setattr(transcription, "create_job", lambda **kw: created.append(kw))
@@ -96,3 +100,137 @@ class TestImportRoute:
 
         assert exc.value.status_code == 500
         assert tracker.ended == ["full-job-id-1234"]
+
+
+class TestRunFileImportDurability:
+    """_run_file_import must persist BEFORE the in-memory job_tracker hand-off."""
+
+    @staticmethod
+    def _model_manager():
+        calls: list[tuple] = []
+
+        class _JT:
+            def set_phase(self, *_a):
+                pass
+
+            def update_progress(self, *_a):
+                pass
+
+            def is_cancelled(self):
+                return False
+
+            def end_job(self, job_id, result=None):
+                calls.append(("end_job", job_id, result))
+                return True
+
+        mm = SimpleNamespace(
+            job_tracker=_JT(),
+            gpu_device_index=0,
+            ensure_transcription_loaded=lambda: SimpleNamespace(model_name="m"),
+        )
+        return mm, calls
+
+    @pytest.fixture(autouse=True)
+    def _no_gpu_cleanup(self, monkeypatch):
+        import server.core.audio_utils as audio_utils
+
+        monkeypatch.setattr(audio_utils, "post_job_gpu_cleanup", lambda *_a, **_k: None)
+
+    def _run(self, monkeypatch, tmp_path, *, dispatch):
+        import server.core.diarization_dispatch as dd
+
+        monkeypatch.setattr(dd, "transcribe_with_optional_diarization", dispatch)
+        mm, calls = self._model_manager()
+        wav = tmp_path / "in.wav"
+        wav.write_bytes(b"RIFF")
+        transcription._run_file_import(
+            model_manager=mm,
+            tmp_path=wav,
+            filename="in.wav",
+            language=None,
+            translation_enabled=False,
+            translation_target_language=None,
+            enable_diarization=False,
+            enable_word_timestamps=True,
+            expected_speakers=None,
+            parallel_diarization=None,
+            use_parallel_default=False,
+            multitrack=False,
+            job_id="job-import-1",
+            event_loop=None,
+        )
+        return calls
+
+    @staticmethod
+    def _ok_dispatch(**kw):
+        result = SimpleNamespace(
+            to_dict=lambda: {"text": "hello", "language": "en", "duration": 1.0}
+        )
+        outcome = SimpleNamespace(
+            to_dict=lambda: {"requested": False, "performed": False, "reason": None}
+        )
+        return SimpleNamespace(result=result, outcome=outcome)
+
+    def test_success_persists_before_end_job(self, monkeypatch, tmp_path):
+        order: list[str] = []
+        saved: list[dict] = []
+
+        def _save(**kw):
+            order.append("save_result")
+            saved.append(kw)
+
+        monkeypatch.setattr(transcription, "save_result", _save)
+        calls = self._run(monkeypatch, tmp_path, dispatch=self._ok_dispatch)
+        order.extend(name for name, *_ in calls)
+
+        assert order == ["save_result", "end_job"]
+        assert saved[0]["job_id"] == "job-import-1"
+        assert saved[0]["result_text"] == "hello"
+        import json as _j
+
+        payload = _j.loads(saved[0]["result_json"])
+        assert payload["transcription"]["text"] == "hello"
+        assert payload["text"] == "hello"  # top-level mirror for /recent previews
+
+    def test_failure_calls_mark_failed(self, monkeypatch, tmp_path):
+        failed: list[tuple] = []
+
+        def _dispatch(**kw):
+            raise RuntimeError("decode error")
+
+        monkeypatch.setattr(
+            transcription, "mark_failed", lambda jid, msg: failed.append((jid, msg))
+        )
+        self._run(monkeypatch, tmp_path, dispatch=_dispatch)
+
+        assert failed and failed[0][0] == "job-import-1"
+        assert "decode error" in failed[0][1]
+
+    def test_cancel_calls_mark_failed_with_cancel_message(self, monkeypatch, tmp_path):
+        from server.core.model_manager import TranscriptionCancelledError
+
+        failed: list[tuple] = []
+
+        def _dispatch(**kw):
+            raise TranscriptionCancelledError("cancelled")
+
+        monkeypatch.setattr(
+            transcription, "mark_failed", lambda jid, msg: failed.append((jid, msg))
+        )
+        self._run(monkeypatch, tmp_path, dispatch=_dispatch)
+
+        assert failed and "cancelled" in failed[0][1].lower()
+
+    def test_save_result_failure_marks_failed(self, monkeypatch, tmp_path):
+        failed: list[tuple] = []
+
+        def _boom(**kw):
+            raise RuntimeError("disk full")
+
+        monkeypatch.setattr(transcription, "save_result", _boom)
+        monkeypatch.setattr(
+            transcription, "mark_failed", lambda jid, msg: failed.append((jid, msg))
+        )
+        self._run(monkeypatch, tmp_path, dispatch=self._ok_dispatch)
+
+        assert failed and "persist" in failed[0][1].lower()

--- a/server/backend/tests/test_session_ephemeral_retention.py
+++ b/server/backend/tests/test_session_ephemeral_retention.py
@@ -1,0 +1,275 @@
+"""Tests for session ephemeral retention (2026-08-09 spec).
+
+Covers the repository purge primitives (delete_job, backstop queries,
+legacy-row query) and the extended cleanup task. Uses a real temporary
+SQLite DB via the same get_connection monkeypatch pattern as
+test_job_repository_imports.py.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sqlite3
+from contextlib import contextmanager
+
+import pytest
+
+repo = importlib.import_module("server.database.job_repository")
+
+
+@pytest.fixture()
+def db(tmp_path, monkeypatch):
+    """Real SQLite DB with the transcription_jobs columns this feature touches."""
+    db_path = tmp_path / "jobs.db"
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE transcription_jobs (
+            id TEXT PRIMARY KEY,
+            status TEXT NOT NULL DEFAULT 'processing',
+            source TEXT,
+            client_name TEXT,
+            language TEXT,
+            task TEXT,
+            translation_target TEXT,
+            job_profile_snapshot TEXT,
+            snapshot_schema_version TEXT,
+            audio_hash TEXT,
+            normalized_audio_hash TEXT,
+            audio_path TEXT,
+            result_text TEXT,
+            result_json TEXT,
+            result_language TEXT,
+            duration_seconds REAL,
+            error_message TEXT,
+            delivered INTEGER NOT NULL DEFAULT 0,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            completed_at TIMESTAMP
+        )
+        """
+    )
+    conn.commit()
+
+    @contextmanager
+    def _get_connection():
+        yield conn
+
+    monkeypatch.setattr(repo, "get_connection", _get_connection)
+    yield conn
+    conn.close()
+
+
+def _insert(
+    conn,
+    job_id: str,
+    *,
+    source: str = "file_import",
+    status: str = "processing",
+    delivered: int = 0,
+    audio_path: str | None = None,
+    result_text: str | None = None,
+    created_at: str = "2020-01-01 00:00:00",
+    completed_at: str | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO transcription_jobs
+            (id, status, source, delivered, audio_path, result_text,
+             created_at, completed_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (job_id, status, source, delivered, audio_path, result_text, created_at, completed_at),
+    )
+    conn.commit()
+
+
+def _row(conn, job_id: str):
+    return conn.execute("SELECT * FROM transcription_jobs WHERE id = ?", (job_id,)).fetchone()
+
+
+class TestDeleteJob:
+    def test_deletes_row_and_audio_file(self, db, tmp_path):
+        wav = tmp_path / "job1.wav"
+        wav.write_bytes(b"RIFF")
+        _insert(db, "job1", audio_path=str(wav))
+
+        repo.delete_job("job1")
+
+        assert _row(db, "job1") is None
+        assert not wav.exists()
+
+    def test_missing_audio_file_still_deletes_row(self, db, tmp_path):
+        _insert(db, "job2", audio_path=str(tmp_path / "gone.wav"))
+
+        repo.delete_job("job2")
+
+        assert _row(db, "job2") is None
+
+    def test_null_audio_path_deletes_row(self, db):
+        _insert(db, "job3", audio_path=None)
+
+        repo.delete_job("job3")
+
+        assert _row(db, "job3") is None
+
+    def test_nonexistent_job_is_noop(self, db):
+        repo.delete_job("missing")  # must not raise
+
+    def test_never_raises_on_db_error(self, monkeypatch):
+        @contextmanager
+        def _broken():
+            raise RuntimeError("db locked")
+            yield  # pragma: no cover
+
+        monkeypatch.setattr(repo, "get_connection", _broken)
+        repo.delete_job("whatever")  # must not raise
+
+
+class TestSessionSources:
+    def test_exactly_websocket_and_file_import(self):
+        assert set(repo.SESSION_SOURCES) == {"websocket", "file_import"}
+
+
+class TestGetPurgeableSessionJobs:
+    def test_returns_old_delivered_session_rows_only(self, db):
+        _insert(
+            db,
+            "ws-old",
+            source="websocket",
+            status="completed",
+            delivered=1,
+            completed_at="2020-01-01T00:00:00+00:00",
+        )
+        _insert(
+            db,
+            "imp-old",
+            source="file_import",
+            status="completed",
+            delivered=1,
+            completed_at="2020-01-02T00:00:00+00:00",
+        )
+        # Excluded: wrong source, undelivered, failed, too recent
+        _insert(
+            db,
+            "upload-old",
+            source="audio_upload",
+            status="completed",
+            delivered=1,
+            completed_at="2020-01-01T00:00:00+00:00",
+        )
+        _insert(
+            db,
+            "ws-undelivered",
+            source="websocket",
+            status="completed",
+            delivered=0,
+            completed_at="2020-01-01T00:00:00+00:00",
+        )
+        _insert(db, "ws-failed", source="websocket", status="failed", delivered=0)
+        _insert(
+            db,
+            "ws-recent",
+            source="websocket",
+            status="completed",
+            delivered=1,
+            completed_at="2099-01-01T00:00:00+00:00",
+        )
+
+        ids = {j["id"] for j in repo.get_purgeable_session_jobs(max_age_days=7)}
+
+        assert ids == {"ws-old", "imp-old"}
+
+
+class TestGetStaleFailedImports:
+    def test_returns_only_aged_failed_imports_without_audio(self, db, tmp_path):
+        _insert(
+            db,
+            "imp-fail-old",
+            source="file_import",
+            status="failed",
+            created_at="2020-01-01 00:00:00",
+        )
+        # Excluded: has audio (hypothetical future), wrong source, recent, not failed
+        _insert(
+            db,
+            "imp-fail-audio",
+            source="file_import",
+            status="failed",
+            audio_path=str(tmp_path / "kept.wav"),
+            created_at="2020-01-01 00:00:00",
+        )
+        _insert(
+            db, "ws-fail-old", source="websocket", status="failed", created_at="2020-01-01 00:00:00"
+        )
+        _insert(
+            db,
+            "imp-fail-recent",
+            source="file_import",
+            status="failed",
+            created_at="2099-01-01 00:00:00",
+        )
+        _insert(
+            db,
+            "imp-done",
+            source="file_import",
+            status="completed",
+            created_at="2020-01-01 00:00:00",
+        )
+
+        ids = {j["id"] for j in repo.get_stale_failed_imports(max_age_days=7)}
+
+        assert ids == {"imp-fail-old"}
+
+
+class TestGetLegacySessionRows:
+    def test_returns_bare_anchors_and_delivered_session_rows(self, db, tmp_path):
+        # Bare /import dedup anchors — any status, no result, no audio
+        _insert(db, "anchor-proc", source="file_import", status="processing")
+        _insert(db, "anchor-failed", source="file_import", status="failed")
+        # Delivered session rows
+        _insert(
+            db,
+            "ws-done",
+            source="websocket",
+            status="completed",
+            delivered=1,
+            result_text="hello",
+            audio_path=str(tmp_path / "a.wav"),
+        )
+        _insert(
+            db,
+            "imp-done",
+            source="file_import",
+            status="completed",
+            delivered=1,
+            result_text="hello",
+        )
+        # Kept: undelivered / failed-with-content / non-session
+        _insert(
+            db,
+            "ws-undelivered",
+            source="websocket",
+            status="completed",
+            delivered=0,
+            result_text="precious",
+        )
+        _insert(
+            db,
+            "ws-failed-wav",
+            source="websocket",
+            status="failed",
+            audio_path=str(tmp_path / "b.wav"),
+        )
+        _insert(
+            db,
+            "upload-done",
+            source="audio_upload",
+            status="completed",
+            delivered=1,
+            result_text="hello",
+        )
+
+        ids = {j["id"] for j in repo.get_legacy_session_rows()}
+
+        assert ids == {"anchor-proc", "anchor-failed", "ws-done", "imp-done"}

--- a/server/backend/tests/test_session_ephemeral_retention.py
+++ b/server/backend/tests/test_session_ephemeral_retention.py
@@ -19,7 +19,17 @@ repo = importlib.import_module("server.database.job_repository")
 
 @pytest.fixture()
 def db(tmp_path, monkeypatch):
-    """Real SQLite DB with the transcription_jobs columns this feature touches."""
+    """Real SQLite DB with the transcription_jobs columns this feature touches.
+
+    Re-resolves the repo module on every use: test_job_repository_imports pops
+    server.database.job_repository from sys.modules and re-imports it, so a
+    handle captured at collection time can diverge from the object that
+    audio_cleanup's function-local imports resolve. Patching the CURRENT
+    module (and rebinding the test-module global) keeps both call paths on
+    the same patched get_connection.
+    """
+    global repo
+    repo = importlib.import_module("server.database.job_repository")
     db_path = tmp_path / "jobs.db"
     # check_same_thread=False: cleanup_old_recordings runs repo queries via
     # asyncio.to_thread; production get_connection opens per-call connections.

--- a/server/backend/tests/test_session_ephemeral_retention.py
+++ b/server/backend/tests/test_session_ephemeral_retention.py
@@ -21,7 +21,9 @@ repo = importlib.import_module("server.database.job_repository")
 def db(tmp_path, monkeypatch):
     """Real SQLite DB with the transcription_jobs columns this feature touches."""
     db_path = tmp_path / "jobs.db"
-    conn = sqlite3.connect(db_path)
+    # check_same_thread=False: cleanup_old_recordings runs repo queries via
+    # asyncio.to_thread; production get_connection opens per-call connections.
+    conn = sqlite3.connect(db_path, check_same_thread=False)
     conn.row_factory = sqlite3.Row
     conn.execute(
         """
@@ -273,3 +275,128 @@ class TestGetLegacySessionRows:
         ids = {j["id"] for j in repo.get_legacy_session_rows()}
 
         assert ids == {"anchor-proc", "anchor-failed", "ws-done", "imp-done"}
+
+
+class TestCleanupOldRecordingsPurgesRows:
+    @staticmethod
+    def _run(max_age_days: int = 7) -> None:
+        import asyncio
+
+        from server.database import audio_cleanup
+
+        asyncio.run(audio_cleanup.cleanup_old_recordings("/data/recordings", max_age_days))
+
+    def test_purges_aged_delivered_session_rows(self, db, tmp_path):
+        wav = tmp_path / "ws.wav"
+        wav.write_bytes(b"RIFF")
+        _insert(
+            db,
+            "ws-old",
+            source="websocket",
+            status="completed",
+            delivered=1,
+            audio_path=str(wav),
+            completed_at="2020-01-01T00:00:00+00:00",
+        )
+
+        self._run()
+
+        assert _row(db, "ws-old") is None
+        assert not wav.exists()
+
+    def test_purges_aged_failed_imports(self, db):
+        _insert(
+            db,
+            "imp-fail-old",
+            source="file_import",
+            status="failed",
+            created_at="2020-01-01 00:00:00",
+        )
+
+        self._run()
+
+        assert _row(db, "imp-fail-old") is None
+
+    def test_keeps_non_session_rows_deletes_only_their_audio(self, db, tmp_path):
+        wav = tmp_path / "up.wav"
+        wav.write_bytes(b"RIFF")
+        _insert(
+            db,
+            "upload-old",
+            source="audio_upload",
+            status="completed",
+            delivered=1,
+            audio_path=str(wav),
+            completed_at="2020-01-01T00:00:00+00:00",
+        )
+
+        self._run()
+
+        assert _row(db, "upload-old") is not None  # row kept (status quo)
+        assert not wav.exists()  # WAV still garbage-collected
+
+    def test_keeps_failed_websocket_rows(self, db, tmp_path):
+        wav = tmp_path / "retryable.wav"
+        wav.write_bytes(b"RIFF")
+        _insert(
+            db,
+            "ws-failed",
+            source="websocket",
+            status="failed",
+            audio_path=str(wav),
+            created_at="2020-01-01 00:00:00",
+        )
+
+        self._run()
+
+        assert _row(db, "ws-failed") is not None
+        assert wav.exists()
+
+    def test_retention_zero_skips_everything(self, db):
+        _insert(
+            db,
+            "ws-old",
+            source="websocket",
+            status="completed",
+            delivered=1,
+            completed_at="2020-01-01T00:00:00+00:00",
+        )
+
+        self._run(max_age_days=0)
+
+        assert _row(db, "ws-old") is not None
+
+
+class TestPurgeLegacySessionRows:
+    def test_purges_anchors_and_delivered_rows_keeps_the_rest(self, db, tmp_path):
+        import asyncio
+
+        from server.database import audio_cleanup
+
+        wav = tmp_path / "done.wav"
+        wav.write_bytes(b"RIFF")
+        _insert(db, "anchor", source="file_import", status="failed")
+        _insert(
+            db,
+            "ws-done",
+            source="websocket",
+            status="completed",
+            delivered=1,
+            result_text="x",
+            audio_path=str(wav),
+        )
+        _insert(
+            db,
+            "ws-undelivered",
+            source="websocket",
+            status="completed",
+            delivered=0,
+            result_text="precious",
+        )
+
+        asyncio.run(audio_cleanup.purge_legacy_session_rows())
+
+        assert _row(db, "anchor") is None
+        assert _row(db, "ws-done") is None
+        assert not wav.exists()
+        assert _row(db, "ws-undelivered") is not None

--- a/server/backend/tests/test_transcription_durability_routes.py
+++ b/server/backend/tests/test_transcription_durability_routes.py
@@ -206,6 +206,87 @@ class TestGetTranscriptionResult:
             asyncio.run(transcription.get_transcription_result("job-corrupt", _request()))
         assert exc.value.status_code == 500
 
+    # ── Session ephemeral retention (2026-08-09 spec) ────────────────────────
+
+    def test_200_purges_session_source_job(self, repo, monkeypatch):
+        purged: list[str] = []
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {
+                "status": "completed",
+                "client_name": None,
+                "source": "file_import",
+                "result_json": '{"text": "hi"}',
+            },
+        )
+        monkeypatch.setattr(repo, "delete_job", lambda jid: purged.append(jid))
+
+        resp = asyncio.run(transcription.get_transcription_result("job-imp", _request()))
+
+        assert resp.status_code == 200
+        assert purged == ["job-imp"]
+
+    def test_200_keeps_non_session_job(self, repo, monkeypatch):
+        purged: list[str] = []
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {
+                "status": "completed",
+                "client_name": None,
+                "source": "audio_upload",
+                "result_json": '{"text": "hi"}',
+            },
+        )
+        monkeypatch.setattr(repo, "delete_job", lambda jid: purged.append(jid))
+
+        resp = asyncio.run(transcription.get_transcription_result("job-up", _request()))
+
+        assert resp.status_code == 200
+        assert purged == []
+
+    def test_410_purges_failed_import_without_audio(self, repo, monkeypatch):
+        purged: list[str] = []
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {
+                "status": "failed",
+                "client_name": None,
+                "source": "file_import",
+                "audio_path": None,
+                "error_message": "boom",
+            },
+        )
+        monkeypatch.setattr(repo, "delete_job", lambda jid: purged.append(jid))
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(transcription.get_transcription_result("job-if", _request()))
+
+        assert exc.value.status_code == 410
+        assert purged == ["job-if"]
+
+    def test_410_keeps_failed_websocket_job(self, repo, monkeypatch):
+        purged: list[str] = []
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {
+                "status": "failed",
+                "client_name": None,
+                "source": "websocket",
+                "audio_path": "/data/recordings/x.wav",
+                "error_message": "boom",
+            },
+        )
+        monkeypatch.setattr(repo, "delete_job", lambda jid: purged.append(jid))
+
+        with pytest.raises(HTTPException):
+            asyncio.run(transcription.get_transcription_result("job-ws", _request()))
+
+        assert purged == []
+
 
 # ── POST /api/transcribe/retry/{job_id} ──────────────────────────────────────
 
@@ -457,6 +538,36 @@ class TestDismissTranscriptionResult:
         resp = asyncio.run(transcription.dismiss_transcription_result("job-null", _request()))
 
         assert resp.status_code == 200
+
+    # ── Session ephemeral retention (2026-08-09 spec) ────────────────────────
+
+    def test_dismiss_purges_completed_session_job(self, repo, monkeypatch):
+        purged: list[str] = []
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {"status": "completed", "client_name": None, "source": "websocket"},
+        )
+        monkeypatch.setattr(repo, "delete_job", lambda jid: purged.append(jid))
+
+        resp = asyncio.run(transcription.dismiss_transcription_result("job-d", _request()))
+
+        assert resp.status_code == 200
+        assert purged == ["job-d"]
+
+    def test_dismiss_keeps_non_session_job(self, repo, monkeypatch):
+        purged: list[str] = []
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {"status": "completed", "client_name": None, "source": "audio_upload"},
+        )
+        monkeypatch.setattr(repo, "delete_job", lambda jid: purged.append(jid))
+
+        resp = asyncio.run(transcription.dismiss_transcription_result("job-d2", _request()))
+
+        assert resp.status_code == 200
+        assert purged == []
 
 
 class TestTranscribeDecodeErrorRouting:

--- a/server/backend/tests/test_websocket_disconnect_salvage.py
+++ b/server/backend/tests/test_websocket_disconnect_salvage.py
@@ -119,6 +119,7 @@ def _patch_transcription(monkeypatch, tmp_path, *, result: _FakeResult | None = 
 
     monkeypatch.setattr(ws_mod, "_save_result", MagicMock())
     monkeypatch.setattr(ws_mod, "_mark_delivered", MagicMock())
+    monkeypatch.setattr(ws_mod, "_delete_job", MagicMock())
     monkeypatch.setattr(ws_mod, "_mark_failed", MagicMock())
     monkeypatch.setattr(ws_mod, "_set_audio_path", MagicMock())
 

--- a/server/backend/tests/test_websocket_notebook_autoadd.py
+++ b/server/backend/tests/test_websocket_notebook_autoadd.py
@@ -100,6 +100,7 @@ def _patch_transcription(monkeypatch, tmp_path, *, result: _FakeResult | None = 
     # Durability writes — irrelevant here, keep them silent.
     monkeypatch.setattr(ws_mod, "_save_result", MagicMock())
     monkeypatch.setattr(ws_mod, "_mark_delivered", MagicMock())
+    monkeypatch.setattr(ws_mod, "_delete_job", MagicMock())
     monkeypatch.setattr(ws_mod, "_mark_failed", MagicMock())
     monkeypatch.setattr(ws_mod, "_set_audio_path", MagicMock())
 

--- a/server/backend/tests/test_websocket_session_purge.py
+++ b/server/backend/tests/test_websocket_session_purge.py
@@ -1,0 +1,197 @@
+"""Tests for the WS session post-delivery purge (session ephemeral retention).
+
+A mic-session job whose final actually reached the client must leave no
+server-side trace: process_transcription purges the transcription_jobs row
+(and its WAV) right after delivery + notebook auto-add. The purge must NOT
+fire for the >1MB result_ready reference path (GET /result purges instead)
+nor when a notebook auto-add fails (row + WAV stay as the recovery copy).
+
+Factory copied from test_websocket_notebook_autoadd.py — do NOT add session
+attributes here; the purge is method-local by design.
+
+Run:  ../../build/.venv/bin/pytest tests/test_websocket_session_purge.py -v --tb=short
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from server.api.routes import websocket as ws_mod
+from server.core import model_manager as mm_mod
+from starlette.websockets import WebSocketState
+
+
+@dataclass
+class _FakeResult:
+    """Duck-typed TranscriptionResult (avoids the torch/webrtcvad import chain)."""
+
+    text: str = "hello world"
+    segments: list[dict[str, Any]] = field(default_factory=list)
+    words: list[dict[str, Any]] = field(default_factory=list)
+    language: str | None = "en"
+    language_probability: float = 0.9
+    duration: float = 2.0
+    num_speakers: int = 0
+    partial: bool = False
+    partial_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "text": self.text,
+            "segments": self.segments,
+            "words": self.words,
+            "language": self.language,
+            "language_probability": self.language_probability,
+            "duration": self.duration,
+            "num_speakers": self.num_speakers,
+            "total_words": len(self.words),
+            "partial": self.partial,
+            "partial_reason": self.partial_reason,
+            "metadata": {"num_segments": len(self.segments)},
+        }
+
+
+def _make_session(*, auto_add: bool = False, job_id: str | None = "job-001"):
+    """Build a TranscriptionSession without running the heavy __init__."""
+    session = object.__new__(ws_mod.TranscriptionSession)
+    session.websocket = MagicMock()
+    session.websocket.client_state = WebSocketState.CONNECTED
+    session.websocket.send_json = AsyncMock()
+    session.client_name = "test-client"
+    session.is_recording = False
+    session.language = None
+    session.audio_chunks = [b"\x00\x01" * 16000]  # 1s of 16 kHz Int16 mono
+    session.sample_rate = 16000
+    session.temp_file = None
+    session.translation_enabled = False
+    session.translation_target_language = "en"
+    session._preview_in_progress = False
+    session._preview_task = None
+    session._client_disconnected = False
+    session._current_job_id = job_id
+    session.auto_add_to_notebook = auto_add
+    session.diarization_enabled = False
+    session.expected_speakers = None
+    session._salvage_reason = None
+    session.send_message = AsyncMock()
+    return session
+
+
+def _patch_transcription(monkeypatch, tmp_path, *, result: _FakeResult | None = None):
+    """Patch everything process_transcription() touches except the purge hop."""
+    fake_engine = MagicMock()
+    fake_engine.model_name = "large-v3"
+    fake_engine.transcribe_file.return_value = result or _FakeResult()
+
+    fake_manager = MagicMock()
+    fake_manager.ensure_transcription_loaded.return_value = fake_engine
+    monkeypatch.setattr(mm_mod, "get_model_manager", lambda: fake_manager)
+
+    monkeypatch.setattr(ws_mod, "_save_result", MagicMock())
+    monkeypatch.setattr(ws_mod, "_mark_delivered", MagicMock())
+    monkeypatch.setattr(ws_mod, "_mark_failed", MagicMock())
+    monkeypatch.setattr(ws_mod, "_set_audio_path", MagicMock())
+
+    import server.config as cfg_mod
+
+    fake_cfg = MagicMock()
+    fake_cfg.get.side_effect = lambda *a, **kw: (
+        str(tmp_path) if a[:2] == ("durability", "recordings_dir") else kw.get("default")
+    )
+    monkeypatch.setattr(cfg_mod, "get_config", lambda: fake_cfg)
+
+    import server.core.webhook as wh_mod
+
+    monkeypatch.setattr(wh_mod, "dispatch", AsyncMock())
+
+    return fake_engine
+
+
+def _sent(session) -> list[str]:
+    return [c.args[0] for c in session.send_message.call_args_list]
+
+
+def test_delivered_session_purges_row(monkeypatch, tmp_path):
+    """Happy path: persisted + delivered inline + no auto-add → purged."""
+    _patch_transcription(monkeypatch, tmp_path)
+    purge = MagicMock()
+    monkeypatch.setattr(ws_mod, "_delete_job", purge)
+
+    session = _make_session()
+    asyncio.run(session.process_transcription())
+
+    assert "final" in _sent(session)
+    purge.assert_called_once_with("job-001")
+
+
+def test_reference_path_defers_purge_to_result_fetch(monkeypatch, tmp_path):
+    """>1MB payload goes out as a result_ready reference — GET /result purges."""
+    big = _FakeResult(text="x" * 1_100_000)
+    _patch_transcription(monkeypatch, tmp_path, result=big)
+    purge = MagicMock()
+    monkeypatch.setattr(ws_mod, "_delete_job", purge)
+
+    session = _make_session()
+    asyncio.run(session.process_transcription())
+
+    assert "result_ready" in _sent(session)
+    purge.assert_not_called()
+
+
+def test_autoadd_success_still_purges(monkeypatch, tmp_path):
+    """Notebook copy exists → the session row has no reason to stay."""
+    _patch_transcription(monkeypatch, tmp_path)
+    monkeypatch.setattr(ws_mod, "_save_session_to_notebook", MagicMock(return_value=42))
+    purge = MagicMock()
+    monkeypatch.setattr(ws_mod, "_delete_job", purge)
+
+    session = _make_session(auto_add=True)
+    asyncio.run(session.process_transcription())
+
+    purge.assert_called_once_with("job-001")
+
+
+def test_autoadd_returning_none_cancels_purge(monkeypatch, tmp_path):
+    """No notebook copy was written → keep row + WAV, nothing may be lost."""
+    _patch_transcription(monkeypatch, tmp_path)
+    monkeypatch.setattr(ws_mod, "_save_session_to_notebook", MagicMock(return_value=None))
+    monkeypatch.setattr(ws_mod, "_warn_notebook_autoadd_failed", MagicMock())
+    purge = MagicMock()
+    monkeypatch.setattr(ws_mod, "_delete_job", purge)
+
+    session = _make_session(auto_add=True)
+    asyncio.run(session.process_transcription())
+
+    purge.assert_not_called()
+
+
+def test_autoadd_exception_cancels_purge(monkeypatch, tmp_path):
+    _patch_transcription(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        ws_mod, "_save_session_to_notebook", MagicMock(side_effect=RuntimeError("disk full"))
+    )
+    monkeypatch.setattr(ws_mod, "_warn_notebook_autoadd_failed", MagicMock())
+    purge = MagicMock()
+    monkeypatch.setattr(ws_mod, "_delete_job", purge)
+
+    session = _make_session(auto_add=True)
+    asyncio.run(session.process_transcription())
+
+    purge.assert_not_called()
+
+
+def test_purge_error_never_reaches_the_client(monkeypatch, tmp_path):
+    """delete_job is never-raise by contract, but the call site is belt-and-braces
+    guarded: a purge error must not surface as a post-delivery error banner."""
+    _patch_transcription(monkeypatch, tmp_path)
+    monkeypatch.setattr(ws_mod, "_delete_job", MagicMock(side_effect=RuntimeError("boom")))
+
+    session = _make_session()
+    asyncio.run(session.process_transcription())
+
+    sent = _sent(session)
+    assert "final" in sent
+    assert "error" not in sent


### PR DESCRIPTION
## Summary

The Session tab is now truly ephemeral. A session transcription (mic recording or file import) leaves no server-side trace - no `transcription_jobs` row, no audio file - once its result is **confirmed delivered** to the client. The only permanent copy is the Audio Notebook entry, and only when auto-add-to-notebook is enabled (mic recordings only). Spec: `docs/superpowers/specs/2026-08-09-session-ephemeral-retention-design.md`, plan: `docs/superpowers/plans/2026-08-09-session-ephemeral-retention.md`.

### The duplicate dialog is gone at the root
- `POST /api/transcribe/import` no longer computes audio hashes or returns `dedup_matches` (also removes a whole-file PCM decode from import startup). The dashboard's session dedup prompt flow (`resolveDuplicateChoice`, `DuplicatePolicy`, the Folder Watch policy setting + its Settings UI and electron-store default) is deleted. `DedupPromptModal` and the standalone `/import/dedup-check` endpoint remain untouched.
- One-time startup purge removes the accumulated bare dedup-anchor rows that trigger today's dialog.

### Purge-after-confirmed-delivery (durability invariant preserved)
- New `job_repository.delete_job()` (best-effort, never raises) + `SESSION_SOURCES = ('websocket', 'file_import')`. Nothing outside these two sources is ever purged.
- WS mic path: purge fires only when the result was persisted, the final actually reached the client, and (when auto-add is ON) the notebook save succeeded. The >1MB `result_ready` reference path defers the purge to `GET /result/{job_id}`.
- `GET /result` 200, dismiss, and failed-import 410 purge session rows; failed mic jobs keep row + WAV indefinitely so `/retry` keeps working. Salvage banner, `/recent`, `/retry` behavior unchanged for anything undelivered.
- Backstop sweep extension catches crash-window stragglers and never-polled failed imports.

### /import durability bug fixed
- `_run_file_import` now persists via `save_result`/`mark_failed` BEFORE the in-memory job_tracker hand-off, so completed imports survive restarts and the orphan sweep stops flipping them to a false `failed`.
- The durability row is now mandatory (500 + slot release if the insert fails) and `/import` returns the FULL job id.
- The dashboard polls `GET /api/transcribe/result/{job_id}` (202/410/200/404) through the GH #202-safe absolute-base-URL client method instead of scraping `/api/admin/status`.

### Tests
- Backend: 2451 passed, 4 skipped (full suite). New: `test_session_ephemeral_retention.py`, `test_import_ephemeral_route.py`, `test_websocket_session_purge.py`, +6 purge tests in `test_transcription_durability_routes.py`.
- Dashboard: 2093 passed (full vitest), `tsc --noEmit` clean, `ui:contract:check` green.

## Smoke checklist
- [ ] Session mic recording -> transcript delivered -> `transcription_jobs` row gone, WAV gone
- [ ] Session mic recording with auto-add ON -> notebook entry exists, row + WAV gone
- [ ] Session file import of a previously-imported file -> NO duplicate dialog
- [ ] Import completes with dashboard closed -> reopen -> recovery banner offers it -> fetch -> row gone
- [ ] Failed import -> queue row shows the real error, no false 'job lost'
- [ ] Failed mic job -> retry works (WAV preserved)
- [ ] Packaged build: >1 MB import result fetch works (GH #202 regression check)
- [ ] Server restart after upgrade: log shows the legacy purge count once; second restart shows nothing