### PR TITLE
fix(stt): honour the configured diarization model on the WhisperX integrated path (GH-288)

### DIFF
--- a/dashboard/electron/__tests__/serverConfigPaths.test.ts
+++ b/dashboard/electron/__tests__/serverConfigPaths.test.ts
@@ -22,6 +22,7 @@ import {
   getServerConfigDir,
   getServerConfigPath,
   ensureServerConfigSeed,
+  resolveDiarizationModelForLaunch,
 } from '../serverConfigPaths.js';
 
 function cleanup(): void {
@@ -59,5 +60,96 @@ describe('serverConfigPaths', () => {
     fs.writeFileSync(getServerConfigPath(), 'stt:\n  buffer_size: 256\n', 'utf-8');
     ensureServerConfigSeed();
     expect(fs.readFileSync(getServerConfigPath(), 'utf-8')).toContain('buffer_size: 256');
+  });
+});
+
+describe('resolveDiarizationModelForLaunch (GH-288)', () => {
+  const DEFAULT = 'pyannote/speaker-diarization-community-1';
+
+  function writeOverlay(text: string): void {
+    fs.mkdirSync(getServerConfigDir(), { recursive: true });
+    fs.writeFileSync(getServerConfigPath(), text, 'utf-8');
+  }
+
+  it('substitutes the overlay diarization.model for the PyAnnote-default request', () => {
+    writeOverlay('diarization:\n    model: pyannote/speaker-diarization-3.1\n');
+    expect(resolveDiarizationModelForLaunch(DEFAULT)).toBe('pyannote/speaker-diarization-3.1');
+  });
+
+  it('matches the PyAnnote default case-insensitively and ignores padding', () => {
+    writeOverlay('diarization:\n    model: pyannote/speaker-diarization-3.1\n');
+    expect(resolveDiarizationModelForLaunch('  Pyannote/Speaker-Diarization-Community-1 ')).toBe(
+      'pyannote/speaker-diarization-3.1',
+    );
+  });
+
+  it('is section-aware: never picks up model keys from other sections', () => {
+    writeOverlay(
+      'main_transcriber:\n    model: nvidia/parakeet-tdt-0.6b-v3\n' +
+        'diarization:\n    model: pyannote/speaker-diarization-3.1\n',
+    );
+    expect(resolveDiarizationModelForLaunch(DEFAULT)).toBe('pyannote/speaker-diarization-3.1');
+
+    // diarization section present but without a model key — the
+    // main_transcriber model must NOT leak into the diarization env.
+    writeOverlay(
+      'main_transcriber:\n    model: nvidia/parakeet-tdt-0.6b-v3\n' +
+        'diarization:\n    parallel: false\n',
+    );
+    expect(resolveDiarizationModelForLaunch(DEFAULT)).toBe(DEFAULT);
+  });
+
+  it('unquotes quoted overlay values', () => {
+    writeOverlay('diarization:\n    model: "pyannote/speaker-diarization-3.1"\n');
+    expect(resolveDiarizationModelForLaunch(DEFAULT)).toBe('pyannote/speaker-diarization-3.1');
+  });
+
+  it('passes explicit Custom models through untouched even when the overlay is set', () => {
+    writeOverlay('diarization:\n    model: pyannote/speaker-diarization-3.1\n');
+    expect(resolveDiarizationModelForLaunch('org/some-custom-diarizer')).toBe(
+      'org/some-custom-diarizer',
+    );
+  });
+
+  it('leaves the empty sentinel (Sortformer/CAM++ server auto-select) untouched', () => {
+    writeOverlay('diarization:\n    model: pyannote/speaker-diarization-3.1\n');
+    expect(resolveDiarizationModelForLaunch('')).toBe('');
+  });
+
+  it('keeps the default when no overlay file exists', () => {
+    expect(resolveDiarizationModelForLaunch(DEFAULT)).toBe(DEFAULT);
+  });
+
+  it('keeps the default on the seeded comment-only stub', () => {
+    ensureServerConfigSeed();
+    expect(resolveDiarizationModelForLaunch(DEFAULT)).toBe(DEFAULT);
+  });
+
+  it('treats an empty overlay model value as unset', () => {
+    writeOverlay('diarization:\n    model: ""\n');
+    expect(resolveDiarizationModelForLaunch(DEFAULT)).toBe(DEFAULT);
+  });
+
+  it('treats YAML null forms as unset — clearing the Settings field writes a bare null', () => {
+    // ServerConfigEditor's parseFieldValue() maps a cleared text input to JS
+    // null, and YAML.stringify emits the bare line `model: null`.
+    writeOverlay('diarization:\n    model: null\n');
+    expect(resolveDiarizationModelForLaunch(DEFAULT)).toBe(DEFAULT);
+    writeOverlay('diarization:\n    model: ~\n');
+    expect(resolveDiarizationModelForLaunch(DEFAULT)).toBe(DEFAULT);
+    writeOverlay('diarization:\n    model: NULL\n');
+    expect(resolveDiarizationModelForLaunch(DEFAULT)).toBe(DEFAULT);
+  });
+
+  it('runs the seed/legacy migration before reading, so the first launch after an upgrade sees the legacy value', () => {
+    // Legacy layout: overlay still at userData/config.yaml, server-config dir
+    // absent. startContainer only seeds/migrates AFTER the env assembly, so the
+    // resolver must trigger the migration itself or the first launch misses it.
+    fs.writeFileSync(
+      path.join(userDataRoot, 'config.yaml'),
+      'diarization:\n    model: pyannote/speaker-diarization-3.1\n',
+      'utf-8',
+    );
+    expect(resolveDiarizationModelForLaunch(DEFAULT)).toBe('pyannote/speaker-diarization-3.1');
   });
 });

