### PR TITLE
feat: Add Nvidia DGX Spark support (Linux ARM64 with NVIDIA Blackwell GB10/CUDA)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,9 @@ codeql-agent-results/
 benchmark_*.json
 benchmark_*.csv
 
+## Local-only private workspace data
+local-private/
+
 ## Runtime data: SQLite + audio caches under server/data
 server/data/
 *.db

--- a/build/docker-build-push.sh
+++ b/build/docker-build-push.sh
@@ -12,7 +12,7 @@
 #   2. Logged into GHCR: docker login ghcr.io -u <username>
 #
 # Usage:
-#   ./docker-build-push.sh [--variant default|legacy|vulkan-wsl2] [TAG]
+#   ./docker-build-push.sh [--variant default|legacy|vulkan-wsl2|dgx-spark] [--build] [--push|--local-only] [TAG]
 #   TAG=v0.3.0 ./docker-build-push.sh
 #   VARIANT=legacy ./docker-build-push.sh v0.3.0
 #
@@ -25,6 +25,15 @@
 #   ./docker-build-push.sh --variant vulkan-wsl2 v0.3.0
 #                                                # Pushes local vulkan-wsl2 image 'v0.3.0' to
 #                                                # ghcr.io/homelab-00/transcriptionsuite-server-vulkan-wsl2
+#   ./docker-build-push.sh --variant dgx-spark v0.3.0
+#                                                # Uses local DGX Spark image 'v0.3.0' by default (no push)
+#   ./docker-build-push.sh --variant dgx-spark --build local-dgx
+#                                                # Builds DGX image locally only (default for dgx-spark)
+#   ./docker-build-push.sh --variant dgx-spark --build --push v0.3.0
+#                                                # Builds then pushes DGX image when explicitly requested
+#   ./docker-build-push.sh --variant dgx-spark --push v0.3.0
+#                                                # Pushes local DGX Spark image 'v0.3.0' to
+#                                                # ghcr.io/homelab-00/transcriptionsuite-server-dgx-spark
 #   TAG=dev ./docker-build-push.sh               # Pushes local image 'dev'
 #
 # Variants (Issue #83, GH-101):
@@ -32,6 +41,7 @@
 #   legacy      — Pascal/Maxwell support (cu126 wheels, sm_50..sm_90)
 #   vulkan-wsl2 — Windows + WSL2 GPU paravirtualization (AMD/Intel); same cu129
 #                 server image, GGML transcription via native whisper-server.exe
+#   dgx-spark   — Linux ARM64 + Blackwell GB10 (sm_121), NGC PyTorch base
 #
 # Each non-default variant pushes to a SEPARATE GHCR repo (suffix `-legacy` /
 # `-vulkan-wsl2`) so the dashboard's tag selector and version-sort logic stay
@@ -50,6 +60,7 @@ readonly NC='\033[0m' # No Color
 readonly DEFAULT_IMAGE_NAME="ghcr.io/homelab-00/transcriptionsuite-server"
 readonly LEGACY_IMAGE_NAME="ghcr.io/homelab-00/transcriptionsuite-server-legacy"
 readonly VULKAN_WSL2_IMAGE_NAME="ghcr.io/homelab-00/transcriptionsuite-server-vulkan-wsl2"
