### PR TITLE
feat(stt): retry Live Mode transcription errors with backoff and add a hang watchdog

### DIFF
--- a/dashboard/src/hooks/useLiveMode.test.ts
+++ b/dashboard/src/hooks/useLiveMode.test.ts
@@ -215,6 +215,65 @@ describe('[P1] useLiveMode', () => {
       expect(result.current.error).toBe('Failed to start Live Mode: CUDA out of memory');
     });
 
+    it('reflects a backend-initiated recovery via state STARTING instead of staying silent', async () => {
+      const { result } = renderHook(() => useLiveMode());
+      await driveToListening(result);
+
+      act(() => {
+        lastSocketCbs.onMessage!({ type: 'state', data: { state: 'STARTING' } });
+      });
+
+      expect(result.current.status).toBe('starting');
+      expect(result.current.statusMessage).toContain('Recovering');
+    });
+
+    it('retries instead of giving up when rejected because another session is still shutting down', () => {
+      const { result } = renderHook(() => useLiveMode());
+
+      act(() => {
+        result.current.start();
+      });
+      act(() => {
+        lastSocketCbs.onMessage!({
+          type: 'error',
+          data: { message: 'Another Live Mode session is already active' },
+        });
+      });
+
+      // Retried through the reconnect budget, not treated as terminal —
+      // the message reflects a pending retry rather than the bare rejection.
+      expect(result.current.status).toBe('error');
+      expect(result.current.error).toContain('Reconnecting in');
+    });
+
+    it('falls back to a terminal error once the session-busy rejection exhausts the retry budget', () => {
+      // Fake timers: each retry schedules a real setTimeout via
+      // scheduleReconnect, and this test fires the rejection repeatedly
+      // without letting any of them run — real timers would otherwise leak
+      // past this test and fire during a later one.
+      vi.useFakeTimers();
+      try {
+        const { result } = renderHook(() => useLiveMode());
+
+        act(() => {
+          result.current.start();
+        });
+        for (let i = 0; i < 6; i++) {
+          act(() => {
+            lastSocketCbs.onMessage!({
+              type: 'error',
+              data: { message: 'Another Live Mode session is already active' },
+            });
+          });
+        }
+
+        expect(result.current.status).toBe('error');
+        expect(result.current.error).toBe('Another Live Mode session is already active');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('transitions to error on socket error callback', () => {
       const { result } = renderHook(() => useLiveMode());
 

--- a/dashboard/src/hooks/useLiveMode.test.ts
+++ b/dashboard/src/hooks/useLiveMode.test.ts
@@ -191,7 +191,10 @@ describe('[P1] useLiveMode', () => {
 
       expect(result.current.status).toBe('error');
       expect(result.current.error).toContain('engine reported an error');
-      expect(result.current.statusMessage).toBeNull();
+      // An engine ERROR now arms an auto-reconnect, and the countdown is
+      // reported through statusMessage so it cannot clobber the specific
+      // reason held in `error`.
+      expect(result.current.statusMessage).toContain('Reconnecting in');
       expect(lastCapture.stop).toHaveBeenCalled();
     });
 
@@ -234,16 +237,47 @@ describe('[P1] useLiveMode', () => {
         result.current.start();
       });
       act(() => {
-        lastSocketCbs.onMessage!({
-          type: 'error',
-          data: { message: 'Another Live Mode session is already active' },
-        });
+        // Real dispatch order: TranscriptionSocket hands a server `error`
+        // frame to onError FIRST and then forwards the same frame to
+        // onMessage. Driving onMessage alone would hide the fact that
+        // onError has already set `error` by the time the retry is armed.
+        const message = 'Another Live Mode session is already active';
+        lastSocketCbs.onError!(message);
+        lastSocketCbs.onMessage!({ type: 'error', data: { message } });
       });
 
-      // Retried through the reconnect budget, not treated as terminal —
-      // the message reflects a pending retry rather than the bare rejection.
+      // Retried through the reconnect budget, not treated as terminal. The
+      // specific rejection stays in `error` (GH-271: the specific message
+      // always wins) and the countdown rides along in statusMessage.
       expect(result.current.status).toBe('error');
-      expect(result.current.error).toContain('Reconnecting in');
+      expect(result.current.error).toBe('Another Live Mode session is already active');
+      expect(result.current.statusMessage).toContain('Reconnecting in');
+    });
+
+    it('keeps the pending retry visible when the server closes the socket after rejecting', () => {
+      vi.useFakeTimers();
+      try {
+        const { result } = renderHook(() => useLiveMode());
+
+        act(() => {
+          result.current.start();
+        });
+        act(() => {
+          const message = 'Another Live Mode session is already active';
+          lastSocketCbs.onError!(message);
+          lastSocketCbs.onMessage!({ type: 'error', data: { message } });
+        });
+        // The server closes the connection right after the rejection. That
+        // close must not reset the UI to idle underneath the armed retry.
+        act(() => {
+          lastSocketCbs.onClose!(1000, 'session busy');
+        });
+
+        expect(result.current.status).toBe('error');
+        expect(result.current.statusMessage).toContain('Reconnecting in');
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('falls back to a terminal error once the session-busy rejection exhausts the retry budget', () => {
@@ -258,12 +292,18 @@ describe('[P1] useLiveMode', () => {
         act(() => {
           result.current.start();
         });
+        // Each rejection must be allowed to run its scheduled retry before
+        // the next one arrives: while a retry is still armed, further
+        // rejections are deliberately ignored rather than burning an attempt
+        // (the socket's own auto-reconnect can fire several in a row).
         for (let i = 0; i < 6; i++) {
           act(() => {
-            lastSocketCbs.onMessage!({
-              type: 'error',
-              data: { message: 'Another Live Mode session is already active' },
-            });
+            const message = 'Another Live Mode session is already active';
+            lastSocketCbs.onError!(message);
+            lastSocketCbs.onMessage!({ type: 'error', data: { message } });
+          });
+          act(() => {
+            vi.advanceTimersByTime(6000);
           });
         }
 

--- a/dashboard/src/hooks/useLiveMode.ts
+++ b/dashboard/src/hooks/useLiveMode.ts
@@ -122,6 +122,44 @@ export function useLiveMode(): LiveModeState {
     };
   }, []);
 
+  // Schedules an auto-reconnect attempt (shared by the engine-ERROR path and
+  // the "another session is already active" rejection — see the 'error' case
+  // below). Returns false once the budget is exhausted so the caller can fall
+  // back to a terminal error instead. Keeps any more specific message an
+  // `error` frame already delivered (or is about to): the two frames can
+  // race, and the specific one always wins.
+  const scheduleReconnect = useCallback(
+    (fallbackMessage: string) => {
+      const attempt = reconnectAttemptsRef.current + 1;
+      if (attempt > MAX_AUTO_RECONNECTS) return false;
+
+      reconnectAttemptsRef.current = attempt;
+      const delaySec = Math.min(attempt, 5);
+      setError(
+        (prev) =>
+          prev ??
+          `${fallbackMessage} Reconnecting in ${delaySec}s (attempt ${attempt}/${MAX_AUTO_RECONNECTS})…`,
+      );
+      setStatusTracked('error');
+      reconnectTimerRef.current = setTimeout(() => {
+        reconnectTimerRef.current = null;
+        const retarget = retargetRef.current;
+        if (!retarget) return;
+        // Treat this like a retarget hop so accumulated sentences and mute
+        // state survive the reconnect.
+        isRetargetingRef.current = true;
+        try {
+          setError(null);
+          retarget();
+        } finally {
+          isRetargetingRef.current = false;
+        }
+      }, delaySec * 1000);
+      return true;
+    },
+    [setStatusTracked],
+  );
+
   // Rearm / diagnostic dispatch for config-changed events. The socket class
   // owns the branching (error rearm, pending-backoff shortcut, active-session
   // host-change warn/retarget) so this listener just forwards the current
@@ -201,6 +239,13 @@ export function useLiveMode(): LiveModeState {
             }
           } else if (state === 'PROCESSING') {
             setStatusTracked('processing');
+          } else if (state === 'STARTING') {
+            // The backend is retrying a transient transcription error
+            // (rebuilding the recorder) — reflect that instead of leaving
+            // the UI on a stale 'listening'/'processing' while audio is
+            // silently dropped underneath it until the rebuild completes.
+            setStatusTracked('starting');
+            setStatusMessage('Recovering from a transcription error…');
           } else if (state === 'ERROR') {
             // GH-271: the engine reports a terminal failure out of band. This
             // branch used to be missing, so an engine that died mid-session
@@ -209,40 +254,20 @@ export function useLiveMode(): LiveModeState {
             captureRef.current?.stop();
             setAnalyser(null);
             setStatusMessage(null);
-            const attempt = reconnectAttemptsRef.current + 1;
-            if (attempt <= MAX_AUTO_RECONNECTS) {
-              // Retry the whole session with backoff — the backend already
-              // retries transient recorder errors on its own (with its own
-              // backoff/watchdog), so reaching ERROR here means it gave up;
-              // a fresh session is the next thing worth trying.
-              reconnectAttemptsRef.current = attempt;
-              const delaySec = Math.min(attempt, 5);
-              setError(
-                `Live Mode error — reconnecting in ${delaySec}s (attempt ${attempt}/${MAX_AUTO_RECONNECTS})…`,
-              );
-              setStatusTracked('error');
-              reconnectTimerRef.current = setTimeout(() => {
-                reconnectTimerRef.current = null;
-                const retarget = retargetRef.current;
-                if (!retarget) return;
-                // Treat this like a retarget hop so accumulated sentences
-                // and mute state survive the reconnect.
-                isRetargetingRef.current = true;
-                try {
-                  setError(null);
-                  retarget();
-                } finally {
-                  isRetargetingRef.current = false;
-                }
-              }, delaySec * 1000);
-            } else {
+            // Retry the whole session with backoff — the backend already
+            // retries transient recorder errors on its own (with its own
+            // backoff/watchdog), so reaching ERROR here means it gave up;
+            // a fresh session is the next thing worth trying.
+            const scheduled = scheduleReconnect(
+              'Live mode stopped because the engine reported an error.',
+            );
+            if (!scheduled) {
               // Out of attempts — keep any more specific message an `error`
               // frame already delivered (or is about to): the two frames
               // race, and the specific one always wins.
               setError(
                 (prev) =>
-                  prev ??
-                  'Live Mode stopped after too many errors. Start again manually to retry.',
+                  prev ?? 'Live Mode stopped after too many errors. Start again manually to retry.',
               );
               setStatusTracked('error');
             }
@@ -289,16 +314,26 @@ export function useLiveMode(): LiveModeState {
           setSentences([]);
           break;
 
-        case 'error':
-          setError((msg.data?.message as string) ?? 'Live mode error');
+        case 'error': {
+          const message = (msg.data?.message as string) ?? 'Live mode error';
+          // The single-session slot is released only after the PREVIOUS
+          // connection's cleanup (including a main-model reload) finishes,
+          // so a reconnect racing that teardown is routinely rejected here
+          // — it is transient, not a reason to give up. Retry it through the
+          // same budget as an engine ERROR instead of stopping cold.
+          if (message.includes('Another Live Mode session is already active')) {
+            if (scheduleReconnect(message)) break;
+          }
+          setError(message);
           setStatusTracked('error');
           captureRef.current?.stop();
           setAnalyser(null);
           setStatusMessage(null);
           break;
+        }
       }
     },
-    [setStatusTracked],
+    [setStatusTracked, scheduleReconnect],
   );
 
   const start = useCallback(

--- a/dashboard/src/hooks/useLiveMode.ts
+++ b/dashboard/src/hooks/useLiveMode.ts
@@ -130,16 +130,24 @@ export function useLiveMode(): LiveModeState {
   // race, and the specific one always wins.
   const scheduleReconnect = useCallback(
     (fallbackMessage: string) => {
+      // A retry is already armed. The socket runs its own auto-reconnect, so
+      // several rejections can arrive here in quick succession; none of them
+      // may burn a fresh attempt or stack a second timer.
+      if (reconnectTimerRef.current !== null) return true;
+
       const attempt = reconnectAttemptsRef.current + 1;
       if (attempt > MAX_AUTO_RECONNECTS) return false;
 
       reconnectAttemptsRef.current = attempt;
       const delaySec = Math.min(attempt, 5);
-      setError(
-        (prev) =>
-          prev ??
-          `${fallbackMessage} Reconnecting in ${delaySec}s (attempt ${attempt}/${MAX_AUTO_RECONNECTS})…`,
-      );
+      setError((prev) => prev ?? fallbackMessage);
+      // The countdown lives in statusMessage, not error. TranscriptionSocket
+      // dispatches a server `error` frame to onError BEFORE forwarding it to
+      // onMessage, and onError sets a specific reason unconditionally - so
+      // folding the countdown into `error` would either be swallowed by the
+      // `prev ??` guard above or clobber that specific reason. Separate fields
+      // show both.
+      setStatusMessage(`Reconnecting in ${delaySec}s (attempt ${attempt}/${MAX_AUTO_RECONNECTS})…`);
       setStatusTracked('error');
       reconnectTimerRef.current = setTimeout(() => {
         reconnectTimerRef.current = null;
@@ -150,6 +158,7 @@ export function useLiveMode(): LiveModeState {
         isRetargetingRef.current = true;
         try {
           setError(null);
+          setStatusMessage(null);
           retarget();
         } finally {
           isRetargetingRef.current = false;
@@ -378,6 +387,11 @@ export function useLiveMode(): LiveModeState {
           if (isRetargetingRef.current) return;
           captureRef.current?.stop();
           setAnalyser(null);
+          // A reconnect is already armed - an engine ERROR, or a session-busy
+          // rejection that the server follows with a close. Leave the status
+          // and the countdown alone so the UI keeps showing the pending retry
+          // instead of flipping to idle underneath it.
+          if (reconnectTimerRef.current !== null) return;
           setStatusMessage(null);
           // GH-237: if the drop happened while a session was actively running
           // (listening/processing), it is an unrecoverable interruption — the

--- a/dashboard/src/hooks/useLiveMode.ts
+++ b/dashboard/src/hooks/useLiveMode.ts
@@ -69,6 +69,10 @@ export interface LiveStartOptions {
   whisperServerModel?: string;
 }
 
+// Cap on consecutive automatic reconnect attempts after the engine reports a
+// terminal ERROR (see the 'ERROR' branch in handleMessage below).
+const MAX_AUTO_RECONNECTS = 5;
+
 export function useLiveMode(): LiveModeState {
   const [status, setStatus] = useState<LiveStatus>('idle');
   const [sentences, setSentences] = useState<LiveSentence[]>([]);
@@ -100,10 +104,19 @@ export function useLiveMode(): LiveModeState {
   // true across a server STOPPED + reconnect so nothing resurrects; reopened
   // only by a user-initiated start()/stop().
   const sessionEstablishedRef = useRef(false);
+  // Auto-reconnect on engine ERROR: counts consecutive reconnect attempts
+  // (reset on a fresh manual start or a successful LISTENING) and holds the
+  // pending timer so a manual start()/stop() can cancel it.
+  const reconnectAttemptsRef = useRef(0);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Cleanup on unmount
   useEffect(() => {
     return () => {
+      if (reconnectTimerRef.current !== null) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
       captureRef.current?.stop();
       socketRef.current?.disconnect();
     };
@@ -157,6 +170,9 @@ export function useLiveMode(): LiveModeState {
           if (state === 'LISTENING') {
             setStatusTracked('listening');
             setStatusMessage(null);
+            // A confirmed-good session resets the auto-reconnect budget so a
+            // later, unrelated error gets the full retry allowance again.
+            reconnectAttemptsRef.current = 0;
             // Start audio capture once engine is ready. Stop any previous
             // instance first — GH-230: replacing a still-starting capture
             // without stopping it would orphan its loopback hold and stream.
@@ -189,14 +205,47 @@ export function useLiveMode(): LiveModeState {
             // GH-271: the engine reports a terminal failure out of band. This
             // branch used to be missing, so an engine that died mid-session
             // left the UI sitting in listening forever with audio still
-            // streaming into a dead session. Keep any more specific message
-            // that an `error` frame already delivered (or is about to): the
-            // two frames race, and the specific one always wins.
+            // streaming into a dead session.
             captureRef.current?.stop();
             setAnalyser(null);
             setStatusMessage(null);
-            setError((prev) => prev ?? 'Live mode stopped because the engine reported an error.');
-            setStatusTracked('error');
+            const attempt = reconnectAttemptsRef.current + 1;
+            if (attempt <= MAX_AUTO_RECONNECTS) {
+              // Retry the whole session with backoff — the backend already
+              // retries transient recorder errors on its own (with its own
+              // backoff/watchdog), so reaching ERROR here means it gave up;
+              // a fresh session is the next thing worth trying.
+              reconnectAttemptsRef.current = attempt;
+              const delaySec = Math.min(attempt, 5);
+              setError(
+                `Live Mode error — reconnecting in ${delaySec}s (attempt ${attempt}/${MAX_AUTO_RECONNECTS})…`,
+              );
+              setStatusTracked('error');
+              reconnectTimerRef.current = setTimeout(() => {
+                reconnectTimerRef.current = null;
+                const retarget = retargetRef.current;
+                if (!retarget) return;
+                // Treat this like a retarget hop so accumulated sentences
+                // and mute state survive the reconnect.
+                isRetargetingRef.current = true;
+                try {
+                  setError(null);
+                  retarget();
+                } finally {
+                  isRetargetingRef.current = false;
+                }
+              }, delaySec * 1000);
+            } else {
+              // Out of attempts — keep any more specific message an `error`
+              // frame already delivered (or is about to): the two frames
+              // race, and the specific one always wins.
+              setError(
+                (prev) =>
+                  prev ??
+                  'Live Mode stopped after too many errors. Start again manually to retry.',
+              );
+              setStatusTracked('error');
+            }
           } else if (state === 'STOPPED') {
             // GH-230: a server-initiated stop must tear down capture too —
             // leaving it running kept streaming audio into a dead session and
@@ -262,6 +311,14 @@ export function useLiveMode(): LiveModeState {
       if (!isRetargetingRef.current) {
         setSentences([]);
         setMuted(false);
+        // A fresh manual start resets the auto-reconnect budget.
+        reconnectAttemptsRef.current = 0;
+      }
+      // Cancel any pending auto-reconnect timer — the user (or a retarget
+      // hop) is already starting a new session before the countdown expired.
+      if (reconnectTimerRef.current !== null) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
       }
       setStatusMessage(null);
       startOptsRef.current = options ?? {};
@@ -370,6 +427,12 @@ export function useLiveMode(): LiveModeState {
   }, [start]);
 
   const stop = useCallback(() => {
+    // A manual stop supersedes any pending auto-reconnect.
+    if (reconnectTimerRef.current !== null) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+    reconnectAttemptsRef.current = 0;
     socketRef.current?.sendJSON({ type: 'stop' });
     socketRef.current?.disconnect(); // sets intentionalDisconnect=true, prevents reconnect loop
     captureRef.current?.stop();

--- a/server/backend/api/routes/live.py
+++ b/server/backend/api/routes/live.py
@@ -225,9 +225,7 @@ class LiveModeSession:
             )
             if _backoff_max is not None:
                 config.retry_backoff_max_seconds = float(_backoff_max)
-            _watchdog = server_cfg.get(
-                "live_transcriber", "watchdog_timeout_seconds", default=None
-            )
+            _watchdog = server_cfg.get("live_transcriber", "watchdog_timeout_seconds", default=None)
             if _watchdog is not None:
                 config.watchdog_timeout_seconds = float(_watchdog)
 
@@ -687,7 +685,7 @@ async def live_mode_endpoint(websocket: WebSocket) -> None:
                 # Handle binary audio data
                 if "bytes" in message:
                     audio_data = message["bytes"]
-                    if session and session._engine and session._engine.is_running:
+                    if session and session._engine and session._engine.is_accepting_audio:
                         # Parse audio format (same as /ws endpoint):
                         # [4 bytes metadata length][metadata JSON][PCM Int16 data]
                         if len(audio_data) > 4:

--- a/server/backend/api/routes/live.py
+++ b/server/backend/api/routes/live.py
@@ -198,6 +198,19 @@ class LiveModeSession:
                         config_data["post_speech_silence_duration"]
                     )
 
+            if not config.model.strip():
+                await self.send_message(
+                    "error",
+                    {
+                        "status_code": 409,
+                        "message": (
+                            "Live model not selected. Choose a Live Mode model in Server settings "
+                            "before starting Live Mode."
+                        ),
+                    },
+                )
+                return False
+
             # Seed reliability tunables from config.yaml's live_transcriber section
             _max_errors = server_cfg.get("live_transcriber", "max_consecutive_errors", default=None)
             if _max_errors is not None:
@@ -217,19 +230,6 @@ class LiveModeSession:
             )
             if _watchdog is not None:
                 config.watchdog_timeout_seconds = float(_watchdog)
-
-            if not config.model.strip():
-                await self.send_message(
-                    "error",
-                    {
-                        "status_code": 409,
-                        "message": (
-                            "Live model not selected. Choose a Live Mode model in Server settings "
-                            "before starting Live Mode."
-                        ),
-                    },
-                )
-                return False
 
             if not is_live_mode_model_supported(config.model):
                 backend_type = detect_backend_type(config.model)

--- a/server/backend/api/routes/live.py
+++ b/server/backend/api/routes/live.py
@@ -198,6 +198,26 @@ class LiveModeSession:
                         config_data["post_speech_silence_duration"]
                     )
 
+            # Seed reliability tunables from config.yaml's live_transcriber section
+            _max_errors = server_cfg.get("live_transcriber", "max_consecutive_errors", default=None)
+            if _max_errors is not None:
+                config.max_consecutive_errors = int(_max_errors)
+            _backoff_base = server_cfg.get(
+                "live_transcriber", "retry_backoff_base_seconds", default=None
+            )
+            if _backoff_base is not None:
+                config.retry_backoff_base_seconds = float(_backoff_base)
+            _backoff_max = server_cfg.get(
+                "live_transcriber", "retry_backoff_max_seconds", default=None
+            )
+            if _backoff_max is not None:
+                config.retry_backoff_max_seconds = float(_backoff_max)
+            _watchdog = server_cfg.get(
+                "live_transcriber", "watchdog_timeout_seconds", default=None
+            )
+            if _watchdog is not None:
+                config.watchdog_timeout_seconds = float(_watchdog)
+
             if not config.model.strip():
                 await self.send_message(
                     "error",

--- a/server/backend/core/live_engine.py
+++ b/server/backend/core/live_engine.py
@@ -13,6 +13,7 @@ import logging
 import queue
 import threading
 import time
+from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum, auto
@@ -32,6 +33,12 @@ SAMPLE_RATE = 16000
 # This ceiling exists only so ``start()`` always reaches a definite answer
 # instead of blocking a client forever; pass ``timeout=None`` to wait outright.
 INIT_TIMEOUT_SECONDS = 300.0
+
+# Cap on audio held back while the recorder is being rebuilt after a transient
+# error. 16-bit mono PCM at SAMPLE_RATE is 32000 bytes/s, so this is ~30s of
+# speech - enough to cover a backoff plus a model reload without letting a
+# pathological rebuild grow the backlog without limit.
+MAX_PENDING_AUDIO_BYTES = SAMPLE_RATE * 2 * 30
 
 
 class LiveModeState(Enum):
@@ -161,6 +168,22 @@ class LiveModeEngine:
         return self._state in (LiveModeState.LISTENING, LiveModeState.PROCESSING)
 
     @property
+    def is_accepting_audio(self) -> bool:
+        """Whether inbound audio should still be admitted to the engine.
+
+        Wider than :attr:`is_running`: it also covers STARTING, so audio that
+        arrives while a transient error is being retried (the recorder is torn
+        down and rebuilt) is buffered by the feeder instead of being dropped at
+        the WebSocket boundary. Dropping it there would silently lose speech
+        the user is still producing (CLAUDE.md save-first invariant).
+        """
+        return self._state in (
+            LiveModeState.LISTENING,
+            LiveModeState.PROCESSING,
+            LiveModeState.STARTING,
+        )
+
+    @property
     def sentence_history(self) -> list[str]:
         """Get history of transcribed sentences."""
         return self._sentence_history.copy()
@@ -217,18 +240,22 @@ class LiveModeEngine:
             except Exception as e:
                 logger.error(f"Sentence callback error: {e}")
 
+    def _shutdown_recorder(self) -> None:
+        """Shut down and drop the current recorder, if there is one."""
+        if self._recorder:
+            try:
+                self._recorder.shutdown()
+            except Exception as e:
+                logger.debug("Error shutting down recorder: %s", e)
+            self._recorder = None
+
     def _create_recorder(self) -> None:
         """Shut down the current recorder (if any) and create a fresh one.
 
         Used both for the initial build in ``_transcription_loop`` and to
         rebuild after a transient error or a watchdog-triggered restart.
         """
-        if self._recorder:
-            try:
-                self._recorder.shutdown()
-            except Exception as e:
-                logger.debug("Error shutting down recorder during rebuild: %s", e)
-            self._recorder = None
+        self._shutdown_recorder()
 
         # Import server's AudioToTextRecorder (not RealtimeSTT's)
         from server.core.stt.engine import AudioToTextRecorder
@@ -263,6 +290,14 @@ class LiveModeEngine:
         # brand-new recorder too, repeating until max_consecutive_errors
         # gives up.
         self._last_sentence_time = time.monotonic()
+        # Also drop any in-flight recording marker and any watchdog arm raised
+        # while this rebuild was running: _create_recorder() leaves _recorder
+        # None for the whole model load, so a watchdog tick landing in that
+        # window arms the flag against nothing, and the arm would otherwise
+        # survive into the fresh recorder and make its first empty text()
+        # raise a spurious restart.
+        self._last_recording_start_time = None
+        self._watchdog_restart_requested = False
 
     def _watchdog_tick(self, now: float) -> None:
         """Run one watchdog check. Split out from ``_watchdog_loop`` for testability.
@@ -287,18 +322,27 @@ class LiveModeEngine:
         # otherwise last_start refers to an utterance that already finished.
         recording_in_flight = last_start > last_sentence
         stale = (now - last_start) > self.config.watchdog_timeout_seconds
-        if recording_in_flight and stale and not self._watchdog_restart_requested:
-            logger.warning(
-                "Live Mode watchdog: recording started %.0fs ago with no "
-                "sentence produced since — triggering recorder restart",
-                now - last_start,
-            )
-            self._watchdog_restart_requested = True
-            if self._recorder:
-                try:
-                    self._recorder.shutdown()
-                except Exception as e:
-                    logger.debug("Watchdog recorder shutdown error: %s", e)
+        if not (recording_in_flight and stale) or self._watchdog_restart_requested:
+            return
+
+        recorder = self._recorder
+        if recorder is None:
+            # A rebuild is already in flight - _create_recorder() drops the
+            # recorder for the whole model load. Arming here would fire the
+            # flag against nothing and make the fresh recorder's first empty
+            # text() raise a spurious restart.
+            return
+
+        logger.warning(
+            "Live Mode watchdog: recording started %.0fs ago with no "
+            "sentence produced since — triggering recorder restart",
+            now - last_start,
+        )
+        self._watchdog_restart_requested = True
+        try:
+            recorder.shutdown()
+        except Exception as e:
+            logger.debug("Watchdog recorder shutdown error: %s", e)
 
     def _watchdog_loop(self) -> None:
         """Poll ``_watchdog_tick`` for a hung ``text()`` call and restart it."""
@@ -361,26 +405,48 @@ class LiveModeEngine:
                         # and gets backoff like any other error instead of
                         # ending the session on the spot.
                         self._create_recorder()
+                        if self._stop_event.is_set():
+                            # stop() raced the rebuild: it has already joined
+                            # (or timed out on) this thread and cleared its own
+                            # reference, so the recorder just built here would
+                            # be orphaned with its model pinned in VRAM.
+                            self._shutdown_recorder()
+                            break
                         need_rebuild = False
                         self._set_state(LiveModeState.LISTENING)
 
                     # text() blocks until a sentence is complete or the recorder
                     # is shut down (e.g. by the watchdog or stop()).
+                    started_before = self._last_recording_start_time
                     text = self._recorder.text()  # type: ignore[union-attr]
 
+                    # The utterance VAD started has resolved, even when it came
+                    # back empty (a VAD false positive on noise, or audio the
+                    # backend trimmed away). Clear the in-flight marker so an
+                    # empty result cannot latch the watchdog into reading the
+                    # next ordinary silence as a hang. Only clear the marker we
+                    # actually observed, so a recording that started while
+                    # text() was returning keeps its own watchdog coverage.
+                    if self._last_recording_start_time == started_before:
+                        self._last_recording_start_time = None
+
+                    watchdog_fired = self._watchdog_restart_requested
+                    self._watchdog_restart_requested = False
+
                     if text:
-                        # A real result beats a pending watchdog flag — whatever
-                        # the watchdog suspected was hung must have resolved on
-                        # its own. Discarding a completed transcription here
-                        # would violate the save-first invariant (CLAUDE.md).
+                        # Save first: a completed transcription is never
+                        # discarded, not even when the watchdog fired while it
+                        # was still in flight (CLAUDE.md save-first invariant).
                         self._process_sentence(text)
                         consecutive_errors = 0
-                        self._watchdog_restart_requested = False
-                    elif self._watchdog_restart_requested:
-                        # No result, and the watchdog's shutdown() is what
-                        # unblocked text() — treat as a transient error and
-                        # rebuild the recorder.
-                        self._watchdog_restart_requested = False
+
+                    if watchdog_fired:
+                        # The watchdog already called shutdown() on this
+                        # recorder, so it is dead whether or not a sentence was
+                        # salvaged from it: every later text() returns ""
+                        # immediately. The rebuild is mandatory - skipping it
+                        # left the loop spinning on a dead recorder with the
+                        # session wedged in LISTENING and no error ever raised.
                         raise RuntimeError("Watchdog triggered recorder restart")
 
                 except Exception as e:
@@ -406,9 +472,10 @@ class LiveModeEngine:
                         e,
                     )
                     # Let the client know a recovery is in progress instead of
-                    # leaving it in LISTENING while audio is silently dropped
-                    # underneath it (feed_audio() no-ops once is_running is
-                    # False, since the recorder is about to be replaced).
+                    # leaving it stuck on LISTENING. STARTING still admits
+                    # audio (see is_accepting_audio); the feeder holds it back
+                    # until the rebuilt recorder can take it, so speech during
+                    # the backoff is buffered rather than dropped.
                     self._set_state(LiveModeState.STARTING)
                     self._stop_event.wait(delay)
                     if self._stop_event.is_set():
@@ -437,17 +504,53 @@ class LiveModeEngine:
 
     def _audio_feeder_loop(self) -> None:
         """Feed audio from queue to recorder (runs in separate thread)."""
+        # Chunks that arrived while the recorder was torn down for a rebuild.
+        # Held rather than dropped so a transient retry does not silently
+        # swallow speech the user is still producing (CLAUDE.md), and bounded
+        # so a slow rebuild cannot grow the backlog without limit.
+        pending: deque[bytes] = deque()
+        pending_bytes = 0
+
         while not self._stop_event.is_set():
             try:
                 # Get audio chunk from queue with timeout
                 try:
                     chunk = self._audio_queue.get(timeout=0.1)
                 except queue.Empty:
+                    chunk = None
+
+                recorder = self._recorder
+                if recorder is None or not self.is_running:
+                    # Recorder is being rebuilt (or the session is not live yet).
+                    # Hold the audio back instead of discarding it.
+                    if chunk is not None:
+                        pending.append(chunk)
+                        pending_bytes += len(chunk)
+                        while pending_bytes > MAX_PENDING_AUDIO_BYTES and pending:
+                            dropped = pending.popleft()
+                            pending_bytes -= len(dropped)
+                            logger.warning(
+                                "Live Mode: recovery backlog above %d bytes, "
+                                "discarding %d bytes of buffered audio",
+                                MAX_PENDING_AUDIO_BYTES,
+                                len(dropped),
+                            )
                     continue
 
-                # Feed to recorder if available
-                if self._recorder and self.is_running:
-                    self._recorder.feed_audio(chunk, SAMPLE_RATE)
+                if pending:
+                    logger.info(
+                        "Live Mode: flushing %d buffered audio chunks (%d bytes) "
+                        "into the rebuilt recorder",
+                        len(pending),
+                        pending_bytes,
+                    )
+                    while pending:
+                        held = pending.popleft()
+                        pending_bytes -= len(held)
+                        recorder.feed_audio(held, SAMPLE_RATE)
+
+                if chunk is not None:
+                    recorder.feed_audio(chunk, SAMPLE_RATE)
 
             except Exception as e:
                 if not self._stop_event.is_set():
@@ -465,7 +568,7 @@ class LiveModeEngine:
             audio_data: Audio data (PCM Int16 bytes or numpy array)
             sample_rate: Sample rate of the audio
         """
-        if not self.is_running:
+        if not self.is_accepting_audio:
             return
 
         # Convert numpy array to bytes if needed

--- a/server/backend/core/live_engine.py
+++ b/server/backend/core/live_engine.py
@@ -141,8 +141,12 @@ class LiveModeEngine:
         # Audio queue for feeding from WebSocket
         self._audio_queue: queue.Queue[bytes] = queue.Queue()
 
-        # Watchdog timing — updated from their respective threads
-        self._last_audio_time: float | None = None
+        # Watchdog timing — updated from their respective threads. A hang is
+        # "a recording started (VAD triggered) more recently than the last
+        # completed sentence, and it's been too long since" — NOT "no audio
+        # fed recently", which is indistinguishable from a quiet user (see
+        # _watchdog_loop).
+        self._last_recording_start_time: float | None = None
         self._last_sentence_time: float | None = None
         self._watchdog_restart_requested = False
 
@@ -183,6 +187,7 @@ class LiveModeEngine:
     def _on_recording_start(self) -> None:
         """Callback when voice activity starts."""
         logger.debug("Live Mode: Voice activity detected")
+        self._last_recording_start_time = time.monotonic()
         self._set_state(LiveModeState.PROCESSING)
 
     def _on_recording_stop(self) -> None:
@@ -251,36 +256,57 @@ class LiveModeEngine:
             shared_backend=self._shared_backend,
         )
 
+        # Reseed so the watchdog waits a full timeout before it considers
+        # this (re)built recorder stale. Without this, a retry or
+        # watchdog-triggered rebuild inherits the OLD recorder's stale
+        # _last_sentence_time and the watchdog immediately restarts the
+        # brand-new recorder too, repeating until max_consecutive_errors
+        # gives up.
+        self._last_sentence_time = time.monotonic()
+
+    def _watchdog_tick(self, now: float) -> None:
+        """Run one watchdog check. Split out from ``_watchdog_loop`` for testability.
+
+        A hang is "a recording started (VAD detected speech) more recently
+        than the last completed sentence, and stayed unresolved past
+        watchdog_timeout_seconds" — NOT "no audio fed recently". The
+        dashboard streams PCM continuously while listening, so audio is
+        "recent" for essentially the entire session even when the user
+        hasn't said a word, and text() legitimately blocks in wait_audio()
+        during silence. Gating on audio recency alone would tear down a
+        healthy recorder on every ordinary pause.
+        """
+        last_start = self._last_recording_start_time
+        last_sentence = self._last_sentence_time
+
+        if last_start is None or last_sentence is None:
+            return
+
+        # A recording is "in flight" (started but not yet resolved into a
+        # sentence) only when it began after the last completed sentence —
+        # otherwise last_start refers to an utterance that already finished.
+        recording_in_flight = last_start > last_sentence
+        stale = (now - last_start) > self.config.watchdog_timeout_seconds
+        if recording_in_flight and stale and not self._watchdog_restart_requested:
+            logger.warning(
+                "Live Mode watchdog: recording started %.0fs ago with no "
+                "sentence produced since — triggering recorder restart",
+                now - last_start,
+            )
+            self._watchdog_restart_requested = True
+            if self._recorder:
+                try:
+                    self._recorder.shutdown()
+                except Exception as e:
+                    logger.debug("Watchdog recorder shutdown error: %s", e)
+
     def _watchdog_loop(self) -> None:
-        """Detect hung text() calls and trigger a recorder restart."""
+        """Poll ``_watchdog_tick`` for a hung ``text()`` call and restart it."""
         while not self._stop_event.is_set():
             self._stop_event.wait(10.0)
             if self._stop_event.is_set():
                 break
-
-            now = time.monotonic()
-            last_audio = self._last_audio_time
-            last_sentence = self._last_sentence_time
-
-            if last_audio is None or last_sentence is None:
-                continue
-
-            # If audio has arrived recently but no sentence in watchdog_timeout_seconds,
-            # the text() call is likely stuck — kick the recorder to unblock it.
-            audio_is_recent = (now - last_audio) < 30.0
-            sentence_is_stale = (now - last_sentence) > self.config.watchdog_timeout_seconds
-            if audio_is_recent and sentence_is_stale and not self._watchdog_restart_requested:
-                logger.warning(
-                    "Live Mode watchdog: no sentence in %.0fs despite active audio — "
-                    "triggering recorder restart",
-                    now - last_sentence,
-                )
-                self._watchdog_restart_requested = True
-                if self._recorder:
-                    try:
-                        self._recorder.shutdown()
-                    except Exception as e:
-                        logger.debug("Watchdog recorder shutdown error: %s", e)
+            self._watchdog_tick(time.monotonic())
 
     def _transcription_loop(self) -> None:
         """Main transcription loop (runs in separate thread).
@@ -317,30 +343,45 @@ class LiveModeEngine:
 
             self._init_ok = True
             self._set_state(LiveModeState.LISTENING)
-            # Seed last_sentence_time so the watchdog waits a full timeout
-            # before it considers the engine stale right after startup.
-            self._last_sentence_time = time.monotonic()
             logger.info("Live Mode started")
             self._init_complete.set()
 
             # Process sentences in a loop, retrying transient errors (including
             # watchdog-triggered restarts) with backoff before giving up.
             consecutive_errors = 0
+            need_rebuild = False
             while not self._stop_event.is_set():
                 try:
+                    if need_rebuild:
+                        # Rebuilding here (inside the try) means a failure — a
+                        # model load can fail transiently, e.g. VRAM/CUDA still
+                        # releasing from the previous recorder — is caught by
+                        # the SAME except block below instead of escaping to
+                        # the outer handler, so it consumes the retry budget
+                        # and gets backoff like any other error instead of
+                        # ending the session on the spot.
+                        self._create_recorder()
+                        need_rebuild = False
+                        self._set_state(LiveModeState.LISTENING)
+
                     # text() blocks until a sentence is complete or the recorder
                     # is shut down (e.g. by the watchdog or stop()).
                     text = self._recorder.text()  # type: ignore[union-attr]
 
-                    if self._watchdog_restart_requested:
-                        # Watchdog detected a hang — treat as a transient error
-                        # and rebuild the recorder.
-                        self._watchdog_restart_requested = False
-                        raise RuntimeError("Watchdog triggered recorder restart")
-
                     if text:
+                        # A real result beats a pending watchdog flag — whatever
+                        # the watchdog suspected was hung must have resolved on
+                        # its own. Discarding a completed transcription here
+                        # would violate the save-first invariant (CLAUDE.md).
                         self._process_sentence(text)
                         consecutive_errors = 0
+                        self._watchdog_restart_requested = False
+                    elif self._watchdog_restart_requested:
+                        # No result, and the watchdog's shutdown() is what
+                        # unblocked text() — treat as a transient error and
+                        # rebuild the recorder.
+                        self._watchdog_restart_requested = False
+                        raise RuntimeError("Watchdog triggered recorder restart")
 
                 except Exception as e:
                     if self._stop_event.is_set():
@@ -364,10 +405,15 @@ class LiveModeEngine:
                         delay,
                         e,
                     )
+                    # Let the client know a recovery is in progress instead of
+                    # leaving it in LISTENING while audio is silently dropped
+                    # underneath it (feed_audio() no-ops once is_running is
+                    # False, since the recorder is about to be replaced).
+                    self._set_state(LiveModeState.STARTING)
                     self._stop_event.wait(delay)
                     if self._stop_event.is_set():
                         break
-                    self._create_recorder()
+                    need_rebuild = True
 
         except Exception as e:
             logger.error(f"Live Mode loop error: {e}")
@@ -402,7 +448,6 @@ class LiveModeEngine:
                 # Feed to recorder if available
                 if self._recorder and self.is_running:
                     self._recorder.feed_audio(chunk, SAMPLE_RATE)
-                    self._last_audio_time = time.monotonic()
 
             except Exception as e:
                 if not self._stop_event.is_set():
@@ -459,7 +504,7 @@ class LiveModeEngine:
         self._init_complete.clear()
         self._init_ok = False
         self._init_error = None
-        self._last_audio_time = None
+        self._last_recording_start_time = None
         self._last_sentence_time = None
         self._watchdog_restart_requested = False
 

--- a/server/backend/core/live_engine.py
+++ b/server/backend/core/live_engine.py
@@ -12,6 +12,7 @@ operates continuously and delivers sentences as they are detected via VAD.
 import logging
 import queue
 import threading
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum, auto
@@ -72,6 +73,14 @@ class LiveModeConfig:
     beam_size: int = 5
     batch_size: int = 16
 
+    # Reliability — retry-with-backoff on transcription errors, and a watchdog
+    # that restarts the recorder if it stops producing sentences despite
+    # incoming audio (a hung text() call).
+    max_consecutive_errors: int = 5
+    retry_backoff_base_seconds: float = 2.0
+    retry_backoff_max_seconds: float = 30.0
+    watchdog_timeout_seconds: float = 90.0
+
 
 class LiveModeEngine:
     """
@@ -112,6 +121,7 @@ class LiveModeEngine:
         self._state = LiveModeState.STOPPED
         self._loop_thread: threading.Thread | None = None
         self._feeder_thread: threading.Thread | None = None
+        self._watchdog_thread: threading.Thread | None = None
         self._stop_event = threading.Event()
 
         # GH-271: initialization handshake between start() and
@@ -130,6 +140,11 @@ class LiveModeEngine:
 
         # Audio queue for feeding from WebSocket
         self._audio_queue: queue.Queue[bytes] = queue.Queue()
+
+        # Watchdog timing — updated from their respective threads
+        self._last_audio_time: float | None = None
+        self._last_sentence_time: float | None = None
+        self._watchdog_restart_requested = False
 
     @property
     def state(self) -> LiveModeState:
@@ -182,6 +197,7 @@ class LiveModeEngine:
             return
 
         text = text.strip()
+        self._last_sentence_time = time.monotonic()
         logger.info(f"Live Mode sentence: {text}")
 
         # Add to history
@@ -196,6 +212,76 @@ class LiveModeEngine:
             except Exception as e:
                 logger.error(f"Sentence callback error: {e}")
 
+    def _create_recorder(self) -> None:
+        """Shut down the current recorder (if any) and create a fresh one.
+
+        Used both for the initial build in ``_transcription_loop`` and to
+        rebuild after a transient error or a watchdog-triggered restart.
+        """
+        if self._recorder:
+            try:
+                self._recorder.shutdown()
+            except Exception as e:
+                logger.debug("Error shutting down recorder during rebuild: %s", e)
+            self._recorder = None
+
+        # Import server's AudioToTextRecorder (not RealtimeSTT's)
+        from server.core.stt.engine import AudioToTextRecorder
+
+        self._recorder = AudioToTextRecorder(
+            instance_name="live_mode",
+            model=self.config.model,
+            language=self.config.language if self.config.language else "",
+            task="translate" if self.config.translation_enabled else "transcribe",
+            translation_target_language=self.config.translation_target_language,
+            compute_type=self.config.compute_type,
+            device=self.config.device,
+            gpu_device_index=self.config.gpu_device_index,
+            silero_sensitivity=self.config.silero_sensitivity,
+            webrtc_sensitivity=self.config.webrtc_sensitivity,
+            post_speech_silence_duration=self.config.post_speech_silence_duration,
+            min_length_of_recording=self.config.min_length_of_recording,
+            min_gap_between_recordings=self.config.min_gap_between_recordings,
+            ensure_sentence_starting_uppercase=self.config.ensure_sentence_starting_uppercase,
+            ensure_sentence_ends_with_period=self.config.ensure_sentence_ends_with_period,
+            beam_size=self.config.beam_size,
+            batch_size=self.config.batch_size,
+            on_recording_start=self._on_recording_start,
+            on_recording_stop=self._on_recording_stop,
+            shared_backend=self._shared_backend,
+        )
+
+    def _watchdog_loop(self) -> None:
+        """Detect hung text() calls and trigger a recorder restart."""
+        while not self._stop_event.is_set():
+            self._stop_event.wait(10.0)
+            if self._stop_event.is_set():
+                break
+
+            now = time.monotonic()
+            last_audio = self._last_audio_time
+            last_sentence = self._last_sentence_time
+
+            if last_audio is None or last_sentence is None:
+                continue
+
+            # If audio has arrived recently but no sentence in watchdog_timeout_seconds,
+            # the text() call is likely stuck — kick the recorder to unblock it.
+            audio_is_recent = (now - last_audio) < 30.0
+            sentence_is_stale = (now - last_sentence) > self.config.watchdog_timeout_seconds
+            if audio_is_recent and sentence_is_stale and not self._watchdog_restart_requested:
+                logger.warning(
+                    "Live Mode watchdog: no sentence in %.0fs despite active audio — "
+                    "triggering recorder restart",
+                    now - last_sentence,
+                )
+                self._watchdog_restart_requested = True
+                if self._recorder:
+                    try:
+                        self._recorder.shutdown()
+                    except Exception as e:
+                        logger.debug("Watchdog recorder shutdown error: %s", e)
+
     def _transcription_loop(self) -> None:
         """Main transcription loop (runs in separate thread).
 
@@ -209,34 +295,7 @@ class LiveModeEngine:
             self._set_state(LiveModeState.STARTING)
 
             try:
-                # Import server's AudioToTextRecorder (not RealtimeSTT's)
-                from server.core.stt.engine import AudioToTextRecorder
-
-                # Create recorder with configuration
-                self._recorder = AudioToTextRecorder(
-                    instance_name="live_mode",
-                    model=self.config.model,
-                    language=self.config.language if self.config.language else "",
-                    task="translate" if self.config.translation_enabled else "transcribe",
-                    translation_target_language=self.config.translation_target_language,
-                    compute_type=self.config.compute_type,
-                    device=self.config.device,
-                    gpu_device_index=self.config.gpu_device_index,
-                    silero_sensitivity=self.config.silero_sensitivity,
-                    webrtc_sensitivity=self.config.webrtc_sensitivity,
-                    post_speech_silence_duration=self.config.post_speech_silence_duration,
-                    min_length_of_recording=self.config.min_length_of_recording,
-                    min_gap_between_recordings=self.config.min_gap_between_recordings,
-                    ensure_sentence_starting_uppercase=(
-                        self.config.ensure_sentence_starting_uppercase
-                    ),
-                    ensure_sentence_ends_with_period=self.config.ensure_sentence_ends_with_period,
-                    beam_size=self.config.beam_size,
-                    batch_size=self.config.batch_size,
-                    on_recording_start=self._on_recording_start,
-                    on_recording_stop=self._on_recording_stop,
-                    shared_backend=self._shared_backend,
-                )
+                self._create_recorder()
             except Exception as e:
                 # Record the failure and publish the terminal state BEFORE
                 # releasing start(), so the caller reads a settled outcome
@@ -258,21 +317,57 @@ class LiveModeEngine:
 
             self._init_ok = True
             self._set_state(LiveModeState.LISTENING)
+            # Seed last_sentence_time so the watchdog waits a full timeout
+            # before it considers the engine stale right after startup.
+            self._last_sentence_time = time.monotonic()
             logger.info("Live Mode started")
             self._init_complete.set()
 
-            # Process sentences in a loop
+            # Process sentences in a loop, retrying transient errors (including
+            # watchdog-triggered restarts) with backoff before giving up.
+            consecutive_errors = 0
             while not self._stop_event.is_set():
                 try:
-                    # text() blocks until a sentence is complete
-                    text = self._recorder.text()
+                    # text() blocks until a sentence is complete or the recorder
+                    # is shut down (e.g. by the watchdog or stop()).
+                    text = self._recorder.text()  # type: ignore[union-attr]
+
+                    if self._watchdog_restart_requested:
+                        # Watchdog detected a hang — treat as a transient error
+                        # and rebuild the recorder.
+                        self._watchdog_restart_requested = False
+                        raise RuntimeError("Watchdog triggered recorder restart")
+
                     if text:
                         self._process_sentence(text)
+                        consecutive_errors = 0
+
                 except Exception as e:
-                    if not self._stop_event.is_set():
-                        logger.error(f"Live Mode transcription error: {e}")
+                    if self._stop_event.is_set():
+                        break
+                    consecutive_errors += 1
+                    if consecutive_errors >= self.config.max_consecutive_errors:
+                        logger.error(
+                            "Live Mode: %d consecutive errors, giving up: %s",
+                            consecutive_errors,
+                            e,
+                        )
                         self._set_state(LiveModeState.ERROR)
                         break
+                    delay = min(
+                        self.config.retry_backoff_base_seconds * (2 ** (consecutive_errors - 1)),
+                        self.config.retry_backoff_max_seconds,
+                    )
+                    logger.warning(
+                        "Live Mode error #%d (retrying in %.1fs): %s",
+                        consecutive_errors,
+                        delay,
+                        e,
+                    )
+                    self._stop_event.wait(delay)
+                    if self._stop_event.is_set():
+                        break
+                    self._create_recorder()
 
         except Exception as e:
             logger.error(f"Live Mode loop error: {e}")
@@ -307,6 +402,7 @@ class LiveModeEngine:
                 # Feed to recorder if available
                 if self._recorder and self.is_running:
                     self._recorder.feed_audio(chunk, SAMPLE_RATE)
+                    self._last_audio_time = time.monotonic()
 
             except Exception as e:
                 if not self._stop_event.is_set():
@@ -363,6 +459,9 @@ class LiveModeEngine:
         self._init_complete.clear()
         self._init_ok = False
         self._init_error = None
+        self._last_audio_time = None
+        self._last_sentence_time = None
+        self._watchdog_restart_requested = False
 
         # Clear audio queue
         while not self._audio_queue.empty():
@@ -396,6 +495,12 @@ class LiveModeEngine:
             self._stop_event.set()
             return False
 
+        # Start watchdog thread now that the recorder is confirmed listening
+        self._watchdog_thread = threading.Thread(
+            target=self._watchdog_loop, daemon=True, name="LiveModeWatchdog"
+        )
+        self._watchdog_thread.start()
+
         return True
 
     def stop(self) -> None:
@@ -422,8 +527,12 @@ class LiveModeEngine:
         if self._feeder_thread and self._feeder_thread.is_alive():
             self._feeder_thread.join(timeout=2.0)
 
+        if self._watchdog_thread and self._watchdog_thread.is_alive():
+            self._watchdog_thread.join(timeout=2.0)
+
         self._loop_thread = None
         self._feeder_thread = None
+        self._watchdog_thread = None
         self._recorder = None
 
     def clear_history(self) -> None:

--- a/server/backend/tests/test_live_engine_retry_watchdog.py
+++ b/server/backend/tests/test_live_engine_retry_watchdog.py
@@ -47,6 +47,17 @@ def _install_recorder_stub(monkeypatch: pytest.MonkeyPatch, factory: Any) -> Non
     monkeypatch.setitem(sys.modules, "server.core.stt.engine", module)
 
 
+class _CollectingRecorder:
+    def __init__(self, **kwargs: Any) -> None:
+        self.fed: list[bytes] = []
+
+    def feed_audio(self, chunk: bytes, sample_rate: int = 16000) -> None:
+        self.fed.append(chunk)
+
+    def shutdown(self) -> None:
+        return None
+
+
 class _ScriptedRecorder:
     """Stand-in for ``AudioToTextRecorder`` whose text() replays a script.
 
@@ -113,8 +124,15 @@ class TestWatchdogDoesNotMisfireOnSilence:
         assert engine._watchdog_restart_requested is False
 
     def test_restart_requested_when_recording_stuck_past_timeout(self):
-        """An in-flight recording stuck past the timeout IS a genuine hang."""
+        """An in-flight recording stuck past the timeout IS a genuine hang.
+
+        A live recorder has to be attached: the tick deliberately no-ops when
+        ``_recorder`` is None, because that means a rebuild is already running
+        and there is nothing to shut down.
+        """
         engine = LiveModeEngine(config=LiveModeConfig(watchdog_timeout_seconds=1.0))
+        recorder = _CollectingRecorder()
+        engine._recorder = recorder
         engine._last_recording_start_time = 10.0
         engine._last_sentence_time = 5.0  # last sentence predates this recording
 
@@ -337,3 +355,197 @@ class TestRebuildFailureConsumesRetryBudget:
             engine._loop_thread.join(timeout=_WAIT)
 
         assert engine.state is LiveModeState.ERROR
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 5. A watchdog restart must rebuild even when a sentence won the race
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestWatchdogRestartAlwaysRebuilds:
+    def test_rebuild_happens_even_when_a_sentence_won_the_race(self, monkeypatch):
+        """Salvaging the sentence must not cancel the rebuild.
+
+        The watchdog calls ``shutdown()`` before the loop ever looks at the
+        flag, so the recorder is dead whether or not a result was salvaged
+        from it: every later ``text()`` returns "" immediately. Clearing the
+        flag without rebuilding left the loop spinning on that dead recorder
+        forever, wedged in LISTENING, with no error and no sentences.
+        """
+        recorders: list[_RaceRecorder] = []
+
+        def _factory(**kwargs):
+            recorder = _RaceRecorder(**kwargs)
+            recorders.append(recorder)
+            return recorder
+
+        _install_recorder_stub(monkeypatch, _factory)
+        sentences: list[str] = []
+        engine = LiveModeEngine(
+            config=LiveModeConfig(
+                watchdog_timeout_seconds=90.0,
+                retry_backoff_base_seconds=0.05,
+                retry_backoff_max_seconds=0.05,
+            ),
+            on_sentence=sentences.append,
+        )
+
+        try:
+            assert engine.start() is True
+            recorder = recorders[0]
+            assert recorder.first_call_started.wait(timeout=_WAIT)
+
+            # Watchdog fires while inference is in flight, then inference
+            # completes on its own with a real sentence.
+            engine._watchdog_restart_requested = True
+            recorder.shutdown()
+            recorder._first_call_result.set()
+
+            deadline = time.monotonic() + _WAIT
+            while time.monotonic() < deadline and len(recorders) < 2:
+                threading.Event().wait(0.05)
+
+            assert sentences == ["Hello world."], "the salvaged sentence was lost"
+            assert len(recorders) >= 2, (
+                "the recorder the watchdog shut down was never rebuilt - the "
+                "loop is spinning on a dead recorder"
+            )
+        finally:
+            engine.stop()
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 6. An empty transcription must not latch the watchdog
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class _EmptyResultRecorder:
+    """First ``text()`` reports a VAD start and then resolves to empty text.
+
+    Models an ordinary VAD false positive (a cough, a door, background
+    chatter): speech onset is detected, but the backend finds no segments and
+    the utterance transcribes to "".
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        self._on_recording_start = kwargs.get("on_recording_start")
+        self._call = 0
+        self._shutdown_event = threading.Event()
+        self.first_result_done = threading.Event()
+
+    def text(self) -> str:
+        self._call += 1
+        if self._call == 1:
+            if self._on_recording_start:
+                self._on_recording_start()
+            self.first_result_done.set()
+            return ""
+        self._shutdown_event.wait(timeout=_WAIT)
+        return ""
+
+    def feed_audio(self, chunk: bytes, sample_rate: int = 16000) -> None:
+        return None
+
+    def shutdown(self) -> None:
+        self._shutdown_event.set()
+
+
+class TestEmptyTranscriptionDoesNotLatchWatchdog:
+    def test_empty_result_clears_the_in_flight_marker(self, monkeypatch):
+        """A VAD trigger resolving to "" must not look like a hang forever.
+
+        ``_last_sentence_time`` only advances on a real sentence, so without
+        clearing the in-flight marker an empty result leaves
+        ``last_start > last_sentence`` true permanently, and the next ordinary
+        silence past the timeout tears down a healthy recorder.
+        """
+        _install_recorder_stub(monkeypatch, _EmptyResultRecorder)
+        engine = LiveModeEngine(config=LiveModeConfig(watchdog_timeout_seconds=1.0))
+
+        try:
+            assert engine.start() is True
+            recorder = engine._recorder
+            assert recorder.first_result_done.wait(timeout=_WAIT)
+
+            deadline = time.monotonic() + _WAIT
+            while time.monotonic() < deadline and engine._last_recording_start_time is not None:
+                threading.Event().wait(0.05)
+
+            assert engine._last_recording_start_time is None, (
+                "an empty transcription left the recording marker latched"
+            )
+
+            # With the marker cleared, a tick far past the timeout is a no-op.
+            engine._watchdog_tick(time.monotonic() + 10_000.0)
+            assert engine._watchdog_restart_requested is False
+        finally:
+            engine.stop()
+
+
+class TestWatchdogDoesNotArmDuringRebuild:
+    def test_tick_is_a_noop_while_the_recorder_is_being_rebuilt(self):
+        """``_create_recorder()`` leaves ``_recorder`` None for the whole model
+        load. Arming there would fire the flag against nothing and make the
+        fresh recorder's first empty ``text()`` raise a spurious restart."""
+        engine = LiveModeEngine(config=LiveModeConfig(watchdog_timeout_seconds=1.0))
+        engine._recorder = None
+        engine._last_sentence_time = 5.0
+        engine._last_recording_start_time = 10.0
+
+        engine._watchdog_tick(10_000.0)
+
+        assert engine._watchdog_restart_requested is False
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 7. Audio arriving during a rebuild is buffered, not dropped
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestAudioBufferedDuringRebuild:
+    def test_chunks_during_starting_are_held_and_flushed(self):
+        """Audio produced while the recorder is rebuilt must survive.
+
+        Dropping it silently is the data-loss failure CLAUDE.md forbids: the
+        user is still speaking, and nothing tells them the words are gone.
+        """
+        engine = LiveModeEngine(config=LiveModeConfig())
+        engine._state = LiveModeState.STARTING
+        engine._recorder = None
+
+        feeder = threading.Thread(target=engine._audio_feeder_loop, daemon=True)
+        feeder.start()
+        try:
+            engine._audio_queue.put(b"\x01\x02")
+            engine._audio_queue.put(b"\x03\x04")
+            threading.Event().wait(0.3)
+
+            recorder = _CollectingRecorder()
+            engine._recorder = recorder
+            engine._state = LiveModeState.LISTENING
+
+            deadline = time.monotonic() + _WAIT
+            while time.monotonic() < deadline and len(recorder.fed) < 2:
+                engine._audio_queue.put(b"\x05\x06")
+                threading.Event().wait(0.05)
+
+            assert recorder.fed[:2] == [b"\x01\x02", b"\x03\x04"], (
+                "audio buffered during the rebuild was dropped instead of "
+                f"being flushed in order (got {recorder.fed[:2]!r})"
+            )
+        finally:
+            engine._stop_event.set()
+            feeder.join(timeout=2.0)
+
+    def test_engine_admits_audio_while_starting(self):
+        """The WebSocket route gates on is_accepting_audio, which must stay
+        open during STARTING so the feeder can buffer instead of the route
+        discarding the frame before it is ever queued."""
+        engine = LiveModeEngine(config=LiveModeConfig())
+
+        engine._state = LiveModeState.STARTING
+        assert engine.is_accepting_audio is True
+        assert engine.is_running is False
+
+        engine._state = LiveModeState.STOPPED
+        assert engine.is_accepting_audio is False

--- a/server/backend/tests/test_live_engine_retry_watchdog.py
+++ b/server/backend/tests/test_live_engine_retry_watchdog.py
@@ -1,0 +1,328 @@
+"""Regression tests for the Live Mode retry/watchdog reliability layer.
+
+Covers bugs found in code review of the retry-with-backoff + hang-watchdog
+feature (PR #300):
+
+1. The watchdog must not treat ordinary silence as a hang — only an
+   in-flight recording (VAD-detected speech with no sentence since) that
+   has run past ``watchdog_timeout_seconds`` counts.
+2. ``_create_recorder()`` must reseed ``_last_sentence_time`` on every
+   (re)build, not just the very first one, so a retry/watchdog rebuild
+   doesn't inherit a stale timestamp and immediately restart again.
+3. A completed transcription must win over a pending watchdog-restart flag
+   instead of being discarded (CLAUDE.md: never silently discard a
+   completed transcription).
+4. A recorder-rebuild failure during retry must consume the retry budget
+   with backoff instead of escaping to the outer handler and ending the
+   session immediately.
+
+Run:  ../../build/.venv/bin/pytest tests/test_live_engine_retry_watchdog.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import types
+from typing import Any
+
+import pytest
+from server.core.live_engine import LiveModeConfig, LiveModeEngine, LiveModeState
+
+# Generous enough that a loaded CI machine never trips it, short enough that a
+# genuine hang fails the test instead of stalling the whole suite.
+_WAIT = 5.0
+
+
+def _install_recorder_stub(monkeypatch: pytest.MonkeyPatch, factory: Any) -> None:
+    """Make the loop's lazy ``AudioToTextRecorder`` import resolve to *factory*.
+
+    Adapted from test_gh271_live_start_synchronous.py — the loop imports
+    ``server.core.stt.engine`` lazily, so a stub module in ``sys.modules``
+    intercepts it without pulling in torch and the whole STT backend stack.
+    """
+    module = types.ModuleType("server.core.stt.engine")
+    module.AudioToTextRecorder = factory  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "server.core.stt.engine", module)
+
+
+class _ScriptedRecorder:
+    """Stand-in for ``AudioToTextRecorder`` whose text() replays a script.
+
+    Each entry in *script* is either a string (returned as the completed
+    sentence) or an exception instance/class (raised). Once the script is
+    exhausted, ``text()`` blocks until ``shutdown()`` releases it — mirroring
+    the real recorder's behavior of blocking in ``wait_audio()`` during
+    silence.
+    """
+
+    def __init__(self, script: list[Any], **kwargs: Any) -> None:
+        self._script = list(script)
+        self._index = 0
+        self._released = threading.Event()
+        self.shutdown_calls = 0
+
+    def text(self) -> str:
+        if self._index < len(self._script):
+            item = self._script[self._index]
+            self._index += 1
+            if isinstance(item, BaseException) or (
+                isinstance(item, type) and issubclass(item, BaseException)
+            ):
+                raise item
+            return item
+        self._released.wait(timeout=_WAIT)
+        return ""
+
+    def feed_audio(self, chunk: bytes, sample_rate: int = 16000) -> None:
+        return None
+
+    def shutdown(self) -> None:
+        self.shutdown_calls += 1
+        self._released.set()
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 1. Watchdog must not misfire on ordinary silence
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestWatchdogDoesNotMisfireOnSilence:
+    def test_no_restart_when_no_recording_ever_started(self):
+        """Continuous audio with no speech must never look like a hang."""
+        engine = LiveModeEngine(config=LiveModeConfig(watchdog_timeout_seconds=1.0))
+        engine._last_sentence_time = 0.0
+        engine._last_recording_start_time = None
+
+        # Far past the timeout — would misfire under the old "audio recency"
+        # heuristic, since the feeder stamps _last_audio_time on every chunk
+        # regardless of whether the user has said anything.
+        engine._watchdog_tick(now=1_000.0)
+
+        assert engine._watchdog_restart_requested is False
+
+    def test_no_restart_when_last_recording_already_resolved_into_a_sentence(self):
+        """A recording that finished normally must not look stale forever."""
+        engine = LiveModeEngine(config=LiveModeConfig(watchdog_timeout_seconds=1.0))
+        engine._last_recording_start_time = 10.0
+        engine._last_sentence_time = 20.0  # sentence completed AFTER the start
+
+        engine._watchdog_tick(now=1_000.0)
+
+        assert engine._watchdog_restart_requested is False
+
+    def test_restart_requested_when_recording_stuck_past_timeout(self):
+        """An in-flight recording stuck past the timeout IS a genuine hang."""
+        engine = LiveModeEngine(config=LiveModeConfig(watchdog_timeout_seconds=1.0))
+        engine._last_recording_start_time = 10.0
+        engine._last_sentence_time = 5.0  # last sentence predates this recording
+
+        engine._watchdog_tick(now=10.0 + 2.0)  # past the 1s timeout
+
+        assert engine._watchdog_restart_requested is True
+
+    def test_no_restart_before_timeout_elapses(self):
+        engine = LiveModeEngine(config=LiveModeConfig(watchdog_timeout_seconds=90.0))
+        engine._last_recording_start_time = 10.0
+        engine._last_sentence_time = 5.0
+
+        engine._watchdog_tick(now=10.0 + 30.0)  # well under the 90s timeout
+
+        assert engine._watchdog_restart_requested is False
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 2. _create_recorder() reseeds _last_sentence_time on every (re)build
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestCreateRecorderReseedsWatchdogBaseline:
+    def test_reseeds_last_sentence_time_on_rebuild(self, monkeypatch):
+        """A rebuild must not inherit the old recorder's stale timestamp.
+
+        Otherwise the watchdog immediately sees a "stale" baseline on the
+        brand-new recorder and restarts it again, repeating until
+        max_consecutive_errors gives up (bug #2 from the PR #300 review).
+        """
+        _install_recorder_stub(monkeypatch, lambda **kw: _ScriptedRecorder([], **kw))
+        engine = LiveModeEngine()
+
+        # Simulate a long-stale watchdog baseline from before the rebuild.
+        engine._last_sentence_time = 0.0
+        engine._last_recording_start_time = 5_000.0  # "in flight" and ancient
+
+        before = engine._last_sentence_time
+        engine._create_recorder()
+
+        assert engine._last_sentence_time is not None
+        assert engine._last_sentence_time > before
+        # The freshly-seeded baseline must clear the "in flight" condition.
+        engine._watchdog_tick(now=engine._last_sentence_time + 5_000.0)
+        assert engine._watchdog_restart_requested is False
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 3. A completed transcription beats a pending watchdog-restart flag
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class _RaceRecorder:
+    """Reproduces the exact race in bug #3: the watchdog fires (flag set,
+    ``shutdown()`` called) at the same moment inference was already about to
+    complete on its own. The first ``text()`` call blocks on a signal that is
+    independent of ``shutdown()`` — modeling that natural completion and the
+    watchdog's shutdown are two separate, racing events — and returns a real
+    sentence once released, regardless of whether shutdown() already fired.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.shutdown_calls = 0
+        self._call = 0
+        self._first_call_result = threading.Event()
+        self._shutdown_event = threading.Event()
+        self.first_call_started = threading.Event()
+
+    def text(self) -> str:
+        self._call += 1
+        if self._call == 1:
+            self.first_call_started.set()
+            self._first_call_result.wait(timeout=_WAIT)
+            return "Hello world."
+        self._shutdown_event.wait(timeout=_WAIT)
+        return ""
+
+    def feed_audio(self, chunk: bytes, sample_rate: int = 16000) -> None:
+        return None
+
+    def shutdown(self) -> None:
+        self.shutdown_calls += 1
+        self._shutdown_event.set()
+
+
+class TestCompletedTranscriptionNotDiscarded:
+    def test_sentence_processed_even_when_watchdog_flag_is_set(self, monkeypatch):
+        """text() winning the race against the watchdog must not be thrown away."""
+        recorders: list[_RaceRecorder] = []
+
+        def _factory(**kwargs):
+            recorder = _RaceRecorder(**kwargs)
+            recorders.append(recorder)
+            return recorder
+
+        _install_recorder_stub(monkeypatch, _factory)
+        sentences: list[str] = []
+        engine = LiveModeEngine(
+            config=LiveModeConfig(watchdog_timeout_seconds=90.0),
+            on_sentence=sentences.append,
+        )
+
+        try:
+            assert engine.start() is True
+            recorder = recorders[0]
+            assert recorder.first_call_started.wait(timeout=_WAIT), (
+                "transcription loop never reached the first text() call"
+            )
+
+            # Simulate the watchdog firing while text() is in flight: it sets
+            # the flag and calls shutdown() — same order as _watchdog_tick.
+            engine._watchdog_restart_requested = True
+            recorder.shutdown()
+
+            # ...but the underlying inference had already progressed far
+            # enough to complete on its own with a real result.
+            recorder._first_call_result.set()
+
+            for _ in range(50):
+                if sentences:
+                    break
+                threading.Event().wait(0.1)
+
+            assert sentences == ["Hello world."], (
+                "a completed transcription was silently discarded in favor of "
+                "the watchdog's synthetic error"
+            )
+            assert engine._watchdog_restart_requested is False
+        finally:
+            engine.stop()
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 4. A recorder-rebuild failure during retry consumes the retry budget
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestRebuildFailureConsumesRetryBudget:
+    def test_rebuild_failures_are_retried_with_backoff_not_fatal_immediately(self, monkeypatch):
+        """A model-load failure on rebuild must not crash straight to ERROR.
+
+        Before the fix, ``_create_recorder()`` was called from inside the
+        ``except`` clause, so an exception it raised propagated past that
+        handler entirely and ended the session on the very first rebuild
+        failure without consuming the configured retry budget.
+        """
+        attempts = {"count": 0}
+
+        def _factory(**kwargs):
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                # Initial build succeeds, but immediately errors out of text().
+                return _ScriptedRecorder([RuntimeError("first failure")], **kwargs)
+            if attempts["count"] < 4:
+                # Every rebuild attempt fails until the 4th.
+                raise RuntimeError("transient CUDA allocation failure")
+            return _ScriptedRecorder([], **kwargs)
+
+        _install_recorder_stub(monkeypatch, _factory)
+        engine = LiveModeEngine(
+            config=LiveModeConfig(
+                max_consecutive_errors=10,
+                retry_backoff_base_seconds=0.01,
+                retry_backoff_max_seconds=0.05,
+            )
+        )
+
+        try:
+            assert engine.start() is True
+
+            for _ in range(100):
+                if attempts["count"] >= 4:
+                    break
+                threading.Event().wait(0.05)
+
+            assert attempts["count"] >= 4, "rebuild retries stopped short of succeeding"
+            assert engine.state is not LiveModeState.ERROR, (
+                "a rebuild failure escaped the retry handler and ended the session"
+            )
+        finally:
+            engine.stop()
+
+    def test_gives_up_after_max_consecutive_errors_of_rebuild_failures(self, monkeypatch):
+        """The retry budget is still finite — persistent rebuild failure gives up."""
+
+        def _factory(**kwargs):
+            raise RuntimeError("persistent CUDA failure")
+
+        # First build must succeed so the loop reaches LISTENING, then every
+        # rebuild inside the retry loop fails.
+        first = {"done": False}
+
+        def _factory_with_initial_success(**kwargs):
+            if not first["done"]:
+                first["done"] = True
+                return _ScriptedRecorder([RuntimeError("boom")], **kwargs)
+            return _factory(**kwargs)
+
+        _install_recorder_stub(monkeypatch, _factory_with_initial_success)
+        engine = LiveModeEngine(
+            config=LiveModeConfig(
+                max_consecutive_errors=3,
+                retry_backoff_base_seconds=0.01,
+                retry_backoff_max_seconds=0.02,
+            )
+        )
+
+        assert engine.start() is True
+        if engine._loop_thread is not None:
+            engine._loop_thread.join(timeout=_WAIT)
+
+        assert engine.state is LiveModeState.ERROR

--- a/server/backend/tests/test_live_engine_retry_watchdog.py
+++ b/server/backend/tests/test_live_engine_retry_watchdog.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import sys
 import threading
+import time
 import types
 from typing import Any
 
@@ -147,11 +148,21 @@ class TestCreateRecorderReseedsWatchdogBaseline:
         _install_recorder_stub(monkeypatch, lambda **kw: _ScriptedRecorder([], **kw))
         engine = LiveModeEngine()
 
+        # Mock the clock instead of anchoring to the real time.monotonic():
+        # its epoch is arbitrary (often boot time), so a fixed offset like
+        # "-10000" is only safe if the runner's uptime exceeds 10000s — false
+        # on a freshly booted CI VM (this is what broke CI: a hardcoded
+        # absolute value happened to work on a long-lived dev machine but not
+        # on a short-uptime runner).
+        fake_clock = {"t": 100.0}
+        monkeypatch.setattr(time, "monotonic", lambda: fake_clock["t"])
+
         # Simulate a long-stale watchdog baseline from before the rebuild.
-        engine._last_sentence_time = 0.0
-        engine._last_recording_start_time = 5_000.0  # "in flight" and ancient
+        engine._last_sentence_time = fake_clock["t"] - 10_000.0
+        engine._last_recording_start_time = fake_clock["t"] - 5.0  # "in flight" and recent
 
         before = engine._last_sentence_time
+        fake_clock["t"] += 1.0  # advance the clock to when the rebuild happens
         engine._create_recorder()
 
         assert engine._last_sentence_time is not None

--- a/server/config.yaml
+++ b/server/config.yaml
@@ -276,6 +276,16 @@ live_transcriber:
     # Trigger early transcription during silence (seconds, 0 = disabled)
     early_transcription_on_silence: 0.5
 
+    # Reliability: retry a failed transcription with exponential backoff
+    # before giving up (max_consecutive_errors) and reporting a terminal
+    # error to the client. The watchdog restarts the recorder if it stops
+    # producing sentences for watchdog_timeout_seconds despite incoming audio
+    # (a hung recognition call).
+    max_consecutive_errors: 5
+    retry_backoff_base_seconds: 2.0
+    retry_backoff_max_seconds: 30.0
+    watchdog_timeout_seconds: 90.0
+
     no_log_file: true
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `LiveModeEngine` now rebuilds the recorder and retries with exponential backoff (`retry_backoff_base_seconds` up to `retry_backoff_max_seconds`) when `recorder.text()` raises, instead of moving straight to a terminal `ERROR` on the first exception. It only gives up after `max_consecutive_errors` in a row.
- A new watchdog thread detects a hung `text()` call — audio still arriving but no sentence produced for `watchdog_timeout_seconds` — and restarts the recorder to unblock it.
- All four thresholds are tunable via `config.yaml`'s `live_transcriber` section and are read into `LiveModeConfig` in the `/ws/live` route.
- On the dashboard side, `useLiveMode` now auto-reconnects the whole session (capped at 5 attempts, short escalating delay) when the engine reports a terminal `ERROR`, instead of immediately surfacing the error to the user.

## Motivation
An engine-side error previously required the user to notice Live Mode had silently died and restart it manually. This adds two independent layers of self-healing (backend retry/watchdog, frontend auto-reconnect) before giving up and surfacing an error.

## Test plan
- [ ] `npm run typecheck` (passes)
- [ ] Backend unit tests (`server/backend`: `../../build/.venv/bin/pytest tests/ -v --tb=short`) — not run in this environment, no build venv available; please run before merging
- [ ] Manually verify: kill/stall the recorder mid-session and confirm the backend retries and recovers without dropping the session
- [ ] Manually verify: simulate a terminal engine ERROR and confirm the dashboard auto-reconnects and eventually gives up with a clear message after 5 attempts