### PR TITLE
feat(dashboard): capture the microphone alongside system audio in Live Mode and recordings

### DIFF
--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -272,6 +272,8 @@ export const SessionView: React.FC<SessionViewProps> = ({
   // Audio Configuration State
   const [audioSource, setAudioSource] = useState<'mic' | 'system'>('mic');
   const [micDevice, setMicDevice] = useState('Default Microphone');
+  // Also capture the microphone alongside system audio (e.g. narrating over a call).
+  const [mixMicWithSystem, setMixMicWithSystem] = useState(false);
   const persistedSelectionsRef = useRef<{
     audioSource?: 'mic' | 'system';
     micDevice?: string;
@@ -529,6 +531,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
         savedDiarizationEnabled,
         savedConstrainSpeakers,
         savedNumSpeakers,
+        savedMixMicWithSystem,
       ] = await Promise.all([
         getConfig<'mic' | 'system'>('session.audioSource'),
         getConfig<string>('session.micDevice'),
@@ -541,6 +544,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
         getConfig<boolean>('diarization.enabledForRecordings'),
         getConfig<boolean>('diarization.constrainSpeakers'),
         getConfig<number>('diarization.numSpeakers'),
+        getConfig<boolean>('session.mixMicWithSystem'),
       ]);
       if (!active) return;
 
@@ -580,6 +584,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
       if (typeof savedNumSpeakers === 'number' && savedNumSpeakers >= 1 && savedNumSpeakers <= 10) {
         setNumSpeakers(savedNumSpeakers);
       }
+      if (typeof savedMixMicWithSystem === 'boolean') setMixMicWithSystem(savedMixMicWithSystem);
     })().catch(() => {});
 
     return () => {
@@ -591,6 +596,11 @@ export const SessionView: React.FC<SessionViewProps> = ({
     setAudioSource(source);
     persistedSelectionsRef.current.audioSource = source;
     void setConfig('session.audioSource', source).catch(() => {});
+  }, []);
+
+  const handleMixMicToggle = useCallback((enabled: boolean) => {
+    setMixMicWithSystem(enabled);
+    void setConfig('session.mixMicWithSystem', enabled).catch(() => {});
   }, []);
 
   const handleDiarizationToggle = useCallback((enabled: boolean) => {
@@ -977,6 +987,8 @@ export const SessionView: React.FC<SessionViewProps> = ({
         // acquires/releases the pactl loopback module via loopbackOwner, so
         // every teardown path releases it (GH-230).
         monitorSinkName: isSystemAudio && isLinux ? sinkNameMap[sysDevice] : undefined,
+        mixMicWithSystem: isSystemAudio && mixMicWithSystem,
+        mixMicDeviceId: isSystemAudio && mixMicWithSystem ? micDeviceIds[micDevice] : undefined,
         autoAddToNotebook,
         // GH-258: forced off when the server reports the feature unavailable.
         diarization: effectiveDiarization,
@@ -1008,6 +1020,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
     captureGain,
     activeModel,
     languagesLoading,
+    mixMicWithSystem,
   ]);
 
   // GH-239 follow-up: a start attempt bounced off an in-progress salvage.
@@ -1298,6 +1311,8 @@ export const SessionView: React.FC<SessionViewProps> = ({
             // Linux system audio: AudioCapture owns the loopback module
             // lifecycle via loopbackOwner (GH-230).
             monitorSinkName: isSystemAudio && isLinux ? sinkNameMap[sysDevice] : undefined,
+            mixMicWithSystem: isSystemAudio && mixMicWithSystem,
+            mixMicDeviceId: isSystemAudio && mixMicWithSystem ? micDeviceIds[micDevice] : undefined,
           });
           // Apply persisted capture gain after capture starts
           if (isSystemAudio) {
@@ -1330,6 +1345,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
       captureGain,
       activeLiveModel,
       languagesLoading,
+      mixMicWithSystem,
     ],
   );
 
@@ -2651,6 +2667,15 @@ export const SessionView: React.FC<SessionViewProps> = ({
                               onChange={(e) => handleCaptureGainChange(parseFloat(e.target.value))}
                               className="ts-gain-slider h-1 w-full cursor-pointer appearance-none rounded-full bg-white/10 accent-cyan-400"
                             />
+                          </div>
+                        )}
+                        {/* Mic mix toggle — capture the mic alongside system audio (e.g. narrating over a call) */}
+                        {audioSource === 'system' && (
+                          <div className="mt-2.5 flex items-center justify-between">
+                            <label className="text-[11px] font-medium text-slate-400">
+                              Also capture microphone
+                            </label>
+                            <AppleSwitch checked={mixMicWithSystem} onChange={handleMixMicToggle} />
                           </div>
                         )}
                       </div>

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -2675,7 +2675,11 @@ export const SessionView: React.FC<SessionViewProps> = ({
                             <label className="text-[11px] font-medium text-slate-400">
                               Also capture microphone
                             </label>
-                            <AppleSwitch checked={mixMicWithSystem} onChange={handleMixMicToggle} />
+                            <AppleSwitch
+                              checked={mixMicWithSystem}
+                              onChange={handleMixMicToggle}
+                              ariaLabel="Also capture microphone"
+                            />
                           </div>
                         )}
                       </div>

--- a/dashboard/electron/main.ts
+++ b/dashboard/electron/main.ts
@@ -483,6 +483,7 @@ const store = new Store({
     'session.audioSource': 'mic',
     'session.micDevice': 'Default Microphone',
     'session.systemDevice': 'Default Output',
+    'session.mixMicWithSystem': false,
     'session.mainLanguage': 'Auto Detect',
     'session.liveLanguage': 'Auto Detect',
     'audio.gracePeriod': 1.0,

--- a/dashboard/src/hooks/useLiveMode.ts
+++ b/dashboard/src/hooks/useLiveMode.ts
@@ -59,6 +59,10 @@ export interface LiveStartOptions {
   model?: string;
   systemAudio?: boolean;
   monitorSinkName?: string;
+  /** Also capture the microphone alongside system audio and mix them. */
+  mixMicWithSystem?: boolean;
+  /** Device ID for the mixed-in microphone. Falls back to the default mic. */
+  mixMicDeviceId?: string;
   /**
    * GGML filename of the live model, used ONLY on the Windows `vulkan-wsl2`
    * profile to relaunch the native whisper-server.exe onto this model before
@@ -170,6 +174,8 @@ export function useLiveMode(): LiveModeState {
                   deviceId: startOptsRef.current.deviceId,
                   systemAudio: startOptsRef.current.systemAudio,
                   monitorSinkName: startOptsRef.current.monitorSinkName,
+                  mixMicWithSystem: startOptsRef.current.mixMicWithSystem,
+                  mixMicDeviceId: startOptsRef.current.mixMicDeviceId,
                 })
                 .then(() => {
                   setAnalyser(captureRef.current?.analyser ?? null);

--- a/dashboard/src/hooks/useTranscription.ts
+++ b/dashboard/src/hooks/useTranscription.ts
@@ -85,6 +85,10 @@ export interface TranscriptionState {
     translationTarget?: string;
     systemAudio?: boolean;
     monitorSinkName?: string;
+    /** Also capture the microphone alongside system audio and mix them. */
+    mixMicWithSystem?: boolean;
+    /** Device ID for the mixed-in microphone. Falls back to the default mic. */
+    mixMicDeviceId?: string;
     /** Save the finished recording to the Audio Notebook (GH-199). */
     autoAddToNotebook?: boolean;
     /** Attach speaker labels to the finished transcript (GH-258). */
@@ -197,6 +201,10 @@ export function useTranscription(): TranscriptionState {
     translationTarget?: string;
     systemAudio?: boolean;
     monitorSinkName?: string;
+    /** Also capture the microphone alongside system audio and mix them. */
+    mixMicWithSystem?: boolean;
+    /** Device ID for the mixed-in microphone. Falls back to the default mic. */
+    mixMicDeviceId?: string;
     /** Active recording-profile id (FR18). Snapshotted server-side at job start. */
     profileId?: number | null;
     /** Save the finished recording to the Audio Notebook (GH-199). */
@@ -358,6 +366,8 @@ export function useTranscription(): TranscriptionState {
                 deviceId: startOptsRef.current.deviceId,
                 systemAudio: startOptsRef.current.systemAudio,
                 monitorSinkName: startOptsRef.current.monitorSinkName,
+                mixMicWithSystem: startOptsRef.current.mixMicWithSystem,
+                mixMicDeviceId: startOptsRef.current.mixMicDeviceId,
                 targetSampleRateHz: captureSampleRateHz,
               })
               .then(() => {
@@ -535,6 +545,8 @@ export function useTranscription(): TranscriptionState {
       translationTarget?: string;
       systemAudio?: boolean;
       monitorSinkName?: string;
+      mixMicWithSystem?: boolean;
+      mixMicDeviceId?: string;
       profileId?: number | null;
       autoAddToNotebook?: boolean;
       /** Attach speaker labels to the finished transcript (GH-258). */

--- a/dashboard/src/services/audioCapture.test.ts
+++ b/dashboard/src/services/audioCapture.test.ts
@@ -37,14 +37,26 @@ let getUserMediaMock: Mock;
 let enumerateDevicesMock: Mock;
 let addModuleMock: Mock;
 
+// Captures the most recently constructed FakeAudioContext so tests can
+// inspect per-instance node mocks (e.g. distinguishing gainNode from
+// micGainNode) without threading a reference through AudioCapture's private
+// fields.
+let lastCtx: FakeAudioContext | undefined;
+
 class FakeAudioContext {
   sampleRate = 48000;
   state = 'running';
   audioWorklet = { addModule: (...args: unknown[]) => addModuleMock(...args) };
-  createMediaStreamSource = vi.fn().mockReturnValue({ connect: vi.fn(), disconnect: vi.fn() });
+  // mockImplementation (not mockReturnValue) so each call gets its own node —
+  // mixMicWithSystem calls both createMediaStreamSource and createGain twice
+  // (primary + secondary), and a single cached return value would make the
+  // mic and system-audio nodes indistinguishable.
+  createMediaStreamSource = vi
+    .fn()
+    .mockImplementation(() => ({ connect: vi.fn(), disconnect: vi.fn() }));
   createGain = vi
     .fn()
-    .mockReturnValue({ connect: vi.fn(), disconnect: vi.fn(), gain: { value: 1 } });
+    .mockImplementation(() => ({ connect: vi.fn(), disconnect: vi.fn(), gain: { value: 1 } }));
   createAnalyser = vi.fn().mockReturnValue({
     connect: vi.fn(),
     disconnect: vi.fn(),
@@ -52,6 +64,10 @@ class FakeAudioContext {
     smoothingTimeConstant: 0,
   });
   close = vi.fn().mockResolvedValue(undefined);
+
+  constructor() {
+    lastCtx = this;
+  }
 }
 
 class FakeAudioWorkletNode {
@@ -234,5 +250,125 @@ describe('[P1] AudioCapture loopback ownership (GH-230)', () => {
     // double-release the hold.
     expect(audioTrack.stop).toHaveBeenCalled();
     expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
+
+  // ── mixMicWithSystem: a second MediaStream mixed alongside system audio ─
+  //
+  // Introduces a second getUserMedia acquisition and MediaStream, which is
+  // exactly the class of resource this suite exists to protect — covered
+  // here for the same teardown/leak guarantees as the primary stream above.
+
+  it('mixMicWithSystem: stop() stops BOTH streams tracks', async () => {
+    const { stream: primaryStream, audioTrack: primaryTrack } = makeStream();
+    const { stream: micStream, audioTrack: micTrack } = makeStream();
+    getUserMediaMock.mockResolvedValueOnce(primaryStream).mockResolvedValueOnce(micStream);
+
+    const capture = new AudioCapture(() => {});
+    await capture.start({
+      systemAudio: true,
+      monitorSinkName: 'sink-a',
+      mixMicWithSystem: true,
+    });
+
+    capture.stop();
+
+    expect(primaryTrack.stop).toHaveBeenCalled();
+    expect(micTrack.stop).toHaveBeenCalled();
+  });
+
+  it('mixMicWithSystem: acquires the mic BEFORE the AudioContext/worklet exist', async () => {
+    const { stream: primaryStream } = makeStream();
+    const { stream: micStream } = makeStream();
+    getUserMediaMock.mockResolvedValueOnce(primaryStream).mockResolvedValueOnce(micStream);
+
+    const capture = new AudioCapture(() => {});
+    await capture.start({
+      systemAudio: true,
+      monitorSinkName: 'sink-a',
+      mixMicWithSystem: true,
+    });
+
+    // Both getUserMedia calls (primary + mic) must land before the worklet
+    // module loads — a mic failure must fail start() cleanly instead of
+    // tearing down an already-wired, already-streaming session.
+    expect(getUserMediaMock.mock.invocationCallOrder[1]).toBeLessThan(
+      addModuleMock.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('mixMicWithSystem: external stop() during the secondary getUserMedia → secondary tracks stopped, loopback released exactly once', async () => {
+    const { stream: primaryStream } = makeStream();
+    const { stream: micStream, audioTrack: micTrack } = makeStream();
+    let resolveMicGum!: (v: MediaStream) => void;
+    getUserMediaMock.mockResolvedValueOnce(primaryStream).mockImplementationOnce(
+      () =>
+        new Promise<MediaStream>((res) => {
+          resolveMicGum = res;
+        }),
+    );
+
+    const capture = new AudioCapture(() => {});
+    const starting = capture.start({
+      systemAudio: true,
+      monitorSinkName: 'sink-a',
+      mixMicWithSystem: true,
+    });
+    const assertion = expect(starting).rejects.toMatchObject({ name: 'AbortError' });
+    // Let the primary acquire settle so start() is inside the SECOND
+    // (mic) getUserMedia call.
+    await vi.waitFor(() => expect(getUserMediaMock).toHaveBeenCalledTimes(2));
+
+    capture.stop();
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+
+    resolveMicGum(micStream);
+    await assertion;
+
+    expect(micTrack.stop).toHaveBeenCalled();
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('mixMicWithSystem: secondary getUserMedia rejection → primary stream tracks stopped AND loopback released', async () => {
+    const { stream: primaryStream, audioTrack: primaryTrack } = makeStream();
+    getUserMediaMock
+      .mockResolvedValueOnce(primaryStream)
+      .mockRejectedValueOnce(new Error('NotFoundError'));
+
+    const capture = new AudioCapture(() => {});
+    await expect(
+      capture.start({ systemAudio: true, monitorSinkName: 'sink-a', mixMicWithSystem: true }),
+    ).rejects.toThrow('NotFoundError');
+
+    expect(primaryTrack.stop).toHaveBeenCalled();
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('mixMicWithSystem: the Capture Gain slider does not touch the mic gain stage', async () => {
+    const { stream: primaryStream } = makeStream();
+    const { stream: micStream } = makeStream();
+    getUserMediaMock.mockResolvedValueOnce(primaryStream).mockResolvedValueOnce(micStream);
+
+    const capture = new AudioCapture(() => {});
+    await capture.start({
+      systemAudio: true,
+      monitorSinkName: 'sink-a',
+      mixMicWithSystem: true,
+    });
+
+    capture.setGain(3);
+
+    const gainNodes = lastCtx!.createGain.mock.results.map((r) => r.value);
+    expect(gainNodes).toHaveLength(2);
+    const [systemGain, micGain] = gainNodes;
+    expect(systemGain.gain.value).toBe(3);
+    expect(micGain.gain.value).toBe(1);
+
+    capture.mute();
+    expect(systemGain.gain.value).toBe(0);
+    expect(micGain.gain.value).toBe(0);
+
+    capture.unmute();
+    expect(systemGain.gain.value).toBe(3);
+    expect(micGain.gain.value).toBe(1);
   });
 });

--- a/dashboard/src/services/audioCapture.test.ts
+++ b/dashboard/src/services/audioCapture.test.ts
@@ -79,6 +79,9 @@ class FakeAudioWorkletNode {
 describe('[P1] AudioCapture loopback ownership (GH-230)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Drop the previous test's context so a test that asserts on `lastCtx`
+    // without starting a capture fails loudly instead of inspecting stale nodes.
+    lastCtx = undefined;
     acquireMock.mockResolvedValue({ label: 'TranscriptionSuite_Loopback', volumePct: 100 });
 
     const { stream } = makeStream();
@@ -370,5 +373,51 @@ describe('[P1] AudioCapture loopback ownership (GH-230)', () => {
     capture.unmute();
     expect(systemGain.gain.value).toBe(3);
     expect(micGain.gain.value).toBe(1);
+  });
+
+  // The load-bearing assertion for a MIXING feature: every other test here
+  // passes with the mic acquired, held, gain-staged, muted and torn down
+  // correctly while its audio goes nowhere. Deleting either connect() in
+  // start() leaves the mic silently absent from the PCM sent to the server —
+  // the toggle becomes a no-op while the OS mic indicator stays lit — and
+  // without this test the suite stays green.
+  it('mixMicWithSystem: the mic is actually wired into the mixed PCM path', async () => {
+    const { stream: primaryStream } = makeStream();
+    const { stream: micStream } = makeStream();
+    getUserMediaMock.mockResolvedValueOnce(primaryStream).mockResolvedValueOnce(micStream);
+
+    const capture = new AudioCapture(() => {});
+    await capture.start({
+      systemAudio: true,
+      monitorSinkName: 'sink-a',
+      mixMicWithSystem: true,
+    });
+
+    const ctx = lastCtx!;
+    const [systemSource, micSource] = ctx.createMediaStreamSource.mock.results.map((r) => r.value);
+    const [systemGain, micGain] = ctx.createGain.mock.results.map((r) => r.value);
+    const analyser = ctx.createAnalyser.mock.results[0].value;
+
+    // Both chains must terminate at the SAME analyser — that node is where the
+    // two signals sum, and it is the only path into the worklet.
+    expect(systemSource.connect).toHaveBeenCalledWith(systemGain);
+    expect(systemGain.connect).toHaveBeenCalledWith(analyser);
+    expect(micSource.connect).toHaveBeenCalledWith(micGain);
+    expect(micGain.connect).toHaveBeenCalledWith(analyser);
+    expect(analyser.connect).toHaveBeenCalledWith(expect.any(FakeAudioWorkletNode));
+  });
+
+  it('mixMicWithSystem: disabled leaves the graph untouched (no mic node is built)', async () => {
+    const { stream: primaryStream } = makeStream();
+    getUserMediaMock.mockResolvedValue(primaryStream);
+
+    const capture = new AudioCapture(() => {});
+    await capture.start({ systemAudio: true, monitorSinkName: 'sink-a' });
+
+    // Exactly one source and one gain stage: the mic path must be a strict
+    // no-op when the toggle is off, not a silently-built dangling branch.
+    expect(lastCtx!.createMediaStreamSource).toHaveBeenCalledTimes(1);
+    expect(lastCtx!.createGain).toHaveBeenCalledTimes(1);
+    expect(getUserMediaMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/dashboard/src/services/audioCapture.ts
+++ b/dashboard/src/services/audioCapture.ts
@@ -47,6 +47,14 @@ export interface AudioCaptureOptions {
    * is used instead.
    */
   monitorSinkName?: string;
+  /**
+   * When systemAudio is also set, capture the microphone alongside the
+   * system audio and mix both into the same stream (e.g. narrating over a
+   * call). Ignored for plain microphone capture.
+   */
+  mixMicWithSystem?: boolean;
+  /** Device ID for the mixed-in microphone. Falls back to the default mic. */
+  mixMicDeviceId?: string;
   /** Target PCM sample rate emitted by the worklet (e.g. 16000 or 24000) */
   targetSampleRateHz?: number;
 }
@@ -55,6 +63,9 @@ export class AudioCapture {
   private ctx: AudioContext | null = null;
   private stream: MediaStream | null = null;
   private sourceNode: MediaStreamAudioSourceNode | null = null;
+  /** Secondary mic stream mixed in alongside system audio (mixMicWithSystem). */
+  private secondaryStream: MediaStream | null = null;
+  private secondarySourceNode: MediaStreamAudioSourceNode | null = null;
   private gainNode: GainNode | null = null;
   private workletNode: AudioWorkletNode | null = null;
   private analyserNode: AnalyserNode | null = null;
@@ -182,6 +193,24 @@ export class AudioCapture {
       this.gainNode.connect(this.analyserNode);
       this.analyserNode.connect(this.workletNode);
       // Don't connect worklet to destination — we don't want to play back the mic
+
+      // 7. Optionally mix in the microphone alongside system audio (e.g.
+      //    narrating over a call). Both sources feed the same gainNode; the
+      //    Web Audio API sums them before the analyser and worklet.
+      if (options.systemAudio && options.mixMicWithSystem) {
+        this.secondaryStream = await navigator.mediaDevices.getUserMedia({
+          audio: {
+            ...(options.mixMicDeviceId ? { deviceId: { exact: options.mixMicDeviceId } } : {}),
+            echoCancellation: false,
+            noiseSuppression: false,
+            autoGainControl: false,
+            channelCount: 1,
+          },
+        });
+        this.assertNotStopped(epoch);
+        this.secondarySourceNode = this.ctx.createMediaStreamSource(this.secondaryStream);
+        this.secondarySourceNode.connect(this.gainNode);
+      }
     } catch (err) {
       // A partial start must not leak: stop() tears down whatever was already
       // grabbed — stream tracks, the AudioContext, and the loopback hold
@@ -205,6 +234,14 @@ export class AudioCapture {
     if (this.sourceNode) {
       this.sourceNode.disconnect();
       this.sourceNode = null;
+    }
+    if (this.secondarySourceNode) {
+      this.secondarySourceNode.disconnect();
+      this.secondarySourceNode = null;
+    }
+    if (this.secondaryStream) {
+      this.secondaryStream.getTracks().forEach((t) => t.stop());
+      this.secondaryStream = null;
     }
     if (this.gainNode) {
       this.gainNode.disconnect();

--- a/dashboard/src/services/audioCapture.ts
+++ b/dashboard/src/services/audioCapture.ts
@@ -67,6 +67,13 @@ export class AudioCapture {
   private secondaryStream: MediaStream | null = null;
   private secondarySourceNode: MediaStreamAudioSourceNode | null = null;
   private gainNode: GainNode | null = null;
+  /**
+   * Fixed-at-1.0 gain stage for the mixed-in mic (mixMicWithSystem). Kept
+   * separate from `gainNode` so the "Capture Gain" slider — which scales
+   * `gainNode` and is documented/intended as a system-audio-only control —
+   * does not also amplify (and clip) the user's own voice.
+   */
+  private micGainNode: GainNode | null = null;
   private workletNode: AudioWorkletNode | null = null;
   private analyserNode: AnalyserNode | null = null;
   private onChunk: AudioChunkCallback;
@@ -153,6 +160,27 @@ export class AudioCapture {
       // can release its tracks when the start was aborted mid-getUserMedia.
       this.assertNotStopped(epoch);
 
+      // 1b. Also acquire the mixed-in microphone now, alongside the primary
+      //     stream and before anything downstream exists. This getUserMedia
+      //     call is an await of unbounded duration (OS permission prompt,
+      //     NotReadableError if the device is busy, NotFoundError on a
+      //     system-audio-only box with no mic) — acquiring it here means a
+      //     failure fails the whole start() cleanly, before the worklet is
+      //     wired up and streaming, instead of tearing down an otherwise-
+      //     healthy, already-live session for want of an optional extra.
+      if (options.systemAudio && options.mixMicWithSystem) {
+        this.secondaryStream = await navigator.mediaDevices.getUserMedia({
+          audio: {
+            ...(options.mixMicDeviceId ? { deviceId: { exact: options.mixMicDeviceId } } : {}),
+            echoCancellation: false,
+            noiseSuppression: false,
+            autoGainControl: false,
+            channelCount: 1,
+          },
+        });
+        this.assertNotStopped(epoch);
+      }
+
       // 2. Create AudioContext
       this.ctx = new AudioContext({
         sampleRate: this.stream.getAudioTracks()[0].getSettings().sampleRate || 48000,
@@ -178,6 +206,14 @@ export class AudioCapture {
         },
       });
 
+      if (this.secondaryStream) {
+        this.secondarySourceNode = this.ctx.createMediaStreamSource(this.secondaryStream);
+        // Fixed at 1.0, independent of `gainNode` and the user's Capture
+        // Gain slider — see the micGainNode field comment.
+        this.micGainNode = this.ctx.createGain();
+        this.micGainNode.gain.value = 1;
+      }
+
       // 5. Handle PCM chunks from the worklet
       this.workletNode.port.onmessage = (ev: MessageEvent) => {
         if (ev.data?.type === 'audio' && !this._muted) {
@@ -187,30 +223,19 @@ export class AudioCapture {
       };
 
       // 6. Wire the graph:
-      //    source → gain → analyser → worklet → (silence — worklet has no output)
-      //    Gain is set to 0 when muted so the visualiser also flatlines.
+      //    source → gain ─────────┐
+      //                            ├→ analyser → worklet → (silence — worklet has no output)
+      //    secondarySource → micGain ┘
+      //    Both gain stages feed the analyser, which sums them — kept
+      //    separate so the Capture Gain slider (which scales `gainNode`,
+      //    see setGain) never touches the mixed-in mic. mute()/unmute()
+      //    zero and restore both stages together.
       this.sourceNode.connect(this.gainNode);
+      this.secondarySourceNode?.connect(this.micGainNode!);
       this.gainNode.connect(this.analyserNode);
+      this.micGainNode?.connect(this.analyserNode);
       this.analyserNode.connect(this.workletNode);
       // Don't connect worklet to destination — we don't want to play back the mic
-
-      // 7. Optionally mix in the microphone alongside system audio (e.g.
-      //    narrating over a call). Both sources feed the same gainNode; the
-      //    Web Audio API sums them before the analyser and worklet.
-      if (options.systemAudio && options.mixMicWithSystem) {
-        this.secondaryStream = await navigator.mediaDevices.getUserMedia({
-          audio: {
-            ...(options.mixMicDeviceId ? { deviceId: { exact: options.mixMicDeviceId } } : {}),
-            echoCancellation: false,
-            noiseSuppression: false,
-            autoGainControl: false,
-            channelCount: 1,
-          },
-        });
-        this.assertNotStopped(epoch);
-        this.secondarySourceNode = this.ctx.createMediaStreamSource(this.secondaryStream);
-        this.secondarySourceNode.connect(this.gainNode);
-      }
     } catch (err) {
       // A partial start must not leak: stop() tears down whatever was already
       // grabbed — stream tracks, the AudioContext, and the loopback hold
@@ -242,6 +267,10 @@ export class AudioCapture {
     if (this.secondaryStream) {
       this.secondaryStream.getTracks().forEach((t) => t.stop());
       this.secondaryStream = null;
+    }
+    if (this.micGainNode) {
+      this.micGainNode.disconnect();
+      this.micGainNode = null;
     }
     if (this.gainNode) {
       this.gainNode.disconnect();
@@ -282,12 +311,17 @@ export class AudioCapture {
   mute(): void {
     this._muted = true;
     if (this.gainNode) this.gainNode.gain.value = 0;
+    // micGainNode feeds the analyser through a path independent of
+    // gainNode (see the field comment) — it must be zeroed too, or the
+    // mixed-in mic keeps animating the visualiser while "muted".
+    if (this.micGainNode) this.micGainNode.gain.value = 0;
   }
 
   /** Unmute — resumes sending audio chunks and restores the visualiser. */
   unmute(): void {
     this._muted = false;
     if (this.gainNode) this.gainNode.gain.value = this._gain;
+    if (this.micGainNode) this.micGainNode.gain.value = 1;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Adds an "Also capture microphone" toggle in the Session view, shown only when the audio source is set to system audio.
- When enabled, `AudioCapture` opens a second `getUserMedia` mic stream alongside the system-audio stream and sums both into the existing gain node ahead of the analyser/worklet, so a single mixed stream is sent to the server.
- The toggle is persisted (`session.mixMicWithSystem`) and threaded through both the Live Mode start path and the recording start path.

## Motivation
Useful for narrating over a call or meeting recording — currently system-audio mode only captures the far side, dropping the user's own mic.

## Test plan
- [ ] `npm run typecheck` (passes)
- [ ] Manually verify: start a system-audio session, enable the toggle, confirm both the system audio and mic are audible in the resulting transcript/recording
- [ ] Manually verify: toggle persists across a reload
- [ ] Manually verify: teardown releases both the mic and system-audio streams (no lingering permission indicator)