### PR TITLE
fix(stt, dashboard): a GPU OOM no longer poisons the backend, and a completed transcript can no longer become unreachable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ TranscriptionSuite.app
 # AI Stuff
 
 .claude/worktrees/
-_bmad/
 .claude/
 .gitnexus/
 .superpowers/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,8 @@
 #
 # Docs:    https://pre-commit.com
 
-# BMad third-party files — excluded globally from all hooks
-exclude: "^(_bmad/|_bmad-output/|\\.claude/skills/bmad-)"
+# Generated design/spec artifacts — excluded globally from all hooks
+exclude: "^_bmad-output/"
 
 repos:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,30 +1,31 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **TranscriptionSuite** (15183 symbols, 27708 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **TranscriptionSuite** (18739 symbols, 36573 relationships, 572 execution flows).
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> Index stale? Run `node .gitnexus/run.cjs analyze --index-only` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? Bootstrap with `npx`, `bunx`, or `pnpm dlx` — e.g. `bunx gitnexus@latest analyze` (npm 11 npx crash; #1939).
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing.** Use `impact({target: "symbolName", direction: "upstream"})` (MCP) or `node .gitnexus/run.cjs impact "symbolName" --direction upstream --repo .` (CLI fallback); report callers, processes, and risk. Never substitute grep for graph analysis.
+- **MUST analyze graph changes before committing.** Use `detect_changes({scope: "all"})` (MCP) or `node .gitnexus/run.cjs detect-changes --scope all --repo .` (CLI fallback). `partial: true` or `truncated: true` is not a clean check — a zero means unseen, not unaffected; re-run it. For regression review: `detect_changes({scope: "compare", base_ref: "main"})` or `node .gitnexus/run.cjs detect-changes --scope compare --base-ref "main" --repo .`.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- **MUST treat `risk: UNKNOWN` as unresolved, not as low.** An empty caller set is not evidence the symbol is unused — it can also mean the callers are not resolvable by the index (plain-object property access, dynamic dispatch, cross-language calls). `impact` pairs `UNKNOWN` with a `riskNote` saying so. Confirm with a text search before treating the symbol as safe to change or delete; do not proceed on the strength of a zero.
 - When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
 - When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
 - For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
-- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER edit a function, class, or method before MCP/CLI impact analysis.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis, and never read `UNKNOWN` as an all-clear — it means the walk could not answer, which is the one verdict that requires confirming by other means.
 - NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER commit before MCP/CLI graph change analysis.
 
 ## Resources
 
 | Resource | Use for |
-|----------|---------|
+| --- | --- |
 | `gitnexus://repo/TranscriptionSuite/context` | Codebase overview, check index freshness |
 | `gitnexus://repo/TranscriptionSuite/clusters` | All functional areas |
 | `gitnexus://repo/TranscriptionSuite/processes` | All execution flows |
@@ -33,12 +34,12 @@ This project is indexed by GitNexus as **TranscriptionSuite** (15183 symbols, 27
 ## CLI
 
 | Task | Read this skill file |
-|------|---------------------|
-| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
-| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
-| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
-| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
-| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
-| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+| --- | --- |
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus-cli/SKILL.md` |
 
 <!-- gitnexus:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,30 +100,31 @@ feat/fix/chore/etc(impacted area e.g. tests, stt, dashboard, ui, server, etc): s
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **TranscriptionSuite** (15183 symbols, 27708 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **TranscriptionSuite** (18739 symbols, 36573 relationships, 572 execution flows).
 
-> Index stale? Run `node .gitnexus/run.cjs analyze` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? `npx gitnexus analyze` (npm 11 crash → `npm i -g gitnexus`; #1939).
+> Index stale? Run `node .gitnexus/run.cjs analyze --index-only` from the project root — it auto-selects an available runner. No `.gitnexus/run.cjs` yet? Bootstrap with `npx`, `bunx`, or `pnpm dlx` — e.g. `bunx gitnexus@latest analyze` (npm 11 npx crash; #1939).
 
 ## Always Do
 
-- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
-- **MUST run `detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows. For regression review, compare against the default branch: `detect_changes({scope: "compare", base_ref: "main"})`.
+- **MUST run impact analysis before editing.** Use `impact({target: "symbolName", direction: "upstream"})` (MCP) or `node .gitnexus/run.cjs impact "symbolName" --direction upstream --repo .` (CLI fallback); report callers, processes, and risk. Never substitute grep for graph analysis.
+- **MUST analyze graph changes before committing.** Use `detect_changes({scope: "all"})` (MCP) or `node .gitnexus/run.cjs detect-changes --scope all --repo .` (CLI fallback). `partial: true` or `truncated: true` is not a clean check — a zero means unseen, not unaffected; re-run it. For regression review: `detect_changes({scope: "compare", base_ref: "main"})` or `node .gitnexus/run.cjs detect-changes --scope compare --base-ref "main" --repo .`.
 - **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- **MUST treat `risk: UNKNOWN` as unresolved, not as low.** An empty caller set is not evidence the symbol is unused — it can also mean the callers are not resolvable by the index (plain-object property access, dynamic dispatch, cross-language calls). `impact` pairs `UNKNOWN` with a `riskNote` saying so. Confirm with a text search before treating the symbol as safe to change or delete; do not proceed on the strength of a zero.
 - When exploring unfamiliar code, use `query({search_query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
 - When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `context({name: "symbolName"})`.
 - For security review, `explain({target: "fileOrSymbol"})` lists taint findings (source→sink flows; needs `analyze --pdg`).
 
 ## Never Do
 
-- NEVER edit a function, class, or method without first running `impact` on it.
-- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER edit a function, class, or method before MCP/CLI impact analysis.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis, and never read `UNKNOWN` as an all-clear — it means the walk could not answer, which is the one verdict that requires confirming by other means.
 - NEVER rename symbols with find-and-replace — use `rename` which understands the call graph.
-- NEVER commit changes without running `detect_changes()` to check affected scope.
+- NEVER commit before MCP/CLI graph change analysis.
 
 ## Resources
 
 | Resource | Use for |
-|----------|---------|
+| --- | --- |
 | `gitnexus://repo/TranscriptionSuite/context` | Codebase overview, check index freshness |
 | `gitnexus://repo/TranscriptionSuite/clusters` | All functional areas |
 | `gitnexus://repo/TranscriptionSuite/processes` | All execution flows |
@@ -132,12 +133,12 @@ This project is indexed by GitNexus as **TranscriptionSuite** (15183 symbols, 27
 ## CLI
 
 | Task | Read this skill file |
-|------|---------------------|
-| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
-| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
-| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
-| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
-| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
-| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+| --- | --- |
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus-cli/SKILL.md` |
 
 <!-- gitnexus:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,9 +56,12 @@ When creating a brownfield PRD or planning a feature, point the planning workflo
 
 ## Branching Policy
 
+NEVER commit directly on `main`, no matter how minor the change, unless the user
+explicitly instructs you to.
+
 When committing, create a new feature branch. Feature branch *within* feature
 branch is allowed. Do not create a new branch if the change is minor (applies
-to both main and feature branches) or if already on feature branch and new
+only to feature branches) or if already on feature branch and new
 commit is about the same feature.
 
 ## PR Workflow

--- a/dashboard/components/__tests__/SessionView.canary-language.test.tsx
+++ b/dashboard/components/__tests__/SessionView.canary-language.test.tsx
@@ -45,6 +45,7 @@ const mockTranscription = {
   toggleMute: vi.fn(),
   setGain: vi.fn(),
   jobId: null,
+  resultJobId: null,
   loadResult: vi.fn(),
 };
 

--- a/dashboard/components/__tests__/SessionView.client-link-stop.test.tsx
+++ b/dashboard/components/__tests__/SessionView.client-link-stop.test.tsx
@@ -30,6 +30,7 @@ const mockTranscription = {
   toggleMute: vi.fn(),
   setGain: vi.fn(),
   jobId: null,
+  resultJobId: null,
   loadResult: vi.fn(),
 };
 

--- a/dashboard/components/__tests__/SessionView.diarization.test.tsx
+++ b/dashboard/components/__tests__/SessionView.diarization.test.tsx
@@ -36,6 +36,7 @@ const mockTranscription = {
   toggleMute: vi.fn(),
   setGain: vi.fn(),
   jobId: null,
+  resultJobId: null,
   loadResult: vi.fn(),
 };
 

--- a/dashboard/components/__tests__/SessionView.greek-sigma.test.tsx
+++ b/dashboard/components/__tests__/SessionView.greek-sigma.test.tsx
@@ -39,6 +39,7 @@ const mockTranscription = {
   toggleMute: vi.fn(),
   setGain: vi.fn(),
   jobId: null,
+  resultJobId: null,
   loadResult: vi.fn(),
 };
 

--- a/dashboard/components/__tests__/SessionView.recovery-refresh.test.tsx
+++ b/dashboard/components/__tests__/SessionView.recovery-refresh.test.tsx
@@ -33,6 +33,7 @@ const mockTranscription = {
   toggleMute: vi.fn(),
   setGain: vi.fn(),
   jobId: null as string | null,
+  resultJobId: null as string | null,
   busyInfo: null as null | { activeUser: string; isSalvage: boolean; salvageJobId: string | null },
   clearBusyInfo: vi.fn(),
   loadResult: vi.fn(),
@@ -297,6 +298,7 @@ describe('SessionView - recovery banner refresh', () => {
     mockTranscription.result = null;
     mockTranscription.error = null;
     mockTranscription.jobId = null;
+    mockTranscription.resultJobId = null;
     mockTranscription.busyInfo = null;
     mockGetConfig.mockResolvedValue(undefined);
     mockFetchRecentUndelivered.mockResolvedValue({ json: async () => [] });
@@ -367,7 +369,8 @@ describe('SessionView - recovery banner refresh', () => {
   it('does not offer to recover the transcript already on screen', async () => {
     // mark_delivered is best-effort, so a just-recovered job can still come
     // back from /recent. Announcing it beside its own transcript reads as a
-    // second, missing result.
+    // second, missing result. The test is resultJobId, not jobId: what matters
+    // is that THIS job's transcript is the one being displayed.
     mockFetchRecentUndelivered.mockResolvedValue({
       json: async () => [
         { job_id: JOB_ID, completed_at: COMPLETED_AT, text_preview: 'on screen now' },
@@ -376,6 +379,7 @@ describe('SessionView - recovery banner refresh', () => {
     });
     mockTranscription.status = 'complete';
     mockTranscription.jobId = JOB_ID;
+    mockTranscription.resultJobId = JOB_ID;
     mockTranscription.result = { text: 'on screen now', words: [] };
     renderSessionView();
 
@@ -385,6 +389,49 @@ describe('SessionView - recovery banner refresh', () => {
     const banners = screen.getAllByText(/is available\./);
     expect(banners).toHaveLength(1);
     expect(banners[0].closest('div')?.textContent).toContain('the half that made it');
+  });
+
+  // The incident, end to end. A longform job died on a CUDA OOM, the user
+  // pressed Retry, the retry succeeded, and the in-memory poll that was meant
+  // to deliver it died. The row stayed completed and undelivered, /retry
+  // refused it as already completed, and the banner - the last route to it -
+  // hid it because the filter tested jobId, which deliberately survives an
+  // error so the Retry button stays live. Nothing on screen pointed at a
+  // transcript that was in the database the whole time.
+  it('offers to recover the failed job whose transcript never arrived', async () => {
+    mockFetchRecentUndelivered.mockResolvedValue({
+      json: async () => [
+        { job_id: JOB_ID, completed_at: COMPLETED_AT, text_preview: 'the transcript nobody saw' },
+      ],
+    });
+    mockTranscription.status = 'error';
+    mockTranscription.error = 'CUDA failed with error out of memory';
+    mockTranscription.jobId = JOB_ID;
+    mockTranscription.result = null;
+    mockTranscription.resultJobId = null;
+    renderSessionView();
+
+    expect(await screen.findByText(/the transcript nobody saw/)).toBeInTheDocument();
+  });
+
+  // Same shape one step later: a PARTIAL transcript is on screen and the user
+  // retried from its amber banner. jobId still points at that job, so the old
+  // filter hid it again even though the retried, complete transcript is a
+  // different result the user has never seen.
+  it('still offers recovery while a partial from the same job is on screen', async () => {
+    mockFetchRecentUndelivered.mockResolvedValue({
+      json: async () => [
+        { job_id: JOB_ID, completed_at: COMPLETED_AT, text_preview: 'the retried whole thing' },
+      ],
+    });
+    mockTranscription.status = 'complete';
+    mockTranscription.jobId = JOB_ID;
+    mockTranscription.result = { text: 'only the first half', words: [], partial: true };
+    // The retry delivery never landed, so nothing on screen belongs to a job.
+    mockTranscription.resultJobId = null;
+    renderSessionView();
+
+    expect(await screen.findByText(/the retried whole thing/)).toBeInTheDocument();
   });
 
   // /recent returns at most 5 rows. A user who has been cancelling recordings
@@ -502,6 +549,49 @@ describe('SessionView - recovery banner refresh', () => {
     await waitFor(() => expect(mockTranscription.loadResult).toHaveBeenCalledTimes(1));
     expect(await screen.findByText(/from three days ago/)).toBeInTheDocument();
     expect(mockFetchRecentUndelivered).toHaveBeenCalledTimes(2);
+  });
+
+  // The banner is the safety net the whole fix leans on, and it was hand
+  // mapping four fewer fields than the hook does. A salvaged PARTIAL transcript
+  // arrived here looking complete: no amber banner, no Retry, no speaker
+  // labels, no reason. It also has to say which job it just delivered, or the
+  // filter above cannot tell that this row is now on screen.
+  it('View delivers the whole payload and names the job it belongs to', async () => {
+    mockFetchRecentUndelivered.mockResolvedValueOnce({ json: async () => SALVAGED });
+    mockFetchTranscriptionResult.mockResolvedValue({
+      status: 200,
+      json: async () => ({
+        result: {
+          text: 'the half that made it',
+          words: [],
+          partial: true,
+          partial_reason: 'Client disconnected mid-recording',
+          num_speakers: 3,
+          diarization: {
+            requested: true,
+            performed: false,
+            reason: 'model_missing',
+            remedy: 'Install the diarization model',
+          },
+        },
+      }),
+    });
+    renderSessionView();
+    expect(await screen.findByText(/the half that made it/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('View'));
+
+    await waitFor(() => expect(mockTranscription.loadResult).toHaveBeenCalledTimes(1));
+    expect(mockTranscription.loadResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'the half that made it',
+        partial: true,
+        partialReason: 'Client disconnected mid-recording',
+        numSpeakers: 3,
+        diarization: expect.objectContaining({ requested: true, performed: false }),
+      }),
+      'salvaged-job',
+    );
   });
 });
 

--- a/dashboard/components/__tests__/SessionView.recovery-refresh.test.tsx
+++ b/dashboard/components/__tests__/SessionView.recovery-refresh.test.tsx
@@ -14,7 +14,7 @@
 
 import React from 'react';
 import { render, screen, waitFor, fireEvent, within, act } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // ── Hoisted mock state ────────────────────────────────────────────────────
@@ -181,6 +181,7 @@ vi.mock('../../src/api/client', () => ({
     getStatus: (...a: unknown[]) => mockGetStatus(...a),
     getAuthToken: vi.fn().mockReturnValue(null),
     setAuthToken: vi.fn(),
+    getJobAudioUrl: (id: string) => `http://localhost:7239/api/transcribe/audio/${id}`,
     getBaseUrl: vi.fn().mockReturnValue('http://localhost:7239'),
     syncFromConfig: vi.fn().mockResolvedValue(undefined),
     unloadModels: vi.fn().mockResolvedValue(undefined),
@@ -279,6 +280,11 @@ function renderSessionView() {
 }
 
 const JOB_ID = '48eae812-f5ff-400e-b2bc-4dede99c5a15';
+
+// The Electron file bridge behind Save Audio. useFileSaveDialog reads
+// window.electronAPI.fileIO directly, so stubbing the object is enough.
+const mockSaveFile = vi.fn();
+const mockDownloadToPath = vi.fn();
 
 /** Fixed so the banner's relative-time label cannot drift between runs. */
 const COMPLETED_AT = '2026-08-03T00:00:00.000Z';
@@ -592,6 +598,114 @@ describe('SessionView - recovery banner refresh', () => {
       }),
       'salvaged-job',
     );
+  });
+});
+
+// Save Audio - the source recording is the one thing that cannot be recreated,
+// and in the recovery row it has to come BEFORE View, because View delivers the
+// transcript and delivering a session job unlinks its WAV.
+describe('SessionView - Save Audio in the recovery row', () => {
+  let previousElectronAPI: typeof window.electronAPI;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTranscription.status = 'idle';
+    mockTranscription.result = null;
+    mockTranscription.error = null;
+    mockTranscription.jobId = null;
+    mockTranscription.resultJobId = null;
+    mockTranscription.busyInfo = null;
+    mockGetConfig.mockResolvedValue(undefined);
+    mockFetchRecentUndelivered.mockResolvedValue({ json: async () => SALVAGED });
+    mockGetStatus.mockResolvedValue({
+      models: { job_tracker: { is_busy: false, salvage: null } },
+    });
+    useSalvageStore.setState({ checkNonce: 0, dropRequestedJobId: null, lastCompletedAt: null });
+    mockSaveFile.mockResolvedValue('/home/user/keep.wav');
+    mockDownloadToPath.mockResolvedValue({ ok: true, bytes: 1024 });
+    previousElectronAPI = window.electronAPI;
+    window.electronAPI = {
+      fileIO: { saveFile: mockSaveFile, downloadToPath: mockDownloadToPath },
+    } as unknown as typeof window.electronAPI;
+  });
+
+  // Restore rather than leave the stub behind: describes that run after this
+  // one share the same jsdom window.
+  afterEach(() => {
+    window.electronAPI = previousElectronAPI;
+  });
+
+  it('renders before View, so the audio can be kept before it is released', async () => {
+    renderSessionView();
+    const button = await screen.findByTestId('recovery-save-audio');
+    const view = screen.getByText('View');
+
+    // Node.DOCUMENT_POSITION_FOLLOWING === 4
+    expect(button.compareDocumentPosition(view) & 4).toBeTruthy();
+  });
+
+  it('downloads the WAV for that job to the chosen path', async () => {
+    renderSessionView();
+    fireEvent.click(await screen.findByTestId('recovery-save-audio'));
+
+    await waitFor(() => expect(mockDownloadToPath).toHaveBeenCalledTimes(1));
+    expect(mockDownloadToPath).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'http://localhost:7239/api/transcribe/audio/salvaged-job',
+        filePath: '/home/user/keep.wav',
+      }),
+    );
+    await waitFor(() => expect(mockToast.success).toHaveBeenCalled());
+    expect(mockToast.success.mock.calls[0][1]).toMatchObject({
+      description: '/home/user/keep.wav',
+    });
+  });
+
+  it('says nothing when the save dialog is cancelled', async () => {
+    mockSaveFile.mockResolvedValue(null);
+    renderSessionView();
+    fireEvent.click(await screen.findByTestId('recovery-save-audio'));
+
+    await waitFor(() => expect(mockSaveFile).toHaveBeenCalledTimes(1));
+    expect(mockDownloadToPath).not.toHaveBeenCalled();
+    expect(mockToast.success).not.toHaveBeenCalled();
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
+  // The 410 body distinguishes never-preserved from lost-on-restart from
+  // already-deleted, and that distinction is the entire answer for the user.
+  it('surfaces the server own reason when the audio is gone', async () => {
+    mockDownloadToPath.mockResolvedValue({
+      ok: false,
+      error: 'HTTP 410',
+      status: 410,
+      body: JSON.stringify({ detail: 'Audio file has been deleted - cannot download' }),
+    });
+    renderSessionView();
+    fireEvent.click(await screen.findByTestId('recovery-save-audio'));
+
+    await waitFor(() => expect(mockToast.error).toHaveBeenCalled());
+    expect(mockToast.error.mock.calls[0][1]).toMatchObject({
+      description: 'Audio file has been deleted - cannot download',
+    });
+  });
+
+  it('disables itself while a save is in flight', async () => {
+    let settle: (v: { ok: true }) => void = () => {};
+    mockDownloadToPath.mockReturnValueOnce(
+      new Promise<{ ok: true }>((resolve) => {
+        settle = resolve;
+      }),
+    );
+    renderSessionView();
+    const button = await screen.findByTestId('recovery-save-audio');
+    fireEvent.click(button);
+
+    await waitFor(() => expect(button).toBeDisabled());
+    await act(async () => {
+      settle({ ok: true });
+    });
+    await waitFor(() => expect(button).not.toBeDisabled());
   });
 });
 