+readonly DGX_SPARK_IMAGE_NAME="ghcr.io/homelab-00/transcriptionsuite-server-dgx-spark"
 
 # Functions
 log_info() {
@@ -142,6 +153,8 @@ build_image() {
     local image_name=$1
     local tag=$2
     local pytorch_variant=$3
+    local base_image=$4
+    local uv_python_bin=$5
 
     # Resolve repo root from this script's location so the build context is correct
     # regardless of the caller's CWD.
@@ -152,6 +165,8 @@ build_image() {
     log_info "Building image: ${image_name}:${tag} (PYTORCH_VARIANT=${pytorch_variant})"
     if docker build \
         --build-arg "PYTORCH_VARIANT=${pytorch_variant}" \
+        --build-arg "BASE_IMAGE=${base_image}" \
+        --build-arg "UV_PYTHON_BIN=${uv_python_bin}" \
         -t "${image_name}:${tag}" \
         -f "${repo_root}/server/docker/Dockerfile" \
         "${repo_root}"; then
@@ -166,19 +181,27 @@ build_image() {
 print_usage() {
     cat <<'EOF'
 Usage:
-  ./docker-build-push.sh [--variant default|legacy|vulkan-wsl2] [--build] [TAG]
+    ./docker-build-push.sh [--variant default|legacy|vulkan-wsl2|dgx-spark] [--build] [--push|--local-only] [TAG]
 
 Flags:
-  --variant {default|legacy|vulkan-wsl2}
+    --variant {default|legacy|vulkan-wsl2|dgx-spark}
                               Image variant (default: default; or set VARIANT env)
                               default     — modern GPUs (cu129)
                               legacy      — Pascal/Maxwell support (cu126), pushes
                                             to ghcr.io/homelab-00/transcriptionsuite-server-legacy
                               vulkan-wsl2 — Windows + WSL2 GPU (AMD/Intel, cu129),
                                             pushes to ghcr.io/homelab-00/transcriptionsuite-server-vulkan-wsl2
+                              dgx-spark   — Linux ARM64 + Blackwell GB10 (sm_121),
+                                            NGC base image; pushes to
+                                            ghcr.io/homelab-00/transcriptionsuite-server-dgx-spark
   --build                     Build the image locally before pushing (passes
                               --build-arg PYTORCH_VARIANT=<variant>). Without
                               this flag the image is expected to already exist.
+    --push                      Push to GHCR after resolving/building the local image.
+                                                            Default for default/legacy/vulkan-wsl2 variants.
+                                                            Optional (opt-in) for dgx-spark.
+    --local-only                Build/resolve local image only; skip GHCR push.
+                                                            Default for dgx-spark.
   -h, --help                  Show this help
 
 Tag may also be provided via the TAG env var.
@@ -189,13 +212,14 @@ main() {
     local variant="${VARIANT:-default}"
     local do_build=false
     local custom_tag="${TAG:-}"
+    local push_mode="auto"
 
     # Argument parsing — accept flags in any order, with the bare positional TAG last.
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --variant)
                 if [[ $# -lt 2 ]]; then
-                    log_error "--variant requires a value (default|legacy|vulkan-wsl2)"
+                    log_error "--variant requires a value (default|legacy|vulkan-wsl2|dgx-spark)"
                     exit 1
                 fi
                 variant="$2"
@@ -207,6 +231,14 @@ main() {
                 ;;
             --build)
                 do_build=true
+                shift
+                ;;
+            --push)
+                push_mode="push"
+                shift
+                ;;
+            --local-only)
+                push_mode="local"
                 shift
                 ;;
             -h|--help)
@@ -232,17 +264,21 @@ main() {
     done
 
     # Resolve variant -> repo + build-arg.
-    local image_name pytorch_variant variant_label
+    local image_name pytorch_variant variant_label base_image uv_python_bin
     case "$variant" in
         default)
             image_name="$DEFAULT_IMAGE_NAME"
             pytorch_variant="cu129"
             variant_label="default (cu129)"
+            base_image="ubuntu:24.04"
+            uv_python_bin="/usr/bin/python3.13"
             ;;
         legacy)
             image_name="$LEGACY_IMAGE_NAME"
             pytorch_variant="cu126"
             variant_label="legacy (cu126, sm_50..sm_90 — Pascal/Maxwell)"
+            base_image="ubuntu:24.04"
+            uv_python_bin="/usr/bin/python3.13"
             ;;
         vulkan-wsl2)
             image_name="$VULKAN_WSL2_IMAGE_NAME"
@@ -252,9 +288,22 @@ main() {
             # never sets PYTORCH_VARIANT for this profile, so it matches `default`.
             pytorch_variant="cu129"
             variant_label="vulkan-wsl2 (cu129, Windows + WSL2 GPU paravirtualization — AMD/Intel)"
+            base_image="ubuntu:24.04"
+            uv_python_bin="/usr/bin/python3.13"
+            ;;
+        dgx-spark)
+            image_name="$DGX_SPARK_IMAGE_NAME"
+            pytorch_variant="cu129"
+            variant_label="dgx-spark (Linux ARM64 + Blackwell GB10, NGC PyTorch base)"
+            base_image="nvcr.io/nvidia/pytorch:25.09-py3"
+            uv_python_bin="/opt/conda/bin/python"
+            # DGX images are large; keep local-only by default.
+            if [[ "$push_mode" == "auto" ]]; then
+                push_mode="local"
+            fi
             ;;
         *)
-            log_error "Unknown variant: '$variant'. Expected 'default', 'legacy', or 'vulkan-wsl2'."
+            log_error "Unknown variant: '$variant'. Expected 'default', 'legacy', 'vulkan-wsl2', or 'dgx-spark'."
             exit 1
             ;;
     esac
@@ -262,17 +311,24 @@ main() {
     # Make IMAGE_NAME visible to push_image / tag_image (they use ${IMAGE_NAME}).
     IMAGE_NAME="$image_name"
 
+    if [[ "$push_mode" == "auto" ]]; then
+        push_mode="push"
+    fi
+
     echo "=========================================="
     echo "  TranscriptionSuite Docker Build & Push"
     echo "=========================================="
     echo ""
     log_info "Variant: ${variant_label}"
     log_info "Target repo: ${image_name}"
+    log_info "Publish mode: $([[ "$push_mode" == "push" ]] && echo "push to GHCR" || echo "local-only (no push)")"
     echo ""
 
     # Run checks
     check_prerequisites
-    check_docker_login
+    if [[ "$push_mode" == "push" ]]; then
+        check_docker_login
+    fi
 
     # Optional local build — needed for the legacy variant the first time it is published.
     if [[ "$do_build" == true ]]; then
@@ -280,7 +336,7 @@ main() {
             log_error "--build requires a TAG (positional or via TAG env)"
             exit 1
         fi
-        if ! build_image "$image_name" "$custom_tag" "$pytorch_variant"; then
+        if ! build_image "$image_name" "$custom_tag" "$pytorch_variant" "$base_image" "$uv_python_bin"; then
             exit 1
         fi
     fi
@@ -298,7 +354,7 @@ main() {
                 log_info "For the ${variant} variant, build it first with:"
                 log_info "  ./docker-build-push.sh --variant ${variant} --build vX.Y.Z"
                 log_info "or manually:"
-                log_info "  docker build --build-arg PYTORCH_VARIANT=${pytorch_variant} -t ${IMAGE_NAME}:vX.Y.Z -f server/docker/Dockerfile ."
+                log_info "  docker build --build-arg PYTORCH_VARIANT=${pytorch_variant} --build-arg BASE_IMAGE=${base_image} --build-arg UV_PYTHON_BIN=${uv_python_bin} -t ${IMAGE_NAME}:vX.Y.Z -f server/docker/Dockerfile ."
             fi
             exit 1
         fi
@@ -317,6 +373,21 @@ main() {
             exit 1
         fi
         log_success "Image found: ${IMAGE_NAME}:$custom_tag"
+    fi
+
+    if [[ "$push_mode" != "push" ]]; then
+        echo ""
+        echo "=========================================="
+        log_success "Local image ready (push skipped)"
+        echo "=========================================="
+        echo ""
+        echo "Variant: ${variant_label}"
+        echo "Local image: ${IMAGE_NAME}:$custom_tag"
+        echo ""
+        echo "Run with compose (DGX overlay):"
+        echo "   IMAGE_REPO=${IMAGE_NAME} TAG=$custom_tag docker compose -f server/docker/docker-compose.yml -f server/docker/docker-compose.linux-host.yml -f server/docker/docker-compose.gpu.yml -f server/docker/docker-compose.dgx-spark.yml up -d"
+        echo ""
+        return
     fi
 
     # Push the requested tag

--- a/dashboard/electron/__tests__/composeFileArgs.test.ts
+++ b/dashboard/electron/__tests__/composeFileArgs.test.ts
@@ -42,13 +42,19 @@ function extractFiles(args: string[]): string[] {
 }
 
 const originalPlatform = process.platform;
+const originalArch = process.arch;
 
 function setPlatform(platform: string): void {
   Object.defineProperty(process, 'platform', { value: platform, writable: true });
 }
 
+function setArch(arch: string): void {
+  Object.defineProperty(process, 'arch', { value: arch, writable: true });
+}
+
 afterEach(() => {
   Object.defineProperty(process, 'platform', { value: originalPlatform, writable: true });
+  Object.defineProperty(process, 'arch', { value: originalArch, writable: true });
 });
 
 // ─── P1-DOCK-001: Compose File Selection ────────────────────────────────────
@@ -64,6 +70,7 @@ describe('[P1] composeFileArgs', () => {
 
   it('Linux + GPU (Docker legacy): base + linux-host + gpu', () => {
     setPlatform('linux');
+    setArch('x64');
     const args = composeFileArgs('gpu', 'docker', 'legacy');
     const files = extractFiles(args);
 
@@ -76,6 +83,7 @@ describe('[P1] composeFileArgs', () => {
 
   it('Linux + GPU (Docker CDI): base + linux-host + gpu-cdi', () => {
     setPlatform('linux');
+    setArch('x64');
     const args = composeFileArgs('gpu', 'docker', 'cdi');
     const files = extractFiles(args);
 
@@ -88,6 +96,7 @@ describe('[P1] composeFileArgs', () => {
 
   it('Linux + GPU (Podman): base + linux-host + podman gpu', () => {
     setPlatform('linux');
+    setArch('x64');
     const args = composeFileArgs('gpu', 'podman', null);
     const files = extractFiles(args);
 
@@ -122,6 +131,20 @@ describe('[P1] composeFileArgs', () => {
       'docker-compose.yml',
       'docker-compose.linux-host.yml',
       'docker-compose.vulkan.yml',
+    ]);
+  });
+
+  it('Linux ARM64 + GPU: adds DGX Spark overlay on top of the GPU stack', () => {
+    setPlatform('linux');
+    setArch('arm64');
+    const args = composeFileArgs('gpu', 'docker', 'legacy');
+    const files = extractFiles(args);
+
+    expect(files).toEqual([
+      'docker-compose.yml',
+      'docker-compose.linux-host.yml',
+      'docker-compose.gpu.yml',
+      'docker-compose.dgx-spark.yml',
     ]);
   });
 

--- a/dashboard/electron/__tests__/dockerManagerLegacyGpu.test.ts
+++ b/dashboard/electron/__tests__/dockerManagerLegacyGpu.test.ts
@@ -39,6 +39,7 @@ vi.mock('electron-store', () => ({
 import {
   IMAGE_REPO,
   LEGACY_IMAGE_REPO,
+  DGX_SPARK_IMAGE_REPO,
   VULKAN_WSL2_IMAGE_REPO,
   VULKAN_LINUX_IMAGE_REPO,
   resolveImageRepo,
@@ -48,6 +49,11 @@ import {
 } from '../dockerManager.js';
 
 const STORE_FILE = path.join(userDataRoot, 'dashboard-config.json');
+const originalArch = process.arch;
+
+function setArch(arch: string): void {
+  Object.defineProperty(process, 'arch', { value: arch, writable: true });
+}
 
 function writeStore(contents: Record<string, unknown>): void {
   fs.writeFileSync(STORE_FILE, JSON.stringify(contents), 'utf8');
@@ -63,6 +69,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  Object.defineProperty(process, 'arch', { value: originalArch, writable: true });
   try {
     fs.unlinkSync(STORE_FILE);
   } catch {
@@ -92,15 +99,24 @@ describe('[P1] Issue #83 — IMAGE_REPO constants', () => {
 
 describe('[P1] Issue #83 — resolveImageRepo', () => {
   it('returns the default repo when useLegacyGpu is false', () => {
+    setArch('x64');
     expect(resolveImageRepo(false)).toBe(IMAGE_REPO);
   });
 
   it('returns the legacy repo when useLegacyGpu is true', () => {
+    setArch('x64');
     expect(resolveImageRepo(true)).toBe(LEGACY_IMAGE_REPO);
   });
 
   it('never mixes repos — the two outputs are distinct', () => {
+    setArch('x64');
     expect(new Set([resolveImageRepo(false), resolveImageRepo(true)]).size).toBe(2);
+  });
+
+  it('routes Linux ARM64 CUDA runtime to the DGX Spark image repo', () => {
+    setArch('arm64');
+    expect(resolveImageRepo(false, 'gpu')).toBe(DGX_SPARK_IMAGE_REPO);
+    expect(resolveImageRepo(true, 'gpu')).toBe(DGX_SPARK_IMAGE_REPO);
   });
 
   it('returns the vulkan-linux repo when the runtime profile is vulkan', () => {
@@ -205,6 +221,7 @@ describe('[P1] Issue #99 — listRemoteTags token-401 mapping', () => {
   });
 
   it('legacy ON + token 401 → not-published (GH-99 defense)', async () => {
+    setArch('x64');
     writeStore({ 'server.useLegacyGpu': true });
     fetchSpy = mockFetch(
       async () => new Response('Unauthorized', { status: 401, statusText: 'Unauthorized' }),
@@ -218,6 +235,7 @@ describe('[P1] Issue #99 — listRemoteTags token-401 mapping', () => {
   });
 
   it('legacy OFF + token 401 → error (default repo 401 is a genuine fault)', async () => {
+    setArch('x64');
     writeStore({ 'server.useLegacyGpu': false });
     fetchSpy = mockFetch(
       async () => new Response('Unauthorized', { status: 401, statusText: 'Unauthorized' }),
@@ -228,6 +246,7 @@ describe('[P1] Issue #99 — listRemoteTags token-401 mapping', () => {
   });
 
   it('legacy ON + token 200 + tags 404 → not-published (regression guard for GH-83)', async () => {
+    setArch('x64');
     writeStore({ 'server.useLegacyGpu': true });
     fetchSpy = mockFetch(async (url) => {
       const s = String(url);
@@ -236,6 +255,17 @@ describe('[P1] Issue #99 — listRemoteTags token-401 mapping', () => {
       }
       return new Response('Not Found', { status: 404, statusText: 'Not Found' });
     });
+    const result = await listRemoteTags();
+    expect(result.status).toBe('not-published');
+    expect(result.tags).toEqual([]);
+  });
+
+  it('DGX Spark runtime + token 401 → not-published (first-push private package)', async () => {
+    setArch('arm64');
+    writeStore({ 'server.useLegacyGpu': false, 'server.runtimeProfile': 'gpu' });
+    fetchSpy = mockFetch(
+      async () => new Response('Unauthorized', { status: 401, statusText: 'Unauthorized' }),
+    );
     const result = await listRemoteTags();
     expect(result.status).toBe('not-published');
     expect(result.tags).toEqual([]);

--- a/dashboard/electron/dockerManager.ts
+++ b/dashboard/electron/dockerManager.ts
@@ -60,6 +60,7 @@ const __dirname = path.dirname(__filename);
 // stays self-contained (same reason as the inline semverDescending() below).
 export const IMAGE_REPO = 'ghcr.io/homelab-00/transcriptionsuite-server';
 export const LEGACY_IMAGE_REPO = 'ghcr.io/homelab-00/transcriptionsuite-server-legacy';
+export const DGX_SPARK_IMAGE_REPO = 'ghcr.io/homelab-00/transcriptionsuite-server-dgx-spark';
 export const VULKAN_WSL2_IMAGE_REPO = 'ghcr.io/homelab-00/transcriptionsuite-server-vulkan-wsl2';
 export const VULKAN_LINUX_IMAGE_REPO = 'ghcr.io/homelab-00/transcriptionsuite-server-vulkan-linux';
 
@@ -80,6 +81,10 @@ export const IMAGE_VARIANT_REPOS: Record<ImageVariant, string> = {
   'vulkan-linux': VULKAN_LINUX_IMAGE_REPO,
 };
 
+function isLinuxArm64Host(): boolean {
+  return process.platform === 'linux' && process.arch === 'arm64';
+}
+
 /**
  * Select the GHCR image repo for this session based on the persisted
  * `server.useLegacyGpu` setting (Issue #83 — Pascal/Maxwell support) and
@@ -94,6 +99,7 @@ export function resolveImageRepo(
 ): string {
   if (runtimeProfile === 'vulkan-wsl2') return VULKAN_WSL2_IMAGE_REPO;
   if (runtimeProfile === 'vulkan') return VULKAN_LINUX_IMAGE_REPO;
+  if (runtimeProfile === 'gpu' && isLinuxArm64Host()) return DGX_SPARK_IMAGE_REPO;
   return useLegacyGpu ? LEGACY_IMAGE_REPO : IMAGE_REPO;
 }
 
@@ -1455,6 +1461,13 @@ export function composeFileArgs(
       files.push('docker-compose.gpu-cdi.yml');
     } else {
       files.push('docker-compose.gpu.yml'); // legacy nvidia runtime
+    }
+
+    // DGX Spark (Linux ARM64 + NVIDIA Blackwell): add a small override that
+    // switches the build base image/interpreter while keeping the same runtime
+    // profile and GPU overlay semantics.
+    if (isLinuxArm64Host()) {
+      files.push('docker-compose.dgx-spark.yml');
     }
   }
 
@@ -4561,7 +4574,10 @@ export async function listRemoteTags(): Promise<RemoteTagsResult> {
       // (the realistic failure mode post-v1.3.3). Route to the same UI
       // affordance as a 404-on-tags-list so users see the actionable banner.
       // Same treatment for vulkan-wsl2 — a new package starts private on GHCR.
-      if (tokenResp.status === 401 && (useLegacyGpu || runtimeProfile === 'vulkan-wsl2')) {
+      if (
+        tokenResp.status === 401 &&
+        (useLegacyGpu || runtimeProfile === 'vulkan-wsl2' || resolveImageRepo(false, runtimeProfile) === DGX_SPARK_IMAGE_REPO)
+      ) {
         return { status: 'not-published', tags: [] };
       }
       return { status: 'error', tags: [] };

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -134,6 +134,10 @@
         "to": "docker/docker-compose.gpu-cdi.yml"
       },
       {
+        "from": "../server/docker/docker-compose.dgx-spark.yml",
+        "to": "docker/docker-compose.dgx-spark.yml"
+      },
+      {
         "from": "../server/docker/podman-compose.gpu.yml",
         "to": "docker/podman-compose.gpu.yml"
       },

--- a/dgx-spark-implemantation.md
+++ b/dgx-spark-implemantation.md
@@ -1,0 +1,156 @@
+# DGX Spark Implementation Plan (Linux ARM64 + NVIDIA Blackwell GB10)
+
+## Goal
+Integrate DGX Spark as an additive platform in the existing multi-platform TranscriptionSuite setup without breaking:
+- Windows CPU/CUDA Docker workflows
+- macOS Apple Silicon Metal bare-metal workflow
+- Linux x86_64 CUDA Docker workflow
+- Existing Vulkan sidecar workflows
+
+## Constraints
+- Keep current defaults unchanged for non-DGX platforms.
+- Avoid introducing a new runtime profile (high blast radius in UI/state/test matrix).
+- Reuse existing GPU runtime profile and compose layering model.
+- Preserve durability and startup invariants.
+
+## Design Summary
+1. Keep runtime profile model unchanged (`gpu`, `cpu`, `vulkan`, `vulkan-wsl2`, `metal`).
+2. Add a DGX-specific compose overlay: `server/docker/docker-compose.dgx-spark.yml`.
+3. Parameterize server Docker build with:
+   - `BASE_IMAGE` (default `ubuntu:24.04`)
+   - `UV_PYTHON_BIN` (default `/usr/bin/python3.13`)
+4. Add a DGX bootstrap mode (`BOOTSTRAP_USE_SYSTEM_TORCH=true`) to reuse NGC-provided torch/torchaudio from base image and skip reinstall into runtime venv.
+5. Route Linux ARM64 + GPU image pulls to a dedicated repo:
+   - `ghcr.io/homelab-00/transcriptionsuite-server-dgx-spark`
+6. Keep all existing behavior byte-compatible when DGX mode is not enabled.
+
+## Step-by-Step Tasks
+
+### Phase 1: Docker Build/Compose Plumbing
+1. Update `server/docker/Dockerfile`:
+   - Add `ARG BASE_IMAGE=ubuntu:24.04` and use `FROM ${BASE_IMAGE}`.
+   - Add `ARG UV_PYTHON_BIN=/usr/bin/python3.13` and export as env.
+2. Update `server/docker/docker-compose.yml`:
+   - Pass through new build args (`BASE_IMAGE`, `UV_PYTHON_BIN`).
+   - Pass through env vars (`UV_PYTHON_BIN`, `BOOTSTRAP_USE_SYSTEM_TORCH`).
+   - Document DGX compose overlay usage.
+3. Create `server/docker/docker-compose.dgx-spark.yml`:
+   - Set `BASE_IMAGE=nvcr.io/nvidia/pytorch:25.09-py3`.
+   - Set `UV_PYTHON_BIN=/opt/conda/bin/python`.
+   - Default `BOOTSTRAP_USE_SYSTEM_TORCH=true`.
+
+### Phase 2: Bootstrap Compatibility Mode
+1. Update `server/docker/bootstrap_runtime.py`:
+   - Read bootstrap interpreter from `UV_PYTHON_BIN`.
+   - In DGX mode, run `uv sync` with:
+     - `--no-install-package torch`
+     - `--no-install-package torchaudio`
+   - In DGX mode, pre-create runtime venv with `--system-site-packages`.
+   - Include DGX mode flag in fingerprinting input to avoid marker mismatches.
+2. Update `server/docker/docker-entrypoint.sh`:
+   - Use `UV_PYTHON_BIN` for pre-bootstrap Python scripts.
+
+### Phase 3: Dashboard/Electron Integration
+1. Update `dashboard/electron/dockerManager.ts`:
+   - Add DGX image repo constant.
+   - Add Linux ARM64 host detection helper.
+   - Resolve repo to DGX repo for `runtimeProfile === 'gpu'` on Linux ARM64.
+   - Add DGX compose overlay in `composeFileArgs()` for Linux ARM64 GPU.
+   - Map GHCR token 401 to `not-published` for DGX repo as first-push private-package case.
+
+### Phase 4: Build/Release Tooling
+1. Update `build/docker-build-push.sh`:
+   - Add `--variant dgx-spark`.
+   - Default DGX Spark mode to local-only (no push) due very large base image.
+   - Add explicit push opt-in (`--push`) and local-only override (`--local-only`).
+   - Push to DGX repo.
+   - Pass `BASE_IMAGE` and `UV_PYTHON_BIN` build args.
+
+### Phase 5: Tests and Validation
+1. Update/extend unit tests:
+   - `dashboard/electron/__tests__/composeFileArgs.test.ts`
+   - `dashboard/electron/__tests__/dockerManagerLegacyGpu.test.ts`
+2. Run targeted tests:
+   - Dashboard electron unit tests for compose/repo logic.
+3. Run full relevant suite for regression confidence:
+   - Dashboard test/typecheck as available.
+4. Optional platform smoke checks:
+   - Linux x86_64 GPU stack unchanged.
+   - Linux ARM64 GPU stack includes DGX overlay and repo resolution.
+
+## Risk Register
+- Python ABI mismatch between NGC base and project constraints.
+- Base-image torch compatibility with project dependencies at runtime.
+- GHCR package visibility defaults (`Private`) causing false-negative tag listing.
+
+## Rollback Plan
+- Remove DGX overlay from compose command to revert to default Linux GPU path.
+- Unset `BOOTSTRAP_USE_SYSTEM_TORCH` to return to default uv torch install behavior.
+- Revert image repo routing to default repo if DGX repo is not available.
+
+---
+
+# Full-Featured Delegation Prompt (for another coding agent/repository)
+
+Use this prompt verbatim:
+
+```text
+Task: Add DGX Spark platform support (Linux ARM64 + NVIDIA Blackwell GB10 sm_121) to an existing multi-platform transcription/diarization project without breaking existing platforms.
+
+Context:
+- Existing platforms:
+  - Windows CPU/CUDA via Docker
+  - macOS Apple Silicon via bare-metal MLX
+  - Linux x86_64 CUDA via Docker
+- Existing container stack uses layered compose overlays and a unified server Dockerfile.
+- Current base image is ubuntu:24.04 and runtime dependencies are bootstrapped at container start into a venv.
+
+Primary objective:
+Introduce DGX Spark support as an additive path that reuses existing GPU runtime profile semantics, while adding architecture-aware Docker/build/runtime behavior.
+
+Hard requirements:
+1) Keep defaults unchanged for all non-DGX users.
+2) Do NOT add a new runtime profile unless absolutely required.
+3) Add a DGX-specific compose overlay file that can be explicitly composed.
+4) Parameterize Dockerfile base image and bootstrap interpreter path.
+5) Support using NVIDIA NGC PyTorch base image on DGX Spark.
+6) Add bootstrap mode to reuse system torch/torchaudio from base image and skip reinstall in app venv.
+7) Add Linux ARM64 + GPU image-repo routing to a dedicated DGX image repo.
+8) Update build/push script with a DGX variant.
+9) DGX variant must default to local-only builds, with GHCR push as explicit opt-in.
+9) Add/adjust tests for compose selection and repo resolution.
+10) Update deployment docs with DGX run instructions.
+
+Implementation details to include:
+- Dockerfile args:
+  - BASE_IMAGE (default ubuntu:24.04)
+  - UV_PYTHON_BIN (default /usr/bin/python3.13)
+- Compose overlay example:
+  - docker-compose.dgx-spark.yml
+  - BASE_IMAGE=nvcr.io/nvidia/pytorch:25.09-py3
+  - UV_PYTHON_BIN=/opt/conda/bin/python
+  - BOOTSTRAP_USE_SYSTEM_TORCH=true
+- Bootstrap behavior:
+  - uv sync uses UV_PYTHON_BIN
+  - if BOOTSTRAP_USE_SYSTEM_TORCH=true:
+    - create venv with --system-site-packages
+    - add --no-install-package torch --no-install-package torchaudio
+    - include mode flag in bootstrap fingerprinting
+- Dashboard/backend runtime resolver behavior:
+  - If runtimeProfile == 'gpu' and host is Linux ARM64, use DGX repo
+- GHCR tag-list behavior:
+  - token 401 for DGX repo should map to not-published state (first push private)
+
+Validation checklist:
+- Unit tests for compose args pass.
+- Unit tests for repo resolution pass.
+- Existing non-DGX tests continue to pass.
+- Compose stack for Linux x86_64 unchanged.
+- DGX stack includes DGX overlay only when Linux ARM64 + GPU profile.
+
+Deliverables:
+1) Code changes.
+2) Test results with command outputs summarized.
+3) Risk notes (any unresolved ABI/runtime assumptions).
+4) Rollback instructions.
+```

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -266,6 +266,43 @@ When TLS is enabled:
   Maxwell (GTX 9-series, Tesla M40) are **not** supported by the default image —
   see [Legacy-GPU image variant](#legacy-gpu-image-variant-issue-83) below.
 
+### DGX Spark (Linux ARM64 + Blackwell GB10 / sm_121)
+
+DGX Spark uses an ARM64 CUDA stack and should run with the DGX overlay, which
+switches the server build to NVIDIA's NGC PyTorch base image.
+
+Manual start:
+
+```bash
+cd server/docker
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.linux-host.yml \
+  -f docker-compose.gpu.yml \
+  -f docker-compose.dgx-spark.yml up -d
+```
+
+Notes:
+- The DGX overlay is additive and does not change existing Windows/macOS/Linux x86_64 stacks.
+- It sets `BASE_IMAGE=nvcr.io/nvidia/pytorch:25.09-py3` and enables
+  `BOOTSTRAP_USE_SYSTEM_TORCH=true` to reuse the CUDA-enabled torch stack from
+  the base image.
+- Dashboard GPU mode on Linux ARM64 resolves to the DGX-specific image repo:
+  `ghcr.io/homelab-00/transcriptionsuite-server-dgx-spark`.
+
+Build/publish guidance for DGX Spark:
+- Use local-only builds by default (recommended due to large NGC base image):
+
+```bash
+./build/docker-build-push.sh --variant dgx-spark --build local-dgx --local-only
+```
+
+- Push to GHCR only when explicitly required:
+
+```bash
+./build/docker-build-push.sh --variant dgx-spark --build --push v1.3.9-dgx
+```
+
 ### Legacy-GPU image variant (Issue #83)
 
 Users with Pascal (`sm_6x`) or Maxwell (`sm_5x`) cards — e.g. **GTX 1070, GTX

--- a/server/docker/.env.dgx.example
+++ b/server/docker/.env.dgx.example
@@ -1,0 +1,13 @@
+# TranscriptionSuite DGX Spark Docker environment template
+# Start with: IMAGE_REPO=ghcr.io/homelab-00/transcriptionsuite-server-dgx-spark TAG=local-dgx docker compose -f docker-compose.yml -f docker-compose.linux-host.yml -f docker-compose.gpu.yml -f docker-compose.dgx-spark.yml up -d
+
+# Hugging Face token for PyAnnote diarization
+HUGGINGFACE_TOKEN=
+
+# DGX defaults
+INSTALL_NEMO=true
+UV_PYTHON_BIN=/usr/bin/python3.13
+BOOTSTRAP_USE_SYSTEM_TORCH=false
+
+# Optional model override
+DIARIZATION_MODEL=pyannote/speaker-diarization-community-1

--- a/server/docker/.env.example
+++ b/server/docker/.env.example
@@ -1,0 +1,45 @@
+# TranscriptionSuite Docker environment template
+# Copy this file to .env (same directory) and fill values as needed.
+# Do NOT commit the real .env file.
+
+# Core server settings
+SERVER_PORT=9786
+LOG_LEVEL=INFO
+
+# Hugging Face token used by compose mapping:
+# HUGGINGFACE_TOKEN -> container HF_TOKEN
+# Required for PyAnnote diarization and other gated HF downloads.
+HUGGINGFACE_TOKEN=
+
+# Optional runtime/model toggles
+INSTALL_WHISPER=false
+INSTALL_NEMO=false
+INSTALL_VIBEVOICE_ASR=false
+INSTALL_FUNASR=false
+
+# DGX/NGC path (override only when needed)
+UV_PYTHON_BIN=/usr/bin/python3.13
+BOOTSTRAP_USE_SYSTEM_TORCH=false
+
+# Optional model overrides (empty means use config defaults)
+MAIN_TRANSCRIBER_MODEL=
+LIVE_TRANSCRIBER_MODEL=
+DIARIZATION_MODEL=
+
+# Diarization (optional)
+# Example PyAnnote model:
+# DIARIZATION_MODEL=pyannote/speaker-diarization-community-1
+
+# Optional network/proxy settings
+HTTP_PROXY=
+HTTPS_PROXY=
+NO_PROXY=
+
+# Optional TLS mode
+TLS_ENABLED=false
+TLS_CERT_PATH=
+TLS_KEY_PATH=
+
+# Optional local config mount
+# USER_CONFIG_DIR=/home/you/.config/TranscriptionSuite
+USER_CONFIG_DIR=

--- a/server/docker/Dockerfile
+++ b/server/docker/Dockerfile
@@ -3,7 +3,8 @@
 # This image keeps application source and runtime bootstrap tooling.
 # Python dependencies are installed at first container startup into /runtime/.venv.
 
-FROM ubuntu:24.04 AS runtime
+ARG BASE_IMAGE=ubuntu:24.04
+FROM ${BASE_IMAGE} AS runtime
 
 # PyTorch wheel-index variant (Issue #83):
 #   cu129 (default) — modern GPUs, sm_70..sm_120 (Volta and newer)
@@ -12,6 +13,10 @@ FROM ubuntu:24.04 AS runtime
 # bootstrap_runtime.py to switch the `uv sync` index. Default = cu129 keeps existing
 # behaviour byte-identical for unchanged builds.
 ARG PYTORCH_VARIANT=cu129
+
+# Python interpreter used by bootstrap/install scripts. Kept configurable so
+# architecture-specific base images can expose Python in a different location.
+ARG UV_PYTHON_BIN=/usr/bin/python3.13
 
 # OCI standard labels for container metadata
 LABEL org.opencontainers.image.title="TranscriptionSuite Server"
@@ -28,6 +33,7 @@ ENV DEBIAN_FRONTEND="noninteractive"
 ENV PYTHONUNBUFFERED="1"
 ENV PYTHONDONTWRITEBYTECODE="1"
 ENV UV_PYTHON="3.13"
+ENV UV_PYTHON_BIN="${UV_PYTHON_BIN}"
 # Propagate the build-time PyTorch variant into runtime so bootstrap_runtime.py
 # can branch its `uv sync` between the cu129 (default) and cu126 (legacy) index.
 ENV PYTORCH_VARIANT="${PYTORCH_VARIANT}"

--- a/server/docker/bootstrap_runtime.py
+++ b/server/docker/bootstrap_runtime.py
@@ -134,6 +134,11 @@ def parse_int_env(name: str, default: int) -> int:
         return default
 
 
+def bootstrap_python_bin() -> str:
+    """Python interpreter used for uv sync and runtime venv creation."""
+    return os.environ.get("UV_PYTHON_BIN", "/usr/bin/python3.13").strip() or "/usr/bin/python3.13"
+
+
 def is_vibevoice_asr_model_name(model_name: str | None) -> bool:
     """Return True when *model_name* selects a VibeVoice-ASR family variant."""
     name = normalize_selected_model_name(model_name)
@@ -429,7 +434,7 @@ def build_uv_sync_env(venv_dir: Path, cache_dir: Path) -> dict[str, str]:
     env = os.environ.copy()
     env["UV_PROJECT_ENVIRONMENT"] = str(venv_dir)
     env["UV_CACHE_DIR"] = str(cache_dir)
-    env["UV_PYTHON"] = "/usr/bin/python3.13"
+    env["UV_PYTHON"] = bootstrap_python_bin()
     # UV_HTTP_TIMEOUT is uv's *read* timeout: how long a transfer may stall
     # between reads before uv abandons the request (connection establishment is
     # governed separately by UV_HTTP_CONNECT_TIMEOUT). The 30s default is fine
@@ -498,6 +503,8 @@ def run_dependency_sync(
         "--project",
         str(PROJECT_DIR),
     ]
+    use_system_torch = parse_bool_env("BOOTSTRAP_USE_SYSTEM_TORCH", False)
+    is_linux_arm64 = sys.platform == "linux" and platform.machine().lower() in {"arm64", "aarch64"}
     # Non-default variants swap the URL of the *named* index `pytorch-cu129`
     # (which [tool.uv.sources] pins torch/torchaudio to): cu126 for legacy GPUs
     # (Pascal/Maxwell, sm_50..sm_90) and cpu for CPU-only hosts (GH #125 — no
@@ -527,8 +534,40 @@ def run_dependency_sync(
             ]
         )
     else:
-        # Default cu129 path — preserve byte-identical behaviour with --frozen.
-        cmd.insert(2, "--frozen")
+        # Default cu129 path — preserve byte-identical behaviour with --frozen,
+        # except in two DGX-related cases where a fresh resolve is required to
+        # avoid x86-only lock pins on Linux arm64 (e.g. triton/torchcodec):
+        # system-torch mode and native arm64 wheel installs.
+        if not use_system_torch and not is_linux_arm64:
+            cmd.insert(2, "--frozen")
+    if use_system_torch:
+        # DGX Spark / NGC mode: torch+torchaudio come from the base image.
+        # torchcodec has no manylinux aarch64 wheels at the locked version and
+        # is optional for pyannote (runtime warning already suppressed).
+        cmd.extend(
+            [
+                "--no-install-package",
+                "torch",
+                "--no-install-package",
+                "torchaudio",
+                "--no-install-package",
+                "torchcodec",
+                "--no-install-package",
+                "triton",
+            ]
+        )
+    elif is_linux_arm64:
+        # Native Linux ARM64 runtime path: these are frequently x86-only pins
+        # in universal locks; skipping them allows the rest of the stack to
+        # resolve to aarch64-compatible wheels.
+        cmd.extend(
+            [
+                "--no-install-package",
+                "torchcodec",
+                "--no-install-package",
+                "triton",
+            ]
+        )
     for extra in extras:
         cmd.extend(["--extra", extra])
     run_command(
@@ -831,17 +870,20 @@ def ensure_runtime_dependencies(
     gpu_driver = detect_gpu_driver_version()
     if gpu_driver:
         log(f"Detected host GPU driver: {gpu_driver}")
+    use_system_torch = parse_bool_env("BOOTSTRAP_USE_SYSTEM_TORCH", False)
+    fingerprint_extras = extras + (("__system_torch__",) if use_system_torch else ())
+
     fingerprint = compute_dependency_fingerprint(
         python_abi=python_abi,
         arch=arch,
-        extras=extras,
+        extras=fingerprint_extras,
         gpu_driver=gpu_driver,
         pytorch_variant=pytorch_variant,
     )
     structural_fp = compute_structural_fingerprint(
         python_abi=python_abi,
         arch=arch,
-        extras=extras,
+        extras=fingerprint_extras,
         gpu_driver=gpu_driver,
         pytorch_variant=pytorch_variant,
     )
@@ -857,7 +899,25 @@ def ensure_runtime_dependencies(
     }
     diagnostics: dict[str, Any] = {
         "selection_reason": "unknown",
+        "use_system_torch": use_system_torch,
     }
+
+    def ensure_runtime_venv_for_mode() -> None:
+        if not use_system_torch:
+            return
+        python_bin = bootstrap_python_bin()
+        venv_python_path = venv_dir / "bin/python"
+        if venv_python_path.exists():
+            return
+        log(
+            "Creating runtime venv with --system-site-packages "
+            f"(BOOTSTRAP_USE_SYSTEM_TORCH=true, python={python_bin})"
+        )
+        run_command(
+            [python_bin, "-m", "venv", "--system-site-packages", str(venv_dir)],
+            timeout_seconds=300,
+            env=os.environ.copy(),
+        )
 
     with lock_file.open("w", encoding="utf-8") as lock:
         fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
@@ -898,7 +958,7 @@ def ensure_runtime_dependencies(
             legacy_fingerprint = compute_dependency_fingerprint(
                 python_abi=python_abi,
                 arch=arch,
-                extras=extras,
+                extras=fingerprint_extras,
                 gpu_driver=gpu_driver,
                 pytorch_variant=pytorch_variant,
                 include_variant=False,
@@ -906,7 +966,7 @@ def ensure_runtime_dependencies(
             legacy_structural_fp = compute_structural_fingerprint(
                 python_abi=python_abi,
                 arch=arch,
-                extras=extras,
+                extras=fingerprint_extras,
                 gpu_driver=gpu_driver,
                 pytorch_variant=pytorch_variant,
                 include_variant=False,
@@ -1007,6 +1067,8 @@ def ensure_runtime_dependencies(
                 if venv_dir.exists():
                     shutil.rmtree(venv_dir, ignore_errors=True)
 
+                ensure_runtime_venv_for_mode()
+
                 log(f"Installing Python runtime dependencies (mode={final_sync_mode})...")
                 sync_start = time.perf_counter()
                 try:
@@ -1046,6 +1108,8 @@ def ensure_runtime_dependencies(
             if venv_dir.exists():
                 log(f"Rebuilding runtime virtual environment ({diagnostics['selection_reason']})")
                 shutil.rmtree(venv_dir, ignore_errors=True)
+
+            ensure_runtime_venv_for_mode()
 
             log(f"Installing Python runtime dependencies (mode={final_sync_mode})...")
             sync_start = time.perf_counter()

--- a/server/docker/docker-compose.dgx-spark.yml
+++ b/server/docker/docker-compose.dgx-spark.yml
@@ -1,0 +1,26 @@
+# DGX Spark overlay (Linux ARM64 + NVIDIA Blackwell GB10)
+#
+# Uses NVIDIA's PyTorch container as the base image for ARM64 CUDA support.
+# This is additive: it is only active when explicitly included in the compose
+# stack and does not affect existing Linux/Windows/macOS flows.
+#
+# Usage:
+#   docker compose \
+#     -f docker-compose.yml \
+#     -f docker-compose.linux-host.yml \
+#     -f docker-compose.gpu.yml \
+#     -f docker-compose.dgx-spark.yml up -d
+
+services:
+  transcriptionsuite:
+    build:
+      args:
+        BASE_IMAGE: ${BASE_IMAGE:-nvcr.io/nvidia/pytorch:25.09-py3}
+        # Keep runtime bootstrap on Python 3.13 (project default).
+        UV_PYTHON_BIN: ${UV_PYTHON_BIN:-/usr/bin/python3.13}
+    environment:
+      - UV_PYTHON_BIN=${UV_PYTHON_BIN:-/usr/bin/python3.13}
+      # Optional: set true to reuse torch from the base image's Python env.
+      - BOOTSTRAP_USE_SYSTEM_TORCH=${BOOTSTRAP_USE_SYSTEM_TORCH:-false}
+      # DGX default: enable NeMo so Parakeet models are ready out of the box.
+      - INSTALL_NEMO=${INSTALL_NEMO:-true}

--- a/server/docker/docker-compose.yml
+++ b/server/docker/docker-compose.yml
@@ -8,10 +8,14 @@
 #   docker-compose.linux-host.yml   — Linux: host networking
 #   docker-compose.desktop-vm.yml   — macOS/Windows: bridge networking + port mapping
 #   docker-compose.gpu.yml          — NVIDIA GPU reservation
+#   docker-compose.dgx-spark.yml    — DGX Spark (Linux ARM64 + Blackwell GB10)
 #   docker-compose.vulkan.yml       — Vulkan sidecar (AMD/Intel GPU via whisper.cpp)
 #
 # Manual usage (Linux + GPU, the default):
 #   docker compose -f docker-compose.yml -f docker-compose.linux-host.yml -f docker-compose.gpu.yml up -d
+#
+# Manual usage (DGX Spark Linux ARM64 + GPU):
+#   docker compose -f docker-compose.yml -f docker-compose.linux-host.yml -f docker-compose.gpu.yml -f docker-compose.dgx-spark.yml up -d
 #
 # Manual usage (macOS/Windows, CPU mode):
 #   docker compose -f docker-compose.yml -f docker-compose.desktop-vm.yml up -d
@@ -62,6 +66,8 @@ services:
       # matters for CLI/dev builds only; see Issue #83.)
       args:
         PYTORCH_VARIANT: ${PYTORCH_VARIANT:-cu129}
+        BASE_IMAGE: ${BASE_IMAGE:-ubuntu:24.04}
+        UV_PYTHON_BIN: ${UV_PYTHON_BIN:-/usr/bin/python3.13}
     # Image repo is templated so the dashboard can switch between the default
     # `transcriptionsuite-server` and the legacy-GPU `transcriptionsuite-server-legacy`
     # repo (Issue #83). The default keeps the existing behaviour for unchanged callers.
@@ -88,6 +94,12 @@ services:
       # (legacy GPU, Issue #83), or cpu (no CUDA). The dashboard's CPU profile
       # sets cpu so CPU-only hosts skip the multi-GB CUDA wheels (GH #125).
       - PYTORCH_VARIANT=${PYTORCH_VARIANT:-cu129}
+      # For DGX Spark/NGC base images, this can be pointed at the preloaded
+      # Python/Torch environment (for example /opt/conda/bin/python).
+      - UV_PYTHON_BIN=${UV_PYTHON_BIN:-/usr/bin/python3.13}
+      # Optional DGX mode: keep torch/torchaudio from the base image and skip
+      # reinstalling them into the runtime venv.
+      - BOOTSTRAP_USE_SYSTEM_TORCH=${BOOTSTRAP_USE_SYSTEM_TORCH:-false}
       # GH #125: opt-in for TLS-intercepting networks (corporate proxy / antivirus
       # HTTPS scanning). true makes uv trust the system/container CA store instead
       # of its bundled roots. Since GH #200 you rarely need this: put your root CA

--- a/server/docker/docker-entrypoint.sh
+++ b/server/docker/docker-entrypoint.sh
@@ -14,6 +14,8 @@ log() {
     echo "[entrypoint.sh] $1"
 }
 
+PY_BOOTSTRAP_BIN="${UV_PYTHON_BIN:-/usr/bin/python3.13}"
+
 # Handle TLS certificates if TLS is enabled
 if [ "${TLS_ENABLED:-false}" = "true" ]; then
     log "TLS enabled - preparing certificates..."
@@ -59,7 +61,7 @@ fi
 # only root context in the container, and it must precede bootstrap_runtime.py, which
 # makes the first HTTPS request. On a TLS-intercepting network (corporate proxy or
 # antivirus HTTPS scanning) nothing downstream can succeed without this.
-/usr/bin/python3.13 docker/install_ca_certs.py || true
+"$PY_BOOTSTRAP_BIN" docker/install_ca_certs.py || true
 
 # Point every HTTPS client at the combined bundle whenever the container carries any
 # locally trusted CA — whether bind-mounted just now, or baked into a derived image at
@@ -89,7 +91,7 @@ chown -R appuser:appuser /data /models /runtime
 # Bootstrap runtime dependencies and feature status.
 log "Bootstrapping runtime environment..."
 BOOTSTRAP_START_NS="$(date +%s%N)"
-gosu appuser /usr/bin/python3.13 docker/bootstrap_runtime.py
+gosu appuser "$PY_BOOTSTRAP_BIN" docker/bootstrap_runtime.py
 BOOTSTRAP_END_NS="$(date +%s%N)"
 BOOTSTRAP_ELAPSED_MS="$(( (BOOTSTRAP_END_NS - BOOTSTRAP_START_NS) / 1000000 ))"
 BOOTSTRAP_ELAPSED_S="$(( BOOTSTRAP_ELAPSED_MS / 1000 ))"


### PR DESCRIPTION
- Introduced a new compose overlay for Nvidia DGX Spark, allowing integration with the existing multi-platform setup.
- Parameterized Dockerfile to accept BASE_IMAGE and UV_PYTHON_BIN for flexibility.
- Updated image repository routing to use a dedicated DGX Spark image repo.
- Implemented bootstrap mode to reuse system-installed torch/torchaudio from the base image.
- Enhanced unit tests to cover new DGX Spark scenarios and ensure existing functionality remains intact.
- Updated deployment documentation to include DGX Spark usage instructions.
- server docker image for DGX Spark only build locally, not automatically pushed to ghcr.io due to large image size