### PR TITLE
fix(dashboard): refill the Session recovery banner right after Dismiss or View

### DIFF
--- a/dashboard/components/__tests__/SessionView.recovery-refresh.test.tsx
+++ b/dashboard/components/__tests__/SessionView.recovery-refresh.test.tsx
@@ -138,6 +138,7 @@ const {
   mockRetryTranscription,
   mockFetchTranscriptionResult,
   mockFetchRecentUndelivered,
+  mockDismissTranscriptionResult,
   mockToast,
   mockGetStatus,
   mockCancelTranscription,
@@ -158,6 +159,7 @@ const {
     mockRetryTranscription: vi.fn(),
     mockFetchTranscriptionResult: vi.fn(),
     mockFetchRecentUndelivered: vi.fn(),
+    mockDismissTranscriptionResult: vi.fn(),
     mockToast: { success: vi.fn(), error: vi.fn() },
     mockGetStatus: vi.fn(),
     mockCancelTranscription: vi.fn(),
@@ -185,7 +187,7 @@ vi.mock('../../src/api/client', () => ({
     loadModelsStream: vi.fn().mockReturnValue(vi.fn()),
     fetchRecentUndelivered: (...a: unknown[]) => mockFetchRecentUndelivered(...a),
     fetchTranscriptionResult: (...a: unknown[]) => mockFetchTranscriptionResult(...a),
-    dismissTranscriptionResult: vi.fn().mockResolvedValue({ status: 200 }),
+    dismissTranscriptionResult: (...a: unknown[]) => mockDismissTranscriptionResult(...a),
     retryTranscription: (...a: unknown[]) => mockRetryTranscription(...a),
   },
 }));
@@ -298,6 +300,7 @@ describe('SessionView - recovery banner refresh', () => {
     mockTranscription.busyInfo = null;
     mockGetConfig.mockResolvedValue(undefined);
     mockFetchRecentUndelivered.mockResolvedValue({ json: async () => [] });
+    mockDismissTranscriptionResult.mockResolvedValue({ status: 200 });
     mockGetStatus.mockResolvedValue({
       models: { job_tracker: { is_busy: false, salvage: null } },
     });
@@ -382,6 +385,123 @@ describe('SessionView - recovery banner refresh', () => {
     const banners = screen.getAllByText(/is available\./);
     expect(banners).toHaveLength(1);
     expect(banners[0].closest('div')?.textContent).toContain('the half that made it');
+  });
+
+  // /recent returns at most 5 rows. A user who has been cancelling recordings
+  // from the tray for days comes back to a full banner, and every Dismiss must
+  // pull the next queued (older) job into view at once, not on the next focus.
+  it('re-checks after a Dismiss so the next queued job surfaces immediately', async () => {
+    mockFetchRecentUndelivered.mockResolvedValueOnce({ json: async () => SALVAGED });
+    let settleDismiss: (v: { status: number }) => void = () => {};
+    mockDismissTranscriptionResult.mockReturnValueOnce(
+      new Promise<{ status: number }>((resolve) => {
+        settleDismiss = resolve;
+      }),
+    );
+    renderSessionView();
+    expect(await screen.findByText(/the half that made it/)).toBeInTheDocument();
+    expect(mockFetchRecentUndelivered).toHaveBeenCalledTimes(1);
+
+    mockFetchRecentUndelivered.mockResolvedValue({
+      json: async () => [
+        { job_id: 'older-job', completed_at: COMPLETED_AT, text_preview: 'from three days ago' },
+      ],
+    });
+    fireEvent.click(screen.getByText('Dismiss'));
+
+    // Optimistic removal is instant, but the re-check waits for the server to
+    // acknowledge the dismiss - otherwise the dismissed row would come back.
+    expect(screen.queryByText(/the half that made it/)).not.toBeInTheDocument();
+    expect(mockFetchRecentUndelivered).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      settleDismiss({ status: 200 });
+    });
+
+    expect(await screen.findByText(/from three days ago/)).toBeInTheDocument();
+    expect(mockFetchRecentUndelivered).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps a row whose dismiss is still in flight out of a concurrent re-check', async () => {
+    const TWO = [
+      ...SALVAGED,
+      { job_id: 'second-job', completed_at: COMPLETED_AT, text_preview: 'the second one' },
+    ];
+    mockFetchRecentUndelivered.mockResolvedValueOnce({ json: async () => TWO });
+    let settleSecond: (v: { status: number }) => void = () => {};
+    mockDismissTranscriptionResult.mockResolvedValueOnce({ status: 200 }).mockReturnValueOnce(
+      new Promise<{ status: number }>((resolve) => {
+        settleSecond = resolve;
+      }),
+    );
+    renderSessionView();
+    expect(await screen.findByText(/the second one/)).toBeInTheDocument();
+
+    // The first dismiss's re-check answers before the server has processed
+    // the second dismiss, so it still lists the second job.
+    mockFetchRecentUndelivered.mockResolvedValue({ json: async () => [TWO[1]] });
+    const [first, second] = screen.getAllByText('Dismiss');
+    fireEvent.click(first);
+    fireEvent.click(second);
+
+    await waitFor(() => expect(mockFetchRecentUndelivered).toHaveBeenCalledTimes(2));
+    expect(screen.queryByText(/the second one/)).not.toBeInTheDocument();
+
+    mockFetchRecentUndelivered.mockResolvedValue({ json: async () => [] });
+    await act(async () => {
+      settleSecond({ status: 200 });
+    });
+    await waitFor(() => expect(mockFetchRecentUndelivered).toHaveBeenCalledTimes(3));
+    expect(screen.queryByText(/the second one/)).not.toBeInTheDocument();
+  });
+
+  it('drops a stale re-check that answers after a newer one', async () => {
+    // A focus-triggered re-check was sent before the Dismiss and is slow. Its
+    // payload still lists the job; it must not overwrite the newer, correct
+    // answer that arrived after the dismiss was acknowledged.
+    mockFetchRecentUndelivered.mockResolvedValueOnce({ json: async () => SALVAGED });
+    renderSessionView();
+    expect(await screen.findByText(/the half that made it/)).toBeInTheDocument();
+
+    let settleStale: (v: { json: () => Promise<unknown> }) => void = () => {};
+    mockFetchRecentUndelivered.mockReturnValueOnce(
+      new Promise<{ json: () => Promise<unknown> }>((resolve) => {
+        settleStale = resolve;
+      }),
+    );
+    fireEvent(window, new Event('focus'));
+    await waitFor(() => expect(mockFetchRecentUndelivered).toHaveBeenCalledTimes(2));
+
+    mockFetchRecentUndelivered.mockResolvedValue({ json: async () => [] });
+    fireEvent.click(screen.getByText('Dismiss'));
+    await waitFor(() => expect(mockFetchRecentUndelivered).toHaveBeenCalledTimes(3));
+
+    await act(async () => {
+      settleStale({ json: async () => SALVAGED });
+    });
+
+    expect(screen.queryByText(/the half that made it/)).not.toBeInTheDocument();
+  });
+
+  it('re-checks after View loads a result so the next queued job surfaces', async () => {
+    mockFetchRecentUndelivered.mockResolvedValueOnce({ json: async () => SALVAGED });
+    mockFetchTranscriptionResult.mockResolvedValue({
+      status: 200,
+      json: async () => ({ result: { text: 'the half that made it', words: [] } }),
+    });
+    renderSessionView();
+    expect(await screen.findByText(/the half that made it/)).toBeInTheDocument();
+
+    mockFetchRecentUndelivered.mockResolvedValue({
+      json: async () => [
+        { job_id: 'older-job', completed_at: COMPLETED_AT, text_preview: 'from three days ago' },
+      ],
+    });
+    fireEvent.click(screen.getByText('View'));
+
+    await waitFor(() => expect(mockTranscription.loadResult).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText(/from three days ago/)).toBeInTheDocument();
+    expect(mockFetchRecentUndelivered).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -1511,14 +1511,26 @@ export const SessionView: React.FC<SessionViewProps> = ({
   const [recoveryJobs, setRecoveryJobs] = useState<
     Array<{ job_id: string; completed_at: string; text_preview: string }>
   >([]);
+  // Jobs whose Dismiss has been sent but not yet acknowledged. A re-check
+  // triggered by an earlier Dismiss can answer before the server has processed
+  // a later one and would otherwise bring that row straight back.
+  const pendingDismissRef = useRef<Set<string>>(new Set());
+  // Re-checks fire from several places (mount, focus, salvage end, Dismiss,
+  // View) and can overlap. Only the newest one may write state: an older
+  // response landing late would resurrect a row the newer one already dropped.
+  const refreshSeqRef = useRef(0);
   const refreshRecoveryJobs = useCallback(() => {
+    const seq = ++refreshSeqRef.current;
     // Absolute base URL via apiClient — a relative fetch resolves to the
     // packaged renderer file:// origin and never reaches the backend (GH-202).
     apiClient
       .fetchRecentUndelivered()
       .then((r) => r.json())
       .then((data) => {
-        if (Array.isArray(data)) setRecoveryJobs(data);
+        if (seq !== refreshSeqRef.current) return;
+        if (Array.isArray(data)) {
+          setRecoveryJobs(data.filter((job) => !pendingDismissRef.current.has(job.job_id)));
+        }
       })
       .catch(() => {});
   }, []);
@@ -1748,6 +1760,9 @@ export const SessionView: React.FC<SessionViewProps> = ({
                               duration: r.duration,
                             });
                             setRecoveryJobs((prev) => prev.filter((j) => j.job_id !== job.job_id));
+                            // /recent is capped at 5 rows: pull the next queued
+                            // job into the freed slot now, not on the next focus.
+                            refreshRecoveryJobs();
                           }
                         })
                         .catch(() => {});
@@ -1758,8 +1773,18 @@ export const SessionView: React.FC<SessionViewProps> = ({
                   <button
                     className="rounded px-2 py-1 text-xs font-semibold text-amber-300/60 hover:bg-amber-500/20 hover:text-amber-300"
                     onClick={() => {
-                      apiClient.dismissTranscriptionResult(job.job_id).catch(() => {});
-                      setRecoveryJobs((prev) => prev.filter((j) => j.job_id !== job.job_id));
+                      const jobId = job.job_id;
+                      pendingDismissRef.current.add(jobId);
+                      setRecoveryJobs((prev) => prev.filter((j) => j.job_id !== jobId));
+                      // Re-check only once the server has acknowledged the
+                      // dismiss; a failed dismiss legitimately comes back.
+                      apiClient
+                        .dismissTranscriptionResult(jobId)
+                        .catch(() => {})
+                        .finally(() => {
+                          pendingDismissRef.current.delete(jobId);
+                          refreshRecoveryJobs();
+                        });
                     }}
                   >
                     Dismiss


### PR DESCRIPTION
## Problem

The amber recovery banner at the top of the Session tab lists completed-but-undelivered jobs from `GET /api/transcribe/recent`, which is capped at 5 rows server-side. Dismiss and View only removed the row locally; the list was re-fetched on mount, on `transcription.status === 'error'`, on window focus and when a salvage ended. A user who had been cancelling recordings from the tray for days came back to a full banner, dismissed five rows, and then saw nothing until an unrelated event (a window focus a while later) pulled in the next, older batch.

## Fix

`dashboard/components/views/SessionView.tsx`

- **Dismiss**: after the server acknowledges `POST /result/{id}/dismiss`, re-fetch `/recent` so the next queued job fills the freed slot immediately. The re-fetch waits for the ack on purpose: fetching in parallel would answer before `mark_delivered` is written and bring the same row back.
- **View**: same re-fetch after the result loads (a 200 from `/result/{id}` marks it delivered).
- **Two race guards**
  - `pendingDismissRef`: rows whose dismiss is still in flight are filtered out of any concurrent re-fetch result, so two quick Dismiss clicks do not flicker the second row back.
  - `refreshSeqRef`: only the newest outstanding re-fetch may write state. A slow focus-triggered response that was sent before the Dismiss can no longer resurrect the dismissed row.

Server side (`LIMIT 5`, `/recent` query) is unchanged.

## Tests

`dashboard/components/__tests__/SessionView.recovery-refresh.test.tsx` (+4, all RED before the fix):

- re-fetch happens only after the dismiss resolves, and the queued older job appears
- a row with an in-flight dismiss stays hidden through a concurrent re-fetch
- a stale re-fetch answering after a newer one is dropped
- View loading a result triggers the re-fetch

`vitest run`: 148 files / 2138 tests pass. `tsc --noEmit`, eslint, prettier and `npm run ui:contract:check` (22 checks) clean.

## Smoke

Not yet smoke-tested in the running app. Repro: cancel several recordings from the tray (more than 5), open the Session tab, Dismiss one; the next older job should appear immediately.