### PR TITLE
feat(dashboard, ui): move the sidebar active indicator onto the Notebook sub-tabs and replay the view animation on every navigation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
       - id: codespell
         args:
           - "--skip=*.lock,*.svg,*.ico,*.icns,*.png,*.woff,*.woff2,*package-lock.json,node_modules,dist-electron,release,.git,dashboard/dist,contract-baseline.json"
-          - "--ignore-words-list=ect,crate,ser,ane,renderd"
+          - "--ignore-words-list=ect,crate,ser,ane,renderd,afterall"
         exclude: "^(dashboard/release/|dashboard/dist-electron/)"
 
   # ── Dashboard: Prettier format ───────────────────────────────────────────

--- a/dashboard/App.tsx
+++ b/dashboard/App.tsx
@@ -844,8 +844,15 @@ const AppInner: React.FC = () => {
               />
             </ErrorBoundary>
           </div>
+          {/* Keyed so the enter animation replays on every navigation instead of
+              only on the first mount out of the Session view. The Notebook
+              sub-tab is folded into the key so Calendar, Search and Import
+              animate exactly like a primary view switch. */}
           {currentView !== View.SESSION && (
-            <div className="animate-in fade-in slide-in-from-bottom-4 h-full w-full duration-500 ease-out">
+            <div
+              key={currentView === View.NOTEBOOK ? `${currentView}:${notebookTab}` : currentView}
+              className="animate-in fade-in slide-in-from-bottom-4 h-full w-full duration-500 ease-out"
+            >
               {renderOtherView()}
             </div>
           )}

--- a/dashboard/components/Sidebar.tsx
+++ b/dashboard/components/Sidebar.tsx
@@ -75,8 +75,9 @@ export const Sidebar: React.FC<SidebarProps> = ({
 }) => {
   const isMetal = runtimeProfile === 'metal';
   const [collapsed, setCollapsed] = useState(false);
-  // Notebook sub-tabs (Search / Import) are collapsed by default; each click
-  // on the Notebook nav item toggles them, and leaving Notebook closes them.
+  // Notebook sub-tabs (Search / Import) are collapsed by default. Entering the
+  // Notebook view from anywhere else reveals them; only a click on the Notebook
+  // row while already parked on that row collapses them again.
   const [notebookSubTabsOpen, setNotebookSubTabsOpen] = useState(false);
   const [expandedWidthPx, setExpandedWidthPx] = useState(SIDEBAR_EXPANDED_BASE_WIDTH_PX);
   const logoContentRef = useRef<HTMLDivElement | null>(null);
@@ -197,18 +198,35 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
   const activeIndex = navItems.findIndex((item) => item.id === currentView);
 
-  // Ref-based pill positioning — measures actual button positions
-  // so the sliding pill works correctly with always-visible sub-tabs.
+  // A Notebook sub-tab owns the active indicator whenever the strip is open and
+  // the selected sub-tab is not the calendar, because the calendar IS the
+  // Notebook row. Everything else keeps the indicator on a primary nav row.
+  const activeNotebookSubTab =
+    currentView === View.NOTEBOOK && notebookSubTabsOpen && notebookTab !== NotebookTab.CALENDAR
+      ? notebookTab
+      : null;
+
+  // Ref-based pill positioning - measures actual button positions so the
+  // sliding pill works for primary nav rows and Notebook sub-tab rows alike.
+  // Sub-tab rows are shorter than nav rows, so the pill tracks height as well
+  // as offset. Keys are plain View ids for nav rows and "VIEW:SUBTAB" for the
+  // Notebook sub-tab rows.
   const navRef = useRef<HTMLElement>(null);
-  const buttonRefs = useRef<Map<View, HTMLButtonElement>>(new Map());
+  const buttonRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
   const [pillTop, setPillTop] = useState<number | null>(null);
+  const [pillHeight, setPillHeight] = useState<number | null>(null);
+
+  const activePillKey =
+    activeNotebookSubTab !== null ? `${View.NOTEBOOK}:${activeNotebookSubTab}` : currentView;
 
   // notebookSubTabsOpen shifts the buttons below the Notebook item, so the
   // pill must re-measure whenever the sub-tabs expand or collapse.
   const measurePillPosition = useCallback(() => {
-    const btn = buttonRefs.current.get(currentView);
-    if (btn) setPillTop(btn.offsetTop);
-  }, [currentView, notebookSubTabsOpen]);
+    const btn = buttonRefs.current.get(activePillKey);
+    if (!btn) return;
+    setPillTop(btn.offsetTop);
+    setPillHeight(btn.offsetHeight);
+  }, [activePillKey, notebookSubTabsOpen]);
 
   useLayoutEffect(() => {
     measurePillPosition();
@@ -276,13 +294,19 @@ export const Sidebar: React.FC<SidebarProps> = ({
         {/* Animated Background Pill for Active State */}
         {activeIndex !== -1 && pillTop !== null && (
           <div
+            data-testid="sidebar-active-indicator"
             className="pointer-events-none absolute top-0 right-3 left-3 z-0 h-12 rounded-xl border border-white/5 bg-linear-to-r from-white/10 to-transparent shadow-inner transition-all duration-200 ease-[cubic-bezier(0.25,0.1,0.25,1)]"
             style={{
               transform: `translateY(${pillTop}px)`,
+              ...(pillHeight !== null ? { height: pillHeight } : {}),
             }}
           >
-            {/* Active Indicator Bar (Cyan) */}
-            <div className="bg-accent-cyan absolute top-1/2 left-0 h-6 w-1 -translate-y-1/2 rounded-r-full shadow-[0_0_10px_#22d3ee]"></div>
+            {/* Active Indicator Bar (Cyan). Half the measured row height so it
+                scales down on the shorter Notebook sub-tab rows. */}
+            <div
+              className="bg-accent-cyan absolute top-1/2 left-0 h-6 w-1 -translate-y-1/2 rounded-r-full shadow-[0_0_10px_#22d3ee]"
+              style={pillHeight !== null ? { height: Math.round(pillHeight / 2) } : undefined}
+            ></div>
           </div>
         )}
 
@@ -293,15 +317,25 @@ export const Sidebar: React.FC<SidebarProps> = ({
               <button
                 ref={(el) => {
                   if (el) buttonRefs.current.set(item.id, el);
+                  else buttonRefs.current.delete(item.id);
                 }}
                 onClick={() => {
-                  onChangeView(item.id);
-                  if (item.id === View.NOTEBOOK) {
-                    setNotebookSubTabsOpen((open) => !open);
-                    onChangeNotebookTab(NotebookTab.CALENDAR);
-                  } else {
+                  if (item.id !== View.NOTEBOOK) {
+                    onChangeView(item.id);
                     setNotebookSubTabsOpen(false);
+                    return;
                   }
+
+                  // A click on the Notebook row only counts as a collapse
+                  // toggle when the user is already parked on that row.
+                  // Arriving from another view reveals the strip, and arriving
+                  // from Search or Import walks back to the calendar with the
+                  // strip left open.
+                  const alreadyOnNotebookRow =
+                    currentView === View.NOTEBOOK && notebookTab === NotebookTab.CALENDAR;
+                  onChangeView(View.NOTEBOOK);
+                  onChangeNotebookTab(NotebookTab.CALENDAR);
+                  setNotebookSubTabsOpen((open) => (alreadyOnNotebookRow ? !open : true));
                 }}
                 className={`relative z-10 flex w-full items-center focus:ring-0 focus:outline-none ${collapsed ? 'justify-center px-0' : 'px-4'} h-12 rounded-xl transition-colors duration-200 ${
                   isActive ? 'text-white' : 'text-slate-400 hover:bg-white/5 hover:text-white'
@@ -342,13 +376,18 @@ export const Sidebar: React.FC<SidebarProps> = ({
                     return (
                       <button
                         key={subItem.id}
+                        ref={(el) => {
+                          const refKey = `${View.NOTEBOOK}:${subItem.id}`;
+                          if (el) buttonRefs.current.set(refKey, el);
+                          else buttonRefs.current.delete(refKey);
+                        }}
                         onClick={() => {
                           onChangeView(View.NOTEBOOK);
                           onChangeNotebookTab(subItem.id);
                         }}
                         className={`relative z-10 flex w-full items-center focus:ring-0 focus:outline-none ${collapsed ? 'justify-center px-0' : 'pr-4 pl-9'} h-9 rounded-xl transition-colors duration-200 ${
                           isSubActive
-                            ? 'bg-white/6 text-slate-200'
+                            ? 'text-slate-200'
                             : 'text-slate-500 hover:bg-white/5 hover:text-slate-400'
                         }`}
                       >

--- a/dashboard/components/__tests__/Sidebar.notebookSubTabs.test.tsx
+++ b/dashboard/components/__tests__/Sidebar.notebookSubTabs.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * Sidebar Notebook sub-tab navigation.
+ *
+ * Two behaviours are locked down here:
+ *   1. The Notebook row only collapses its Search / Import strip when the
+ *      user clicks it while already parked on the Notebook row. Reaching the
+ *      row from another view, or from one of the sub-tabs, never collapses.
+ *   2. The cyan active indicator retargets onto the selected sub-tab row,
+ *      which is shorter than a primary nav row, so the pill tracks the
+ *      measured row height and not just its offset.
+ */
+
+import React, { useState } from 'react';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { Sidebar } from '../Sidebar';
+import { View, NotebookTab } from '../../types';
+
+vi.mock('../profiles/ProfileSelector', () => ({
+  ProfileSelector: () => React.createElement('div', { 'data-testid': 'profile-selector' }),
+}));
+
+vi.mock('../profiles/ModelProfileSelector', () => ({
+  ModelProfileSelector: () =>
+    React.createElement('div', { 'data-testid': 'model-profile-selector' }),
+}));
+
+const NAV_ROW_HEIGHT_PX = 48;
+const SUB_ROW_HEIGHT_PX = 36;
+
+// jsdom reports every offset as 0, so the pill has nothing to measure. Derive
+// the row height from the Tailwind height class the row actually carries.
+let originalOffsetHeight: PropertyDescriptor | undefined;
+
+beforeAll(() => {
+  originalOffsetHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get(this: HTMLElement) {
+      return this.className.includes('h-9') ? SUB_ROW_HEIGHT_PX : NAV_ROW_HEIGHT_PX;
+    },
+  });
+});
+
+afterAll(() => {
+  if (originalOffsetHeight) {
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', originalOffsetHeight);
+  }
+});
+
+/** Sidebar is fully controlled, so the test owns the view + sub-tab state. */
+const Harness: React.FC = () => {
+  const [currentView, setCurrentView] = useState<View>(View.SESSION);
+  const [notebookTab, setNotebookTab] = useState<NotebookTab>(NotebookTab.CALENDAR);
+
+  return (
+    <Sidebar
+      currentView={currentView}
+      onChangeView={setCurrentView}
+      notebookTab={notebookTab}
+      onChangeNotebookTab={setNotebookTab}
+      onOpenSettings={() => {}}
+      onOpenAbout={() => {}}
+      onOpenBugReport={() => {}}
+      containerRunning={false}
+      containerExists={false}
+      clientRunning={false}
+    />
+  );
+};
+
+const clickRow = (name: string) => fireEvent.click(screen.getByRole('button', { name }));
+const subTabsVisible = () => screen.queryByRole('button', { name: 'Search' }) !== null;
+const indicatorHeight = () => screen.getByTestId('sidebar-active-indicator').style.height;
+
+describe('Sidebar Notebook sub-tabs', () => {
+  it('reveals the sub-tabs when the Notebook row is reached from another view', () => {
+    render(<Harness />);
+    expect(subTabsVisible()).toBe(false);
+
+    clickRow('Notebook');
+
+    expect(subTabsVisible()).toBe(true);
+    expect(screen.getByRole('button', { name: 'Import' })).toBeInTheDocument();
+  });
+
+  it('collapses the sub-tabs on a second click from the Notebook row itself', () => {
+    render(<Harness />);
+
+    clickRow('Notebook');
+    expect(subTabsVisible()).toBe(true);
+
+    clickRow('Notebook');
+    expect(subTabsVisible()).toBe(false);
+  });
+
+  it('keeps the sub-tabs open when the Notebook row is reached from a sub-tab', () => {
+    render(<Harness />);
+
+    clickRow('Notebook');
+    clickRow('Search');
+    expect(subTabsVisible()).toBe(true);
+
+    // The click that used to collapse the strip now only walks back to the
+    // calendar, because the user was parked on Search rather than on Notebook.
+    clickRow('Notebook');
+    expect(subTabsVisible()).toBe(true);
+
+    // And the next click, now genuinely from the Notebook row, collapses.
+    clickRow('Notebook');
+    expect(subTabsVisible()).toBe(false);
+  });
+
+  it('re-opens the sub-tabs after a detour through another view', () => {
+    render(<Harness />);
+
+    clickRow('Notebook');
+    clickRow('Notebook');
+    expect(subTabsVisible()).toBe(false);
+
+    clickRow('Server');
+    clickRow('Notebook');
+
+    expect(subTabsVisible()).toBe(true);
+  });
+
+  it('collapses the sub-tabs when leaving the Notebook view', () => {
+    render(<Harness />);
+
+    clickRow('Notebook');
+    expect(subTabsVisible()).toBe(true);
+
+    clickRow('Logs');
+    expect(subTabsVisible()).toBe(false);
+  });
+});
+
+describe('Sidebar active indicator', () => {
+  it('retargets onto the selected sub-tab row and back', () => {
+    render(<Harness />);
+
+    clickRow('Notebook');
+    expect(indicatorHeight()).toBe(`${NAV_ROW_HEIGHT_PX}px`);
+
+    clickRow('Search');
+    expect(indicatorHeight()).toBe(`${SUB_ROW_HEIGHT_PX}px`);
+
+    clickRow('Import');
+    expect(indicatorHeight()).toBe(`${SUB_ROW_HEIGHT_PX}px`);
+
+    clickRow('Notebook');
+    expect(indicatorHeight()).toBe(`${NAV_ROW_HEIGHT_PX}px`);
+  });
+
+  it('stays on the nav row for the primary views', () => {
+    render(<Harness />);
+
+    clickRow('Server');
+    expect(indicatorHeight()).toBe(`${NAV_ROW_HEIGHT_PX}px`);
+  });
+});


### PR DESCRIPTION
## What

Three sidebar changes, requested together.

### 1. The active indicator follows the Notebook sub-tabs

The cyan pill used to be pinned to the four nav rows. It now retargets onto the selected Search or Import row.

Sub-tab rows are `h-9` (36px) while nav rows are `h-12` (48px), so tracking offset alone would have left the pill overflowing into the neighbouring row. The pill now measures `offsetTop` **and** `offsetHeight`, and the cyan bar scales to half the measured height so it stays proportionate on the shorter row.

Two supporting changes fall out of this:

- the ref map is keyed by string (`"NOTEBOOK:SEARCH"` for sub-tab rows) and entries are **deleted on unmount**. The previous `if (el) map.set(...)` never cleaned up, so a collapsed sub-tab would have left a detached node behind for the pill to measure at `offsetTop === 0`.
- the active sub-tab drops its own `bg-white/6`, because the pill now supplies the background. Keeping both produced a doubled surface.

### 2. Collapse only counts from the Notebook row itself

Previously every click on Notebook toggled the strip unconditionally. Now:

| starting point | click on Notebook |
|---|---|
| already on Notebook (Calendar) | toggles collapse / expand, as before |
| on Search or Import | walks back to the calendar, strip stays open |
| on Session / Server / Logs | enters Notebook and reveals the strip |

### 3. The content enter animation replays on every navigation

`animate-in fade-in slide-in-from-bottom-4 duration-500` lives on a wrapper div in `App.tsx` that carried no `key`, so React reused the same DOM node and the CSS animation only ran when the wrapper mounted or unmounted around the Session view. Notebook to Server to Logs never animated.

The wrapper is now keyed on the view plus the Notebook sub-tab, so every navigation animates and Search / Import animate exactly like a primary view switch. Same pattern already used by the settings tabs in `SettingsModal.tsx`.

Also adds `afterall` to the codespell ignore list. This suite is the first in the repo to use the vitest `afterAll` global, which codespell read as a typo for "after all".

## Test plan

- [x] New suite `dashboard/components/__tests__/Sidebar.notebookSubTabs.test.tsx` (7 tests) drives the controlled Sidebar through the full click matrix and asserts the measured indicator height per row type.
- [x] Red/green verified: reverting the click handler and the pill key made exactly the two behavioural tests fail (`expected false to be true`, `expected 48px to be 36px`), and restoring turned them green.
- [x] Full dashboard suite: 148 files / 2118 tests passing.
- [x] `npm run check` (typecheck + eslint + prettier + ui-contract) clean.
- [ ] Visual smoke on the running app. jsdom does not do layout, so the pill **position** is not covered by tests, only its height. Worth eyeballing that the pill lands squarely on the Search and Import rows and that the slide between rows looks right in both the expanded and collapsed sidebar.