--- a/dashboard/components/__tests__/SessionView.retry-failed.test.tsx
+++ b/dashboard/components/__tests__/SessionView.retry-failed.test.tsx
@@ -14,7 +14,7 @@
 
 import React from 'react';
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // ── Hoisted mock state ────────────────────────────────────────────────────
@@ -137,6 +137,8 @@ const {
   mockRetryTranscription,
   mockFetchTranscriptionResult,
   mockFetchRecentUndelivered,
+  mockSaveFile,
+  mockDownloadToPath,
   mockToast,
 } = vi.hoisted(() => {
   class HoistedAPIError extends Error {
@@ -154,6 +156,8 @@ const {
     mockRetryTranscription: vi.fn(),
     mockFetchTranscriptionResult: vi.fn(),
     mockFetchRecentUndelivered: vi.fn(),
+    mockSaveFile: vi.fn(),
+    mockDownloadToPath: vi.fn(),
     mockToast: { success: vi.fn(), error: vi.fn() },
   };
 });
@@ -172,6 +176,7 @@ vi.mock('../../src/api/client', () => ({
     unloadLLMModel: vi.fn().mockResolvedValue(undefined),
     loadModelsStream: vi.fn().mockReturnValue(vi.fn()),
     fetchRecentUndelivered: (...a: unknown[]) => mockFetchRecentUndelivered(...a),
+    getJobAudioUrl: (id: string) => `http://localhost:7239/api/transcribe/audio/${id}`,
     fetchTranscriptionResult: (...a: unknown[]) => mockFetchTranscriptionResult(...a),
     dismissTranscriptionResult: vi.fn().mockResolvedValue({ status: 200 }),
     retryTranscription: (...a: unknown[]) => mockRetryTranscription(...a),
@@ -552,5 +557,75 @@ describe('SessionView - retry poll lifetime', () => {
     });
 
     expect(mockTranscription.loadResult).not.toHaveBeenCalled();
+  });
+});
+
+// Save Audio - the recording itself, kept before the transcript pipeline gets
+// another chance to fail. It sits beside Retry in both banners.
+describe('SessionView - Save Audio beside Retry', () => {
+  let previousElectronAPI: typeof window.electronAPI;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTranscription.status = 'error';
+    mockTranscription.result = null;
+    mockTranscription.error = OOM_ERROR;
+    mockTranscription.jobId = JOB_ID;
+    mockTranscription.resultJobId = null;
+    mockGetConfig.mockResolvedValue(undefined);
+    mockFetchRecentUndelivered.mockResolvedValue({ json: async () => [] });
+    mockSaveFile.mockResolvedValue('/home/user/keep.wav');
+    mockDownloadToPath.mockResolvedValue({ ok: true, bytes: 4096 });
+    previousElectronAPI = window.electronAPI;
+    window.electronAPI = {
+      fileIO: { saveFile: mockSaveFile, downloadToPath: mockDownloadToPath },
+    } as unknown as typeof window.electronAPI;
+  });
+
+  afterEach(() => {
+    window.electronAPI = previousElectronAPI;
+  });
+
+  it('offers Save Audio on the error banner and downloads that job WAV', async () => {
+    renderSessionView();
+    fireEvent.click(await screen.findByTestId('save-audio-error'));
+
+    await waitFor(() => expect(mockSaveFile).toHaveBeenCalledTimes(1));
+    expect(mockSaveFile.mock.calls[0][0]).toMatchObject({
+      filters: [{ name: 'WAV Audio', extensions: ['wav'] }],
+    });
+    await waitFor(() =>
+      expect(mockDownloadToPath).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: `http://localhost:7239/api/transcribe/audio/${JOB_ID}`,
+          filePath: '/home/user/keep.wav',
+        }),
+      ),
+    );
+    await waitFor(() => expect(mockToast.success).toHaveBeenCalled());
+  });
+
+  it('offers Save Audio on the partial-transcript banner too', async () => {
+    mockTranscription.status = 'complete';
+    mockTranscription.error = null;
+    mockTranscription.result = {
+      text: 'only the first half',
+      words: [],
+      partial: true,
+      partialReason: 'sidecar died',
+    };
+    renderSessionView();
+
+    expect(await screen.findByTestId('save-audio-partial')).toBeInTheDocument();
+  });
+
+  it('sends the auth token as a header, never in the URL', async () => {
+    renderSessionView();
+    fireEvent.click(await screen.findByTestId('save-audio-error'));
+
+    await waitFor(() => expect(mockDownloadToPath).toHaveBeenCalledTimes(1));
+    const sent = mockDownloadToPath.mock.calls[0][0] as { url: string; headers: unknown };
+    expect(sent.url).not.toContain('token=');
+    expect(sent.headers).toEqual({});
   });
 });

