### PR TITLE
chore(ci): bump GitHub Actions off deprecated Node.js 20 runtimes

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -34,7 +34,7 @@ jobs:
           packages: ffmpeg
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
 

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           packages: ffmpeg
 
+      # setup-uv stopped publishing floating major/minor tags at v9.0.0 as a
+      # supply-chain measure, so `@v10` does not resolve. Pin the exact release
+      # and bump it deliberately.
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -22,7 +22,7 @@ jobs:
         working-directory: server/backend
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install system dependencies (FFmpeg)
         # Required by tests/test_ffmpeg_utils.py, which exercises the
@@ -34,12 +34,12 @@ jobs:
           packages: ffmpeg
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v10
         with:
           enable-cache: true
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -63,7 +63,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/dashboard-quality.yml
+++ b/.github/workflows/dashboard-quality.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22.22.3"
           cache: "npm"

--- a/.github/workflows/dashboard-quality.yml
+++ b/.github/workflows/dashboard-quality.yml
@@ -20,7 +20,7 @@ jobs:
         working-directory: dashboard
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22.22.3"
           cache: "npm"
@@ -57,7 +57,7 @@ jobs:
         run: bash ../build/sign-electron-artifacts.sh release
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-linux
           path: |
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22.22.3"
           cache: "npm"
@@ -117,7 +117,7 @@ jobs:
         run: bash ../build/sign-electron-artifacts.sh release
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-windows
           path: |
@@ -134,7 +134,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22.22.3"
           cache: "npm"
@@ -162,7 +162,7 @@ jobs:
         run: bash build/sign-electron-artifacts.sh dashboard/release
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-macos
           path: |
@@ -185,14 +185,22 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22.22.3"
           cache: "npm"
           cache-dependency-path: dashboard/package-lock.json
 
+      # setup-uv stopped publishing floating major/minor tags at v9.0.0 as a
+      # supply-chain measure, so `@v10` does not resolve. Pin the exact release
+      # and bump it deliberately.
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
+        with:
+          # setup-uv v5 turned caching on by default and v9 stopped pruning it.
+          # This job only runs on release tags, so the cache is always cold here
+          # and its unpruned entries would evict the per-PR backend-tests cache.
+          enable-cache: false
 
       - name: Install npm dependencies
         working-directory: dashboard
@@ -460,7 +468,7 @@ jobs:
         run: bash build/sign-electron-artifacts.sh dashboard/release
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-macos-metal
           path: |
@@ -480,7 +488,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: release-artifacts
           merge-multiple: true
@@ -489,7 +497,7 @@ jobs:
         run: ls -lh release-artifacts/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,7 +192,7 @@ jobs:
           cache-dependency-path: dashboard/package-lock.json
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Install npm dependencies
         working-directory: dashboard

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         working-directory: dashboard
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -74,7 +74,7 @@ jobs:
         working-directory: dashboard
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -131,7 +131,7 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -141,7 +141,7 @@ jobs:
           cache-dependency-path: dashboard/package-lock.json
 
       - name: Setup Python (for dmgbuild)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -182,7 +182,7 @@ jobs:
       PYTHONDONTWRITEBYTECODE: "1"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -192,7 +192,7 @@ jobs:
           cache-dependency-path: dashboard/package-lock.json
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v10
 
       - name: Install npm dependencies
         working-directory: dashboard
@@ -477,7 +477,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/scripts-lint.yml
+++ b/.github/workflows/scripts-lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install shellcheck
         uses: ./.github/actions/apt-install
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install PowerShell (if missing)
         uses: ./.github/actions/apt-install

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      # setup-uv stopped publishing floating major/minor tags at v9.0.0 as a
+      # supply-chain measure, so `@v10` does not resolve. Pin the exact release
+      # and bump it deliberately.
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
 

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -20,15 +20,15 @@ jobs:
         working-directory: server/backend
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v10
         with:
           enable-cache: true
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
 


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` (v4 to v7), `actions/setup-python` (v5 to v7), and `astral-sh/setup-uv` (v4 to v10) across all workflow files.

## Motivation
GitHub Actions is deprecating Node.js 20 on its runners. CI runs were showing:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-python@v5, astral-sh/setup-uv@v4.

The newer majors target Node.js 24 natively, clearing the warning.

## Test plan
- [ ] CI passes on all workflows (checkout, setup-python, and setup-uv steps run without the deprecation warning)