--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -27,6 +27,7 @@ import {
   ensureServerConfigSeed,
   getServerConfigDir,
   getServerConfigPath,
+  resolveDiarizationModelForLaunch,
 } from './serverConfigPaths.js';
 import {
   type ContainerRuntimeKind,
@@ -2620,8 +2621,11 @@ async function startContainer(options: StartContainerOptions): Promise<string> {
     envUpdates['LIVE_TRANSCRIBER_MODEL'] = liveTranscriberModel;
   }
   if (diarizationModel !== undefined) {
-    composeEnv['DIARIZATION_MODEL'] = diarizationModel;
-    envUpdates['DIARIZATION_MODEL'] = diarizationModel;
+    // GH-288: the PyAnnote pill sends the default model name; substitute the
+    // Settings-modal overlay value so config.yaml's diarization.model is honoured.
+    const effectiveDiarizationModel = resolveDiarizationModelForLaunch(diarizationModel);
+    composeEnv['DIARIZATION_MODEL'] = effectiveDiarizationModel;
+    envUpdates['DIARIZATION_MODEL'] = effectiveDiarizationModel;
   }
   if (sensevoiceDiarizationEngine !== undefined) {
     composeEnv['SENSEVOICE_DIARIZATION_ENGINE'] = sensevoiceDiarizationEngine;

--- a/dashboard/electron/mlxServerManager.ts
+++ b/dashboard/electron/mlxServerManager.ts
@@ -16,7 +16,11 @@ import { promisify } from 'util';
 import { app, BrowserWindow } from 'electron';
 import * as fs from 'fs';
 import * as path from 'path';
-import { ensureServerConfigSeed, getServerConfigDir } from './serverConfigPaths.js';
+import {
+  ensureServerConfigSeed,
+  getServerConfigDir,
+  resolveDiarizationModelForLaunch,
+} from './serverConfigPaths.js';
 import { hfCacheDirName } from './hfRepoAliases.js';
 import { resolveMacDmgAssetName } from './appVariant.js';
 import type { MlxLogSink } from './mlxLogSink.js';
@@ -132,7 +136,10 @@ export class MLXServerManager {
     if (opts.hfToken) env.HF_TOKEN = opts.hfToken;
     if (opts.mainTranscriberModel) env.MAIN_TRANSCRIBER_MODEL = opts.mainTranscriberModel;
     if (opts.liveTranscriberModel) env.LIVE_TRANSCRIBER_MODEL = opts.liveTranscriberModel;
-    if (opts.diarizationModel) env.DIARIZATION_MODEL = opts.diarizationModel;
+    // GH-288: substitute the Settings-modal overlay model when the PyAnnote
+    // pill's default sentinel is requested (same funnel as the Docker path).
+    if (opts.diarizationModel)
+      env.DIARIZATION_MODEL = resolveDiarizationModelForLaunch(opts.diarizationModel);
 
     // Ensure required directories exist.
     for (const dir of [

--- a/dashboard/electron/serverConfigPaths.ts
+++ b/dashboard/electron/serverConfigPaths.ts
@@ -56,6 +56,84 @@ const SPARSE_STUB: string = [
  *
  * Idempotent. Returns the absolute path to config.yaml.
  */
+/**
+ * The Server tab's "PyAnnote" pill stores this literal model name — it is also
+ * the server's own bundled default (server/config.yaml `diarization.model`).
+ */
+export const PYANNOTE_DEFAULT_DIARIZATION_MODEL = 'pyannote/speaker-diarization-community-1';
+
+/**
+ * Read `diarization.model` from the user's sparse overlay config.yaml.
+ *
+ * Section-aware line scan (no YAML dependency in the main process): only a
+ * `model:` line INSIDE the top-level `diarization:` block counts — a naive
+ * whole-document key match would pick up `main_transcriber.model` instead.
+ */
+function readOverlayDiarizationModel(): string | undefined {
+  let text: string;
+  try {
+    text = fs.readFileSync(getServerConfigPath(), 'utf-8');
+  } catch {
+    return undefined;
+  }
+
+  let inDiarization = false;
+  for (const line of text.split(/\r?\n/)) {
+    if (/^diarization:\s*(?:#.*)?$/.test(line)) {
+      inDiarization = true;
+      continue;
+    }
+    if (!inDiarization) continue;
+    // Any non-blank, non-comment line at column 0 starts the next top-level section.
+    if (/^\S/.test(line)) break;
+    const m = /^\s+model:\s*(["']?)([^"'#\r\n]*?)\1\s*(?:#.*)?$/.exec(line);
+    if (m) {
+      const value = m[2].trim();
+      // Clearing the Settings-modal field stores JS null, which YAML.stringify
+      // writes as a bare `model: null` — YAML null forms mean "unset", never a
+      // literal model name.
+      if (!value || /^(null|~)$/i.test(value)) return undefined;
+      return value;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Launch-time diarization model resolution (GH-288).
+ *
+ * The Server tab's "PyAnnote" pill bridges an EXPLICIT
+ * `DIARIZATION_MODEL=pyannote/speaker-diarization-community-1` into the
+ * container/native env, and env bridges beat the config.yaml overlay — so the
+ * Settings modal's `diarization.model` field could never take effect. The pill
+ * means "pyannote engine", not "this exact model": when the requested model is
+ * that default sentinel, substitute the overlay's configured model instead.
+ * Explicit Custom picks and the empty auto-select sentinel (Sortformer/CAM++)
+ * pass through untouched. Reads the overlay at launch time so a Settings edit
+ * only needs a server restart, never a dashboard restart.
+ *
+ * A Custom entry whose text exactly equals the default sentinel is
+ * indistinguishable at this funnel and is treated as the pill — ServerView's
+ * hydration (mapDiarizationModelToSelection) collapses that state to the pill
+ * anyway, so the distinction does not survive in the UI either.
+ */
+export function resolveDiarizationModelForLaunch(requested: string): string {
+  if (!requested) return requested;
+  if (requested.trim().toLowerCase() !== PYANNOTE_DEFAULT_DIARIZATION_MODEL.toLowerCase()) {
+    return requested;
+  }
+  // The call sites seed/migrate the server-config dir only AFTER assembling the
+  // env, so trigger the (idempotent) seed here — otherwise the first launch
+  // after a legacy-layout upgrade reads a not-yet-migrated overlay. A config-dir
+  // hiccup must never abort a server launch: fall back to the requested model.
+  try {
+    ensureServerConfigSeed();
+  } catch {
+    return requested;
+  }
+  return readOverlayDiarizationModel() ?? requested;
+}
+
 export function ensureServerConfigSeed(): string {
   const dir = getServerConfigDir();
   const target = getServerConfigPath();

--- a/server/backend/core/stt/backends/whisperx_backend.py
+++ b/server/backend/core/stt/backends/whisperx_backend.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import numpy as np
 import soundfile as sf
+from server.config import get_config
 from server.core.audio_utils import clear_gpu_cache
 from server.core.stt.backends.base import (
     BackendSegment,
@@ -346,11 +347,23 @@ class WhisperXBackend(STTBackend):
         _report(80)  # alignment done
 
         # 3. Diarize
-        logger.info("WhisperX: running diarization")
+        # Honour the configured diarization model (config.yaml `diarization.model`,
+        # or the DIARIZATION_MODEL env override). Omitting model_name makes whisperx
+        # fall back to its own bundled default, silently ignoring the user's choice
+        # and re-downloading a model they did not ask for (GH #288).
+        diarization_model = get_config().config.get("diarization", {}).get("model") or None
+        logger.info(
+            "WhisperX: running diarization (model=%s)",
+            diarization_model or "whisperx default",
+        )
         # whisperx >= 3.8 renamed the HuggingFace-token kwarg from ``use_auth_token``
         # to ``token`` (GH #152). Passing the old name raises TypeError, which the
         # route silently swallows and degrades to the fragile sequential pyannote path.
-        diarize_model = DiarizationPipeline(token=token, device=self._device)
+        diarize_model = DiarizationPipeline(
+            model_name=diarization_model,
+            token=token,
+            device=self._device,
+        )
 
         diarize_kwargs: dict[str, Any] = {}
         if num_speakers is not None:

--- a/server/backend/tests/test_whisperx_backend.py
+++ b/server/backend/tests/test_whisperx_backend.py
@@ -566,6 +566,65 @@ def test_whisperx_diarization_progress_callback_failure_does_not_discard_result(
     assert calls == [(0, 1), (0, 1), (1, 1)]
 
 
+@pytest.mark.parametrize(
+    ("app_config", "expected_model_name"),
+    [
+        (
+            {"diarization": {"model": "pyannote/speaker-diarization-3.1"}},
+            "pyannote/speaker-diarization-3.1",
+        ),
+        ({}, None),
+        ({"diarization": {"model": ""}}, None),
+    ],
+    ids=["configured", "unconfigured", "empty-string"],
+)
+def test_whisperx_diarization_passes_configured_model(
+    monkeypatch, app_config, expected_model_name
+) -> None:
+    """GH #288: the configured diarization.model must reach DiarizationPipeline.
+
+    whisperx falls back to its own bundled default model when ``model_name`` is
+    omitted, silently ignoring config.yaml / the DIARIZATION_MODEL override and
+    re-downloading a model the user did not ask for. When no model is configured
+    (or it is an empty string), model_name must be None so whisperx keeps its
+    own default.
+    """
+    module = _import_whisperx_backend()
+    backend = module.WhisperXBackend()
+    backend._model = _ModernFakeModel()
+    backend._device = "cpu"
+    backend._align = lambda wx_result, audio, language: wx_result
+
+    whisperx_mod = types.ModuleType("whisperx")
+    whisperx_mod.assign_word_speakers = lambda diarize_segments, wx_result: wx_result
+
+    captured: dict[str, object] = {}
+
+    diarize_mod = types.ModuleType("whisperx.diarize")
+
+    class FakeDiarizationPipeline:
+        # Mirror the real whisperx>=3.8 signature (see GH #152 contract test below).
+        def __init__(self, model_name=None, token=None, device="cpu", cache_dir=None) -> None:
+            captured["model_name"] = model_name
+
+        def __call__(self, audio, **kwargs):
+            return [{"speaker": "SPEAKER_00"}]
+
+    diarize_mod.DiarizationPipeline = FakeDiarizationPipeline
+
+    monkeypatch.setitem(sys.modules, "whisperx", whisperx_mod)
+    monkeypatch.setitem(sys.modules, "whisperx.diarize", diarize_mod)
+    monkeypatch.setattr(
+        module,
+        "get_config",
+        lambda: types.SimpleNamespace(config=app_config),
+    )
+
+    backend.transcribe_with_diarization(np.zeros(16000, dtype=np.float32), hf_token="hf_test")
+
+    assert captured["model_name"] == expected_model_name
+
+
 def test_configure_decode_options_creates_instance_copy() -> None:
     """configure_decode_options() must store an instance copy, not mutate class default."""
     module = _import_whisperx_backend()
@@ -598,12 +657,16 @@ def test_real_diarization_pipeline_accepts_token_kwarg() -> None:
     sig = inspect.signature(diarize.DiarizationPipeline.__init__)
 
     # The exact kwargs the production code passes must bind without error.
+    # model_name carries the configured diarization.model (GH #288).
     try:
-        sig.bind_partial(token="hf_test", device="cpu")
+        sig.bind_partial(
+            model_name="pyannote/speaker-diarization-3.1", token="hf_test", device="cpu"
+        )
     except TypeError as exc:  # pragma: no cover - only hit on a real upstream rename
         pytest.fail(
-            "whisperx.diarize.DiarizationPipeline no longer accepts (token=, device=); "
-            f"update whisperx_backend.py to the new signature (GH #152): {exc}"
+            "whisperx.diarize.DiarizationPipeline no longer accepts "
+            "(model_name=, token=, device=); update whisperx_backend.py to the new "
+            f"signature (GH #152 / GH #288): {exc}"
         )
 
     # And the old name must not silently come back without us noticing.


### PR DESCRIPTION
## Summary

GH-288: changing the diarization model (config.yaml `diarization.model`, the `DIARIZATION_MODEL` env override, or the dashboard settings that feed them) had no effect - the server always used `pyannote/speaker-diarization-community-1`. Two independent bugs, fixed in two commits:

1. **Server (WhisperX call site):** the integrated single-pass path never passed `model_name` to whisperx's `DiarizationPipeline`, so whisperx fell back to its own bundled default regardless of config.
2. **Dashboard (env bridge):** the Server tab's PyAnnote pill bridges an EXPLICIT `DIARIZATION_MODEL=pyannote/speaker-diarization-community-1` into the container/native env, and env bridges beat the config.yaml overlay - so the Settings modal's Diarization > Model field could never take effect (empirically confirmed: overlay contained `speaker-diarization-3.1`, server still resolved community-1).

Thanks to @AppEternal for the report and the accurate diagnosis of the whisperx call site.

## Fix

**Commit 1 - server:**
- `whisperx_backend.py` resolves `diarization.model` from `get_config()` (same source as the sequential pyannote path, which already includes the `DIARIZATION_MODEL` env override) and passes it as `model_name=`. Unset/empty passes `None`, keeping whisperx's own default. The pre-diarization log line now includes the resolved model.
- No change to the `transcribe_with_diarization` signature (pinned cross-backend interface).

**Commit 2 - dashboard:**
- New launch-time guard `resolveDiarizationModelForLaunch()` in `serverConfigPaths.ts`: when the PyAnnote pill's default-model sentinel is bridged, substitute the `diarization.model` from the user's config.yaml overlay. The pill means "pyannote engine", not "this exact model". Explicit Custom picks and the empty auto-select sentinel (Sortformer/CAM++) pass through untouched.
- Applied in both launch funnels: `dockerManager.startContainer` (Docker) and `mlxServerManager.start` (macOS native), covering every start surface (ServerView, SessionView, App auto-start, MLX IPC).
- Overlay scan is section-aware (never picks up `main_transcriber.model`), treats YAML null forms (bare `null`/`~` written by clearing the Settings field) as unset, and triggers the idempotent seed/legacy migration before reading so the first launch after an upgrade sees the migrated value.
- Side benefit: bootstrap's model pre-download reads the same env, so it now pre-downloads the model that will actually run.

## Precedence (unchanged, now actually reachable)

Custom pill (explicit env bridge) > Settings modal `diarization.model` (overlay) > bundled default. Adversarial note: a Custom entry whose text exactly equals the default model name is indistinguishable from the pill at the launch funnel and is treated as the pill - ServerView's hydration collapses that state to the pill anyway.

## Known limitation

The Server tab's diarization download/cache badge still checks the pill's default model id, so with an overlay override it may report cache status for the wrong model. Cosmetic - the server downloads whatever model it actually needs at run time.

## Tests

- Server: new parametrized test pins the model pass-through and the unconfigured/empty fallback (watched RED before the fix); the GH-152 real-signature contract test now also binds `model_name=`. Full backend suite: 2454 passed, 5 skipped.
- Dashboard: 11 new `serverConfigPaths` cases (substitution, case-insensitive sentinel match, section-awareness, quoting, null forms, custom/empty passthrough, legacy-migration ordering) - all watched RED first. Full dashboard suite: 2111 passed, 147 files; typecheck clean.

## Testing checklist

- [x] GPU smoke (Docker): Settings modal Diarization > Model = `pyannote/speaker-diarization-3.1`, Server tab pill = PyAnnote, restart server, run a WhisperX import with diarization - server.log must show `Configured diarization model: pyannote/speaker-diarization-3.1` (bootstrap) and `WhisperX: running diarization (model=pyannote/speaker-diarization-3.1)`
- [x] GPU smoke (Docker): Server tab Custom = `pyannote/speaker-diarization-3.1` still works (already verified pre-fix via temp2.log, re-check post-fix)
- [x] Clearing the Settings modal Model field (writes `model: null`) falls back to the default, not a literal "null"
- [x] Default config (no overlay, PyAnnote pill) still uses `pyannote/speaker-diarization-community-1`
- [x] Sequential pyannote path (non-WhisperX model + diarization) unaffected