--- a/dashboard/components/__tests__/SessionView.retry-failed.test.tsx
+++ b/dashboard/components/__tests__/SessionView.retry-failed.test.tsx
@@ -13,7 +13,7 @@
  */
 
 import React from 'react';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -33,6 +33,7 @@ const mockTranscription = {
   toggleMute: vi.fn(),
   setGain: vi.fn(),
   jobId: null as string | null,
+  resultJobId: null as string | null,
   loadResult: vi.fn(),
   previewText: null,
   previewLanguage: undefined,
@@ -131,25 +132,31 @@ vi.mock('../../src/stores/importQueueStore', () => ({
 // vi.mock factories are hoisted above the declarations in this file, and the
 // api/client factory dereferences APIError eagerly — so the class has to be
 // created inside vi.hoisted or it is still in the temporal dead zone.
-const { MockAPIError, mockRetryTranscription, mockFetchTranscriptionResult, mockToast } =
-  vi.hoisted(() => {
-    class HoistedAPIError extends Error {
-      constructor(
-        public readonly status: number,
-        public readonly body: string,
-        public readonly path: string,
-      ) {
-        super(`API ${status} on ${path}`);
-        this.name = 'APIError';
-      }
+const {
+  MockAPIError,
+  mockRetryTranscription,
+  mockFetchTranscriptionResult,
+  mockFetchRecentUndelivered,
+  mockToast,
+} = vi.hoisted(() => {
+  class HoistedAPIError extends Error {
+    constructor(
+      public readonly status: number,
+      public readonly body: string,
+      public readonly path: string,
+    ) {
+      super(`API ${status} on ${path}`);
+      this.name = 'APIError';
     }
-    return {
-      MockAPIError: HoistedAPIError,
-      mockRetryTranscription: vi.fn(),
-      mockFetchTranscriptionResult: vi.fn(),
-      mockToast: { success: vi.fn(), error: vi.fn() },
-    };
-  });
+  }
+  return {
+    MockAPIError: HoistedAPIError,
+    mockRetryTranscription: vi.fn(),
+    mockFetchTranscriptionResult: vi.fn(),
+    mockFetchRecentUndelivered: vi.fn(),
+    mockToast: { success: vi.fn(), error: vi.fn() },
+  };
+});
 
 vi.mock('../../src/api/client', () => ({
   APIError: MockAPIError,
@@ -164,7 +171,7 @@ vi.mock('../../src/api/client', () => ({
     unloadModels: vi.fn().mockResolvedValue(undefined),
     unloadLLMModel: vi.fn().mockResolvedValue(undefined),
     loadModelsStream: vi.fn().mockReturnValue(vi.fn()),
-    fetchRecentUndelivered: vi.fn().mockResolvedValue({ json: async () => [] }),
+    fetchRecentUndelivered: (...a: unknown[]) => mockFetchRecentUndelivered(...a),
     fetchTranscriptionResult: (...a: unknown[]) => mockFetchTranscriptionResult(...a),
     dismissTranscriptionResult: vi.fn().mockResolvedValue({ status: 200 }),
     retryTranscription: (...a: unknown[]) => mockRetryTranscription(...a),
@@ -272,9 +279,11 @@ describe('SessionView - retry a failed transcription', () => {
     mockTranscription.result = null;
     mockTranscription.error = OOM_ERROR;
     mockTranscription.jobId = JOB_ID;
+    mockTranscription.resultJobId = null;
     mockGetConfig.mockResolvedValue(undefined);
     mockRetryTranscription.mockResolvedValue({ job_id: JOB_ID, status: 'processing' });
     mockFetchTranscriptionResult.mockResolvedValue({ status: 202, json: async () => ({}) });
+    mockFetchRecentUndelivered.mockResolvedValue({ json: async () => [] });
   });
 
   it('shows the error message with a Retry button when a job id is known', async () => {
@@ -314,6 +323,7 @@ describe('SessionView - retry a failed transcription', () => {
     await waitFor(() =>
       expect(mockTranscription.loadResult).toHaveBeenCalledWith(
         expect.objectContaining({ text: 'recovered transcript', language: 'el', duration: 329.6 }),
+        JOB_ID,
       ),
     );
   });
@@ -361,5 +371,186 @@ describe('SessionView - retry a failed transcription', () => {
         expect.objectContaining({ description: expect.stringContaining('deleted') }),
       ),
     );
+  });
+
+  // The toast from the incident. The first retry had already succeeded and its
+  // transcript was sitting in the database; every later press was refused with
+  // "Only failed or partial jobs can be retried (current status: completed)"
+  // and the user was shown that refusal instead of their transcript.
+  it('turns a completed-job 409 into a delivery instead of a refusal', async () => {
+    mockRetryTranscription.mockRejectedValue(
+      new MockAPIError(
+        409,
+        JSON.stringify({
+          detail: 'Only failed or partial jobs can be retried (current status: completed)',
+        }),
+        '/api/transcribe/retry/x',
+      ),
+    );
+    mockFetchTranscriptionResult.mockResolvedValue({
+      status: 200,
+      json: async () => ({ result: { text: 'the transcript nobody saw', words: [] } }),
+    });
+    renderSessionView();
+
+    await waitFor(() => expect(findErrorRetryButton()).toBeDefined());
+    fireEvent.click(findErrorRetryButton()!);
+
+    await waitFor(() =>
+      expect(mockTranscription.loadResult).toHaveBeenCalledWith(
+        expect.objectContaining({ text: 'the transcript nobody saw' }),
+        JOB_ID,
+      ),
+    );
+    expect(mockToast.error).not.toHaveBeenCalled();
+    await waitFor(() => expect(findErrorRetryButton()).not.toBeDisabled());
+  });
+
+  // The same 409 status also means "model busy", which is a genuine refusal.
+  // The probe answers 202 there, so it must fall through to the toast. This is
+  // why the branch is chosen on the status code and never on the refusal text.
+  it('still refuses when the 409 is a busy model rather than a finished job', async () => {
+    mockRetryTranscription.mockRejectedValue(
+      new MockAPIError(
+        409,
+        JSON.stringify({
+          detail: 'Model is currently busy. Try again when the active session ends.',
+        }),
+        '/api/transcribe/retry/x',
+      ),
+    );
+    mockFetchTranscriptionResult.mockResolvedValue({ status: 202, json: async () => ({}) });
+    renderSessionView();
+
+    await waitFor(() => expect(findErrorRetryButton()).toBeDefined());
+    fireEvent.click(findErrorRetryButton()!);
+
+    await waitFor(() => expect(mockToast.error).toHaveBeenCalled());
+    expect(mockTranscription.loadResult).not.toHaveBeenCalled();
+  });
+
+  // A retried job that was diarized used to come back with its speaker labels
+  // stripped, because this delivery site hand mapped fewer fields than the hook.
+  it('delivers the speaker fields a diarized job carries', async () => {
+    mockFetchTranscriptionResult.mockResolvedValue({
+      status: 200,
+      json: async () => ({
+        result: {
+          text: 'recovered transcript',
+          words: [],
+          num_speakers: 2,
+          diarization: { requested: true, performed: true, reason: null, remedy: null },
+          partial: true,
+          partial_reason: 'sidecar died',
+        },
+      }),
+    });
+    renderSessionView();
+
+    await waitFor(() => expect(findErrorRetryButton()).toBeDefined());
+    fireEvent.click(findErrorRetryButton()!);
+
+    await waitFor(() =>
+      expect(mockTranscription.loadResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numSpeakers: 2,
+          diarization: expect.objectContaining({ performed: true }),
+          partial: true,
+          partialReason: 'sidecar died',
+        }),
+        JOB_ID,
+      ),
+    );
+  });
+
+  // A throw while DELIVERING used to sit inside the same try as the fetch, so
+  // it read as "not ready yet": the poll span on forever and the button stayed
+  // stuck on "Retrying...".
+  it('recovers when delivering the transcript itself throws', async () => {
+    mockFetchTranscriptionResult.mockResolvedValue({
+      status: 200,
+      json: async () => ({ result: { text: 'recovered transcript', words: [] } }),
+    });
+    mockTranscription.loadResult.mockImplementationOnce(() => {
+      throw new Error('render blew up');
+    });
+    renderSessionView();
+    await waitFor(() => expect(findErrorRetryButton()).toBeDefined());
+    mockFetchRecentUndelivered.mockClear();
+
+    fireEvent.click(findErrorRetryButton()!);
+
+    await waitFor(() => expect(mockToast.error).toHaveBeenCalled());
+    // The button is usable again and the banner has been re-checked, so the
+    // transcript is still reachable from the recovery notice.
+    await waitFor(() => expect(findErrorRetryButton()).not.toBeDisabled());
+    expect(mockFetchRecentUndelivered).toHaveBeenCalled();
+  });
+
+  it('ignores a second press while a retry is already in flight', async () => {
+    renderSessionView();
+    await waitFor(() => expect(findErrorRetryButton()).toBeDefined());
+    const button = findErrorRetryButton()!;
+    fireEvent.click(button);
+    await waitFor(() => expect(mockRetryTranscription).toHaveBeenCalledTimes(1));
+    fireEvent.click(button);
+
+    expect(mockRetryTranscription).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SessionView - retry poll lifetime', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTranscription.status = 'error';
+    mockTranscription.result = null;
+    mockTranscription.error = OOM_ERROR;
+    mockTranscription.jobId = JOB_ID;
+    mockTranscription.resultJobId = null;
+    mockGetConfig.mockResolvedValue(undefined);
+    mockRetryTranscription.mockResolvedValue({ job_id: JOB_ID, status: 'processing' });
+    mockFetchRecentUndelivered.mockResolvedValue({ json: async () => [] });
+  });
+
+  // Every give-up now ends by refreshing the recovery banner and saying so.
+  // Before, it ended in a toast that told the user to reopen the tab, which is
+  // exactly the manoeuvre that had already failed them.
+  it('refreshes the recovery banner and frees the button when the poll gives up', async () => {
+    mockFetchTranscriptionResult.mockResolvedValue({ status: 404, json: async () => ({}) });
+    renderSessionView();
+    await waitFor(() => expect(findErrorRetryButton()).toBeDefined());
+    mockFetchRecentUndelivered.mockClear();
+
+    fireEvent.click(findErrorRetryButton()!);
+
+    await waitFor(() => expect(mockToast.error).toHaveBeenCalled());
+    expect(mockFetchRecentUndelivered).toHaveBeenCalled();
+    expect(mockTranscription.loadResult).not.toHaveBeenCalled();
+    await waitFor(() => expect(findErrorRetryButton()).not.toBeDisabled());
+  });
+
+  // The poll used to survive the component. An in-flight request that answers
+  // after unmount must be dropped, not delivered into a dead tree.
+  it('drops a response that lands after the view unmounts', async () => {
+    let answer: (v: { status: number; json: () => Promise<unknown> }) => void = () => {};
+    mockFetchTranscriptionResult.mockReturnValue(
+      new Promise<{ status: number; json: () => Promise<unknown> }>((resolve) => {
+        answer = resolve;
+      }),
+    );
+    const { unmount } = renderSessionView();
+    await waitFor(() => expect(findErrorRetryButton()).toBeDefined());
+    fireEvent.click(findErrorRetryButton()!);
+    await waitFor(() => expect(mockFetchTranscriptionResult).toHaveBeenCalledTimes(1));
+
+    unmount();
+    await act(async () => {
+      answer({
+        status: 200,
+        json: async () => ({ result: { text: 'too late', words: [] } }),
+      });
+    });
+
+    expect(mockTranscription.loadResult).not.toHaveBeenCalled();
   });
 });

--- a/dashboard/components/__tests__/SessionView.test.tsx
+++ b/dashboard/components/__tests__/SessionView.test.tsx
@@ -26,6 +26,7 @@ const mockTranscription = {
   toggleMute: vi.fn(),
   setGain: vi.fn(),
   jobId: null,
+  resultJobId: null,
   loadResult: vi.fn(),
 };
 

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -45,6 +45,7 @@ import { useLanguages } from '../../src/hooks/useLanguages';
 import { summarizeJobProgress } from '../../src/services/jobProgress';
 import { JobProgressBlock } from '../ui/JobProgressBlock';
 import { writeToClipboard } from '../../src/hooks/useClipboard';
+import { useFileSaveDialog } from '../../src/hooks/useFileSaveDialog';
 import {
   pollForTranscriptionResult,
   toTranscriptionResult,
@@ -245,6 +246,9 @@ export const SessionView: React.FC<SessionViewProps> = ({
       retryPollHandleRef.current = null;
     };
   }, []);
+  // Guards the Save Audio buttons while one download is in flight.
+  const [savingAudio, setSavingAudio] = useState(false);
+  const openSaveDialog = useFileSaveDialog();
   useEffect(() => {
     setEditedResultText(transcription.result?.text ?? '');
   }, [transcription.result?.text]);
@@ -1621,6 +1625,72 @@ export const SessionView: React.FC<SessionViewProps> = ({
     });
   }, [transcription, retrying, deliverExistingResult, refreshRecoveryJobs]);
 
+  // Save the source recording itself. A transcript can always be produced
+  // again from the audio; the audio cannot be produced again from anything.
+  //
+  // The window this is offered in is exactly the window Retry is offered in,
+  // and that is not a coincidence: viewing a delivered transcript deletes the
+  // WAV along with the job row (session ephemeral retention), while a FAILED
+  // job's audio is never swept. So the button belongs beside Retry, and in the
+  // recovery row it belongs BEFORE View, because View is what destroys it.
+  const handleSaveAudio = useCallback(
+    async (jobId: string, createdAt?: string) => {
+      if (savingAudio) return;
+      const url = apiClient.getJobAudioUrl(jobId);
+      if (!url) {
+        toast.error('Remote host not configured', {
+          description: 'Set the server address in the Server tab, then try again.',
+        });
+        return;
+      }
+      const stamp = (createdAt ?? '').replace(/[^0-9A-Za-z]/g, '-').slice(0, 19);
+      const filePath = await openSaveDialog({
+        defaultPath: stamp ? `transcription-${stamp}-${jobId}.wav` : `transcription-${jobId}.wav`,
+        filters: [{ name: 'WAV Audio', extensions: ['wav'] }],
+      });
+      // Cancelled, or there is no desktop bridge to open a dialog with.
+      if (!filePath) return;
+
+      setSavingAudio(true);
+      try {
+        // The bytes are streamed to disk by the main process. A five hour
+        // recording is roughly 576 MB, so buffering it in the renderer and
+        // structure-cloning it across the bridge would cost that twice over.
+        // The token travels as a header rather than a query param so it stays
+        // out of the URL and out of any access log.
+        const token = apiClient.getAuthToken();
+        const outcome = await window.electronAPI?.fileIO?.downloadToPath?.({
+          url,
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+          filePath,
+        });
+        if (!outcome) {
+          toast.error('Could not save the audio', {
+            description: 'The desktop bridge is unavailable.',
+          });
+          return;
+        }
+        // Written as an explicit `=== false` because this tsconfig does not
+        // enable strictNullChecks, and without it TypeScript will not narrow a
+        // union by a boolean literal on the falsy side of the test.
+        if (outcome.ok === false) {
+          // A 410 carries the server's own reason: never preserved, lost from
+          // temporary storage on a restart, or already deleted. That distinction
+          // is the whole answer for the user, so surface it verbatim rather than
+          // flattening it into a generic failure.
+          toast.error('Could not save the audio', {
+            description: (outcome.body ? extractDetail(outcome.body) : undefined) ?? outcome.error,
+          });
+          return;
+        }
+        toast.success('Audio saved', { description: filePath });
+      } finally {
+        setSavingAudio(false);
+      }
+    },
+    [savingAudio, openSaveDialog],
+  );
+
   // Scroll State
   const leftScrollRef = useRef<HTMLDivElement>(null);
   const rightScrollRef = useRef<HTMLDivElement>(null);
@@ -1796,8 +1866,25 @@ export const SessionView: React.FC<SessionViewProps> = ({
                       {job.text_preview.length >= 100 ? '\u2026' : ''}&rdquo;
                     </span>
                   )}
+                  <span className="mt-1 block text-amber-300/60">
+                    Save Audio first if you want to keep the recording: opening the transcript
+                    releases it.
+                  </span>
                 </div>
                 <div className="flex shrink-0 gap-2">
+                  {/* Before View on purpose: View delivers the transcript, and
+                    delivering a session job deletes its row AND unlinks its
+                    WAV. This is the last moment the audio exists. */}
+                  <button
+                    data-testid="recovery-save-audio"
+                    disabled={savingAudio}
+                    className="rounded px-2 py-1 text-xs font-semibold text-amber-300 hover:bg-amber-500/20 disabled:opacity-50"
+                    onClick={() => {
+                      void handleSaveAudio(job.job_id, job.completed_at);
+                    }}
+                  >
+                    Save Audio
+                  </button>
                   <button
                     className="rounded px-2 py-1 text-xs font-semibold text-amber-300 hover:bg-amber-500/20"
                     onClick={() => {
@@ -2478,13 +2565,28 @@ export const SessionView: React.FC<SessionViewProps> = ({
                                 : ''}
                               .
                             </span>
-                            <Button
-                              variant="secondary"
-                              disabled={retrying || !transcription.jobId}
-                              onClick={handleRetry}
-                            >
-                              {retrying ? 'Retrying…' : 'Retry'}
-                            </Button>
+                            <div className="flex items-center gap-2">
+                              <Button
+                                variant="secondary"
+                                size="sm"
+                                icon={<FileAudio size={14} />}
+                                data-testid="save-audio-partial"
+                                disabled={savingAudio || !transcription.jobId}
+                                onClick={() => {
+                                  if (transcription.jobId)
+                                    void handleSaveAudio(transcription.jobId);
+                                }}
+                              >
+                                {savingAudio ? 'Saving…' : 'Save Audio'}
+                              </Button>
+                              <Button
+                                variant="secondary"
+                                disabled={retrying || !transcription.jobId}
+                                onClick={handleRetry}
+                              >
+                                {retrying ? 'Retrying…' : 'Retry'}
+                              </Button>
+                            </div>
                           </div>
                         )}
                         {/* GH-258: diarization degrades rather than failing, so a
@@ -2568,9 +2670,23 @@ export const SessionView: React.FC<SessionViewProps> = ({
                       >
                         <span>{transcription.error}</span>
                         {transcription.jobId && (
-                          <Button variant="secondary" disabled={retrying} onClick={handleRetry}>
-                            {retrying ? 'Retrying…' : 'Retry'}
-                          </Button>
+                          <div className="flex items-center gap-2">
+                            <Button
+                              variant="secondary"
+                              size="sm"
+                              icon={<FileAudio size={14} />}
+                              data-testid="save-audio-error"
+                              disabled={savingAudio}
+                              onClick={() => {
+                                if (transcription.jobId) void handleSaveAudio(transcription.jobId);
+                              }}
+                            >
+                              {savingAudio ? 'Saving…' : 'Save Audio'}
+                            </Button>
+                            <Button variant="secondary" disabled={retrying} onClick={handleRetry}>
+                              {retrying ? 'Retrying…' : 'Retry'}
+                            </Button>
+                          </div>
                         )}
                       </div>
                     )}

--- a/dashboard/components/views/SessionView.tsx
+++ b/dashboard/components/views/SessionView.tsx
@@ -45,6 +45,11 @@ import { useLanguages } from '../../src/hooks/useLanguages';
 import { summarizeJobProgress } from '../../src/services/jobProgress';
 import { JobProgressBlock } from '../ui/JobProgressBlock';
 import { writeToClipboard } from '../../src/hooks/useClipboard';
+import {
+  pollForTranscriptionResult,
+  toTranscriptionResult,
+  type PollHandle,
+} from '../../src/services/resultPolling';
 import { useTranscription } from '../../src/hooks/useTranscription';
 import type { LiveModeState } from '../../src/hooks/useLiveMode';
 import { useConfirm } from '../../src/hooks/useConfirm';
@@ -79,16 +84,6 @@ import { useNotificationsStore } from '../../src/stores/notificationsStore';
 import { toast } from 'sonner';
 import { isRuntimeProfile, type RuntimeProfile } from '../../src/types/runtime';
 
-/** How long to wait between polls for the result of a retried job. */
-const RETRY_POLL_INTERVAL_MS = 3000;
-/**
- * Give up polling after this many misses (~5 min). Long recordings legitimately
- * take minutes to re-transcribe, and giving up early strands a result that has
- * already been persisted — the recovery banner still finds it, but only after
- * the user navigates away and back.
- */
-const RETRY_POLL_MAX_ATTEMPTS = 100;
-
 /** Pull the human-readable reason out of a FastAPI detail body. */
 function extractDetail(body: string): string | undefined {
   try {
@@ -99,14 +94,6 @@ function extractDetail(body: string): string | undefined {
   }
   const trimmed = body.trim();
   return trimmed && trimmed.length <= 200 ? trimmed : undefined;
-}
-
-async function readDetail(resp: Response): Promise<string | undefined> {
-  try {
-    return extractDetail(await resp.text());
-  } catch {
-    return undefined;
-  }
 }
 
 /**
@@ -244,14 +231,18 @@ export const SessionView: React.FC<SessionViewProps> = ({
   // 'completed' job, so the user cannot otherwise tell a truncated transcript
   // from a whole one) and an outright failure.
   const [retrying, setRetrying] = useState(false);
-  const retryPollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const retryCancelledRef = useRef(false);
+  // One handle per retry. The previous shape was a shared cancel flag, so a
+  // second Retry cancelled the first ones chain AND its own, and an older run
+  // could still resolve into the newer runs state. Cancelling this handle stops
+  // exactly the chain it came from.
+  const retryPollHandleRef = useRef<PollHandle | null>(null);
   // Stop the poll on unmount so it cannot setState into a dead component. The
-  // transcript is already durable server-side, so dropping the poll loses nothing.
+  // transcript is already durable server-side, so dropping the poll loses
+  // nothing: the recovery banner is what brings it back.
   useEffect(() => {
     return () => {
-      retryCancelledRef.current = true;
-      if (retryPollTimerRef.current) clearTimeout(retryPollTimerRef.current);
+      retryPollHandleRef.current?.cancel();
+      retryPollHandleRef.current = null;
     };
   }, []);
   useEffect(() => {
@@ -1176,77 +1167,6 @@ export const SessionView: React.FC<SessionViewProps> = ({
     transcription.startPreview(seconds);
   }, [transcription]);
 
-  // Re-transcribe from the job's saved audio. Serves both the partial-transcript
-  // banner (the server accepts /retry for a partial job even though its status is
-  // 'completed') and the error banner — the retention sweep only collects
-  // completed+delivered jobs, so the audio of a FAILED job is never
-  // garbage-collected and a CUDA OOM or a crashed backend stays recoverable.
-  //
-  // The WebSocket that carried the original job is gone by the time either banner
-  // is on screen, so the result can only come back by polling the durability
-  // endpoint — the same contract used by the reconnect path in useTranscription.
-  const handleRetry = useCallback(async () => {
-    const jobId = transcription.jobId;
-    if (!jobId || retrying) return;
-    setRetrying(true);
-    retryCancelledRef.current = false;
-
-    try {
-      await apiClient.retryTranscription(jobId);
-    } catch (err) {
-      setRetrying(false);
-      toast.error('Could not retry the transcription', { description: describeRetryError(err) });
-      return;
-    }
-
-    toast.success('Retrying transcription', {
-      description: 'Re-transcribing from the saved audio.',
-    });
-
-    let attempts = 0;
-    const poll = async () => {
-      if (retryCancelledRef.current) return;
-      try {
-        const resp = await apiClient.fetchTranscriptionResult(jobId);
-        if (retryCancelledRef.current) return;
-        if (resp.status === 200) {
-          const data = await resp.json();
-          const r = data.result ?? {};
-          transcription.loadResult({
-            text: r.text ?? '',
-            words: r.words ?? [],
-            language: r.language,
-            duration: r.duration,
-            partial: r.partial ?? false,
-            partialReason: r.partial_reason ?? null,
-          });
-          setRetrying(false);
-          return;
-        }
-        // 410 — the retry itself failed on the server (it reports the reason).
-        if (resp.status === 410) {
-          setRetrying(false);
-          toast.error('Retry failed', { description: await readDetail(resp) });
-          return;
-        }
-      } catch {
-        // Network blip — treat like a not-ready poll and try again.
-      }
-      if (retryCancelledRef.current) return;
-      attempts += 1;
-      if (attempts >= RETRY_POLL_MAX_ATTEMPTS) {
-        setRetrying(false);
-        toast.error('Retry is still running', {
-          description:
-            'The transcript did not arrive in time. It is saved on the server — reopen this tab to pick it up.',
-        });
-        return;
-      }
-      retryPollTimerRef.current = setTimeout(poll, RETRY_POLL_INTERVAL_MS);
-    };
-    void poll();
-  }, [transcription, retrying]);
-
   // Copy transcription result to clipboard (prefers the edited text)
   const handleCopyTranscription = useCallback(() => {
     const text = editedResultText ?? transcription.result?.text;
@@ -1573,7 +1493,133 @@ export const SessionView: React.FC<SessionViewProps> = ({
   // mark_delivered is best-effort, so the job whose transcript is already on
   // screen can still come back from /recent. Offering to recover it there reads
   // as a second, missing result.
-  const visibleRecoveryJobs = recoveryJobs.filter((job) => job.job_id !== transcription.jobId);
+  //
+  // The test is "does the transcript on screen belong to THIS job", not "is this
+  // the current job". Filtering on transcription.jobId hid the one row that
+  // mattered most: jobId survives an error on purpose, so after a retry whose
+  // delivery poll died the banner suppressed the very job whose transcript was
+  // sitting completed in the database, while /retry refused it as completed.
+  // resultJobId is null until a transcript is actually on screen, so every one
+  // of those interrupted paths now surfaces here.
+  const visibleRecoveryJobs = recoveryJobs.filter(
+    (job) => job.job_id !== transcription.resultJobId,
+  );
+
+  // Deliver a result the server already holds. Used by the 409 branch below:
+  // returns true only when a transcript actually reached the screen.
+  const deliverExistingResult = useCallback(
+    async (jobId: string): Promise<boolean> => {
+      let recovered;
+      try {
+        const resp = await apiClient.fetchTranscriptionResult(jobId);
+        if (resp.status !== 200) return false;
+        const data = await resp.json();
+        recovered = toTranscriptionResult(data?.result);
+      } catch {
+        return false;
+      }
+      transcription.loadResult(recovered, jobId);
+      return true;
+    },
+    [transcription],
+  );
+
+  // Re-transcribe from the job's saved audio. Serves both the partial-transcript
+  // banner (the server accepts /retry for a partial job even though its status is
+  // 'completed') and the error banner — the retention sweep only collects
+  // completed+delivered jobs, so the audio of a FAILED job is never
+  // garbage-collected and a CUDA OOM or a crashed backend stays recoverable.
+  //
+  // The WebSocket that carried the original job is gone by the time either banner
+  // is on screen, so the result can only come back by polling the durability
+  // endpoint — the same shared helper the reconnect path in useTranscription uses.
+  //
+  // Defined here rather than beside the other handlers because it depends on
+  // refreshRecoveryJobs and on visibleRecoveryJobs above it. Hoisting it back up
+  // would put refreshRecoveryJobs in a dependency array before its own const is
+  // initialised, which throws on every render.
+  const handleRetry = useCallback(async () => {
+    const jobId = transcription.jobId;
+    if (!jobId || retrying) return;
+    setRetrying(true);
+    // Cancel whatever an earlier press left running before starting a new chain,
+    // so two chains can never both resolve into this components state.
+    retryPollHandleRef.current?.cancel();
+    retryPollHandleRef.current = null;
+
+    try {
+      await apiClient.retryTranscription(jobId);
+    } catch (err) {
+      // A 409 can mean the job already COMPLETED, which is precisely the dead
+      // end this fixes: a retry succeeded, the poll meant to deliver it died,
+      // and every later press was refused as already completed while the
+      // transcript sat in the database. Probe once before giving the user a
+      // refusal they are one fetch away from resolving.
+      //
+      // Deliberately NOT matched on the refusal text: that wording is a human
+      // message, not a contract. A 409 that really means "model busy" answers
+      // 202 to this probe and falls straight through to the toast below.
+      if (err instanceof APIError && err.status === 409 && (await deliverExistingResult(jobId))) {
+        setRetrying(false);
+        return;
+      }
+      setRetrying(false);
+      toast.error('Could not retry the transcription', { description: describeRetryError(err) });
+      return;
+    }
+
+    toast.success('Retrying transcription', {
+      description: 'Re-transcribing from the saved audio.',
+    });
+
+    retryPollHandleRef.current = pollForTranscriptionResult({
+      jobId,
+      onResult: (recovered, forJobId) => {
+        transcription.loadResult(recovered, forJobId);
+        setRetrying(false);
+      },
+      onDeliveryError: () => {
+        // Delivery threw, so nothing reached the screen. Clear the flag the
+        // button would otherwise be stuck on and fall back to the banner, which
+        // reads the same row straight from the server.
+        setRetrying(false);
+        refreshRecoveryJobs();
+        toast.error('Could not show the retried transcript', {
+          description: 'It is saved on the server. Use the recovery notice above to open it.',
+        });
+      },
+      onFailure: (failure) => {
+        setRetrying(false);
+        if (failure.kind === 'failed') {
+          // The retry itself failed on the server, which reports the reason.
+          toast.error('Retry failed', {
+            description: failure.body ? extractDetail(failure.body) : undefined,
+          });
+          return;
+        }
+        // Every remaining outcome leaves a row that may still complete, so
+        // refresh the banner FIRST and then point the user at it.
+        refreshRecoveryJobs();
+        if (failure.kind === 'network') {
+          toast.error('Lost contact with the server', {
+            description:
+              'The retry may still be running. A finished transcript appears in the recovery notice above.',
+          });
+          return;
+        }
+        if (failure.kind === 'unavailable') {
+          toast.error('The retried transcript could not be read', {
+            description: 'If the server still has it, it appears in the recovery notice above.',
+          });
+          return;
+        }
+        toast.error('Retry is still running', {
+          description:
+            'The transcript did not arrive in time. It is saved on the server and appears in the recovery notice above once it lands.',
+        });
+      },
+    });
+  }, [transcription, retrying, deliverExistingResult, refreshRecoveryJobs]);
 
   // Scroll State
   const leftScrollRef = useRef<HTMLDivElement>(null);
@@ -1760,13 +1806,14 @@ export const SessionView: React.FC<SessionViewProps> = ({
                         .then(async (resp) => {
                           if (resp.status === 200) {
                             const data = await resp.json();
-                            const r = data.result ?? {};
-                            transcription.loadResult({
-                              text: r.text ?? '',
-                              words: r.words ?? [],
-                              language: r.language,
-                              duration: r.duration,
-                            });
+                            // Shared mapper. Hand mapping here dropped partial,
+                            // partialReason, numSpeakers and diarization, so the
+                            // safety net rendered a truncated transcript as if it
+                            // were whole, with no amber banner and no Retry.
+                            transcription.loadResult(
+                              toTranscriptionResult(data?.result),
+                              job.job_id,
+                            );
                             setRecoveryJobs((prev) => prev.filter((j) => j.job_id !== job.job_id));
                             // /recent is capped at 5 rows: pull the next queued
                             // job into the freed slot now, not on the next focus.

--- a/dashboard/electron/__tests__/downloadToFile.test.ts
+++ b/dashboard/electron/__tests__/downloadToFile.test.ts
@@ -1,0 +1,173 @@
+// @vitest-environment node
+
+/**
+ * downloadToFile - streaming an HTTP download straight to disk.
+ *
+ * This function deletes files, so the cleanup rule is the point of the suite:
+ * a partial write it created must be removed, and a pre-existing file it never
+ * opened must be left exactly as it was. The user reaches this code by picking
+ * a path in a save dialog, so "the destination already exists" is the normal
+ * case, not the exotic one.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { Readable } from 'stream';
+
+import { downloadToFile, MAX_ERROR_BODY_CHARS } from '../downloadToFile.js';
+
+/** A minimal stand-in for the parts of Response this module reads. */
+function okResponse(body: Buffer | NodeJS.ReadableStream) {
+  const stream = Buffer.isBuffer(body) ? Readable.from([body]) : body;
+  return {
+    ok: true,
+    status: 200,
+    body: Readable.toWeb(stream as Readable),
+  };
+}
+
+function errorResponse(status: number, text: string) {
+  return {
+    ok: false,
+    status,
+    body: null,
+    text: async () => text,
+  };
+}
+
+describe('downloadToFile', () => {
+  let dir: string;
+  let target: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), 'download-to-file-'));
+    target = path.join(dir, 'recording.wav');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes the response body to the chosen path and reports its size', async () => {
+    const payload = Buffer.from('RIFF____WAVEfmt this is the recording');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okResponse(payload)));
+
+    const result = await downloadToFile({ url: 'http://server/audio/job-1', filePath: target });
+
+    expect(result).toEqual({ ok: true, bytes: payload.length });
+    expect(readFileSync(target).equals(payload)).toBe(true);
+  });
+
+  it('passes the caller headers through, so the token never rides in the URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(Buffer.from('x')));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await downloadToFile({
+      url: 'http://server/audio/job-1',
+      headers: { Authorization: 'Bearer secret' },
+      filePath: target,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('http://server/audio/job-1', {
+      headers: { Authorization: 'Bearer secret' },
+    });
+  });
+
+  // The 410 body distinguishes never-preserved from lost-on-restart from
+  // already-deleted. Relaying it verbatim is the whole point of carrying it.
+  it('relays the server own message on a non-ok response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          errorResponse(410, JSON.stringify({ detail: 'Audio file has been deleted' })),
+        ),
+    );
+
+    const result = await downloadToFile({ url: 'http://server/audio/job-1', filePath: target });
+
+    expect(result).toMatchObject({ ok: false, status: 410 });
+    expect((result as { body: string }).body).toContain('Audio file has been deleted');
+  });
+
+  it('caps a runaway error body instead of relaying all of it', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(errorResponse(500, 'x'.repeat(MAX_ERROR_BODY_CHARS * 3))),
+    );
+
+    const result = await downloadToFile({ url: 'http://server/audio/job-1', filePath: target });
+
+    expect((result as { body: string }).body).toHaveLength(MAX_ERROR_BODY_CHARS);
+  });
+
+  // The save dialog hands back a path the user confirmed overwriting, so an
+  // existing file is normal. A failure before this code opens anything must
+  // leave that file alone: deleting it would destroy data the download never
+  // even attempted to replace.
+  it('leaves a pre-existing file untouched when the request itself fails', async () => {
+    const precious = Buffer.from('the users existing recording');
+    writeFileSync(target, precious);
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+
+    const result = await downloadToFile({ url: 'http://server/audio/job-1', filePath: target });
+
+    expect(result).toMatchObject({ ok: false });
+    expect(existsSync(target)).toBe(true);
+    expect(readFileSync(target).equals(precious)).toBe(true);
+  });
+
+  it('leaves a pre-existing file untouched when the server refuses', async () => {
+    const precious = Buffer.from('the users existing recording');
+    writeFileSync(target, precious);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(errorResponse(410, 'gone')));
+
+    await downloadToFile({ url: 'http://server/audio/job-1', filePath: target });
+
+    expect(readFileSync(target).equals(precious)).toBe(true);
+  });
+
+  // The mirror image: once the write has begun, a truncated file IS this
+  // function's doing and must not be left behind looking like a valid WAV.
+  it('removes the half-written file when the stream dies mid-download', async () => {
+    const dying = new Readable({
+      read() {
+        this.push(Buffer.from('RIFF____WAVE'));
+        this.destroy(new Error('connection reset'));
+      },
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okResponse(dying)));
+
+    const result = await downloadToFile({ url: 'http://server/audio/job-1', filePath: target });
+
+    expect(result).toMatchObject({ ok: false });
+    expect(existsSync(target)).toBe(false);
+  });
+
+  it('reports a response with no body instead of writing an empty file', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200, body: null }));
+
+    const result = await downloadToFile({ url: 'http://server/audio/job-1', filePath: target });
+
+    expect(result).toMatchObject({ ok: false, status: 200 });
+    expect(existsSync(target)).toBe(false);
+  });
+
+  // The renderer is promised this never rejects, and its tsconfig has no
+  // strictNullChecks, so a null path from a cancelled dialog type-checks fine.
+  it('resolves rather than rejects when the path is not a string', async () => {
+    vi.stubGlobal('fetch', vi.fn());
+
+    const result = await downloadToFile({
+      url: 'http://server/audio/job-1',
+      filePath: null as unknown as string,
+    });
+
+    expect(result).toMatchObject({ ok: false });
+    expect((result as { error: string }).error).toContain('ERR_INVALID_ARG_TYPE');
+  });
+});

