### PR TITLE
fix(dashboard): make a mute reach the audio it is supposed to mute

### DIFF
--- a/dashboard/components/__tests__/SessionView.test.tsx
+++ b/dashboard/components/__tests__/SessionView.test.tsx
@@ -9,7 +9,7 @@
 
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const mockTranscription = {
@@ -719,5 +719,81 @@ describe('capture gain handed to the live hook at Live Mode start', () => {
     expect(live.setGain).toHaveBeenLastCalledWith(1);
     const orders = live.setGain.mock.invocationCallOrder;
     expect(orders[orders.length - 1]).toBeLessThan(live.start.mock.invocationCallOrder[0]);
+  });
+});
+
+// ── The Main Transcription card's mute button drove the wrong hook ─────────
+//
+// That card owns the one-shot recording - the Record/Stop button, the result,
+// the errors - but its header mute button called live.toggleMute() and
+// rendered live.muted, left behind by the layout refactor that moved a Live
+// Mode toolbar out of it (a8155a5f). Pressing it during a recording turned it
+// red and flipped the tray to 'recording-muted' - SessionView feeds
+// useTraySync the combined `transcription.muted || live.muted` - while the
+// recording went on streaming to the server and being transcribed. The tray
+// menu item was the only mute a recording actually had, and pressing THAT to
+// "unmute" muted it for real without changing the icon.
+
+describe('the Main Transcription card mutes the recording it owns', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTranscription.status = 'idle';
+    mockTranscription.result = null;
+    mockTranscription.error = null;
+    mockTranscription.vadActive = false;
+    mockTranscription.processingProgress = null;
+    mockTranscription.muted = false;
+
+    vi.mocked(isModelDisabled).mockReturnValue(false);
+
+    (window as any).electronAPI = {
+      config: {
+        get: vi.fn().mockResolvedValue(undefined),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+      docker: {
+        readComposeEnvValue: vi.fn().mockResolvedValue('false'),
+      },
+      audio: { listSinks: vi.fn().mockResolvedValue([]) },
+      tray: { onAction: vi.fn().mockReturnValue(vi.fn()) },
+      notifications: { show: vi.fn() },
+    };
+  });
+
+  // mockTranscription is shared across every describe in this file, so a muted
+  // state left set here would leak into whatever runs next.
+  afterEach(() => {
+    mockTranscription.muted = false;
+  });
+
+  it('routes the card mute button to the transcription hook, not the live one', () => {
+    const live = { ...baseLiveState, toggleMute: vi.fn() };
+    mockTranscription.status = 'recording';
+    render(React.createElement(SessionView, { ...baseProps, live }), { wrapper: createWrapper() });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mute recording' }));
+
+    expect(mockTranscription.toggleMute).toHaveBeenCalledTimes(1);
+    expect(live.toggleMute).not.toHaveBeenCalled();
+  });
+
+  it('reads its muted state from the recording, not from Live Mode', () => {
+    // A muted Live Mode session must not paint this button red: the card is
+    // about the recording, and Live Mode has its own mute button.
+    mockTranscription.status = 'recording';
+    const live = { ...baseLiveState, muted: true, toggleMute: vi.fn() };
+    render(React.createElement(SessionView, { ...baseProps, live }), { wrapper: createWrapper() });
+
+    expect(screen.getByRole('button', { name: 'Mute recording' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Unmute recording' })).toBeNull();
+  });
+
+  it('offers to unmute once the recording is muted', () => {
+    mockTranscription.status = 'recording';
+    mockTranscription.muted = true;
+    render(React.createElement(SessionView, baseProps), { wrapper: createWrapper() });
+
+    expect(screen.getByRole('button', { name: 'Unmute recording' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Mute recording' })).toBeNull();
   });
 });

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -2065,12 +2065,24 @@ export const SessionView: React.FC<SessionViewProps> = ({
                   title="Main Transcription"
                   className="flex-none"
                   action={
+                    // This card owns the one-shot recording - the Record/Stop
+                    // button, the result, the errors - so its mute button has
+                    // to mute the recording. It drove live.toggleMute() and
+                    // rendered live.muted instead, left behind by the layout
+                    // refactor that moved a Live Mode toolbar out of here
+                    // (a8155a5f), which made it the one control that could turn
+                    // itself red, flip the tray to 'recording-muted' through
+                    // the combined `transcription.muted || live.muted`
+                    // indicator, and leave the recording streaming to the
+                    // server. The tray menu item was the only mute a recording
+                    // actually had.
                     <button
-                      onClick={() => live.toggleMute()}
-                      className={`flex h-7 w-7 items-center justify-center rounded-lg border transition-colors ${live.muted ? 'border-red-500/30 bg-red-500/20 text-red-400 hover:bg-red-500/30' : 'border-white/10 bg-white/5 text-slate-400 hover:bg-white/10 hover:text-white'}`}
-                      title={live.muted ? 'Unmute' : 'Mute'}
+                      onClick={() => transcription.toggleMute()}
+                      className={`flex h-7 w-7 items-center justify-center rounded-lg border transition-colors ${transcription.muted ? 'border-red-500/30 bg-red-500/20 text-red-400 hover:bg-red-500/30' : 'border-white/10 bg-white/5 text-slate-400 hover:bg-white/10 hover:text-white'}`}
+                      title={transcription.muted ? 'Unmute' : 'Mute'}
+                      aria-label={transcription.muted ? 'Unmute recording' : 'Mute recording'}
                     >
-                      {live.muted ? <VolumeX size={14} /> : <Volume2 size={14} />}
+                      {transcription.muted ? <VolumeX size={14} /> : <Volume2 size={14} />}
                     </button>
                   }
                 >

--- a/dashboard/src/hooks/useLiveMode.test.ts
+++ b/dashboard/src/hooks/useLiveMode.test.ts
@@ -886,6 +886,136 @@ describe('[P1] useLiveMode', () => {
     });
   });
 
+  // ── Mute must reach the AudioCapture built on LISTENING ──────────────
+  //
+  // Same lifetime gap as the capture gain: `muted` is React state here, while
+  // the object that gates chunk delivery is the AudioCapture the engine's
+  // LISTENING message builds. A mute landing before that existed reached
+  // `captureRef.current?.mute()` with nothing behind it, so the session came
+  // up unmuted - audio streaming and being transcribed while all three mute
+  // buttons and the tray icon showed muted.
+  //
+  // This hook makes it worse than the longform one: the retarget hop and the
+  // auto-reconnect-on-ERROR both destroy the capture and build a fresh,
+  // unmuted replacement, and both deliberately preserve the mute state across
+  // the hop - so the UI keeps promising a mute the new capture never got.
+  //
+  // The flag cannot be handed over before start() the way the gain is:
+  // start() opens with a defensive stop() and stop() clears it.
+
+  describe('mute reaches the AudioCapture built on LISTENING', () => {
+    it('mutes the capture built after a mute pressed before LISTENING', async () => {
+      const { result } = renderHook(() => useLiveMode());
+
+      act(() => {
+        result.current.start({});
+      });
+      act(() => {
+        lastSocketCbs.onMessage!({ type: 'auth_ok' });
+      });
+      // No AudioCapture yet - the engine has not reported LISTENING. The mute
+      // buttons are live throughout this window.
+      act(() => {
+        result.current.toggleMute();
+      });
+      expect(result.current.muted).toBe(true);
+
+      await act(async () => {
+        lastSocketCbs.onMessage!({ type: 'state', data: { state: 'LISTENING' } });
+      });
+
+      expect(lastCapture.mute).toHaveBeenCalled();
+      // AFTER start(), not before - the opposite of the gain. start()'s
+      // defensive stop() clears the muted flag, so a mute handed over first
+      // would be wiped before the graph was built.
+      expect(lastCapture.mute.mock.invocationCallOrder[0]).toBeGreaterThan(
+        lastCapture.start.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('keeps the capture muted across a retarget hop', async () => {
+      // EC-6: the user changed hosts mid-session. start() is re-entered from
+      // inside this hook with the retarget flag set, which deliberately keeps
+      // the accumulated sentences and the mute - so the remembered flag has to
+      // survive it too, and the capture the new host builds has to honour it.
+      // The auto-reconnect-on-ERROR takes the same path.
+      const { result } = renderHook(() => useLiveMode());
+      await driveToListening(result);
+
+      act(() => {
+        result.current.toggleMute();
+      });
+      const firstCapture = lastCapture;
+      expect(firstCapture.mute).toHaveBeenCalled();
+
+      await act(async () => {
+        lastSocketCbs.onHostMismatch?.('ws://old-host:9786/ws/live', 'ws://new-host:9786/ws/live');
+        // Flush the retarget's queueMicrotask with a microtask of our own.
+        await Promise.resolve();
+      });
+      act(() => {
+        lastSocketCbs.onMessage!({ type: 'auth_ok' });
+      });
+      await act(async () => {
+        lastSocketCbs.onMessage!({ type: 'state', data: { state: 'LISTENING' } });
+      });
+
+      expect(lastCapture).not.toBe(firstCapture);
+      expect(result.current.muted).toBe(true);
+      expect(lastCapture.mute).toHaveBeenCalled();
+    });
+
+    it('does not mute a capture the user never muted', async () => {
+      const { result } = renderHook(() => useLiveMode());
+      await driveToListening(result);
+
+      expect(lastCapture.mute).not.toHaveBeenCalled();
+      expect(result.current.muted).toBe(false);
+    });
+
+    it('a restart without an intervening stop still opens unmuted', async () => {
+      // start() clears `muted` for anything that is not a retarget hop, so the
+      // remembered flag has to be cleared with it - otherwise every session
+      // after a muted one would come up silently muted. Driven without stop()
+      // on purpose: stop() clears the flag too, and going through it would let
+      // a start() that stopped clearing pass.
+      const { result } = renderHook(() => useLiveMode());
+      await driveToListening(result);
+
+      act(() => {
+        result.current.toggleMute();
+      });
+      expect(result.current.muted).toBe(true);
+
+      await driveToListening(result);
+
+      expect(result.current.muted).toBe(false);
+      expect(lastCapture.mute).not.toHaveBeenCalled();
+    });
+
+    it('stop() clears the mute along with the capture it belonged to', async () => {
+      // SessionView hands the tray `transcription.muted || live.muted`, so a
+      // mute left set after this capture died painted 'live-muted' over the
+      // next one-shot recording - and the tray's mute item, which routes to
+      // the recording while it is active, then MUTED that recording in an
+      // attempt to unmute this one. Only start() cleared the flag, and
+      // starting Live Mode again is not what the user does next.
+      const { result } = renderHook(() => useLiveMode());
+      await driveToListening(result);
+
+      act(() => {
+        result.current.toggleMute();
+      });
+      expect(result.current.muted).toBe(true);
+
+      act(() => {
+        result.current.stop();
+      });
+
+      expect(result.current.muted).toBe(false);
+    });
+  });
+
   // ── GH-237: WS reconnect must not resurrect a dead live session ───────
   //
   // Same root cause as the longform hook: the server cannot resume a dropped

--- a/dashboard/src/hooks/useLiveMode.ts
+++ b/dashboard/src/hooks/useLiveMode.ts
@@ -93,6 +93,14 @@ export function useLiveMode(): LiveModeState {
   // setGain() before that reached `captureRef.current?.` with nothing behind it
   // and was silently dropped.
   const gainRef = useRef(1);
+  // Mirror of `muted`, carried across the same gap but applied differently.
+  // Gain belongs to the device - it is persisted per sink and survives stop(),
+  // so it can be handed to a not-yet-started instance. Mute belongs to the
+  // session: stop() clears it and start() opens with a defensive stop(), so a
+  // mute seeded before start() is wiped before the graph is built. This ref is
+  // what the construction site re-applies once start() has resolved. Written
+  // only by setMutedTracked, which keeps it in lockstep with `muted`.
+  const mutedRef = useRef(false);
   const startOptsRef = useRef<LiveStartOptions>({});
   // Retarget hook: holds the latest `start` closure so the socket's
   // onHostMismatch callback can reopen the session on the new URL without
@@ -105,6 +113,13 @@ export function useLiveMode(): LiveModeState {
   const setStatusTracked = useCallback((s: LiveStatus) => {
     statusRef.current = s;
     setStatus(s);
+  }, []);
+  // Single writer for the muted pair, mirroring setStatusTracked. Every place
+  // that changes `muted` goes through here, so the ref the WS message handler
+  // reads can never drift from what the UI is showing.
+  const setMutedTracked = useCallback((next: boolean) => {
+    mutedRef.current = next;
+    setMuted(next);
   }, []);
   // GH-237: gate the `start` re-send across auto-reconnects (same rationale as
   // useTranscription). The server cannot resume a dropped live session, so
@@ -258,6 +273,17 @@ export function useLiveMode(): LiveModeState {
                 })
                 .then(() => {
                   setAnalyser(captureRef.current?.analyser ?? null);
+                  // Re-apply a mute the user pressed before this instance
+                  // existed. Two ways in: the mute buttons stay live while the
+                  // engine is still coming up, and the retarget hop and the
+                  // auto-reconnect-on-ERROR both land here having deliberately
+                  // kept the mute state while destroying the capture that was
+                  // honouring it. This has to run AFTER start(), unlike the
+                  // gain seeded above: start() opens with a defensive stop()
+                  // and stop() clears the muted flag. Nothing escapes in the
+                  // meantime - the worklet posts chunks as tasks, and this is
+                  // a microtask off start()'s promise, so it runs first.
+                  if (mutedRef.current) captureRef.current?.mute();
                 })
                 .catch((err) => {
                   // A stop() that raced the start — the stop already put the
@@ -376,7 +402,7 @@ export function useLiveMode(): LiveModeState {
       // transcript doesn't visually reset on host change.
       if (!isRetargetingRef.current) {
         setSentences([]);
-        setMuted(false);
+        setMutedTracked(false);
         // A fresh manual start resets the auto-reconnect budget.
         reconnectAttemptsRef.current = 0;
       }
@@ -487,7 +513,7 @@ export function useLiveMode(): LiveModeState {
         sock.connect();
       }
     },
-    [handleMessage, setStatusTracked],
+    [handleMessage, setStatusTracked, setMutedTracked],
   );
 
   // Keep the retarget ref pointed at the latest `start` closure. Updated every
@@ -509,6 +535,13 @@ export function useLiveMode(): LiveModeState {
     captureRef.current?.stop();
     setAnalyser(null);
     setStatusMessage(null);
+    // The mute belonged to the capture that just died. Leaving it set kept the
+    // tray on 'live-muted' through whatever came next, because SessionView
+    // feeds it `transcription.muted || live.muted` - so a mute left over here
+    // painted a muted icon over an unmuted one-shot recording, and the tray's
+    // mute item then MUTED that recording to "unmute" it. Only start() cleared
+    // it, and starting Live Mode again is not what the user does next.
+    setMutedTracked(false);
     // GH-237: user stop reopens the start-gate for the next session.
     sessionEstablishedRef.current = false;
     setStatusTracked('idle');
@@ -520,19 +553,21 @@ export function useLiveMode(): LiveModeState {
     void window.electronAPI?.docker?.switchWhisperServerModel?.(null).catch((err) => {
       console.warn('[useLiveMode] whisper-server main-model restore failed:', err);
     });
-  }, [setStatusTracked]);
+  }, [setStatusTracked, setMutedTracked]);
 
   const toggleMute = useCallback(() => {
-    setMuted((prev) => {
-      const next = !prev;
-      if (next) {
-        captureRef.current?.mute();
-      } else {
-        captureRef.current?.unmute();
-      }
-      return next;
-    });
-  }, []);
+    // Remember first, forward second - same shape as setGain. The ref is the
+    // only copy that survives until the next AudioCapture is constructed, and
+    // reading it here (rather than React's `prev`) also keeps the capture calls
+    // out of a state updater, which React may invoke more than once per press.
+    const next = !mutedRef.current;
+    setMutedTracked(next);
+    if (next) {
+      captureRef.current?.mute();
+    } else {
+      captureRef.current?.unmute();
+    }
+  }, [setMutedTracked]);
 
   const setGain = useCallback((value: number) => {
     // Remember first, forward second - the ref is the only copy that survives

--- a/dashboard/src/hooks/useTranscription.test.ts
+++ b/dashboard/src/hooks/useTranscription.test.ts
@@ -1105,6 +1105,160 @@ describe('[P1] useTranscription', () => {
     });
   });
 
+  // ── Mute must reach the AudioCapture built on session_started ─────────
+  //
+  // The same lifetime gap as the capture gain, with a worse payload. `muted`
+  // is React state in this hook; the object that actually gates chunk delivery
+  // is the AudioCapture, and that is built a server round trip later. A mute
+  // pressed before it existed forwarded through `captureRef.current?.mute()`
+  // and hit nothing, so the session came up unmuted: audio kept streaming to
+  // the server and being transcribed while the tray icon showed muted.
+  //
+  // Both mute controls are live in exactly that window. The tray's mute item
+  // is enabled from `connecting` onwards (useTraySync counts connecting as
+  // recording) and SessionView routes it to this hook for that status, and the
+  // Main Transcription card's own mute button - rewired to this hook on this
+  // branch - is never disabled.
+  //
+  // Unlike the gain, the flag cannot be handed over before start(): start()
+  // opens with a defensive stop() and stop() clears it, so the mute has to be
+  // re-applied once start() has built the graph.
+
+  describe('mute reaches the AudioCapture built on session_started', () => {
+    /** Drive to an open socket with no AudioCapture built yet. */
+    async function driveToConnecting(result: {
+      current: ReturnType<typeof useTranscription>;
+    }): Promise<void> {
+      act(() => {
+        result.current.start({});
+      });
+      await act(async () => {
+        lastSocketCbs.onMessage!({ type: 'auth_ok' });
+      });
+    }
+
+    /** Deliver the message the AudioCapture is constructed on. */
+    async function deliverSessionStarted(): Promise<void> {
+      await act(async () => {
+        lastSocketCbs.onMessage!({
+          type: 'session_started',
+          data: { job_id: 'job-1', capture_sample_rate_hz: 16000 },
+        });
+      });
+    }
+
+    it('mutes the capture built after a mute pressed while connecting', async () => {
+      const { result } = renderHook(() => useTranscription());
+      await driveToConnecting(result);
+
+      act(() => {
+        result.current.toggleMute();
+      });
+      expect(result.current.muted).toBe(true);
+
+      await deliverSessionStarted();
+
+      expect(lastCapture.mute).toHaveBeenCalled();
+      // AFTER start(), not before - the opposite of the gain. start()'s
+      // defensive stop() clears the muted flag, so a mute handed over first
+      // would be wiped before the graph was built. Re-applying here still
+      // leaks nothing: the worklet delivers chunks as tasks and this runs as a
+      // microtask off start()'s promise, which drains first.
+      expect(lastCapture.mute.mock.invocationCallOrder[0]).toBeGreaterThan(
+        lastCapture.start.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('does not mute a capture the user never muted', async () => {
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+
+      expect(lastCapture.mute).not.toHaveBeenCalled();
+      expect(result.current.muted).toBe(false);
+    });
+
+    it('honours an unmute that lands before the capture is built', async () => {
+      // This one constrains the toggle, not the re-apply: the pre-fix code
+      // also left the new capture unmuted here, so the `mute` assertion alone
+      // would pass against the bug. What it pins is that the remembered flag
+      // toggles BOTH ways - stop writing it on the off-branch and the second
+      // press stops registering, leaving `muted` stuck true.
+      const { result } = renderHook(() => useTranscription());
+      await driveToConnecting(result);
+
+      act(() => {
+        result.current.toggleMute();
+      });
+      act(() => {
+        result.current.toggleMute();
+      });
+      expect(result.current.muted).toBe(false);
+
+      await deliverSessionStarted();
+
+      expect(lastCapture.mute).not.toHaveBeenCalled();
+    });
+
+    it('unmutes the capture it muted on construction', async () => {
+      // The round trip the two tests above only cover half of each: the mute
+      // crosses the gap, and the unmute afterwards reaches the instance the
+      // mute was applied to rather than being dropped on the floor.
+      const { result } = renderHook(() => useTranscription());
+      await driveToConnecting(result);
+
+      act(() => {
+        result.current.toggleMute();
+      });
+      await deliverSessionStarted();
+      expect(lastCapture.mute).toHaveBeenCalled();
+
+      act(() => {
+        result.current.toggleMute();
+      });
+
+      expect(result.current.muted).toBe(false);
+      expect(lastCapture.unmute).toHaveBeenCalled();
+    });
+
+    it('a restart without an intervening stop still opens unmuted', async () => {
+      // start() clears `muted`, so the remembered flag must be cleared with
+      // it. Driven without stop() on purpose - stop() clears the flag too, and
+      // going through it would let a start() that stopped clearing pass.
+      const { result } = renderHook(() => useTranscription());
+      await driveToConnecting(result);
+
+      act(() => {
+        result.current.toggleMute();
+      });
+      expect(result.current.muted).toBe(true);
+
+      await driveToRecording(result);
+
+      expect(result.current.muted).toBe(false);
+      expect(lastCapture.mute).not.toHaveBeenCalled();
+    });
+
+    it('stop() clears the mute along with the capture it belonged to', async () => {
+      // SessionView hands the tray `transcription.muted || live.muted`, so a
+      // mute left set after this capture died painted a muted icon over
+      // whatever ran next - and the tray's mute item then muted THAT session
+      // in an attempt to unmute this one.
+      const { result } = renderHook(() => useTranscription());
+      await driveToRecording(result);
+
+      act(() => {
+        result.current.toggleMute();
+      });
+      expect(result.current.muted).toBe(true);
+
+      act(() => {
+        result.current.stop();
+      });
+
+      expect(result.current.muted).toBe(false);
+    });
+  });
+
   // ── GH-237: WS reconnect must not spawn zombie server sessions ────────
   //
   // The server assigns a NEW session_id + job_id per WS connection and cannot

--- a/dashboard/src/hooks/useTranscription.ts
+++ b/dashboard/src/hooks/useTranscription.ts
@@ -176,6 +176,14 @@ export function useTranscription(): TranscriptionState {
   // next instance, so the recording opens at the gain the slider is showing
   // rather than always at 1.0.
   const gainRef = useRef(1);
+  // Mirror of `muted`, carried across the same gap but applied differently.
+  // Gain belongs to the device - it is persisted per sink and survives stop(),
+  // so it can be handed to a not-yet-started instance. Mute belongs to the
+  // session: stop() clears it and start() opens with a defensive stop(), so a
+  // mute seeded before start() is wiped before the graph is built. This ref is
+  // what the construction site re-applies once start() has resolved. Written
+  // only by setMutedTracked, which keeps it in lockstep with `muted`.
+  const mutedRef = useRef(false);
   const [jobId, setJobId] = useState<string | null>(null);
   const jobIdRef = useRef<string | null>(null);
   const statusRef = useRef<TranscriptionStatus>('idle');
@@ -199,6 +207,14 @@ export function useTranscription(): TranscriptionState {
   const setStatusTracked = useCallback((s: TranscriptionStatus) => {
     statusRef.current = s;
     setStatus(s);
+  }, []);
+
+  // Single writer for the muted pair, mirroring setStatusTracked. Every place
+  // that changes `muted` goes through here, so the ref the WS message handler
+  // reads can never drift from what the UI is showing.
+  const setMutedTracked = useCallback((next: boolean) => {
+    mutedRef.current = next;
+    setMuted(next);
   }, []);
 
   const startOptsRef = useRef<{
@@ -391,6 +407,15 @@ export function useTranscription(): TranscriptionState {
               })
               .then(() => {
                 setAnalyser(captureRef.current?.analyser ?? null);
+                // Re-apply a mute the user pressed before this instance
+                // existed - the tray action is the only way to mute a one-shot
+                // recording, and SessionView routes it here while the status
+                // is still `connecting`. This has to run AFTER start(), unlike
+                // the gain seeded above: start() opens with a defensive stop()
+                // and stop() clears the muted flag. Nothing escapes in the
+                // meantime - the worklet posts chunks as tasks, and this is a
+                // microtask off start()'s promise, so it runs first.
+                if (mutedRef.current) captureRef.current?.mute();
               })
               .catch((err) => {
                 // A stop() that raced the start — the stop already put the
@@ -578,7 +603,7 @@ export function useTranscription(): TranscriptionState {
       setError(null);
       setBusyInfo(null);
       setVadActive(false);
-      setMuted(false);
+      setMutedTracked(false);
       jobIdRef.current = null;
       setJobId(null);
       // GH-237: a user-initiated session reopens the start-gate.
@@ -718,7 +743,7 @@ export function useTranscription(): TranscriptionState {
       });
       socketRef.current.connect();
     },
-    [handleMessage, setStatusTracked, stopPreview, haltPreviewLoop],
+    [handleMessage, setStatusTracked, setMutedTracked, stopPreview, haltPreviewLoop],
   );
 
   const stop = useCallback(() => {
@@ -731,9 +756,14 @@ export function useTranscription(): TranscriptionState {
       // Stop audio capture immediately
       captureRef.current?.stop();
       setAnalyser(null);
+      // The mute belonged to the capture that just died. Leaving it set kept
+      // the tray on 'recording-muted' through whatever came next, because
+      // SessionView feeds it `transcription.muted || live.muted` - so a mute
+      // left over here painted a muted icon over an unmuted Live Mode session.
+      setMutedTracked(false);
       setStatusTracked('processing');
     }
-  }, [status, setStatusTracked, haltPreviewLoop]);
+  }, [status, setStatusTracked, setMutedTracked, haltPreviewLoop]);
 
   const reset = useCallback(() => {
     captureRef.current?.stop();
@@ -744,7 +774,7 @@ export function useTranscription(): TranscriptionState {
     setBusyInfo(null);
     setAnalyser(null);
     setVadActive(false);
-    setMuted(false);
+    setMutedTracked(false);
     setProcessingProgress(null);
     jobIdRef.current = null;
     setJobId(null);
@@ -753,21 +783,23 @@ export function useTranscription(): TranscriptionState {
     stopPreview();
     // reset() disconnects the socket — the in-flight response (if any) is lost.
     previewLoadingRef.current = false;
-  }, [setStatusTracked, stopPreview]);
+  }, [setStatusTracked, setMutedTracked, stopPreview]);
 
   const clearBusyInfo = useCallback(() => setBusyInfo(null), []);
 
   const toggleMute = useCallback(() => {
-    setMuted((prev) => {
-      const next = !prev;
-      if (next) {
-        captureRef.current?.mute();
-      } else {
-        captureRef.current?.unmute();
-      }
-      return next;
-    });
-  }, []);
+    // Remember first, forward second - same shape as setGain. The ref is the
+    // only copy that survives until the next AudioCapture is constructed, and
+    // reading it here (rather than React's `prev`) also keeps the capture calls
+    // out of a state updater, which React may invoke more than once per press.
+    const next = !mutedRef.current;
+    setMutedTracked(next);
+    if (next) {
+      captureRef.current?.mute();
+    } else {
+      captureRef.current?.unmute();
+    }
+  }, [setMutedTracked]);
 
   const setGain = useCallback((value: number) => {
     // Remember first, forward second: the ref is the only copy that survives

--- a/dashboard/src/services/audioCapture.test.ts
+++ b/dashboard/src/services/audioCapture.test.ts
@@ -393,6 +393,26 @@ describe('[P1] AudioCapture loopback ownership (GH-230)', () => {
     expect(systemGain.gain.value).toBe(3);
   });
 
+  // The asymmetry between gain and mute, which is why the hooks carry them
+  // differently. Gain belongs to the device - it is persisted per sink and
+  // survives stop(), so a hook can hand it to a not-yet-started instance (see
+  // the test above). Mute belongs to the session: stop() clears it, and
+  // start() opens with a defensive stop(), so a mute handed over first is
+  // wiped before the graph is built. That is why both hooks re-apply the mute
+  // once start() has resolved instead of seeding it the way they seed gain.
+  it('a mute set before start() does NOT survive into the built graph', async () => {
+    const capture = new AudioCapture(() => {});
+
+    capture.mute();
+    expect(capture.isMuted).toBe(true);
+
+    await capture.start({ systemAudio: true, monitorSinkName: 'sink-a' });
+
+    expect(capture.isMuted).toBe(false);
+    const [systemGain] = lastCtx!.createGain.mock.results.map((r) => r.value);
+    expect(systemGain.gain.value).toBe(1);
+  });
+
   // The load-bearing assertion for a MIXING feature: every other test here
   // passes with the mic acquired, held, gain-staged, muted and torn down
   // correctly while its audio goes nowhere. Deleting either connect() in


### PR DESCRIPTION
Follow-up to #303, which fixed the same lifetime gap for the capture gain and left this one described but unfixed.

Three defects, all with the same user-visible shape: **the UI says muted while the audio is still being streamed to the server and transcribed.** The first is the one #303 named. The other two were found reviewing the fix for the first, and are included because without them the fix does not actually reach the mute controls a user presses.

## 1. A mute never reached the AudioCapture the session built

`muted` is React state in `useTranscription` / `useLiveMode`, but the object that gates chunk delivery is the `AudioCapture` - and that is constructed a server round trip after `start()`, in the `session_started` handler (longform) and the `state === 'LISTENING'` handler (Live Mode). `toggleMute` forwarded through `captureRef.current?.mute()`, so a mute pressed before the instance existed hit `null` and the optional chain swallowed it. The fresh instance is born `_muted = false`, and nothing at either construction site read the hook's state.

`audioCapture.ts` gates delivery on `!this._muted`, so the chunks went out and came back as transcript. Meanwhile the tray sat on the dimmed `'recording-muted'` icon captioned "Recording (Muted)".

Both mute controls are live in exactly that window:

- **Longform.** `useTraySync` counts `connecting` as recording, so the tray's mute item is enabled from the moment the session opens, and SessionView routes it to this hook for `connecting` as well as `recording`. During a model swap that window is seconds long.
- **Live Mode.** The mute buttons are never disabled. And there is a second way in that has nothing to do with timing: the retarget hop (`onHostMismatch`) and the auto-reconnect-on-ERROR both destroy the capture and build a replacement, while *deliberately* preserving the mute state - `start()` skips `setMuted(false)` when `isRetargetingRef` is set, with a comment saying so. The UI kept a promise the new capture never received.

**The fix.** A `mutedRef` mirrors the state, and the construction site re-applies it once `start()` resolves.

It cannot be seeded before `start()` the way the capture gain is, one line above. **Gain belongs to the device** - it is persisted per sink and survives `stop()`. **Mute belongs to the session** - `stop()` clears it, and `start()` opens with a defensive `stop()`, so a mute handed over first is wiped before the graph is built.

Re-applying in the `.then()` leaks nothing: the worklet posts PCM chunks to the main thread as *tasks*, and the `.then()` is a *microtask* off `start()`'s promise, so it runs before the first chunk can be dispatched.

The ref is written only by a new `setMutedTracked`, mirroring the `setStatusTracked`/`statusRef` pair the same files already use, so it cannot drift from what the UI shows.

## 2. The Main Transcription card's mute button drove the wrong hook

That card owns the one-shot recording - the Record/Stop button, the result, the errors - and its header mute button called `live.toggleMute()` and rendered `live.muted`. `git log -L` puts its arrival in the layout refactor `a8155a5f`, in the same hunk that moved a Live Mode toolbar out of the card.

So the only on-screen mute a recording had was wired to the other engine. Pressing it turned the button red and flipped the tray to `'recording-muted'` through the combined `transcription.muted || live.muted` indicator, while the recording went on streaming. Pressing the tray item to "unmute" then muted it for real without changing the icon, so the next press unmuted it again.

Now points at `transcription`, and carries an accessible name so a screen reader can tell the two on-screen mute buttons apart.

## 3. Neither hook's `stop()` cleared the mute

Only `start()` and `reset()` did, and starting the same engine again is not what a user does next. A mute left set on the engine just stopped kept painting a muted icon over the *other* engine's fresh, unmuted session - and the tray's mute item, which routes by status, then muted that session in an attempt to unmute this one.

## Also

`toggleMute` now reads the ref instead of React's `prev`, which takes the `mute()`/`unmute()` calls out of a state updater React may invoke more than once per press.

## Evidence

Eighteen mutants, all caught:

| Mutation | Caught by |
|---|---|
| Drop the mute re-apply in `useTranscription`'s `.then()` | 2 hook tests |
| Drop the mute re-apply in `useLiveMode`'s `.then()` | 2 hook tests |
| **Seed the mute before `start()` instead (the naive fix)** | the ordering assertion, each hook |
| Re-apply unconditionally (every session muted) | 3 + 2 hook tests |
| `setMutedTracked` stops writing the ref | 4 + 3 hook tests |
| `start()` stops clearing the mute (each hook) | the restart test |
| `stop()` stops clearing the mute (each hook) | the stop test |
| Reset the remembered mute even on a retarget hop | the retarget test |
| `toggleMute` stops forwarding `mute()` / stops forwarding `unmute()` | 2 + 2 hook tests |
| Card mute button reverts to `live.toggleMute()` | the routing test |
| Card mute button renders `live.muted` | 2 SessionView tests |
| `AudioCapture.stop()` stops clearing `_muted` | the new characterization test |

Two are worth calling out. **Seeding the mute before `start()`** is the obvious way to write this fix, mirroring the gain seeded on the line above - it is caught by an assertion that the re-apply happens *after* `start()`, so the `stop()` trap is guarded executably and not only by a comment. And the new **`AudioCapture` characterization test** pins the trap itself: a mute set before `start()` does not survive into the built graph. If someone later makes `stop()` preserve `_muted`, that test fails and points at the hooks.

## Test plan

- [x] `vitest run` - 2160 passed, 148 files
- [x] `tsc --noEmit` (renderer) and `tsc -p electron/tsconfig.json --noEmit`
- [x] `eslint . --max-warnings=0`
- [x] `ui:contract:validate` + `ui:contract:test` (22 checks, v1.18.0 - no class tokens changed)
- [ ] Hardware smoke: mute from the tray while the status still reads connecting (easiest to hit during a model swap), then talk - the transcript should be empty
- [ ] Hardware smoke: Live Mode, mute, then force a retarget or an engine error so the session reconnects - it must come back still muted
- [ ] Hardware smoke: the Main Transcription card's mute button now mutes the recording, and a muted Live Mode session no longer paints it red

`electron/__tests__/macVariantUpdater.test.ts > deletes the partial file and falls back when the stream fails mid-download` failed once in three full-suite runs and passes 7/7 in isolation. This branch changes no line under `electron/`; it is the same flaky test seen on #303.
