### PR TITLE
feat(dashboard): add a Client-tab toggle that auto-stops an interrupted recovery and records

### DIFF
--- a/dashboard/components/__tests__/SessionView.recovery-refresh.test.tsx
+++ b/dashboard/components/__tests__/SessionView.recovery-refresh.test.tsx
@@ -418,6 +418,14 @@ describe('SessionView - salvage drop popup (GH-239 follow-up)', () => {
     expect(mockTranscription.clearBusyInfo).toHaveBeenCalled();
   });
 
+  it('points at the Settings toggle that suppresses the dialog', async () => {
+    mockTranscription.busyInfo = { ...BUSY };
+    renderSessionView();
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText(/Settings . Client . Recovery/)).toBeInTheDocument();
+  });
+
   it('auto-stop setting drops the salvage without showing the confirm', async () => {
     mockGetConfig.mockImplementation(async (key: unknown) =>
       key === 'recovery.autoStopAndRecord' ? true : undefined,

--- a/dashboard/components/__tests__/SessionView.recovery-refresh.test.tsx
+++ b/dashboard/components/__tests__/SessionView.recovery-refresh.test.tsx
@@ -404,6 +404,9 @@ describe('SessionView - salvage drop popup (GH-239 follow-up)', () => {
     });
     mockFetchRecentUndelivered.mockResolvedValue({ json: async () => [] });
     mockWaitForJobSlotFree.mockResolvedValue(true);
+    // vi.clearAllMocks() keeps implementations, so the auto-stop test below
+    // would otherwise leak its config answer into every later test.
+    mockGetConfig.mockResolvedValue(undefined);
     useSalvageStore.setState({ checkNonce: 0, dropRequestedJobId: null, lastCompletedAt: null });
   });
 
@@ -413,6 +416,27 @@ describe('SessionView - salvage drop popup (GH-239 follow-up)', () => {
 
     expect(await screen.findByText(/interrupted recording/)).toBeInTheDocument();
     expect(mockTranscription.clearBusyInfo).toHaveBeenCalled();
+  });
+
+  it('auto-stop setting drops the salvage without showing the confirm', async () => {
+    mockGetConfig.mockImplementation(async (key: unknown) =>
+      key === 'recovery.autoStopAndRecord' ? true : undefined,
+    );
+    mockGetStatus.mockResolvedValueOnce({
+      models: {
+        job_tracker: {
+          is_busy: true,
+          salvage: { job_id: 'salv-1', client_name: 'laptop', started_at: 1 },
+        },
+      },
+    });
+    mockTranscription.busyInfo = { ...BUSY };
+    renderSessionView();
+
+    await waitFor(() => expect(mockTranscription.start).toHaveBeenCalledTimes(1));
+    expect(mockCancelTranscription).toHaveBeenCalledTimes(1);
+    expect(useSalvageStore.getState().dropRequestedJobId).toBe('salv-1');
+    expect(screen.queryByText('Stop and record')).not.toBeInTheDocument();
   });
 
   it('drop flow: cancels the salvage, marks the drop, and restarts recording', async () => {

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -1031,7 +1031,12 @@ export const SessionView: React.FC<SessionViewProps> = ({
           (await confirm(
             `The server is still transcribing an interrupted recording (from ${info.activeUser}). ` +
               'Stop it and start your new recording? The interrupted audio is saved and can be retried later.',
-            { title: 'Recovery in progress', confirmLabel: 'Stop and record', danger: true },
+            {
+              title: 'Recovery in progress',
+              confirmLabel: 'Stop and record',
+              danger: true,
+              hint: 'Always answer this the same way? Turn on Settings → Client → Recovery to skip this prompt.',
+            },
           ));
         if (!ok) return;
         setDroppingSalvage(true);

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -1021,11 +1021,18 @@ export const SessionView: React.FC<SessionViewProps> = ({
       // ignored forever after the first dialog was dismissed.
       salvageFlowActiveRef.current = true;
       try {
-        const ok = await confirm(
-          `The server is still transcribing an interrupted recording (from ${info.activeUser}). ` +
-            'Stop it and start your new recording? The interrupted audio is saved and can be retried later.',
-          { title: 'Recovery in progress', confirmLabel: 'Stop and record', danger: true },
-        );
+        // Settings -> Client -> Recovery: when the user has opted in, take the
+        // "Stop and record" branch without prompting. Read fresh from config
+        // (not from mount-time state) so a change made in the Settings modal
+        // applies to the very next collision.
+        const autoStop = (await getConfig<boolean>('recovery.autoStopAndRecord')) ?? false;
+        const ok =
+          autoStop ||
+          (await confirm(
+            `The server is still transcribing an interrupted recording (from ${info.activeUser}). ` +
+              'Stop it and start your new recording? The interrupted audio is saved and can be retried later.',
+            { title: 'Recovery in progress', confirmLabel: 'Stop and record', danger: true },
+          ));
         if (!ok) return;
         setDroppingSalvage(true);
         try {

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -1035,7 +1035,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
               title: 'Recovery in progress',
               confirmLabel: 'Stop and record',
               danger: true,
-              hint: 'Always answer this the same way? Turn on Settings → Client → Recovery to skip this prompt.',
+              hint: 'Tip: You can auto-skip this prompt by toggling Settings → Client → Recovery.',
             },
           ));
         if (!ok) return;

--- a/dashboard/components/views/SettingsModal.tsx
+++ b/dashboard/components/views/SettingsModal.tsx
@@ -245,6 +245,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
     useHttps: false,
     hfToken: '',
     hideTimestamps: false,
+    autoStopRecovery: false,
   });
 
   // Display-only mirror of connection.useRemote, loaded when the modal opens.
@@ -415,6 +416,8 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
                 autoAddNotebook: (cfg['notebook.autoAdd'] as boolean) ?? prev.autoAddNotebook,
                 hfToken: (cfg['server.hfToken'] as string) ?? prev.hfToken,
                 hideTimestamps: (cfg['output.hideTimestamps'] as boolean) ?? prev.hideTimestamps,
+                autoStopRecovery:
+                  (cfg['recovery.autoStopAndRecord'] as boolean) ?? prev.autoStopRecovery,
               }));
               const loadedBlurEffectsEnabled = (cfg['ui.blurEffectsEnabled'] as boolean) ?? true;
               savedBlurEffectsRef.current = loadedBlurEffectsEnabled;
@@ -548,6 +551,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
         ['notebook.autoAdd', clientSettings.autoAddNotebook],
         ['server.hfToken', clientSettings.hfToken],
         ['output.hideTimestamps', clientSettings.hideTimestamps],
+        ['recovery.autoStopAndRecord', clientSettings.autoStopRecovery],
         ['app.autoCopy', appSettings.autoCopy],
         ['app.showNotifications', appSettings.showNotifications],
         ['app.stopServerOnQuit', appSettings.stopServerOnQuit],
@@ -1364,6 +1368,18 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
             </button>
           </div>
         </div>
+      </Section>
+
+      <Section title="Recovery">
+        <AppleSwitch
+          checked={clientSettings.autoStopRecovery}
+          onChange={(v) => {
+            setClientSettings((prev) => ({ ...prev, autoStopRecovery: v }));
+            setIsDirty(true);
+          }}
+          label="Always stop an interrupted recovery and record"
+          description="Skip the 'Recovery in progress' prompt when a new recording collides with the server still transcribing an interrupted one. The interrupted audio stays saved and can be retried later."
+        />
       </Section>
 
       <Section title="Output">

--- a/dashboard/electron/main.ts
+++ b/dashboard/electron/main.ts
@@ -500,6 +500,10 @@ const store = new Store({
     'app.updateCheckCustomHours': 24,
     'app.modelSelectionOnboardingCompleted': false,
     'output.hideTimestamps': false,
+    /* GH-239 follow-up - when true, a start attempt that bounces off an
+       in-progress salvage skips the "Recovery in progress" confirm and takes
+       the "Stop and record" branch automatically. Default false. */
+    'recovery.autoStopAndRecord': false,
     'ui.sidebarCollapsed': false,
     // Issue #87 — user-facing escape valve for backdrop-blur CPU/GPU cost.
     // Default true preserves the iOS-glass design; users can opt out per

--- a/dashboard/src/config/store.ts
+++ b/dashboard/src/config/store.ts
@@ -86,6 +86,16 @@ export interface ClientConfig {
   output: {
     hideTimestamps: boolean;
   };
+  /** Interrupted-recording recovery (GH-239 salvage popup) */
+  recovery: {
+    /**
+     * When true, a start attempt that bounces off an in-progress salvage skips
+     * the "Recovery in progress" confirm dialog and takes the "Stop and record"
+     * branch automatically. Default false - the dialog is the safe default
+     * because the drop cancels a transcription that is still running.
+     */
+    autoStopAndRecord: boolean;
+  };
   /** UI preferences */
   ui: {
     sidebarCollapsed: boolean;
@@ -163,6 +173,9 @@ const DEFAULT_CONFIG: ClientConfig = {
   },
   output: {
     hideTimestamps: false,
+  },
+  recovery: {
+    autoStopAndRecord: false,
   },
   ui: {
     sidebarCollapsed: false,

--- a/dashboard/src/hooks/useConfirm.tsx
+++ b/dashboard/src/hooks/useConfirm.tsx
@@ -6,6 +6,12 @@ interface ConfirmOptions {
   title?: string;
   confirmLabel?: string;
   danger?: boolean;
+  /**
+   * Secondary line rendered under the message in a muted, smaller style. For
+   * asides that must not compete with the question itself - e.g. pointing at
+   * the Settings toggle that suppresses this particular prompt.
+   */
+  hint?: string;
 }
 
 interface ConfirmState {
@@ -50,6 +56,9 @@ export function useConfirm() {
           </div>
           <div className="bg-black/20 px-6 py-5">
             <p className="text-sm text-slate-300">{state.message}</p>
+            {state.options.hint && (
+              <p className="mt-3 text-xs text-slate-500">{state.options.hint}</p>
+            )}
           </div>
           <div className="flex justify-end gap-3 border-t border-white/10 bg-white/5 px-6 py-4 select-none">
             <Button variant="ghost" onClick={() => handleClose(false)}>


### PR DESCRIPTION
## What

Adds **Settings -> Client -> Recovery -> "Always stop an interrupted recovery and record"**.

When a new recording collides with the server still transcribing an interrupted one, the client raises a "Recovery in progress" confirm whose primary action is **Stop and record** (GH-239 follow-up). With the new toggle on, that branch is taken automatically and the dialog never appears.

The dialog itself now advertises the toggle: a muted second line reads *"Tip: You can auto-skip this prompt by toggling Settings → Client → Recovery."* - so the setting is discoverable from the prompt it turns off, rather than only by browsing Settings.

## How

- New client config key `recovery.autoStopAndRecord`, default `false`, declared in both the electron-store defaults (`dashboard/electron/main.ts`) and the renderer `DEFAULT_CONFIG` (`dashboard/src/config/store.ts`). Default off, so the shipped behaviour is unchanged for anyone who does not opt in.
- `SettingsModal` grows a `Recovery` section in the Client tab (existing `Section` + `AppleSwitch`, no new CSS classes) and loads/saves the key alongside the other client settings.
- `useConfirm` grows an optional `hint` option, rendered under the message in a smaller muted style so the aside never competes with the question. Purely additive - every existing confirm call is unaffected.
- `SessionView.handleSalvageBusy` reads the key **fresh from config** at collision time rather than from mount-time state, mirroring how `handleStartRecording` reads `notebook.autoAdd`. A change in the Settings modal therefore applies to the very next collision without a remount.

What deliberately did **not** change:

- The `salvageFlowActiveRef` guard still wraps the whole flow, so repeat busy events stay coalesced.
- The re-read of the job tracker before the untargeted `POST /cancel`, the `waitForJobSlotFree` wait, the restart, and both error toasts (cancel rejected / slot never freed) are untouched.
- The `droppingSalvage` banner ("Stopping the recovery job... Your recording will start automatically") still renders, so the bypass is not silent.
- Interrupted audio is still saved server-side and retryable - only the prompt is skipped.

## Test plan

- [x] `npx vitest run components/__tests__/SessionView.recovery-refresh.test.tsx` - 15 passed, including the new "auto-stop setting drops the salvage without showing the confirm" and "points at the Settings toggle that suppresses the dialog" cases
- [x] Full dashboard suite: 147 files / 2113 tests passed
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check`
- [x] `npm run ui:contract:check` - 22 checks, contract 1.18.0 unchanged (only existing components reused)
- [ ] Manual smoke: interrupt a recording so the server salvages it, then start a new one with the toggle **off** (dialog appears, now carrying the hint line) and **on** (no dialog, salvage cancelled, recording starts)
- [ ] Manual smoke: toggle it on, save, and confirm it survives an app restart