--- a/dashboard/electron/downloadToFile.ts
+++ b/dashboard/electron/downloadToFile.ts
@@ -1,0 +1,98 @@
+/**
+ * downloadToFile - stream an HTTP download straight to disk in the main process.
+ *
+ * The renderer's `file:writeText` channel takes a JS string and is not binary
+ * safe, so audio needs its own path. More importantly the bytes must never
+ * cross the IPC bridge: a supported 5-hour recording is roughly 576 MB at
+ * 16 kHz mono 16-bit, and buffering that into the renderer to structured-clone
+ * it would spike memory twice over or exceed the message limit outright.
+ * Piping the response body into a write stream here keeps renderer memory flat
+ * regardless of recording length.
+ *
+ * Lives in its own module rather than inline in main.ts so the cleanup rule
+ * below is testable, which matters: this function deletes files.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { Readable } from 'stream';
+import { pipeline } from 'stream/promises';
+import type { ReadableStream as NodeWebReadableStream } from 'stream/web';
+
+export interface DownloadToFileOptions {
+  url: string;
+  headers?: Record<string, string>;
+  filePath: string;
+}
+
+export type DownloadToFileResult =
+  | { ok: true; bytes?: number }
+  | { ok: false; error: string; status?: number; body?: string };
+
+/** Cap on the error body relayed to the renderer. */
+export const MAX_ERROR_BODY_CHARS = 2000;
+
+/**
+ * Fetch `url` and write the response body to `filePath`.
+ *
+ * Never throws: always resolves to the result union, so the renderer never has
+ * to try/catch an IPC rejection.
+ *
+ * On a non-ok response the destination is left untouched and the server's own
+ * body is relayed back, because the audio endpoint answers 410 with a distinct
+ * `detail` per reason (never preserved / lost with /tmp / deleted) and that
+ * distinction is the whole answer for the user.
+ */
+export async function downloadToFile(opts: DownloadToFileOptions): Promise<DownloadToFileResult> {
+  // Everything, path.resolve included, sits inside the try: it throws
+  // ERR_INVALID_ARG_TYPE for a non-string filePath, and callers are promised
+  // this never rejects.
+  let resolved = '';
+  // Flipped only once the write stream exists, i.e. once this function has
+  // actually created or truncated the destination. The cleanup below keys off
+  // it. Unlinking unconditionally would delete a pre-existing file the user
+  // picked in the save dialog even when the download never wrote a byte to it,
+  // which is exactly the kind of silent loss this feature exists to prevent.
+  let destinationOpened = false;
+  try {
+    resolved = path.resolve(opts.filePath);
+    const res = await fetch(opts.url, { headers: opts.headers });
+    if (!res.ok) {
+      let body = '';
+      try {
+        body = (await res.text()).slice(0, MAX_ERROR_BODY_CHARS);
+      } catch {
+        body = '';
+      }
+      return { ok: false, error: `Download failed: HTTP ${res.status}`, status: res.status, body };
+    }
+    if (!res.body) {
+      return { ok: false, error: 'Download failed: response had no body', status: res.status };
+    }
+    // The DOM lib's ReadableStream and node:stream/web's are structurally
+    // distinct to TypeScript even though fetch hands back the same object at
+    // runtime, so the cast is the documented bridge between them.
+    const source = Readable.fromWeb(res.body as unknown as NodeWebReadableStream<Uint8Array>);
+    destinationOpened = true;
+    await pipeline(source, fs.createWriteStream(resolved));
+    let bytes: number | undefined;
+    try {
+      bytes = (await fs.promises.stat(resolved)).size;
+    } catch {
+      bytes = undefined;
+    }
+    return bytes === undefined ? { ok: true } : { ok: true, bytes };
+  } catch (err) {
+    // Best-effort cleanup so a half-written file is never left behind looking
+    // valid. Scoped to a file this call actually opened, and errors from the
+    // unlink itself are swallowed.
+    if (destinationOpened && resolved) {
+      try {
+        await fs.promises.unlink(resolved);
+      } catch {
+        // Nothing to clean up, or the path is not ours to remove.
+      }
+    }
+    return { ok: false, error: String(err) };
+  }
+}

--- a/dashboard/electron/main.ts
+++ b/dashboard/electron/main.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import https from 'https';
 import http from 'http';
 import { fileURLToPath } from 'url';
