### PR TITLE
ci: harden apt-get steps against wedged runner mirrors

### DIFF
--- a/.github/actions/apt-install/action.yml
+++ b/.github/actions/apt-install/action.yml
@@ -1,0 +1,54 @@
+name: apt-get install (mirror-hang hardened)
+description: >-
+  apt-get update + install with bounded network timeouts, a bounded dpkg-lock
+  wait, and a short retry loop. The Azure apt mirror on ubuntu-latest runners
+  intermittently wedges plain apt-get for 20+ minutes (a ~20s FFmpeg install
+  has repeatedly hung past 25 minutes), so each attempt is capped and a bad
+  mirror fails the step within minutes instead of stalling the whole job.
+
+inputs:
+  packages:
+    description: Space-separated apt package names to install.
+    required: true
+  skip-if-present:
+    description: >-
+      Optional command name; when it already resolves on PATH the install is
+      skipped entirely (for tools preinstalled on runner images).
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: apt-get install with retry
+      shell: bash
+      env:
+        PACKAGES: ${{ inputs.packages }}
+        SKIP_IF_PRESENT: ${{ inputs.skip-if-present }}
+      run: |
+        set -u
+        if [[ -n "$SKIP_IF_PRESENT" ]] && command -v "$SKIP_IF_PRESENT" >/dev/null 2>&1; then
+          echo "'$SKIP_IF_PRESENT' already available; skipping apt install of: $PACKAGES"
+          exit 0
+        fi
+        read -ra packages <<< "$PACKAGES"
+        apt_opts=(
+          -o Acquire::Retries=3
+          -o Acquire::http::Timeout=30
+          -o Acquire::https::Timeout=30
+          -o DPkg::Lock::Timeout=120
+        )
+        # Worst case: 3 attempts x (90s update + 180s install) + 2 x 10s sleep
+        # = 830s (~14 min); the callers' timeout-minutes: 16 backstop must stay
+        # comfortably above this so our ::error:: annotation fires, not GitHub's
+        # generic step-timeout message.
+        for attempt in 1 2 3; do
+          if sudo timeout 90 apt-get "${apt_opts[@]}" update &&
+             sudo timeout 180 apt-get "${apt_opts[@]}" install -y --no-install-recommends "${packages[@]}"; then
+            exit 0
+          fi
+          echo "::warning::apt attempt ${attempt}/3 for '${PACKAGES}' failed or timed out"
+          if (( attempt < 3 )); then sleep 10; fi
+        done
+        echo "::error::apt-get install of '${PACKAGES}' failed after 3 attempts"
+        exit 1

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - "server/**"
       - ".github/workflows/backend-tests.yml"
+      - ".github/actions/apt-install/**"
   pull_request:
     branches: ["main"]
     paths:
       - "server/**"
       - ".github/workflows/backend-tests.yml"
+      - ".github/actions/apt-install/**"
 
 jobs:
   backend-tests:
@@ -26,7 +28,10 @@ jobs:
         # Required by tests/test_ffmpeg_utils.py, which exercises the
         # production audio-processing pipeline against the real ffmpeg
         # binary (resampling, normalization, format conversion).
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg
+        uses: ./.github/actions/apt-install
+        timeout-minutes: 16
+        with:
+          packages: ffmpeg
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/.github/workflows/scripts-lint.yml
+++ b/.github/workflows/scripts-lint.yml
@@ -14,9 +14,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install shellcheck
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y shellcheck
+        uses: ./.github/actions/apt-install
+        timeout-minutes: 16
+        with:
+          packages: shellcheck
 
       - name: Validate Bash syntax
         run: |
@@ -61,11 +62,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install PowerShell (if missing)
-        run: |
-          if ! command -v pwsh >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y powershell
-          fi
+        uses: ./.github/actions/apt-install
+        timeout-minutes: 16
+        with:
+          packages: powershell
+          skip-if-present: pwsh
 
       - name: Validate PowerShell syntax and lint
         shell: pwsh


### PR DESCRIPTION
## Summary

The `backend-tests` FFmpeg install step - historically 16-27 seconds - recurrently hangs for 20+ minutes when the ubuntu-latest runner lands on a wedged Azure apt mirror (latest occurrence: run 31795936650 attempt 1, stuck 28+ minutes in `apt-get update` before being cancelled; githubstatus.com showed all-operational, as mirror hiccups usually do). It happens often enough to be worth hardening.

## Change

New local composite action **`.github/actions/apt-install`** wrapping `apt-get update && install`:

- Bounded network behavior: `Acquire::Retries=3`, `Acquire::http/https::Timeout=30`, `DPkg::Lock::Timeout=120`
- Each attempt capped with `timeout(1)`: 90s for `update`, 180s for `install`
- 3 attempts with a 10s pause between them, `::warning::`/`::error::` annotations, so a bad mirror fails the step within minutes with a clear message instead of stalling the job
- Optional `skip-if-present` input: skips the install when the tool already resolves on PATH
- Worst case ~830s; every calling step carries a `timeout-minutes: 16` backstop so the action's own diagnostics fire before GitHub's generic step timeout

Applied to all three apt steps in CI:

| Workflow | Step | Notes |
|---|---|---|
| backend-tests | FFmpeg | also adds `.github/actions/apt-install/**` to the path filters so action edits trigger the workflow |
| scripts-lint | shellcheck | behavior otherwise unchanged |
| scripts-lint | powershell | keeps its skip-when-preinstalled guard via `skip-if-present: pwsh` |

The install steps now use `--no-install-recommends` uniformly (ffmpeg already did; shellcheck and powershell are self-contained tools with no meaningful recommends).

## Validation

- YAML parses cleanly; the embedded script passes shellcheck under GitHub's `bash -e -o pipefail` invocation semantics
- The retry loop's failure path avoids `set -e` pitfalls (`if A && B` condition form; `if (( attempt < 3 ))` guard instead of a bare `&&` list)
- This PR itself exercises the hardened FFmpeg step in `backend-tests` (the workflow file is in its own path filter)

## Testing checklist

- [ ] backend-tests run on this PR passes with the new FFmpeg step at normal speed (~20-30s)
- [ ] scripts-lint run on this PR passes (shellcheck installed via the action; powershell step skips as preinstalled)