### PR TITLE
fix(dashboard): apply the persisted Capture Gain from a recording's first sample

### DIFF
--- a/dashboard/components/__tests__/SessionView.test.tsx
+++ b/dashboard/components/__tests__/SessionView.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -576,5 +576,148 @@ describe('Start Recording disabled-reason surface', () => {
     render(React.createElement(SessionView, props), { wrapper: createWrapper() });
 
     expect(screen.queryByTestId('recording-disabled-reason')).toBeNull();
+  });
+});
+
+// ── Capture Gain must be handed to the hook BEFORE start() ─────────────────
+//
+// The AudioCapture instance is built a server round trip after start(), so the
+// hook has nothing to apply a gain to at the moment start() is called. Handing
+// the value over first is what gets it into the recording's first sample; the
+// original code called setGain() on the line *after* start(), where it landed
+// on a null ref (first recording) or the previous, already-stopped instance.
+
+describe('capture gain handed to the hook at recording start', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTranscription.status = 'idle';
+    mockTranscription.result = null;
+    mockTranscription.error = null;
+    mockTranscription.vadActive = false;
+    mockTranscription.processingProgress = null;
+
+    vi.mocked(isModelDisabled).mockReturnValue(false);
+
+    (window as any).electronAPI = {
+      config: {
+        get: vi.fn().mockResolvedValue(undefined),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+      docker: {
+        readComposeEnvValue: vi.fn().mockResolvedValue('false'),
+      },
+      audio: { listSinks: vi.fn().mockResolvedValue([]) },
+      tray: { onAction: vi.fn().mockReturnValue(vi.fn()) },
+      notifications: { show: vi.fn() },
+    };
+  });
+
+  /** Order of the LAST setGain call - the one that must precede start(). */
+  const lastSetGainOrder = (): number => {
+    const orders = mockTranscription.setGain.mock.invocationCallOrder;
+    return orders[orders.length - 1];
+  };
+
+  it('hands the slider gain to the hook before start() on system audio', async () => {
+    render(React.createElement(SessionView, baseProps), { wrapper: createWrapper() });
+
+    fireEvent.click(screen.getByRole('button', { name: /System Audio/i }));
+    fireEvent.change(screen.getByRole('slider'), { target: { value: '3' } });
+    fireEvent.click(screen.getByRole('button', { name: /Start Recording/i }));
+
+    await waitFor(() => expect(mockTranscription.start).toHaveBeenCalled());
+
+    expect(mockTranscription.setGain).toHaveBeenLastCalledWith(3);
+    expect(lastSetGainOrder()).toBeLessThan(mockTranscription.start.mock.invocationCallOrder[0]);
+  });
+
+  it('resets the gain to unity for a microphone recording', async () => {
+    // Capture Gain is a system-audio-only control (its slider is not even
+    // rendered for the mic). Now that the hook remembers the last value across
+    // captures, a mic recording started after a boosted system one has to be
+    // told to go back to 1.0 - otherwise it would inherit the amplification.
+    render(React.createElement(SessionView, baseProps), { wrapper: createWrapper() });
+
+    fireEvent.click(screen.getByRole('button', { name: /System Audio/i }));
+    fireEvent.change(screen.getByRole('slider'), { target: { value: '3' } });
+    // Exact name: the mic-mix switch rendered by the system-audio card is also
+    // named "Also capture microphone" and would match a loose pattern.
+    fireEvent.click(screen.getByRole('button', { name: 'Microphone' }));
+    fireEvent.click(screen.getByRole('button', { name: /Start Recording/i }));
+
+    await waitFor(() => expect(mockTranscription.start).toHaveBeenCalled());
+
+    expect(mockTranscription.start.mock.calls[0][0]).toMatchObject({ systemAudio: false });
+    expect(mockTranscription.setGain).toHaveBeenLastCalledWith(1);
+    expect(lastSetGainOrder()).toBeLessThan(mockTranscription.start.mock.invocationCallOrder[0]);
+  });
+});
+
+// ── Live Mode has its own copy of the gain-before-start call site ──────────
+//
+// SessionView seeds the gain twice - once in handleStartRecording and once in
+// handleLiveToggle - and the two are independent lines that can drift apart.
+// The recording half is covered above; this covers the Live Mode half.
+
+describe('capture gain handed to the live hook at Live Mode start', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTranscription.status = 'idle';
+    mockTranscription.result = null;
+    mockTranscription.error = null;
+    mockTranscription.vadActive = false;
+    mockTranscription.processingProgress = null;
+
+    vi.mocked(isModelDisabled).mockReturnValue(false);
+
+    (window as any).electronAPI = {
+      config: {
+        get: vi.fn().mockResolvedValue(undefined),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+      docker: {
+        readComposeEnvValue: vi.fn().mockResolvedValue('false'),
+      },
+      audio: { listSinks: vi.fn().mockResolvedValue([]) },
+      tray: { onAction: vi.fn().mockReturnValue(vi.fn()) },
+      notifications: { show: vi.fn() },
+    };
+  });
+
+  /** A live state with its own mocks, so call order is not shared across tests. */
+  function makeLive() {
+    return { ...baseLiveState, start: vi.fn(), stop: vi.fn(), setGain: vi.fn() };
+  }
+
+  it('hands the slider gain to the live hook before start() on system audio', async () => {
+    const live = makeLive();
+    render(React.createElement(SessionView, { ...baseProps, live }), { wrapper: createWrapper() });
+
+    fireEvent.click(screen.getByRole('button', { name: /System Audio/i }));
+    fireEvent.change(screen.getByRole('slider'), { target: { value: '3' } });
+    fireEvent.click(screen.getAllByRole('switch', { name: 'Live Mode' })[0]);
+
+    await waitFor(() => expect(live.start).toHaveBeenCalled());
+
+    expect(live.setGain).toHaveBeenLastCalledWith(3);
+    const orders = live.setGain.mock.invocationCallOrder;
+    expect(orders[orders.length - 1]).toBeLessThan(live.start.mock.invocationCallOrder[0]);
+  });
+
+  it('resets the live gain to unity for a microphone session', async () => {
+    const live = makeLive();
+    render(React.createElement(SessionView, { ...baseProps, live }), { wrapper: createWrapper() });
+
+    fireEvent.click(screen.getByRole('button', { name: /System Audio/i }));
+    fireEvent.change(screen.getByRole('slider'), { target: { value: '3' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Microphone' }));
+    fireEvent.click(screen.getAllByRole('switch', { name: 'Live Mode' })[0]);
+
+    await waitFor(() => expect(live.start).toHaveBeenCalled());
+
+    expect(live.start.mock.calls[0][0]).toMatchObject({ systemAudio: false });
+    expect(live.setGain).toHaveBeenLastCalledWith(1);
+    const orders = live.setGain.mock.invocationCallOrder;
+    expect(orders[orders.length - 1]).toBeLessThan(live.start.mock.invocationCallOrder[0]);
   });
 });

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -977,6 +977,17 @@ export const SessionView: React.FC<SessionViewProps> = ({
       // recording into the Audio Notebook when it finishes.
       const autoAddToNotebook = (await getConfig<boolean>('notebook.autoAdd')) ?? false;
 
+      // Hand the capture gain over BEFORE start(): start() only opens the
+      // socket, and the AudioCapture is built a server round trip later, so the
+      // hook has to remember this value and apply it to that instance (see
+      // gainRef in useTranscription). Calling setGain after start() - as this
+      // did - landed on a null ref on the first recording and on the previous,
+      // already-stopped capture on every one after it, so the slider showed the
+      // persisted gain while the audio was captured at 1.0.
+      // Mic capture always runs at unity: Capture Gain is a system-audio-only
+      // control (its slider is not even rendered for the mic), and leaving a
+      // previous system session's value in place would silently amplify it.
+      transcription.setGain(isSystemAudio ? captureGain : 1);
       transcription.start({
         language: resolvedLang,
         deviceId: isSystemAudio ? undefined : micDeviceIds[micDevice],
@@ -994,10 +1005,6 @@ export const SessionView: React.FC<SessionViewProps> = ({
         diarization: effectiveDiarization,
         expectedSpeakers: effectiveDiarization && constrainSpeakers ? numSpeakers : undefined,
       });
-      // Apply persisted capture gain after capture starts
-      if (isSystemAudio) {
-        transcription.setGain(captureGain);
-      }
     })();
   }, [
     canStartRecording,
@@ -1298,6 +1305,11 @@ export const SessionView: React.FC<SessionViewProps> = ({
             await window.electronAPI?.audio?.enableSystemAudioLoopback?.();
           }
 
+          // Before start(), for the same reason as the recording path above:
+          // the AudioCapture only exists once the engine reports LISTENING, so
+          // the hook remembers this and applies it to that instance. Mic
+          // capture runs at unity - Capture Gain is system-audio only.
+          live.setGain(isSystemAudio ? captureGain : 1);
           live.start({
             language: resolvedLiveLang,
             deviceId: isSystemAudio ? undefined : micDeviceIds[micDevice],
@@ -1314,10 +1326,6 @@ export const SessionView: React.FC<SessionViewProps> = ({
             mixMicWithSystem: isSystemAudio && mixMicWithSystem,
             mixMicDeviceId: isSystemAudio && mixMicWithSystem ? micDeviceIds[micDevice] : undefined,
           });
-          // Apply persisted capture gain after capture starts
-          if (isSystemAudio) {
-            live.setGain(captureGain);
-          }
         })();
       } else {
         // live.stop() → capture.stop() → loopbackOwner release (GH-230).
@@ -2897,6 +2905,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
                               <AppleSwitch
                                 checked={isLive}
                                 onChange={handleLiveToggle}
+                                ariaLabel="Live Mode"
                                 size="sm"
                                 disabled={
                                   !isLive &&
@@ -3025,6 +3034,7 @@ export const SessionView: React.FC<SessionViewProps> = ({
                           <AppleSwitch
                             checked={isLive}
                             onChange={handleLiveToggle}
+                            ariaLabel="Live Mode"
                             size="sm"
                             disabled={
                               !isLive &&

--- a/dashboard/src/hooks/useLiveMode.test.ts
+++ b/dashboard/src/hooks/useLiveMode.test.ts
@@ -68,9 +68,14 @@ vi.mock('../services/audioCapture', () => ({
 // ── Helpers ────────────────────────────────────────────────────────────
 
 /** Drive the hook through auth → state LISTENING → listening. */
-async function driveToListening(result: { current: ReturnType<typeof useLiveMode> }) {
+async function driveToListening(
+  result: { current: ReturnType<typeof useLiveMode> },
+  // Capture gain is clamped to unity for a microphone session, so gain tests
+  // have to say which source they are starting.
+  options: Parameters<ReturnType<typeof useLiveMode>['start']>[0] = {},
+) {
   act(() => {
-    result.current.start();
+    result.current.start(options);
   });
   act(() => {
     lastSocketCbs.onMessage!({ type: 'auth_ok' });
@@ -807,6 +812,77 @@ describe('[P1] useLiveMode', () => {
           monitorSinkName: 'alsa_output.sink',
         }),
       );
+    });
+  });
+
+  // ── Capture gain must cross the gap between start() and the instance ──
+  //
+  // Same shape as the longform hook: start() only opens the socket, and the
+  // AudioCapture is constructed later, when the engine reports LISTENING. A
+  // setGain() in between reached `captureRef.current?.setGain(...)` with
+  // nothing behind it and was silently dropped.
+
+  describe('capture gain reaches the AudioCapture built on LISTENING', () => {
+    it('applies a gain set before start() to the capture instance', async () => {
+      const { result } = renderHook(() => useLiveMode());
+
+      act(() => {
+        result.current.setGain(3);
+      });
+      await driveToListening(result, { systemAudio: true });
+
+      expect(lastCapture.setGain).toHaveBeenCalledWith(3);
+      // Before start(): start() reads the remembered gain when it builds the
+      // gain node, so a later call would leave the opening audio at unity.
+      expect(lastCapture.setGain.mock.invocationCallOrder[0]).toBeLessThan(
+        lastCapture.start.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('remembers a gain set mid-session and re-applies it to the next capture', async () => {
+      const { result } = renderHook(() => useLiveMode());
+      await driveToListening(result, { systemAudio: true });
+      const firstCapture = lastCapture;
+
+      act(() => {
+        result.current.setGain(2.5);
+      });
+      expect(firstCapture.setGain).toHaveBeenCalledWith(2.5);
+
+      act(() => {
+        result.current.stop();
+      });
+      await driveToListening(result, { systemAudio: true });
+
+      expect(lastCapture).not.toBe(firstCapture);
+      expect(lastCapture.setGain).toHaveBeenCalledWith(2.5);
+    });
+
+    it('a microphone session rebuilt inside the hook still opens at unity', async () => {
+      // The retarget hop and the auto-reconnect-on-ERROR re-enter start() from
+      // inside this hook with the same startOptsRef, so SessionView never gets
+      // to reset the gain for them. Meanwhile the Capture Gain slider forwards
+      // here unconditionally and the Active Input Source buttons stay live
+      // mid-session, so a mic session really can have a system gain remembered
+      // against it. Without the clamp at the seed, the rebuilt microphone
+      // capture would open amplified.
+      const { result } = renderHook(() => useLiveMode());
+      await driveToListening(result, { systemAudio: false });
+      expect(lastCapture.setGain).toHaveBeenCalledWith(1);
+
+      act(() => {
+        result.current.setGain(4);
+      });
+
+      // Drive the construction site directly rather than the reconnect timer:
+      // the LISTENING handler rebuilds whenever the previous capture is not
+      // capturing, which is the same code path a retarget lands on.
+      await act(async () => {
+        lastSocketCbs.onMessage!({ type: 'state', data: { state: 'LISTENING' } });
+      });
+
+      expect(lastCapture.setGain).toHaveBeenCalledWith(1);
+      expect(lastCapture.setGain).not.toHaveBeenCalledWith(4);
     });
   });
 

--- a/dashboard/src/hooks/useLiveMode.ts
+++ b/dashboard/src/hooks/useLiveMode.ts
@@ -88,6 +88,11 @@ export function useLiveMode(): LiveModeState {
 
   const socketRef = useRef<TranscriptionSocket | null>(null);
   const captureRef = useRef<AudioCapture | null>(null);
+  // Capture gain last requested by the UI - same rationale as useTranscription:
+  // the AudioCapture is only built once the engine reports LISTENING, so a
+  // setGain() before that reached `captureRef.current?.` with nothing behind it
+  // and was silently dropped.
+  const gainRef = useRef(1);
   const startOptsRef = useRef<LiveStartOptions>({});
   // Retarget hook: holds the latest `start` closure so the socket's
   // onHostMismatch callback can reopen the session on the new URL without
@@ -232,6 +237,17 @@ export function useLiveMode(): LiveModeState {
               captureRef.current = new AudioCapture((chunk) => {
                 socketRef.current?.sendAudio(chunk);
               });
+              // Hand over the remembered gain BEFORE start(), which reads it
+              // when it builds the gain node (see gainRef).
+              // Clamped to unity for a microphone session, and clamped HERE
+              // rather than only at the SessionView call site: the retarget hop
+              // and the auto-reconnect-on-ERROR both re-enter start() from
+              // inside this hook with the same startOptsRef, so SessionView
+              // never gets to reset the gain for them. The Capture Gain slider
+              // writes through unconditionally and the Active Input Source
+              // buttons are not disabled mid-session, so a mic session really
+              // can end up with a system gain remembered against it.
+              captureRef.current.setGain(startOptsRef.current.systemAudio ? gainRef.current : 1);
               captureRef.current
                 .start({
                   deviceId: startOptsRef.current.deviceId,
@@ -519,6 +535,9 @@ export function useLiveMode(): LiveModeState {
   }, []);
 
   const setGain = useCallback((value: number) => {
+    // Remember first, forward second - the ref is the only copy that survives
+    // until the next AudioCapture is constructed (see gainRef).
+    gainRef.current = value;
     captureRef.current?.setGain(value);
   }, []);
 

--- a/dashboard/src/hooks/useTranscription.test.ts
+++ b/dashboard/src/hooks/useTranscription.test.ts
@@ -109,9 +109,14 @@ vi.mock('../api/client', () => ({
 // ── Helpers ────────────────────────────────────────────────────────────
 
 /** Drive the hook through auth → session_started → recording. */
-async function driveToRecording(result: { current: ReturnType<typeof useTranscription> }) {
+async function driveToRecording(
+  result: { current: ReturnType<typeof useTranscription> },
+  // Capture gain is clamped to unity for a microphone session, so gain tests
+  // have to say which source they are starting.
+  options: Parameters<ReturnType<typeof useTranscription>['start']>[0] = {},
+) {
   act(() => {
-    result.current.start();
+    result.current.start(options);
   });
   await act(async () => {
     lastSocketCbs.onMessage!({ type: 'auth_ok' });
@@ -1030,6 +1035,73 @@ describe('[P1] useTranscription', () => {
       expect(result.current.error).toBeNull();
       // The socket was NOT torn down by the swallowed abort.
       expect(lastSocket.disconnect).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Capture gain must cross the gap between start() and the instance ──
+  //
+  // start() only opens the socket; the AudioCapture is constructed a server
+  // round trip later, in the session_started handler. setGain() therefore has
+  // no instance to talk to at the moment the UI calls it - and because it
+  // forwards through `captureRef.current?.setGain(...)`, the value used to
+  // vanish without a sound: the recording ran at 1.0 while the slider went on
+  // displaying the gain the user had chosen and persisted.
+
+  describe('capture gain reaches the AudioCapture built on session_started', () => {
+    it('applies a gain set before start() to the capture instance', async () => {
+      const { result } = renderHook(() => useTranscription());
+
+      act(() => {
+        result.current.setGain(3);
+      });
+      await driveToRecording(result, { systemAudio: true });
+
+      expect(lastCapture.setGain).toHaveBeenCalledWith(3);
+      // Before start(), not after: start() reads the remembered gain when it
+      // builds the gain node, so anything applied afterwards would leave the
+      // opening audio of every recording at unity.
+      expect(lastCapture.setGain.mock.invocationCallOrder[0]).toBeLessThan(
+        lastCapture.start.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('remembers a gain set mid-session and re-applies it to the next capture', async () => {
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result, { systemAudio: true });
+      const firstCapture = lastCapture;
+
+      act(() => {
+        result.current.setGain(2.5);
+      });
+      expect(firstCapture.setGain).toHaveBeenCalledWith(2.5);
+
+      // Second recording: a fresh instance, born at unity unless the hook
+      // hands it the remembered value. The old one is dead - writing to it is
+      // what the buggy path did on every recording after the first.
+      act(() => {
+        result.current.stop();
+      });
+      await driveToRecording(result, { systemAudio: true });
+
+      expect(lastCapture).not.toBe(firstCapture);
+      expect(lastCapture.setGain).toHaveBeenCalledWith(2.5);
+    });
+
+    it('opens a microphone recording at unity whatever gain is remembered', async () => {
+      // Capture Gain is a system-audio control, but the slider forwards to both
+      // hooks unconditionally and the Active Input Source buttons stay live
+      // mid-session, so the remembered value can belong to a source this
+      // recording is not using. The clamp lives next to the seed so it holds
+      // for whatever builds the capture, not only for the SessionView path.
+      const { result } = renderHook(() => useTranscription());
+
+      act(() => {
+        result.current.setGain(4);
+      });
+      await driveToRecording(result, { systemAudio: false });
+
+      expect(lastCapture.setGain).toHaveBeenCalledWith(1);
+      expect(lastCapture.setGain).not.toHaveBeenCalledWith(4);
     });
   });
 

--- a/dashboard/src/hooks/useTranscription.ts
+++ b/dashboard/src/hooks/useTranscription.ts
@@ -169,6 +169,13 @@ export function useTranscription(): TranscriptionState {
 
   const socketRef = useRef<TranscriptionSocket | null>(null);
   const captureRef = useRef<AudioCapture | null>(null);
+  // Capture gain last requested by the UI. AudioCapture instances are built one
+  // per session and only after the server answers, so for most of a session's
+  // life setGain() has no instance to talk to - and `captureRef.current?.` made
+  // that a silent drop. Remembering the value here is what carries it into the
+  // next instance, so the recording opens at the gain the slider is showing
+  // rather than always at 1.0.
+  const gainRef = useRef(1);
   const [jobId, setJobId] = useState<string | null>(null);
   const jobIdRef = useRef<string | null>(null);
   const statusRef = useRef<TranscriptionStatus>('idle');
@@ -361,6 +368,18 @@ export function useTranscription(): TranscriptionState {
             captureRef.current = new AudioCapture((chunk) => {
               socketRef.current?.sendAudio(chunk);
             });
+            // Hand over the remembered gain BEFORE start(): start() reads it
+            // when it builds the gain node, so the very first PCM chunk is
+            // already scaled. Applying it afterwards would open every
+            // recording at unity.
+            // Clamped to unity for a microphone session. Capture Gain is a
+            // system-audio control, but the slider writes through to both hooks
+            // unconditionally, so the remembered value can belong to a source
+            // this session is not using. Keeping the clamp next to the seed
+            // means the invariant holds for whatever builds the capture, not
+            // only for the SessionView path (see the same clamp in useLiveMode,
+            // where the retarget and reconnect paths need it).
+            captureRef.current.setGain(startOptsRef.current.systemAudio ? gainRef.current : 1);
             captureRef.current
               .start({
                 deviceId: startOptsRef.current.deviceId,
@@ -751,6 +770,9 @@ export function useTranscription(): TranscriptionState {
   }, []);
 
   const setGain = useCallback((value: number) => {
+    // Remember first, forward second: the ref is the only copy that survives
+    // until the next AudioCapture is constructed (see gainRef).
+    gainRef.current = value;
     captureRef.current?.setGain(value);
   }, []);
 

--- a/dashboard/src/services/audioCapture.test.ts
+++ b/dashboard/src/services/audioCapture.test.ts
@@ -375,6 +375,24 @@ describe('[P1] AudioCapture loopback ownership (GH-230)', () => {
     expect(micGain.gain.value).toBe(1);
   });
 
+  // The contract the hooks depend on to get the Capture Gain slider's value
+  // into a recording's first sample: an AudioCapture is only constructed after
+  // the server answers, so the value has to be handed to a not-yet-started
+  // instance and survive until start() builds the gain node. Simplifying
+  // start() to `gain.value = 1` would silently return every recording to unity
+  // while the slider went on displaying whatever the user picked.
+  it('a gain set before start() is the gain the graph is built with', async () => {
+    const capture = new AudioCapture(() => {});
+
+    capture.setGain(3);
+    expect(capture.gain).toBe(3);
+
+    await capture.start({ systemAudio: true, monitorSinkName: 'sink-a' });
+
+    const [systemGain] = lastCtx!.createGain.mock.results.map((r) => r.value);
+    expect(systemGain.gain.value).toBe(3);
+  });
+
   // The load-bearing assertion for a MIXING feature: every other test here
   // passes with the mic acquired, held, gain-staged, muted and torn down
   // correctly while its audio goes nowhere. Deleting either connect() in


### PR DESCRIPTION
## The bug

The Capture Gain slider (system audio, 0.25x-5x) is persisted per sink as `session.sinkGain.<sink>` and rehydrated into SessionView's `captureGain` state on startup and on every sink change. It never reached the recording.

SessionView called `transcription.setGain(captureGain)` on the line *after* `transcription.start({...})`. But `start()` is a synchronous `useCallback` that only opens the WebSocket - it never touches `captureRef`. The `AudioCapture` is constructed a server round trip later, inside the `session_started` handler (longform) and the `state === 'LISTENING'` handler (Live Mode).

So the hook's `setGain` reached `captureRef.current?.setGain(value)`:

- **first recording** - `captureRef.current` is `null`, and the optional chain made the drop silent;
- **every recording after** - it mutated the *previous, already-stopped* instance, which was discarded moments later.

The fresh instance is born at `private _gain = 1` (`audioCapture.ts:81`) and `start()` applies `this._gain` to the gain node. Net effect: the slider correctly displayed e.g. 3.00x while the audio was captured at 1.0x. The gain only ever took effect if the user dragged the slider *while already recording*.

Pre-existing on `main`, unrelated to #299.

## The fix

**Both hooks** gained a `gainRef` that remembers the last value the UI asked for. `setGain` records it and forwards to the live instance; the construction site hands it to the fresh instance *before* `start()`, which reads it when it builds the gain node, so the first PCM chunk is already scaled.

**The seed is clamped to unity for a microphone session, at the seed rather than only at the SessionView call sites.** This matters: Live Mode's retarget hop and its auto-reconnect-on-ERROR both re-enter `start()` from inside the hook with the same `startOptsRef`, so SessionView never gets to reset the gain for them. Meanwhile `handleCaptureGainChange` forwards to both hooks unconditionally and the Active Input Source buttons are not disabled mid-session, so a mic session really can have a system gain remembered against it. Without the clamp, a mic session rebuilt on either path would open amplified - a regression the ref-based cure would otherwise have introduced.

**SessionView** hands the gain over before `start(...)` in both entry points, mic sessions at unity.

**The two Live Mode switches** got an `ariaLabel`. They rendered `aria-label={undefined}`, so a screen reader announced an unnamed switch - the same gap the neighbouring mic-mix switch already had fixed.

## Evidence

Nine mutants, all caught:

| Mutation | Caught by |
|---|---|
| Drop the seed in `useTranscription` | 2 hook tests |
| `setGain` stops recording into `gainRef` | 2 hook tests |
| Drop the seed in `useLiveMode` | 2 hook tests |
| Drop the mic unity reset in SessionView (recording) | the mic test only |
| Move the seed back after `start()` (recording) | 2 SessionView tests |
| Move the seed back after `start()` (Live Mode) | 2 SessionView tests |
| Drop the unity clamp in `useTranscription` | the new mic-unity test |
| Drop the unity clamp in `useLiveMode` | the new rebuild test |
| `gainNode.gain.value = 1` in `AudioCapture.start()` | the new characterization test |

The last one is worth calling out: before that test existed, `start()` could discard the remembered gain entirely and all 17 tests in `audioCapture.test.ts` stayed green. It is the contract the whole fix rests on.

## Not included

Mute has the same lifetime bug and is deliberately left alone here. `toggleMute` forwards through the same `captureRef.current?.mute()`, a mute issued while the status is `connecting` (explicitly routed there by `SessionView.tsx:872`) is dropped, and the fresh capture is born `_muted = false`. It cannot be fixed by mirroring the gain seeding: `start()` calls `this.stop()` defensively and `stop()` resets `_muted`, so the mute has to be re-applied in the `.then()` after `start()` resolves. Separate change.

## Test plan

- [x] `vitest run` - 2145 passed, 148 files
- [x] `tsc --noEmit` (renderer) and `tsc -p electron/tsconfig.json --noEmit`
- [x] `eslint . --max-warnings=0`
- [x] `ui:contract:validate` + `ui:contract:test` (22 checks, v1.18.0)
- [ ] Hardware smoke: set Capture Gain to 3x on a sink, restart the app, start a system-audio recording, confirm the audio is boosted from the first second (previously this required dragging the slider mid-recording)
- [ ] Hardware smoke: start a mic recording after a boosted system one, confirm it is not amplified
- [ ] Hardware smoke: Live Mode on system audio with a non-unity gain, confirm it applies at the first sentence