+import { downloadToFile, type DownloadToFileResult } from './downloadToFile.js';
 import {
   ensureServerConfigSeed,
   getServerConfigDir,
@@ -1151,6 +1152,17 @@ ipcMain.handle('file:writeText', async (_event, filePath: string, content: strin
   const resolved = path.resolve(filePath);
   await fs.promises.writeFile(resolved, content, 'utf-8');
 });
+
+// Binary sibling of `file:writeText` above, which takes a JS string and is not
+// binary safe. The bytes deliberately never cross the IPC bridge - see
+// downloadToFile.ts for why that matters for a multi-hundred-MB recording.
+ipcMain.handle(
+  'file:downloadToPath',
+  async (
+    _event,
+    opts: { url: string; headers?: Record<string, string>; filePath: string },
+  ): Promise<DownloadToFileResult> => downloadToFile(opts),
+);
 
 ipcMain.handle('dialog:selectFolder', async () => {
   const mainWindow = BrowserWindow.getAllWindows()[0];

--- a/dashboard/electron/preload.ts
+++ b/dashboard/electron/preload.ts
@@ -437,6 +437,18 @@ export interface ElectronAPI {
       defaultPath?: string;
       filters?: { name: string; extensions: string[] }[];
     }) => Promise<string | null>;
+    /**
+     * Stream an HTTP download straight to disk in the main process. The bytes
+     * never cross the IPC bridge, so a multi-hundred-MB WAV costs no renderer
+     * memory. Resolves to a result union and never rejects.
+     */
+    downloadToPath: (opts: {
+      url: string;
+      headers?: Record<string, string>;
+      filePath: string;
+    }) => Promise<
+      { ok: true; bytes?: number } | { ok: false; error: string; status?: number; body?: string }
+    >;
   };
   watcher: {
     startSession: (folderPath: string) => Promise<void>;
@@ -798,6 +810,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('file:writeText', filePath, content) as Promise<void>,
     selectFolder: () => ipcRenderer.invoke('dialog:selectFolder') as Promise<string | null>,
     saveFile: (opts) => ipcRenderer.invoke('dialog:saveFile', opts) as Promise<string | null>,
+    downloadToPath: (opts) =>
+      ipcRenderer.invoke('file:downloadToPath', opts) as Promise<
+        { ok: true; bytes?: number } | { ok: false; error: string; status?: number; body?: string }
+      >,
   },
   watcher: {
     startSession: (folderPath: string) =>

--- a/dashboard/src/api/client.jobAudioUrl.test.ts
+++ b/dashboard/src/api/client.jobAudioUrl.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { APIClient } from './client';
+
+// getJobAudioUrl backs the "Save Audio" action: the renderer hands the URL to
+// the Electron main process, which streams the WAV to disk. Two properties are
+// load-bearing and asserted here - it gates on isBaseUrlConfigured() like its
+// getAudioUrl / getExportUrl neighbours, and it never carries the auth token as
+// a query param (the token travels as an Authorization header instead, so it
+// stays out of any access log).
+
+function installConfigBridge(seed: Record<string, unknown>) {
+  (window as any).electronAPI = {
+    config: {
+      get: vi.fn(async (key: string) => seed[key]),
+      set: vi.fn(),
+    },
+  };
+}
+
+describe('APIClient.getJobAudioUrl', () => {
+  beforeEach(() => {
+    delete (window as any).electronAPI;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (window as any).electronAPI;
+  });
+
+  it('returns null on a pre-sync client', () => {
+    const client = new APIClient();
+    expect(client.getJobAudioUrl('job-1')).toBeNull();
+  });
+
+  it('returns null after sync when baseUrl is blank-remote', async () => {
+    installConfigBridge({
+      'connection.useRemote': true,
+      'connection.remoteProfile': 'tailscale',
+      'connection.remoteHost': '',
+    });
+    const client = new APIClient();
+    await client.syncFromConfig();
+    expect(client.getJobAudioUrl('job-1')).toBeNull();
+  });
+
+  it('returns an absolute URL under the configured base after sync', async () => {
+    installConfigBridge({ 'connection.useRemote': false });
+    const client = new APIClient();
+    await client.syncFromConfig();
+
+    const url = client.getJobAudioUrl('job-1');
+    expect(url).not.toBeNull();
+    expect(url).toBe(`${client.getBaseUrl()}/api/transcribe/audio/job-1`);
+  });
+
+  it('never appends a token query param, even when a token is set', async () => {
+    installConfigBridge({ 'connection.useRemote': false });
+    const client = new APIClient();
+    await client.syncFromConfig();
+    client.setAuthToken('secret-token');
+
+    const url = client.getJobAudioUrl('job-1');
+    expect(url).not.toBeNull();
+    expect(url).not.toContain('?');
+    expect(url).not.toContain('secret-token');
+  });
+
+  it('URL-encodes the job id', async () => {
+    installConfigBridge({ 'connection.useRemote': false });
+    const client = new APIClient();
+    await client.syncFromConfig();
+
+    expect(client.getJobAudioUrl('a b/c')).toBe(
+      `${client.getBaseUrl()}/api/transcribe/audio/a%20b%2Fc`,
+    );
+  });
+});

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -783,6 +783,22 @@ export class APIClient {
     return `${this.baseUrl}/api/notebook/recordings/${id}/export?${params}`;
   }
 
+  /**
+   * GET /api/transcribe/audio/:jobId
+   * Absolute URL for a transcription job's preserved source WAV. Returns null
+   * when the base URL is not configured (pre-sync or blank-remote) so callers
+   * can surface the established "Remote host not configured" message.
+   *
+   * Unlike getAudioUrl / getExportUrl this deliberately carries NO token query
+   * param: the caller hands the URL to the Electron main process, which can set
+   * a real Authorization header, so the token stays out of the URL and out of
+   * any access log.
+   */
+  getJobAudioUrl(jobId: string): string | null {
+    if (!this.isBaseUrlConfigured()) return null;
+    return `${this.baseUrl}/api/transcribe/audio/${encodeURIComponent(jobId)}`;
+  }
+
   // ─── Notebook: Upload & Transcribe ────────────────────────────────────────
 
   /**

--- a/dashboard/src/hooks/useTranscription.ts
+++ b/dashboard/src/hooks/useTranscription.ts
@@ -11,6 +11,11 @@ import { TranscriptionSocket, ServerMessage } from '../services/websocket';
 import { AudioCapture } from '../services/audioCapture';
 import { apiClient } from '../api/client';
 import { useSalvageStore } from '../stores/salvageStore';
+import {
+  pollForTranscriptionResult,
+  toTranscriptionResult,
+  type PollHandle,
+} from '../services/resultPolling';
 
 export type TranscriptionStatus =
   | 'idle'
@@ -26,20 +31,6 @@ export interface BusyInfo {
   isSalvage: boolean;
   salvageJobId: string | null;
 }
-
-/** Gap between attempts when polling for a result the socket cannot deliver. */
-const POLL_INTERVAL_MS = 3000;
-
-/**
- * How long to keep polling for such a result before giving up.
- *
- * Sized for the slow case rather than the common one: after a mid-recording
- * drop the server still has to transcribe everything it received (GH-239), so
- * the wait scales with the length of the recording, not with the round-trip.
- * Giving up early would strand a result that is already saved in the database -
- * it stays reachable from the recovery list, but the user has to find it.
- */
-const POLL_BUDGET_MS = 15 * 60 * 1000;
 
 export interface TranscriptionResult {
   text: string;
@@ -112,8 +103,26 @@ export interface TranscriptionState {
   setGain: (value: number) => void;
   /** Job ID assigned by the server for this transcription session */
   jobId: string | null;
-  /** Load an externally-fetched result into the hook (e.g. recovered from DB) */
-  loadResult: (result: TranscriptionResult) => void;
+  /**
+   * Which job the transcript currently on screen belongs to, or null when there
+   * is none.
+   *
+   * Distinct from `jobId`, and the distinction is load bearing. `jobId` is the
+   * job the Retry button acts on and it deliberately survives an error, so it
+   * cannot answer "is this transcript already visible". The recovery banner
+   * needs that answer: hiding a job because it is the CURRENT one hid the one
+   * job that most needed recovering, while /retry refused it as already
+   * completed.
+   */
+  resultJobId: string | null;
+  /**
+   * Load an externally-fetched result into the hook (e.g. recovered from DB).
+   *
+   * `forJobId` says which job the transcript belongs to and defaults to the
+   * current session job. The recovery banner must pass it explicitly, because
+   * the job it views is by definition not the current one.
+   */
+  loadResult: (result: TranscriptionResult, forJobId?: string | null) => void;
   /** Ephemeral "last N seconds" preview text (null until a preview has run) */
   previewText: string | null;
   /** Detected language of the most recent preview */
@@ -140,6 +149,9 @@ const PREVIEW_REFRESH_BASE_MS = 5000;
 export function useTranscription(): TranscriptionState {
   const [status, setStatus] = useState<TranscriptionStatus>('idle');
   const [result, setResult] = useState<TranscriptionResult | null>(null);
+  // Written at every setResult site, so "whose transcript is on screen" can
+  // never drift from the transcript itself.
+  const [resultJobId, setResultJobId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busyInfo, setBusyInfo] = useState<BusyInfo | null>(null);
   const [analyser, setAnalyser] = useState<AnalyserNode | null>(null);
@@ -197,11 +209,11 @@ export function useTranscription(): TranscriptionState {
   // reconnect can't spawn a phantom job while the poll-for-result fallback
   // recovers the real one.
   const sessionEstablishedRef = useRef(false);
-  // Ref-based cancel flag for the disconnect poll loop — accessible from the
-  // useEffect cleanup on unmount (a plain `let cancelled` in the onClose closure
-  // cannot be reached from the cleanup function).
-  const pollCancelledRef = useRef(false);
-  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Handle for the disconnect poll loop, held in a ref so the useEffect cleanup
+  // on unmount can reach it (a plain `let` inside the onClose closure cannot be).
+  // One handle per invocation: cancelling this one never touches a poll started
+  // elsewhere, such as the one behind SessionView's Retry button.
+  const pollHandleRef = useRef<PollHandle | null>(null);
 
   // Keep statusRef in sync so onClose can read the latest status without stale closure
   const setStatusTracked = useCallback((s: TranscriptionStatus) => {
@@ -251,11 +263,8 @@ export function useTranscription(): TranscriptionState {
       previewActiveRef.current = false;
       const active = statusRef.current === 'recording' || statusRef.current === 'processing';
       if (!active) {
-        pollCancelledRef.current = true;
-        if (pollTimerRef.current !== null) {
-          clearTimeout(pollTimerRef.current);
-          pollTimerRef.current = null;
-        }
+        pollHandleRef.current?.cancel();
+        pollHandleRef.current = null;
         captureRef.current?.stop();
         socketRef.current?.disconnect();
       }
@@ -472,6 +481,7 @@ export function useTranscription(): TranscriptionState {
             numSpeakers: (msg.data?.num_speakers as number | undefined) ?? 0,
             diarization: msg.data?.diarization as TranscriptionResult['diarization'],
           });
+          setResultJobId(jobIdRef.current);
           setProcessingProgress(null);
           setStatusTracked('complete');
           captureRef.current?.stop();
@@ -490,17 +500,10 @@ export function useTranscription(): TranscriptionState {
             .then(async (resp) => {
               if (resp.status === 200) {
                 const data = await resp.json();
-                const r = data.result ?? {};
-                setResult({
-                  text: r.text ?? '',
-                  words: r.words ?? [],
-                  language: r.language,
-                  duration: r.duration,
-                  partial: r.partial ?? false,
-                  partialReason: r.partial_reason ?? null,
-                  numSpeakers: r.num_speakers ?? 0,
-                  diarization: r.diarization,
-                });
+                setResult(toTranscriptionResult(data.result));
+                // jobIdRef was already cleared below so onClose skips the poll,
+                // so the id has to come from the message that sent us here.
+                setResultJobId(job_id);
                 setProcessingProgress(null);
                 setStatusTracked('complete');
               } else {
@@ -600,6 +603,7 @@ export function useTranscription(): TranscriptionState {
     }) => {
       // Reset previous state
       setResult(null);
+      setResultJobId(null);
       setError(null);
       setBusyInfo(null);
       setVadActive(false);
@@ -670,74 +674,31 @@ export function useTranscription(): TranscriptionState {
           // server was already transcribing, or it is now salvaging the
           // interrupted recording.
           if ((wasRecording || statusRef.current === 'processing') && currentJobId) {
-            let networkErrors = 0;
-            const maxRetries = 10;
-            // A wall-clock budget, not an attempt count: the server has to
-            // transcribe the whole recording before the result exists, and the
-            // old ten-attempt cap gave up after 30 seconds - short of any real
-            // recording. Date.now() is read once so a suspended machine that
-            // wakes up late gives up rather than polling forever.
-            const pollDeadline = Date.now() + POLL_BUDGET_MS;
-            pollCancelledRef.current = false;
-
-            // Cancel polling if the hook re-initialises a new session
-            // (jobIdRef will be cleared by start() before a new socket is created)
-            const poll = async () => {
-              if (pollCancelledRef.current || jobIdRef.current !== currentJobId) return;
-              try {
-                // Absolute base URL via apiClient — a relative fetch fails in
-                // the packaged (file://) renderer (GH-202).
-                const resp = await apiClient.fetchTranscriptionResult(currentJobId);
-                if (pollCancelledRef.current || jobIdRef.current !== currentJobId) return;
-                if (resp.status === 200) {
-                  const data = await resp.json();
-                  const r = data.result ?? {};
-                  setResult({
-                    text: r.text ?? '',
-                    words: r.words ?? [],
-                    language: r.language,
-                    duration: r.duration,
-                    partial: r.partial ?? false,
-                    partialReason: r.partial_reason ?? null,
-                    numSpeakers: r.num_speakers ?? 0,
-                    diarization: r.diarization,
-                  });
-                  setProcessingProgress(null);
-                  // The recovery succeeded, so the "connection lost" banner has
-                  // done its job. A salvaged transcript still carries `partial`,
-                  // which SessionView renders as its own amber banner - showing
-                  // a red error next to a recovered transcript reads as failure.
-                  setError(null);
-                  setStatusTracked('complete');
-                  return;
-                }
-                if (resp.status === 202 && Date.now() < pollDeadline) {
-                  pollTimerRef.current = setTimeout(poll, POLL_INTERVAL_MS);
-                  return;
-                }
-                // 410 = server says job failed
-                if (resp.status === 410) {
-                  setStatusTracked('error');
-                  setError('Transcription failed on server');
-                  return;
-                }
-                // 404 or unexpected — surface as error rather than silently idling
+            // Shared with SessionView's Retry button. It owns the wall-clock
+            // budget, the separate network-error budget, and the rule that a
+            // throw while delivering is never retried as "not ready yet".
+            pollHandleRef.current?.cancel();
+            pollHandleRef.current = pollForTranscriptionResult({
+              jobId: currentJobId,
+              // Drop the poll if the hook re-initialises a new session.
+              // start() clears jobIdRef before a new socket is created.
+              isStale: () => jobIdRef.current !== currentJobId,
+              onResult: (recovered, forJobId) => {
+                setResult(recovered);
+                setResultJobId(forJobId);
+                setProcessingProgress(null);
+                // The recovery succeeded, so the "connection lost" banner has
+                // done its job. A salvaged transcript still carries `partial`,
+                // which SessionView renders as its own amber banner - showing
+                // a red error next to a recovered transcript reads as failure.
+                setError(null);
+                setStatusTracked('complete');
+              },
+              onFailure: (failure) => {
                 setStatusTracked('error');
-                setError('Transcription result unavailable');
-              } catch {
-                // Network errors keep their own small budget: an unreachable
-                // server will not produce a result no matter how long we wait,
-                // so this must not inherit the long transcription budget.
-                if (!pollCancelledRef.current && networkErrors < maxRetries) {
-                  networkErrors++;
-                  pollTimerRef.current = setTimeout(poll, POLL_INTERVAL_MS);
-                } else if (!pollCancelledRef.current) {
-                  setStatusTracked('error');
-                  setError('Could not retrieve transcription result');
-                }
-              }
-            };
-            poll();
+                setError(failure.message);
+              },
+            });
           }
         },
       });
@@ -770,6 +731,7 @@ export function useTranscription(): TranscriptionState {
     socketRef.current?.disconnect();
     setStatusTracked('idle');
     setResult(null);
+    setResultJobId(null);
     setError(null);
     setBusyInfo(null);
     setAnalyser(null);
@@ -809,8 +771,12 @@ export function useTranscription(): TranscriptionState {
   }, []);
 
   const loadResult = useCallback(
-    (r: TranscriptionResult) => {
+    (r: TranscriptionResult, forJobId?: string | null) => {
       setResult(r);
+      // Default to the current session job. The recovery banner overrides it,
+      // because the job it views is by definition not the current one, and
+      // recording the wrong owner here would hide the wrong row from the banner.
+      setResultJobId(forJobId !== undefined ? forJobId : jobIdRef.current);
       // A delivered transcript supersedes whatever went wrong before it — a
       // recovered or retried result must not leave the old error banner on
       // screen next to the transcript it just replaced.
@@ -836,6 +802,7 @@ export function useTranscription(): TranscriptionState {
     setGain,
     processingProgress,
     jobId,
+    resultJobId,
     loadResult,
     previewText,
     previewLanguage,

--- a/dashboard/src/services/resultPolling.test.ts
+++ b/dashboard/src/services/resultPolling.test.ts
@@ -1,0 +1,257 @@
+/**
+ * resultPolling - the shared way a transcript reaches the UI when the socket
+ * that ordered it is gone.
+ *
+ * Two call sites used to own unequal copies of this loop. The weaker one is
+ * what stranded a completed transcript in the database with nothing on screen
+ * pointing at it, so the behaviours below are the ones that must not regress:
+ * a wall-clock budget rather than an attempt count, a separate budget for
+ * network failures, per-invocation cancellation, and a delivery throw that is
+ * never mistaken for "not ready yet".
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { apiClient } from '../api/client';
+import {
+  pollForTranscriptionResult,
+  toTranscriptionResult,
+  POLL_INTERVAL_MS,
+  POLL_BUDGET_MS,
+  MAX_NETWORK_ERRORS,
+  type PollFailure,
+} from './resultPolling';
+
+vi.mock('../api/client', () => ({
+  apiClient: { fetchTranscriptionResult: vi.fn() },
+}));
+
+const fetchResult = apiClient.fetchTranscriptionResult as unknown as ReturnType<typeof vi.fn>;
+
+/** Fixed epoch so the wall-clock budget is exercised without the real clock. */
+const EPOCH = new Date('2026-09-04T16:00:00.000Z').getTime();
+
+function ready(result: unknown) {
+  return { status: 200, json: async () => ({ result }) };
+}
+
+describe('toTranscriptionResult', () => {
+  it('maps every field the durability endpoint sends', () => {
+    expect(
+      toTranscriptionResult({
+        text: 'hello',
+        words: [{ word: 'hello', start: 0, end: 1 }],
+        language: 'el',
+        duration: 12.5,
+        partial: true,
+        partial_reason: 'sidecar died',
+        num_speakers: 3,
+        diarization: { requested: true, performed: false, reason: 'missing', remedy: 'install' },
+      }),
+    ).toEqual({
+      text: 'hello',
+      words: [{ word: 'hello', start: 0, end: 1 }],
+      language: 'el',
+      duration: 12.5,
+      partial: true,
+      partialReason: 'sidecar died',
+      numSpeakers: 3,
+      diarization: { requested: true, performed: false, reason: 'missing', remedy: 'install' },
+    });
+  });
+
+  it('produces a usable result from an empty or absent payload', () => {
+    expect(toTranscriptionResult(undefined)).toEqual({
+      text: '',
+      words: [],
+      language: undefined,
+      duration: undefined,
+      partial: false,
+      partialReason: null,
+      numSpeakers: 0,
+      diarization: undefined,
+    });
+  });
+});
+
+describe('pollForTranscriptionResult', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
+    vi.setSystemTime(new Date(EPOCH));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('delivers on the first attempt when the result is already there', async () => {
+    fetchResult.mockResolvedValue(ready({ text: 'done', words: [], num_speakers: 2 }));
+    const onResult = vi.fn();
+    const onFailure = vi.fn();
+
+    pollForTranscriptionResult({ jobId: 'job-1', onResult, onFailure });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fetchResult).toHaveBeenCalledWith('job-1');
+    expect(onResult).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'done', numSpeakers: 2 }),
+      'job-1',
+    );
+    expect(onFailure).not.toHaveBeenCalled();
+  });
+
+  it('keeps polling on 202 and stops the moment the result lands', async () => {
+    fetchResult
+      .mockResolvedValueOnce({ status: 202, json: async () => ({}) })
+      .mockResolvedValueOnce({ status: 202, json: async () => ({}) })
+      .mockResolvedValue(ready({ text: 'finally', words: [] }));
+    const onResult = vi.fn();
+
+    pollForTranscriptionResult({ jobId: 'job-1', onResult, onFailure: vi.fn() });
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 3);
+
+    expect(onResult).toHaveBeenCalledTimes(1);
+    const callsAtDelivery = fetchResult.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 5);
+    expect(fetchResult.mock.calls.length).toBe(callsAtDelivery);
+  });
+
+  it('reports a 410 as a server-side failure and carries the reason back', async () => {
+    fetchResult.mockResolvedValue({
+      status: 410,
+      json: async () => ({}),
+      text: async () => JSON.stringify({ detail: 'Audio file has been deleted' }),
+    });
+    const onFailure = vi.fn();
+
+    pollForTranscriptionResult({ jobId: 'job-1', onResult: vi.fn(), onFailure });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onFailure).toHaveBeenCalledTimes(1);
+    const failure = onFailure.mock.calls[0][0] as PollFailure;
+    expect(failure.kind).toBe('failed');
+    expect(failure.status).toBe(410);
+    expect(failure.body).toContain('Audio file has been deleted');
+  });
+
+  it('reports an unexpected status as unavailable rather than idling forever', async () => {
+    fetchResult.mockResolvedValue({ status: 404, json: async () => ({}) });
+    const onFailure = vi.fn();
+
+    pollForTranscriptionResult({ jobId: 'job-1', onResult: vi.fn(), onFailure });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onFailure).toHaveBeenCalledWith(expect.objectContaining({ kind: 'unavailable' }));
+  });
+
+  // The count-based cap it replaced ignored request latency, so it always gave
+  // up sooner than it claimed to. This budget is real elapsed time.
+  it('gives up on wall-clock time, not on a count of attempts', async () => {
+    fetchResult.mockResolvedValue({ status: 202, json: async () => ({}) });
+    const onFailure = vi.fn();
+
+    pollForTranscriptionResult({ jobId: 'job-1', onResult: vi.fn(), onFailure });
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 40);
+
+    // Well past the old hundred-attempt idea of five minutes, still going.
+    expect(onFailure).not.toHaveBeenCalled();
+    expect(fetchResult.mock.calls.length).toBeGreaterThan(11);
+
+    vi.setSystemTime(new Date(EPOCH + POLL_BUDGET_MS + 1000));
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+    expect(onFailure).toHaveBeenCalledWith(expect.objectContaining({ kind: 'timeout' }));
+  });
+
+  // An unreachable server will not produce a result no matter how long we wait,
+  // so network failures must not inherit the long transcription budget.
+  it('keeps a separate, much smaller budget for network failures', async () => {
+    fetchResult.mockRejectedValue(new Error('ECONNREFUSED'));
+    const onFailure = vi.fn();
+
+    pollForTranscriptionResult({ jobId: 'job-1', onResult: vi.fn(), onFailure });
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * (MAX_NETWORK_ERRORS - 1));
+    expect(onFailure).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 3);
+    expect(onFailure).toHaveBeenCalledWith(expect.objectContaining({ kind: 'network' }));
+    expect(fetchResult.mock.calls.length).toBe(MAX_NETWORK_ERRORS + 1);
+  });
+
+  it('abandons silently once isStale turns true', async () => {
+    fetchResult.mockResolvedValue({ status: 202, json: async () => ({}) });
+    const onResult = vi.fn();
+    const onFailure = vi.fn();
+    let stale = false;
+
+    pollForTranscriptionResult({
+      jobId: 'job-1',
+      onResult,
+      onFailure,
+      isStale: () => stale,
+    });
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    const before = fetchResult.mock.calls.length;
+
+    stale = true;
+    fetchResult.mockResolvedValue(ready({ text: 'not ours any more', words: [] }));
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 5);
+
+    expect(fetchResult.mock.calls.length).toBe(before);
+    expect(onResult).not.toHaveBeenCalled();
+    expect(onFailure).not.toHaveBeenCalled();
+  });
+
+  it('cancel stops its own chain and leaves every other one running', async () => {
+    fetchResult.mockResolvedValue({ status: 202, json: async () => ({}) });
+    const firstResult = vi.fn();
+    const secondResult = vi.fn();
+
+    const first = pollForTranscriptionResult({
+      jobId: 'job-1',
+      onResult: firstResult,
+      onFailure: vi.fn(),
+    });
+    const second = pollForTranscriptionResult({
+      jobId: 'job-2',
+      onResult: secondResult,
+      onFailure: vi.fn(),
+    });
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+    first.cancel();
+    fetchResult.mockResolvedValue(ready({ text: 'second one wins', words: [] }));
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 2);
+
+    expect(firstResult).not.toHaveBeenCalled();
+    expect(secondResult).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'second one wins' }),
+      'job-2',
+    );
+  });
+
+  // The old shape put the delivery inside the same try as the fetch, so a
+  // throw here read as "not ready yet": the loop ran on forever and the caller
+  // never learned it had failed.
+  it('routes a throw from the delivery handler to onDeliveryError and stops', async () => {
+    fetchResult.mockResolvedValue(ready({ text: 'done', words: [] }));
+    const onDeliveryError = vi.fn();
+    const onFailure = vi.fn();
+
+    pollForTranscriptionResult({
+      jobId: 'job-1',
+      onResult: () => {
+        throw new Error('render blew up');
+      },
+      onFailure,
+      onDeliveryError,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    const callsAfterThrow = fetchResult.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 5);
+
+    expect(onDeliveryError).toHaveBeenCalledTimes(1);
+    expect(onFailure).not.toHaveBeenCalled();
+    expect(fetchResult.mock.calls.length).toBe(callsAfterThrow);
+  });
+});

--- a/dashboard/src/services/resultPolling.ts
+++ b/dashboard/src/services/resultPolling.ts
@@ -1,0 +1,260 @@
+/**
+ * resultPolling - the one way a finished transcript reaches the UI when the
+ * WebSocket cannot carry it.
+ *
+ * Two paths need this and used to own separate, unequal copies of it: the
+ * socket-drop recovery inside useTranscription, and the Retry button in
+ * SessionView. The SessionView copy was the weaker one, and its weaknesses are
+ * what stranded a completed transcript in the database with no way to reach it:
+ * an attempt counter that undercounted real elapsed time, a shared cancel flag
+ * that let two overlapping retries write into each other, and a try block wide
+ * enough that a throw while DELIVERING the result read as "not ready yet",
+ * so the loop ran on forever and the caller never cleared its in-flight flag.
+ *
+ * Everything here goes through apiClient so the request carries the absolute
+ * base URL. A bare relative fetch resolves against the packaged renderer
+ * file:// origin and never reaches the backend (GH-202).
+ */
+
+import { apiClient } from '../api/client';
+import type { TranscriptionResult } from '../hooks/useTranscription';
+
+/** Gap between attempts. */
+export const POLL_INTERVAL_MS = 3000;
+
+/**
+ * How long to keep polling before giving up, as wall clock rather than a count
+ * of attempts. An attempt count ignores request latency, so it always
+ * undercounts the time actually spent. Sized for the slow case: the server has
+ * to transcribe the whole recording before the result exists, so the wait
+ * scales with the length of the recording, not with the round trip.
+ */
+export const POLL_BUDGET_MS = 15 * 60 * 1000;
+
+/**
+ * Network failures keep their own much smaller budget. An unreachable server
+ * will not produce a result no matter how long we wait, so this must not
+ * inherit the long transcription budget above.
+ */
+export const MAX_NETWORK_ERRORS = 10;
+
+/**
+ * Why a poll stopped without a transcript.
+ *
+ * - `failed`: the server says the job failed (HTTP 410). Terminal.
+ * - `unavailable`: 404, or any status the endpoint is not documented to
+ *   return. Terminal.
+ * - `timeout`: still processing when the wall clock budget ran out. The result
+ *   is NOT lost: it stays in the database and the recovery banner finds it.
+ * - `network`: the request itself kept failing.
+ */
+export type PollFailureKind = 'failed' | 'unavailable' | 'timeout' | 'network';
+
+export interface PollFailure {
+  kind: PollFailureKind;
+  /** Default wording, suitable for putting straight on screen. */
+  message: string;
+  /** HTTP status that produced it, when there was one. */
+  status?: number;
+  /**
+   * Raw response body for the statuses that carry a reason. The 410 branch of
+   * the result endpoint returns three distinct explanations, and the user needs
+   * the specific one.
+   */
+  body?: string;
+}
+
+/** Cancel handle. One per invocation, so cancelling one never touches another. */
+export interface PollHandle {
+  cancel: () => void;
+}
+
+/**
+ * The snake_case payload the durability endpoints return under `result`.
+ * Declared rather than inlined so the mapping below cannot silently drop a
+ * field when the server grows one.
+ */
+export interface RawTranscriptionResult {
+  text?: string;
+  words?: TranscriptionResult['words'];
+  language?: string;
+  duration?: number;
+  partial?: boolean;
+  partial_reason?: string | null;
+  num_speakers?: number;
+  diarization?: TranscriptionResult['diarization'];
+}
+
+/**
+ * Map a persisted result onto the hook's shape.
+ *
+ * Single source of truth on purpose. Three call sites used to hand-map this and
+ * two of them dropped fields: a retried job lost its speaker labels, and the
+ * recovery banner rendered a PARTIAL transcript as if it were whole, with no
+ * amber banner and no Retry affordance.
+ */
+export function toTranscriptionResult(
+  raw: RawTranscriptionResult | null | undefined,
+): TranscriptionResult {
+  const r = raw ?? {};
+  return {
+    text: r.text ?? '',
+    words: r.words ?? [],
+    language: r.language,
+    duration: r.duration,
+    partial: r.partial ?? false,
+    partialReason: r.partial_reason ?? null,
+    numSpeakers: r.num_speakers ?? 0,
+    diarization: r.diarization,
+  };
+}
+
+export interface PollOptions {
+  /** Job whose result to wait for. */
+  jobId: string;
+  /** Called once, with the mapped result, when the server returns 200. */
+  onResult: (result: TranscriptionResult, jobId: string) => void;
+  /** Called once when the poll stops without a transcript. */
+  onFailure: (failure: PollFailure) => void;
+  /**
+   * Called when `onResult` itself throws. Without this the caller would be left
+   * with its in-flight flag stuck on, which is exactly the bug that made a
+   * Retry button say "Retrying..." forever.
+   */
+  onDeliveryError?: (err: unknown, jobId: string) => void;
+  /**
+   * Return true to abandon the poll silently. Used by the hook to drop a poll
+   * whose session has been replaced by a newer one.
+   */
+  isStale?: () => boolean;
+  intervalMs?: number;
+  budgetMs?: number;
+  maxNetworkErrors?: number;
+}
+
+/** What one attempt learned, before any state is written. */
+type Envelope =
+  | { kind: 'ready'; result: TranscriptionResult }
+  | { kind: 'pending' }
+  | { kind: 'gone'; status: number; body?: string }
+  | { kind: 'missing'; status: number };
+
+async function readBody(resp: Response): Promise<string | undefined> {
+  try {
+    return await resp.text();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Poll the durability endpoint until the transcript arrives or the budget runs
+ * out. The first attempt fires immediately; the returned handle cancels this
+ * invocation and only this one.
+ */
+export function pollForTranscriptionResult(options: PollOptions): PollHandle {
+  const {
+    jobId,
+    onResult,
+    onFailure,
+    onDeliveryError,
+    isStale,
+    intervalMs = POLL_INTERVAL_MS,
+    budgetMs = POLL_BUDGET_MS,
+    maxNetworkErrors = MAX_NETWORK_ERRORS,
+  } = options;
+
+  let cancelled = false;
+  let networkErrors = 0;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  // Read once rather than per attempt, so a machine that suspends mid poll
+  // gives up on waking instead of polling on for another full budget.
+  const deadline = Date.now() + budgetMs;
+
+  const abandoned = (): boolean => cancelled || (isStale ? isStale() : false);
+
+  const schedule = (): void => {
+    timer = setTimeout(() => {
+      void attempt();
+    }, intervalMs);
+  };
+
+  const attempt = async (): Promise<void> => {
+    if (abandoned()) return;
+
+    // Deliberately narrow. Only the request and reading its body live in here.
+    // Delivery happens below, outside the catch, because a throw while
+    // delivering is not a "not ready yet" and must never be retried as one.
+    let envelope: Envelope;
+    try {
+      const resp = await apiClient.fetchTranscriptionResult(jobId);
+      if (abandoned()) return;
+      if (resp.status === 200) {
+        const data = await resp.json();
+        envelope = { kind: 'ready', result: toTranscriptionResult(data?.result) };
+      } else if (resp.status === 202) {
+        envelope = { kind: 'pending' };
+      } else if (resp.status === 410) {
+        envelope = { kind: 'gone', status: resp.status, body: await readBody(resp) };
+      } else {
+        envelope = { kind: 'missing', status: resp.status };
+      }
+    } catch {
+      if (abandoned()) return;
+      networkErrors += 1;
+      if (networkErrors <= maxNetworkErrors) {
+        schedule();
+        return;
+      }
+      onFailure({ kind: 'network', message: 'Could not retrieve transcription result' });
+      return;
+    }
+
+    if (abandoned()) return;
+
+    switch (envelope.kind) {
+      case 'ready':
+        try {
+          onResult(envelope.result, jobId);
+        } catch (err) {
+          onDeliveryError?.(err, jobId);
+        }
+        return;
+      case 'pending':
+        if (Date.now() < deadline) {
+          schedule();
+          return;
+        }
+        onFailure({ kind: 'timeout', message: 'Transcription result unavailable', status: 202 });
+        return;
+      case 'gone':
+        onFailure({
+          kind: 'failed',
+          message: 'Transcription failed on server',
+          status: envelope.status,
+          body: envelope.body,
+        });
+        return;
+      default:
+        onFailure({
+          kind: 'unavailable',
+          message: 'Transcription result unavailable',
+          status: envelope.status,
+        });
+        return;
+    }
+  };
+
+  void attempt();
+
+  return {
+    cancel: () => {
+      cancelled = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    },
+  };
+}

--- a/dashboard/src/types/electron.d.ts
+++ b/dashboard/src/types/electron.d.ts
@@ -279,6 +279,18 @@ interface ElectronAPI {
       defaultPath?: string;
       filters?: { name: string; extensions: string[] }[];
     }) => Promise<string | null>;
+    /**
+     * Stream an HTTP download straight to disk in the main process. The bytes
+     * never cross the IPC bridge, so a multi-hundred-MB WAV costs no renderer
+     * memory. Resolves to a result union and never rejects.
+     */
+    downloadToPath: (opts: {
+      url: string;
+      headers?: Record<string, string>;
+      filePath: string;
+    }) => Promise<
+      { ok: true; bytes?: number } | { ok: false; error: string; status?: number; body?: string }
+    >;
   };
   notifications: {
     show: (options: {

--- a/docs/README_DEV.md
+++ b/docs/README_DEV.md
@@ -4068,23 +4068,12 @@ for quick comparison in a spreadsheet.
 ## 17.1 AI Agent Information
 
 If you are a fellow developer working on this project with the help of an AI
-coding agent and you want to share the same "thinking context" I use day-to-day,
-install the **BMad Method** in your own environment:
+coding agent, the project-level context it needs — architecture, API
+contracts, data models, source tree, invariants — lives in `docs/` and is
+indexed from `docs/index.md`. That is the entry point to point any agent at,
+regardless of which coding assistant you use.
 
-- Repo: https://github.com/bmad-code-org/BMAD-METHOD
-
-BMad is what I drive ~90% of the time while working on TranscriptionSuite. It
-is agent-agnostic — it installs into Claude Code, Codex, Cursor, Windsurf, and
-others — so you don't need to match my exact setup, only the methodology.
-
-A few notes:
-
-- The `.claude/` and `_bmad/` folders are intentionally **not** tracked in this
-  repo. They are large, change constantly as tooling evolves, and are personal
-  to each developer's environment. Install BMad fresh in your own clone via
-  its installer rather than expecting them to be checked in.
-- The project-level context an agent actually needs — architecture, API
-  contracts, data models, source tree, invariants — lives in `docs/` and is
-  indexed from `docs/index.md`. That is the entry point to point any agent at,
-  regardless of which coding assistant you use.
+The `.claude/` folder is intentionally **not** tracked in this repo. It is
+personal to each developer's environment and changes constantly as tooling
+evolves.
 

--- a/server/backend/api/routes/_http_utils.py
+++ b/server/backend/api/routes/_http_utils.py
@@ -1,0 +1,31 @@
+"""Shared HTTP header helpers for the route modules.
+
+Small, dependency-free utilities that more than one router needs. Kept
+separate so a second caller never has to copy-paste a header builder whose
+correctness is subtle (see ``_content_disposition`` and Issue #106).
+"""
+
+from urllib.parse import quote
+
+# C0 control chars + backslash + quote violate RFC 7230 quoted-string rules.
+_ASCII_FALLBACK_REPLACE = str.maketrans(
+    {chr(c): "_" for c in range(0x20)} | {'"': "_", "\\": "_", "\x7f": "_"}
+)
+
+
+def _content_disposition(disposition: str, filename: str) -> str:
+    """Build an RFC 6266 Content-Disposition value with both an ASCII
+    fallback and a UTF-8 form so non-ASCII filenames (Greek, Cyrillic,
+    CJK, etc.) survive Uvicorn's Latin-1 header encoding. Issue #106.
+    """
+    if not isinstance(filename, str) or not filename.strip():
+        safe_name = "audio"
+    else:
+        # Round-trip through UTF-8 with replacement to scrub lone surrogates
+        # that filesystems on some platforms leak; quote() would otherwise raise.
+        safe_name = filename.encode("utf-8", "replace").decode("utf-8")
+    ascii_fallback = (
+        safe_name.encode("ascii", "replace").decode("ascii").translate(_ASCII_FALLBACK_REPLACE)
+    )
+    utf8_quoted = quote(safe_name, safe="")
+    return f"{disposition}; filename=\"{ascii_fallback}\"; filename*=UTF-8''{utf8_quoted}"

--- a/server/backend/api/routes/notebook.py
+++ b/server/backend/api/routes/notebook.py
@@ -16,7 +16,6 @@ import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Annotated, Any
-from urllib.parse import quote
 
 import aiofiles
 from fastapi import (
@@ -31,6 +30,15 @@ from fastapi import (
 )
 from fastapi.responses import FileResponse, Response, StreamingResponse
 from pydantic import BaseModel, field_validator
+
+# _content_disposition and its translate table live in _http_utils so the
+# transcription router can build the same RFC 6266 header (Issue #106). They are
+# re-imported here under their original names: this module's call sites and the
+# tests that reach for notebook._content_disposition keep working unchanged.
+from server.api.routes._http_utils import (
+    _ASCII_FALLBACK_REPLACE,  # noqa: F401  re-exported for backwards compatibility
+    _content_disposition,
+)
 from server.api.routes.utils import get_client_name, sanitize_for_log
 from server.config import get_config, resolve_parallel_diarization_default
 from server.core.stt.backends.factory import detect_backend_type
@@ -61,12 +69,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-# C0 control chars + backslash + quote violate RFC 7230 quoted-string rules.
-_ASCII_FALLBACK_REPLACE = str.maketrans(
-    {chr(c): "_" for c in range(0x20)} | {'"': "_", "\\": "_", "\x7f": "_"}
-)
-
-
 def _sanitize_for_log(value: object) -> str:
     """Strip CR/LF (and equivalents) from any value flowing into a logger.
 
@@ -77,24 +79,6 @@ def _sanitize_for_log(value: object) -> str:
     here before being logged.
     """
     return str(value).replace("\r", " ").replace("\n", " ")
-
-
-def _content_disposition(disposition: str, filename: str) -> str:
-    """Build an RFC 6266 Content-Disposition value with both an ASCII
-    fallback and a UTF-8 form so non-ASCII filenames (Greek, Cyrillic,
-    CJK, etc.) survive Uvicorn's Latin-1 header encoding. Issue #106.
-    """
-    if not isinstance(filename, str) or not filename.strip():
-        safe_name = "audio"
-    else:
-        # Round-trip through UTF-8 with replacement to scrub lone surrogates
-        # that filesystems on some platforms leak; quote() would otherwise raise.
-        safe_name = filename.encode("utf-8", "replace").decode("utf-8")
-    ascii_fallback = (
-        safe_name.encode("ascii", "replace").decode("ascii").translate(_ASCII_FALLBACK_REPLACE)
-    )
-    utf8_quoted = quote(safe_name, safe="")
-    return f"{disposition}; filename=\"{ascii_fallback}\"; filename*=UTF-8''{utf8_quoted}"
 
 
 class RecordingResponse(BaseModel):

--- a/server/backend/api/routes/transcription.py
+++ b/server/backend/api/routes/transcription.py
@@ -13,6 +13,7 @@ import functools
 import json as _json
 import logging
 import tempfile
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal
 
@@ -26,8 +27,9 @@ from fastapi import (
     Response,
     UploadFile,
 )
-from fastapi.responses import JSONResponse
+from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel
+from server.api.routes._http_utils import _content_disposition
 from server.api.routes.utils import get_client_name
 from server.config import resolve_main_transcriber_model, resolve_parallel_diarization_default
 from server.core.json_utils import sanitize_for_json
@@ -1167,6 +1169,86 @@ async def get_transcription_result(job_id: str, request: Request) -> JSONRespons
     return JSONResponse(
         status_code=200,
         content={"job_id": job_id, "status": "completed", "result": result_data},
+    )
+
+
+def _job_audio_filename(job_id: str, created_at: Any) -> str:
+    """Build the download filename for a job's saved source WAV.
+
+    ``created_at`` is written by SQLite CURRENT_TIMESTAMP, i.e. the string
+    "YYYY-MM-DD HH:MM:SS" (see job_repository.get_jobs_for_cleanup for the
+    format note), but legacy rows may hold an isoformat string or nothing at
+    all. The parse is total by design: anything unreadable degrades to the
+    timestamp-free form rather than raising and losing the download.
+    """
+    stamp = ""
+    if created_at:
+        try:
+            stamp = datetime.fromisoformat(str(created_at)).strftime("%Y%m%d-%H%M%S")
+        except (TypeError, ValueError):
+            stamp = ""
+    if stamp:
+        return f"transcription-{stamp}-{job_id}.wav"
+    return f"transcription-{job_id}.wav"
+
+
+@router.get("/audio/{job_id}", response_model=None)
+async def get_job_audio(job_id: str, request: Request) -> FileResponse:
+    """Download the source audio a transcription job was produced from.
+
+    Lets the user keep the recording itself even when transcription died (e.g.
+    a GPU OOM), so nothing irreplaceable depends on the transcript pipeline
+    succeeding. This is a PURE READ: it must never mark the job delivered and
+    never purge it, otherwise saving the audio would destroy it. The audio
+    exists only while the job is failed or awaiting delivery - fetching a
+    session job's result unlinks the WAV (session ephemeral retention), which
+    is deliberate and untouched here.
+
+    Returns:
+        200: The WAV file, sent as an attachment (audio/wav).
+        403: Job belongs to a different client.
+        404: Job not found.
+        410: Audio not available (never preserved, lost with /tmp, or deleted).
+    """
+    from ...database.job_repository import get_job
+
+    job = get_job(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    client_name = get_client_name(request)
+    if job.get("client_name") is not None and job["client_name"] != client_name:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    audio_path = job.get("audio_path")
+    if not audio_path:
+        raise HTTPException(
+            status_code=410, detail="Audio was not preserved for this job - cannot download"
+        )
+    if not Path(audio_path).exists():
+        if audio_path.startswith("/tmp/"):
+            raise HTTPException(
+                status_code=410,
+                detail=(
+                    "Audio was in temporary storage (/tmp) and lost on server restart "
+                    "- cannot download"
+                ),
+            )
+        raise HTTPException(status_code=410, detail="Audio file has been deleted - cannot download")
+
+    filename = _job_audio_filename(job_id, job.get("created_at"))
+    logger.info(
+        "Serving saved audio for job %s as %s",
+        sanitize_log_value(job_id),
+        sanitize_log_value(filename),
+    )
+    # Content-Disposition is built explicitly (not via FileResponse's own
+    # filename= kwarg) so non-ASCII names survive Uvicorn's Latin-1 header
+    # encoding - see _http_utils._content_disposition, Issue #106.
+    return FileResponse(
+        path=audio_path,
+        media_type="audio/wav",
+        headers={"Content-Disposition": _content_disposition("attachment", filename)},
     )
 
 

--- a/server/backend/core/stt/engine.py
+++ b/server/backend/core/stt/engine.py
@@ -762,6 +762,10 @@ class AudioToTextRecorder:
                 # is really a full GPU. Say what actually happened.
                 oom = as_gpu_oom(e)
                 if oom is not None:
+                    # The OOM also poisoned the backend's CUDA context, so it
+                    # cannot be reused. Reset only - the error still reaches the
+                    # caller with its remedy, and the user decides about a retry.
+                    self._discard_backend_after_oom("_perform_transcription")
                     raise oom from e
                 raise
 
@@ -934,6 +938,8 @@ class AudioToTextRecorder:
                 # Transcribe via backend
                 partial = False
                 partial_reason: str | None = None
+                # Initialised here so the success path below is always defined.
+                oom_partial = False
                 try:
                     backend_segments, backend_info = self._backend.transcribe(
                         audio_data,
@@ -956,6 +962,12 @@ class AudioToTextRecorder:
                     # whole job being lost (GH #168 follow-up).
                     partial = True
                     partial_reason = str(partial_exc)
+                    # A partial caused by an OOM leaves exactly the same poisoned
+                    # CUDA context as a total failure, but it never reaches the
+                    # OOM handler below because this branch falls through to a
+                    # normal return. Remember it and discard the backend once the
+                    # salvaged result is assembled.
+                    oom_partial = as_gpu_oom(partial_exc.__cause__ or partial_exc) is not None
                     backend_segments = partial_exc.segments
                     backend_info = partial_exc.info
                     logger.warning(
@@ -1014,6 +1026,15 @@ class AudioToTextRecorder:
                     f"{len(all_segments)} segments, language={backend_info.language}, task={effective_task}"
                 )
 
+                if oom_partial:
+                    # Placement is deliberate: the partial transcript is fully
+                    # assembled in locals by now and the helper cannot raise, so
+                    # the salvaged text is still returned here and persisted
+                    # downstream. Save first, clean up second - discarding the
+                    # backend earlier would put the durability invariant at risk
+                    # for no gain.
+                    self._discard_backend_after_oom("partial result after GPU OOM")
+
                 return TranscriptionResult(
                     text=full_text,
                     segments=all_segments,
@@ -1029,6 +1050,17 @@ class AudioToTextRecorder:
                 logger.exception(f"Transcription error: {e}")
                 oom = as_gpu_oom(e)
                 if oom is not None:
+                    # Drop the poisoned backend before re-raising, deliberately
+                    # while transcription_lock is still held: discarding after
+                    # the lock is released would leave a window in which another
+                    # thread starts a transcription on the known-bad backend. The
+                    # helper takes no locks of its own, so this cannot deadlock.
+                    # Accepted residual: a thread that already passed
+                    # ensure_transcription_loaded() and is blocked on the lock
+                    # now hits the "_backend is None" guard and fails. Its route
+                    # marks that job failed with the audio preserved, so it stays
+                    # retryable and no transcript is lost.
+                    self._discard_backend_after_oom("transcribe_audio")
                     raise oom from e
                 raise
 
@@ -1216,6 +1248,63 @@ class AudioToTextRecorder:
         self._backend = None
         self._model_loaded = False
         logger.info("Model unloaded")
+
+    def _discard_backend_after_oom(self, reason: str) -> None:
+        """Detach and tear down the backend after a GPU out-of-memory failure.
+
+        A backend that hit an OOM keeps a poisoned CUDA context. Reusing it does
+        not fail on the current VRAM situation but on a *sticky* error code left
+        on the context - which is how a retry made one second after the user
+        freed VRAM still died with "parallel_for failed: cudaErrorInvalidDevice:
+        invalid device ordinal". The OOM path never clears ``_model_loaded``, so
+        neither ``load_model()`` nor ``ensure_transcription_loaded()`` can heal
+        it, and ``clear_gpu_cache()`` only returns cached allocator blocks.
+        Dropping the backend here is what lets the next
+        ``ensure_transcription_loaded()`` rebuild a clean one.
+
+        Reset only, no auto-retry: the caller still raises the classified OOM so
+        the user sees the remedy and decides.
+
+        Never raises - it runs from an ``except`` block whose own exception has
+        to reach the caller intact - and takes no locks, because both call sites
+        already hold ``transcription_lock``.
+
+        Args:
+            reason: Short call-site tag, logged so a hardware smoke test can
+                confirm the discard fired exactly once.
+        """
+        if self._backend is None:
+            return
+
+        if not self._owns_backend:
+            # A shared backend belongs to whoever built it (Live Mode). This
+            # recorder cannot rebuild it, and dropping the reference would strand
+            # the live engine with a backend nobody ever unloads.
+            logger.warning(
+                "GPU OOM during %s on a shared backend - leaving it attached; "
+                "only its owner can rebuild it",
+                reason,
+            )
+            return
+
+        logger.warning(
+            "Discarding the STT backend after a GPU out-of-memory failure (%s): "
+            "its CUDA context is poisoned and every retry on it would fail with a "
+            "sticky error. The next transcription reloads the model.",
+            reason,
+        )
+        try:
+            self._backend.unload()
+        except Exception:
+            # Tearing down a poisoned context can trip the same sticky CUDA
+            # error. Swallow it: this helper must never mask the OOM that the
+            # caller is about to raise.
+            logger.warning("Backend unload during OOM discard failed", exc_info=True)
+        finally:
+            # Load-bearing: even when unload() blows up, the poisoned backend has
+            # to be detached, or the recorder stays wedged on it forever.
+            self._backend = None
+            self._model_loaded = False
 
     def is_loaded(self) -> bool:
         """Check if the model is loaded."""

--- a/server/backend/tests/test_ensure_transcription_loaded.py
+++ b/server/backend/tests/test_ensure_transcription_loaded.py
@@ -100,6 +100,43 @@ class TestEnsureTranscriptionLoaded:
         assert result is loaded_engine
         load_spy.assert_called_once()
 
+    def test_reloads_after_an_oom_discard(self, tmp_path: Path):
+        """A GPU OOM discard must self-heal on the next request.
+
+        ``AudioToTextRecorder._discard_backend_after_oom()`` drops the backend
+        whose CUDA context an out-of-memory failure poisoned, leaving exactly
+        ``_backend is None`` / ``_model_loaded False``. Every route that reaches
+        transcription calls this helper first, so that state has to rebuild into
+        a fresh backend - which is what makes "reset, no auto-retry" sufficient.
+        """
+        mgr = _build_manager(tmp_path)
+
+        # The state the OOM discard leaves behind.
+        discarded_engine = SimpleNamespace(
+            _backend=None,
+            _model_loaded=False,
+            is_loaded=lambda: False,
+            model_name="tiny",
+        )
+        mgr._transcription_engine = discarded_engine
+
+        rebuilt_engine = SimpleNamespace(
+            _backend=MagicMock(name="rebuilt_backend"),
+            _model_loaded=True,
+            is_loaded=lambda: True,
+            model_name="tiny",
+        )
+
+        def fake_load(*_a, **_kw):
+            mgr._transcription_engine = rebuilt_engine
+
+        with patch.object(mgr, "load_transcription_model", side_effect=fake_load) as load_spy:
+            result = mgr.ensure_transcription_loaded()
+
+        load_spy.assert_called_once()
+        assert result is rebuilt_engine
+        assert result._backend is not None
+
     def test_reloads_when_engine_never_created(self, tmp_path: Path):
         """Scenario 3: preload failed at startup; engine is None."""
         mgr = _build_manager(tmp_path)

--- a/server/backend/tests/test_job_audio_route.py
+++ b/server/backend/tests/test_job_audio_route.py
@@ -1,0 +1,358 @@
+"""Tests for GET /api/transcribe/audio/{job_id} - downloading a job's source WAV.
+
+The route exists so a user can keep the recording itself when transcription
+dies (e.g. a GPU OOM), instead of being left with nothing. That makes two
+properties load-bearing:
+
+- it is a PURE READ - it must never mark the job delivered and never purge it,
+  or the Save Audio button would destroy the very thing it saves;
+- its Content-Disposition must survive Uvicorn's Latin-1 header encoding, so
+  non-ASCII (Greek) names still download (Issue #106).
+
+Follows the direct-call pattern from test_transcription_durability_routes.py:
+- monkeypatch repository functions in server.database.job_repository
+- monkeypatch get_client_name in server.api.routes.transcription
+- invoke async handlers directly with asyncio.run()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import inspect
+
+import pytest
+from fastapi import HTTPException
+from server.api.routes import _http_utils, notebook, transcription
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _request() -> object:
+    """Minimal stand-in for Request when get_client_name is patched."""
+    return object()
+
+
+def _wav(tmp_path, name: str = "saved.wav"):
+    """Write a real (tiny) file so Path.exists() and FileResponse are honest."""
+    audio = tmp_path / name
+    audio.write_bytes(b"RIFF____WAVEfmt ")
+    return audio
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _patch_client_name(monkeypatch):
+    """All tests in this module assume the caller is 'test-client'."""
+    monkeypatch.setattr(transcription, "get_client_name", lambda _req: "test-client")
+
+
+@pytest.fixture()
+def repo(monkeypatch):
+    """Job repository whose destructive functions blow up if the route calls them.
+
+    The route is a pure read; any write reaching the repository is a bug, so the
+    default stubs fail loudly rather than silently succeeding.
+    """
+    r = importlib.import_module("server.database.job_repository")
+
+    def _forbidden(name):
+        def _boom(*_args, **_kwargs):
+            raise AssertionError(f"{name} must never be called by the audio download route")
+
+        return _boom
+
+    monkeypatch.setattr(r, "mark_delivered", _forbidden("mark_delivered"))
+    monkeypatch.setattr(r, "delete_job", _forbidden("delete_job"))
+    return r
+
+
+# ── Status-code matrix ────────────────────────────────────────────────────────
+
+
+class TestRouteRegistration:
+    def test_mounted_at_api_transcribe_audio_job_id(self):
+        """The dashboard is written against this exact URL - pin it here.
+
+        The router is mounted with prefix="/api/transcribe" in api/main.py, so
+        the full path is GET /api/transcribe/audio/{job_id}.
+        """
+        matches = [
+            r
+            for r in transcription.router.routes
+            if getattr(r, "endpoint", None) is transcription.get_job_audio
+        ]
+        assert len(matches) == 1
+        assert matches[0].path == "/audio/{job_id}"
+        assert matches[0].methods == {"GET"}
+
+
+class TestGetJobAudio:
+    def test_404_when_job_not_found(self, repo, monkeypatch):
+        monkeypatch.setattr(repo, "get_job", lambda _: None)
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(transcription.get_job_audio("missing", _request()))
+        assert exc.value.status_code == 404
+        assert exc.value.detail == "Job not found"
+
+    def test_403_for_different_client(self, repo, monkeypatch, tmp_path):
+        audio = _wav(tmp_path)
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {
+                "status": "failed",
+                "client_name": "other-client",
+                "audio_path": str(audio),
+            },
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(transcription.get_job_audio("job-other", _request()))
+        assert exc.value.status_code == 403
+        assert exc.value.detail == "Access denied"
+
+    def test_200_for_job_with_null_client_name(self, repo, monkeypatch, tmp_path):
+        """A null client_name means the job is not owned - any caller may fetch it."""
+        audio = _wav(tmp_path)
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {"status": "failed", "client_name": None, "audio_path": str(audio)},
+        )
+
+        resp = asyncio.run(transcription.get_job_audio("job-null", _request()))
+
+        assert resp.status_code == 200
+
+    def test_410_when_audio_was_never_preserved(self, repo, monkeypatch):
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {"status": "failed", "client_name": None, "audio_path": None},
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(transcription.get_job_audio("job-na", _request()))
+        assert exc.value.status_code == 410
+        assert exc.value.detail == "Audio was not preserved for this job - cannot download"
+
+    def test_410_when_tmp_path_lost_on_restart(self, repo, monkeypatch):
+        """A /tmp path that no longer exists gets its own diagnosable message."""
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {
+                "status": "failed",
+                "client_name": None,
+                "audio_path": "/tmp/does-not-exist-4c1f/session.wav",
+            },
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(transcription.get_job_audio("job-tmp", _request()))
+        assert exc.value.status_code == 410
+        assert "temporary storage (/tmp)" in exc.value.detail
+        assert "lost on server restart" in exc.value.detail
+        assert exc.value.detail.endswith("cannot download")
+
+    def test_410_when_audio_file_deleted(self, repo, monkeypatch):
+        # Deliberately NOT tmp_path: pytest puts tmp_path under /tmp on Linux,
+        # which would land in the "lost on server restart" branch instead. This
+        # path is only ever read via Path.exists() - nothing is written.
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {
+                "status": "failed",
+                "client_name": None,
+                "audio_path": "/var/lib/transcriptionsuite-does-not-exist/gone.wav",
+            },
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(transcription.get_job_audio("job-gone", _request()))
+        assert exc.value.status_code == 410
+        assert exc.value.detail == "Audio file has been deleted - cannot download"
+
+    def test_200_returns_the_wav_as_a_file_response(self, repo, monkeypatch, tmp_path):
+        audio = _wav(tmp_path)
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {
+                "status": "failed",
+                "client_name": "test-client",
+                "audio_path": str(audio),
+                "created_at": "2026-09-04 13:45:07",
+            },
+        )
+
+        resp = asyncio.run(transcription.get_job_audio("job-ok", _request()))
+
+        assert resp.status_code == 200
+        assert str(resp.path) == str(audio)
+        assert resp.media_type == "audio/wav"
+        assert (
+            resp.headers["content-disposition"]
+            == 'attachment; filename="transcription-20260904-134507-job-ok.wav"; '
+            "filename*=UTF-8''transcription-20260904-134507-job-ok.wav"
+        )
+
+    def test_200_filename_falls_back_when_created_at_is_unusable(self, repo, monkeypatch, tmp_path):
+        """An absent or unparsable created_at must degrade, never raise."""
+        audio = _wav(tmp_path)
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {
+                "status": "failed",
+                "client_name": None,
+                "audio_path": str(audio),
+                "created_at": "not a timestamp",
+            },
+        )
+
+        resp = asyncio.run(transcription.get_job_audio("job-nots", _request()))
+
+        assert 'filename="transcription-job-nots.wav"' in resp.headers["content-disposition"]
+
+    def test_served_as_an_attachment_not_an_inline_player_source(self, repo, monkeypatch, tmp_path):
+        """This is a download, not a seekable player.
+
+        The notebook recordings route serves `inline` because a browser audio
+        element streams from it. This one exists so the user can keep the file,
+        so it must arrive as an attachment with a filename, and the route adds
+        no Range handling of its own. (Starlette's FileResponse still advertises
+        accept-ranges itself; that comes from the framework, not from here.)
+        """
+        audio = _wav(tmp_path)
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {"status": "failed", "client_name": None, "audio_path": str(audio)},
+        )
+
+        resp = asyncio.run(transcription.get_job_audio("job-nr", _request()))
+
+        assert resp.status_code == 200
+        disposition = resp.headers["content-disposition"]
+        assert disposition.startswith("attachment;")
+        assert "inline" not in disposition
+        # The route's own source carries no Range/206 branch at all.
+        source = inspect.getsource(transcription.get_job_audio)
+        assert "206" not in source
+        assert "Range" not in source
+
+
+# ── Issue #106 regression guard: Greek names survive Latin-1 headers ──────────
+
+
+class TestContentDispositionEncoding:
+    def test_greek_name_survives_latin1_header_encoding(self, repo, monkeypatch, tmp_path):
+        """Uvicorn encodes header values as Latin-1; a raw Greek name would explode."""
+        audio = _wav(tmp_path)
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {"status": "failed", "client_name": None, "audio_path": str(audio)},
+        )
+
+        resp = asyncio.run(transcription.get_job_audio("συνεδρία-α1", _request()))
+
+        header = resp.headers["content-disposition"]
+        header.encode("latin-1")  # exactly what Uvicorn does - must not raise
+        assert "filename*=UTF-8''" in header
+        assert header.startswith("attachment; ")
+        # The percent-encoded form carries the real Greek name.
+        assert "%CF%83%CF%85%CE%BD%CE%B5%CE%B4%CF%81%CE%AF%CE%B1" in header
+
+    def test_helper_is_shared_not_copied(self):
+        """notebook must import the helper, not keep a second definition of it."""
+        assert notebook._content_disposition is _http_utils._content_disposition
+        assert notebook._ASCII_FALLBACK_REPLACE is _http_utils._ASCII_FALLBACK_REPLACE
+
+
+# ── The download must never consume the thing it downloads ───────────────────
+
+
+class TestDownloadIsAPureRead:
+    """The most important test in this file.
+
+    delete_job unlinks the WAV as well as deleting the row, and mark_delivered
+    makes the job sweepable by the retention task. If the download route ever
+    calls either, saving the audio would be what destroys it.
+    """
+
+    def test_does_not_mark_delivered_or_purge_and_leaves_the_wav_on_disk(
+        self, repo, monkeypatch, tmp_path
+    ):
+        audio = _wav(tmp_path)
+        calls: list[str] = []
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {
+                "status": "failed",
+                "client_name": "test-client",
+                "source": "websocket",
+                "audio_path": str(audio),
+                "created_at": "2026-09-04 13:45:07",
+            },
+        )
+        # Record instead of raise, so a regression reports *which* call happened.
+        monkeypatch.setattr(repo, "mark_delivered", lambda jid: calls.append(f"delivered:{jid}"))
+        monkeypatch.setattr(repo, "delete_job", lambda jid: calls.append(f"deleted:{jid}"))
+
+        resp = asyncio.run(transcription.get_job_audio("job-keep", _request()))
+
+        assert resp.status_code == 200
+        assert calls == []
+        assert audio.exists(), "the source WAV must still be on disk after a download"
+        assert audio.read_bytes() == b"RIFF____WAVEfmt "
+
+    def test_repeated_downloads_stay_available(self, repo, monkeypatch, tmp_path):
+        """A second download must work - the first one consumed nothing."""
+        audio = _wav(tmp_path)
+        monkeypatch.setattr(
+            repo,
+            "get_job",
+            lambda _: {"status": "failed", "client_name": None, "audio_path": str(audio)},
+        )
+
+        first = asyncio.run(transcription.get_job_audio("job-twice", _request()))
+        second = asyncio.run(transcription.get_job_audio("job-twice", _request()))
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert audio.exists()
+
+
+# ── Filename builder unit tests ───────────────────────────────────────────────
+
+
+class TestJobAudioFilename:
+    @pytest.mark.parametrize(
+        "created_at",
+        [None, "", "not a timestamp", "2026-13-45 99:99:99", 0, object()],
+    )
+    def test_parse_is_total(self, created_at):
+        """No created_at value may ever raise - a bad timestamp must not block a save."""
+        assert transcription._job_audio_filename("abc", created_at) == "transcription-abc.wav"
+
+    def test_sqlite_current_timestamp_form(self):
+        """created_at is written by SQLite CURRENT_TIMESTAMP (space separator)."""
+        assert (
+            transcription._job_audio_filename("abc", "2026-09-04 13:45:07")
+            == "transcription-20260904-134507-abc.wav"
+        )
+
+    def test_isoformat_form(self):
+        """Legacy/hand-written rows may hold an isoformat string instead."""
+        assert (
+            transcription._job_audio_filename("abc", "2026-09-04T13:45:07+00:00")
+            == "transcription-20260904-134507-abc.wav"
+        )

--- a/server/backend/tests/test_oom_discards_backend.py
+++ b/server/backend/tests/test_oom_discards_backend.py
@@ -1,0 +1,279 @@
+"""A GPU out-of-memory failure must take the poisoned backend down with it.
+
+Incident of 2026-09-04: a longform WebSocket transcription died with
+``CUDA failed with error out of memory`` at 22.65/24 GB VRAM. The user freed
+VRAM and pressed Retry; that retry failed in one second with
+``parallel_for failed: cudaErrorInvalidDevice: invalid device ordinal``, a
+*sticky* error code left on the CUDA context by the OOM and unrelated to the
+VRAM actually free at that moment. A second retry 19 seconds later succeeded.
+
+The OOM handler used to re-raise without touching ``self._backend``, so the
+CTranslate2 instance kept its broken context and every retry replayed the same
+failure. ``_model_loaded`` was never cleared either, so ``load_model()`` and
+``ensure_transcription_loaded()`` both no-opped and could not heal it.
+
+These tests pin the fix: on a *classified* OOM the recorder discards its owned
+backend (``_backend is None``, ``_model_loaded is False``) while still raising
+the ``GpuOutOfMemoryError`` with its remedy. Reset only - no auto-retry.
+
+Run:  ../../build/.venv/bin/pytest tests/test_oom_discards_backend.py -v --tb=short
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import types
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+# The observed OOM wordings live with the classifier's own tests; import them
+# rather than retyping strings that were copied verbatim from container logs.
+from test_cuda_oom_classification import CT2_PLAIN_OOM, CT2_THRUST_OOM
+
+
+def _ensure_engine_importable() -> None:
+    """Install lightweight stubs for engine top-level imports.
+
+    Mirrors tests/test_stt_engine_shared_backend.py - keep the two in sync.
+    """
+    if "torch" not in sys.modules:
+        torch_stub = types.ModuleType("torch")
+        torch_stub.Tensor = type("Tensor", (), {})  # type: ignore[attr-defined]
+        torch_stub.float16 = "float16"  # type: ignore[attr-defined]
+        torch_stub.float32 = "float32"  # type: ignore[attr-defined]
+        torch_stub.from_numpy = lambda x: x  # type: ignore[attr-defined]
+        torch_stub.cuda = types.SimpleNamespace(  # type: ignore[attr-defined]
+            is_available=lambda: False,
+        )
+        sys.modules["torch"] = torch_stub
+
+    if "scipy" not in sys.modules:
+        scipy = types.ModuleType("scipy")
+        scipy_signal = types.ModuleType("scipy.signal")
+        scipy_signal.resample = lambda *a, **kw: np.array([])  # type: ignore[attr-defined]
+        scipy.signal = scipy_signal  # type: ignore[attr-defined]
+        sys.modules["scipy"] = scipy
+        sys.modules["scipy.signal"] = scipy_signal
+
+    factory_mod_name = "server.core.stt.backends.factory"
+    if factory_mod_name not in sys.modules:
+        factory_stub = types.ModuleType(factory_mod_name)
+        factory_stub.create_backend = MagicMock()  # type: ignore[attr-defined]
+        factory_stub.detect_backend_type = MagicMock(return_value="whisper")  # type: ignore[attr-defined]
+        sys.modules[factory_mod_name] = factory_stub
+
+    vad_mod_name = "server.core.stt.vad"
+    if vad_mod_name not in sys.modules:
+        vad_stub = types.ModuleType(vad_mod_name)
+
+        class _FakeVAD:
+            def __init__(self, **kw: Any):
+                pass
+
+            def reset_states(self) -> None:
+                pass
+
+        vad_stub.VoiceActivityDetector = _FakeVAD  # type: ignore[attr-defined]
+        sys.modules[vad_mod_name] = vad_stub
+
+
+_ensure_engine_importable()
+
+
+_mock_cfg = MagicMock()
+_mock_cfg.get.return_value = {}
+_mock_cfg.stt = MagicMock()
+_mock_cfg.stt.get.return_value = None
+
+
+with (
+    patch("server.config.get_config", return_value=_mock_cfg),
+    patch("server.config.resolve_main_transcriber_model", return_value="tiny"),
+):
+    from server.core.stt.backends.base import (  # noqa: E402
+        BackendSegment,
+        BackendTranscriptionInfo,
+        GpuOutOfMemoryError,
+        PartialTranscriptionError,
+    )
+    from server.core.stt.engine import AudioToTextRecorder  # noqa: E402
+
+
+AUDIO = np.zeros(16000, dtype=np.float32)
+
+
+def _bare_recorder(backend: Any, *, owns_backend: bool = True) -> AudioToTextRecorder:
+    """Build a recorder without running __init__ (which starts a worker thread).
+
+    Only the attributes the two transcription entry points actually touch are
+    populated, matching the bare-recorder pattern in
+    tests/test_stt_engine_shared_backend.py.
+    """
+    rec = object.__new__(AudioToTextRecorder)
+    rec.transcription_lock = threading.Lock()
+    rec._backend = backend
+    rec._model_loaded = True
+    rec._owns_backend = owns_backend
+    rec.instance_name = "main"
+    rec.model_name = "tiny"
+    rec.normalize_audio = False
+    rec.language = "en"
+    rec.task = "transcribe"
+    rec.translation_target_language = None
+    rec.initial_prompt = None
+    rec.beam_size = 5
+    rec.suppress_tokens = [-1]
+    rec.faster_whisper_vad_filter = False
+    rec.ensure_sentence_starting_uppercase = False
+    rec.ensure_sentence_ends_with_period = False
+    rec.state = "inactive"
+    rec.audio = None
+    return rec
+
+
+def _make_partial(message: str = "chunk 4 of 9 failed") -> PartialTranscriptionError:
+    """A salvageable partial carrying one completed chunk."""
+    return PartialTranscriptionError(
+        message,
+        segments=[BackendSegment(text="salvaged words", start=0.0, end=1.0)],
+        info=BackendTranscriptionInfo(language="en", language_probability=0.9),
+        completed_seconds=42.0,
+    )
+
+
+def _raise_partial_from(cause: BaseException):
+    """Return a side_effect that raises a partial chained to ``cause``.
+
+    Raising inside an ``except`` block is what sets ``__cause__`` the way a real
+    chunking backend does, which is exactly what the fix reads.
+    """
+
+    def _side_effect(*_a: Any, **_kw: Any):
+        try:
+            raise cause
+        except BaseException as err:
+            raise _make_partial() from err
+
+    return _side_effect
+
+
+class TestTranscribeAudioDiscardsOnOom:
+    @pytest.mark.parametrize(
+        "message",
+        [CT2_PLAIN_OOM, CT2_THRUST_OOM],
+        ids=["ct2-plain", "ct2-thrust-misreport"],
+    )
+    def test_backend_is_discarded_and_the_oom_still_propagates(self, message: str) -> None:
+        """The thrust wording is the regression guard for the 2026-09-04 incident."""
+        backend = MagicMock()
+        backend.transcribe.side_effect = RuntimeError(message)
+        rec = _bare_recorder(backend)
+
+        with pytest.raises(GpuOutOfMemoryError) as excinfo:
+            rec.transcribe_audio(AUDIO)
+
+        assert rec._backend is None
+        assert rec._model_loaded is False
+        backend.unload.assert_called_once_with()
+        # The remedy must survive the discard - it is the whole user-facing value
+        # of the classification.
+        assert excinfo.value.remedy
+        assert message in str(excinfo.value)
+
+    def test_non_oom_failure_keeps_the_backend(self) -> None:
+        """A plain bug must not cost a model reload."""
+        backend = MagicMock()
+        backend.transcribe.side_effect = ValueError("boom")
+        rec = _bare_recorder(backend)
+
+        with pytest.raises(ValueError, match="boom"):
+            rec.transcribe_audio(AUDIO)
+
+        assert rec._backend is backend
+        assert rec._model_loaded is True
+        backend.unload.assert_not_called()
+
+    def test_shared_backend_is_left_attached(self) -> None:
+        """A borrowed Live Mode backend is not ours to tear down or drop."""
+        backend = MagicMock()
+        backend.transcribe.side_effect = RuntimeError(CT2_PLAIN_OOM)
+        rec = _bare_recorder(backend, owns_backend=False)
+
+        with pytest.raises(GpuOutOfMemoryError):
+            rec.transcribe_audio(AUDIO)
+
+        assert rec._backend is backend
+        backend.unload.assert_not_called()
+
+    def test_failing_unload_still_detaches(self) -> None:
+        """Guards the ``finally``: unload() on a poisoned context can itself trip
+        the sticky CUDA error, and the recorder must not stay wedged on it."""
+        backend = MagicMock()
+        backend.transcribe.side_effect = RuntimeError(CT2_PLAIN_OOM)
+        backend.unload.side_effect = RuntimeError(CT2_THRUST_OOM)
+        rec = _bare_recorder(backend)
+
+        with pytest.raises(GpuOutOfMemoryError):
+            rec.transcribe_audio(AUDIO)
+
+        assert rec._backend is None
+        assert rec._model_loaded is False
+
+
+class TestPartialResultsStillSalvaged:
+    """Save first, clean up second - the durability invariant outranks the reset."""
+
+    def test_partial_caused_by_oom_returns_the_text_and_discards(self) -> None:
+        backend = MagicMock()
+        backend.transcribe.side_effect = _raise_partial_from(RuntimeError(CT2_PLAIN_OOM))
+        rec = _bare_recorder(backend)
+
+        result = rec.transcribe_audio(AUDIO)
+
+        assert result.partial is True
+        assert "salvaged words" in result.text
+        assert rec._backend is None
+        assert rec._model_loaded is False
+        backend.unload.assert_called_once_with()
+
+    def test_partial_from_a_non_oom_cause_keeps_the_backend(self) -> None:
+        backend = MagicMock()
+        backend.transcribe.side_effect = _raise_partial_from(ValueError("corrupt chunk"))
+        rec = _bare_recorder(backend)
+
+        result = rec.transcribe_audio(AUDIO)
+
+        assert result.partial is True
+        assert "salvaged words" in result.text
+        assert rec._backend is backend
+        assert rec._model_loaded is True
+        backend.unload.assert_not_called()
+
+
+class TestPerformTranscriptionDiscardsOnOom:
+    def test_oom_discards_the_backend(self) -> None:
+        backend = MagicMock()
+        backend.transcribe.side_effect = RuntimeError(CT2_THRUST_OOM)
+        rec = _bare_recorder(backend)
+
+        with pytest.raises(GpuOutOfMemoryError):
+            rec._perform_transcription(AUDIO)
+
+        assert rec._backend is None
+        assert rec._model_loaded is False
+        backend.unload.assert_called_once_with()
+
+    def test_non_oom_keeps_the_backend(self) -> None:
+        backend = MagicMock()
+        backend.transcribe.side_effect = ValueError("boom")
+        rec = _bare_recorder(backend)
+
+        with pytest.raises(ValueError, match="boom"):
+            rec._perform_transcription(AUDIO)
+
+        assert rec._backend is backend
+        backend.unload.assert_not_called()


### PR DESCRIPTION
On 2026-09-04 a longform WebSocket transcription (130 s of Greek audio) died with `CUDA failed with error out of memory` at 22.65/24 GB on an RTX 3090. The user freed VRAM and pressed **Retry**. That retry failed in one second with `parallel_for failed: cudaErrorInvalidDevice: invalid device ordinal`. A second retry 19 seconds later succeeded and the transcript was saved. It never appeared in the UI, and every further Retry click was refused with `409 Only failed or partial jobs can be retried (current status: completed)` - leaving no way to reach a transcript that was in the database the whole time.

Two independent defects produced that dead end, plus a third gap the incident exposed: the user had no way to keep the recording itself.

## Fix A - a GPU OOM leaves a poisoned backend in place

The OOM handler classified the error and re-raised without touching `self._backend`. The CTranslate2 instance kept its broken CUDA context, so the next attempt reused it and died on a *sticky* error code unrelated to the current VRAM situation. `_model_loaded` was never cleared, so `ensure_transcription_loaded()` and `load_model()` both no-op'd and could not heal it, and `clear_gpu_cache()` only frees cached allocator blocks.

New `_discard_backend_after_oom()` unloads and detaches on a classified OOM at both sites, with the detach in a `finally` so a poisoned backend whose `unload()` also trips the sticky error is still dropped. Reset only, no auto-retry: the classified OOM still reaches the caller with its remedy text, and every entry point already calls `ensure_transcription_loaded()`, which rebuilds when `_backend is None`.

It also closes the inverse hole: a `PartialTranscriptionError` caused by an OOM never reached the OOM handler, because that branch falls through to a normal return. The discard now runs after the salvaged transcript is fully assembled and immediately before the return - save first, clean up second.

A borrowed Live Mode backend (`_owns_backend == False`) is left attached and only logged; this recorder cannot rebuild what it did not create.

## Fix B - a completed result must never be unreachable

The recovery banner filtered out every job whose id equalled `transcription.jobId`, and `jobId` deliberately survives an error so the Retry button stays live. So the one job that most needed recovering was the one the banner hid, while `/retry` refused it as already completed.

- The hook now tracks `resultJobId`: does the transcript on screen belong to *this* job. That is the interruption-agnostic guarantee - the cap, an unmount, an app reload, overlapping retries, a throw in the delivery branch all end with the row still completed and undelivered, and `/recent` plus the focus listener surface it.
- A 409 now probes `/result` once and delivers on 200, matched on the status code and never on the refusal text, which is a human message and not a contract. A 409 that really means "model busy" answers 202 and falls through to the existing toast.
- Both polling loops now share `src/services/resultPolling.ts`, extracted from the mature socket-drop loop: a per-invocation cancel handle, a wall-clock budget instead of the 100-attempt cap (which ignored request latency), a separate network-error budget, and a narrow `try` so a throw while *delivering* is no longer read as "not ready yet" - that was what left the button stuck on "Retrying..." forever.
- Two payload-shape bugs fixed by a shared mapper: Retry dropped `numSpeakers` and `diarization`, and banner **View** also dropped `partial` and `partialReason`, so the safety net rendered a truncated transcript as if it were whole.

## Fix C - a Save Audio button beside Retry

A transcript can always be made again from the audio; the audio cannot be made again from anything.

- New `GET /api/transcribe/audio/{job_id}` serving the preserved WAV, reusing `/retry`'s 404/403/410 checks and its three distinct 410 reasons. It is a pure read: it must never mark the job delivered and never purge, or saving the audio would destroy it.
- `_content_disposition` moved to a shared `api/routes/_http_utils.py` - Uvicorn encodes headers as Latin-1, so a Greek filename needs the RFC 6266 UTF-8 form (GH-106).
- A new `file:downloadToPath` IPC channel streams the response body to disk in the main process. The bytes never cross the bridge: a supported 5-hour recording is roughly 576 MB. The token travels as an `Authorization` header, so it stays out of the URL and out of any log.
- The button sits beside Retry in both banners and **before View** in the recovery row, because View delivers the transcript and delivering a session job unlinks its WAV. That window is exactly the window Retry is offered in, which is not a coincidence.

## Verification

- Backend: 2499 passed, 5 skipped (full suite).
- Frontend: 2207 passed across 151 files; `typecheck`, `lint` and `ui:contract:check` clean.
- The two banner regression tests were confirmed red against the old `jobId` filter and green after; the pre-existing-file guard in the download cleanup was confirmed red against an unconditional unlink.
- No CSS classes were added, so the UI contract needs no rebuild.
- GitNexus `detect_changes` run for `all` and `compare --base-ref main`: neither partial nor truncated. Risk is reported **critical**, dominated by symbols whose line numbers shifted in `SessionView.tsx` and `useTranscription.ts`; the genuinely changed flows are the four `transcribe_audio` consumers (`transcribe_with_optional_diarization`, `transcribe_and_diarize`, `transcribe_then_diarize`, `transcribe_multitrack`), each reviewed for the discard and unaffected.

## Smoke pending

Hardware smoke on the RTX 3090 has **not** been run:

1. **Fix A** - saturate VRAM, force an OOM on a longform recording, free the VRAM, click Retry **once**. It must succeed on the first click with the discard warning logged exactly once. Fix A is a strong hypothesis, not a proven diagnosis: the logs do not prove the model *instance* was the poison rather than the CUDA context or residual VRAM. If it still needs two clicks, the premise is wrong and the remaining work is a process-level CUDA reset - Fix B still guarantees the transcript is reachable either way.
2. **Fix B** - force an OOM, retry, kill the poll by closing and reopening the tab. The banner must list the job, View must load it, a partial must still show its amber banner, and the row must be gone afterwards.
3. **Fix C** - Save Audio on a failed job, confirm the WAV opens and plays and matches the server copy; repeat with a long recording to confirm the streaming write does not stall the UI; then view the transcript and confirm Save Audio reports the audio as gone rather than failing opaquely; repeat once against a **remote** server.

## Follow-ups logged, not fixed here

- `diarization_dispatch._run_integrated` swallows every exception with `return None`, so an OOM there is neither classified nor discarded.
- `multitrack.transcribe_multitrack` discards already-transcribed tracks when a later track fails.
- `components/recording/DownloadButtons.tsx` and its test are orphaned - mounted nowhere.
- `GET /api/notebook/recordings/{id}/audio` has no `get_client_name` ownership check, unlike every job route.
- SessionView's live transcript Download uses a Blob and an anchor click, dropping the file into the OS Downloads folder with no dialog - inconsistent with the Save Audio button this PR adds.
- The committed UI contract YAML is stale by one file entry (`Sidebar.notebookSubTabs.test.tsx`, added in 6ba099b5); left alone here so this PR does not absorb an unrelated regeneration.